### PR TITLE
bench(mv-gcd): add matched comparator matrix

### DIFF
--- a/HexMvGcd/SPEC/hex-mv-gcd.md
+++ b/HexMvGcd/SPEC/hex-mv-gcd.md
@@ -1556,10 +1556,10 @@ cover the decomposition surface over `ℤ` and `ℚ`, and its `modulus=`
 argument covers the positive-characteristic Boolean cases above. Extension
 fields `F_q` are not covered by SymPy and are out of scope for the
 oracle; `GFq` Boolean cases are checked in Lean, with their arity-one
-specializations compared to hex-poly-fp. python-flint's `fmpz_mpoly.gcd` is a
-stronger implementation but does not expose cofactors or squarefree
-decomposition uniformly, so it appears below as a performance comparator
-rather than as the oracle.
+specializations compared to hex-poly-fp. python-flint exposes the matching
+GCD, exact-division, and squarefree operations, but not the complete
+certificate and cofactor surface required above, so it appears below as a
+performance comparator rather than as the oracle.
 
 The companion adds randomised comparison against
 `MvPolynomial (Fin n) ℤ` through hex-mv-poly's `equiv`, checking the
@@ -1596,18 +1596,26 @@ gap:
 - **Cofactor-heavy**, where the gcd is small and the cofactors are large,
   which stresses `divExact?` rather than the interpolation.
 
-**Comparators.** FLINT's `fmpz_mpoly_gcd` is `informational`. It selects
-among Brown, Zippel, a sparse Hensel route, and subresultants with tuned
-crossovers, while this library specifies Brown and the subresultant
-fallback. A required broad ratio would therefore be a check on routes that
-do not exist. The written-down
-expectation is therefore narrow: on the **coprime**
-family the ratio should be within a small constant, since both sides do
-one evaluation and one univariate gcd per variable, and a large ratio
-there means the fast path is not firing. No advance claim is made on the
-sparse family, where FLINT's Hensel route has no counterpart here.
-Singular is `informational` for the same reason. SymPy is the oracle and
+**Comparators.** Every family has two matched endpoints and three arms: Hex,
+FLINT, and Singular. The arms return Hex's ascending canonical term list (or
+the sorted squarefree multiplicity signature), and every registration pins
+the shared output hash. The FLINT driver uses `fmpz_mpoly.gcd` for the
+integer GCD families, `fmpq_mpoly.gcd` for rationals, exact `divmod` for the
+cofactor-heavy family, and `factor_squarefree` for squarefree decomposition.
+The Singular driver uses `gcd`, checked exact quotient, and `factorize` in a
+persistent characteristic-zero polynomial ring. SymPy remains the oracle and
 is not a performance comparator.
+
+Both performance comparators are `informational`. FLINT selects among Brown,
+Zippel, a sparse Hensel route, and subresultants with tuned crossovers, while
+this library specifies Brown and the subresultant fallback; Singular likewise
+has sparse routes outside this SPEC. A required broad ratio would therefore
+check routes that do not exist. The written-down expectation is narrow: on
+the **coprime** family the ratio should be within a small constant, since all
+three sides should discharge the inputs without full interpolation. A large
+ratio there means the fast path is not firing. No advance ratio claim is made
+on the remaining families, especially sparse stress, where the comparator
+route has no Hex counterpart.
 
 ## The Mathlib layer
 

--- a/bench/HexMvGcd/Bench.lean
+++ b/bench/HexMvGcd/Bench.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 import HexMvGcd
 import HexMvGcd.Families
 import HexMvGcd.Matrix
+import HexMvGcd.Comparators
 import HexMvPolyCorpus
 import HexMvGcdFlint
 import HexMvGcdSingular

--- a/bench/HexMvGcd/ComparatorCases.lean
+++ b/bench/HexMvGcd/ComparatorCases.lean
@@ -1,0 +1,224 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexMvGcd.Matrix
+import HexMvGcdFlint
+import HexMvGcdSingular
+
+/-!
+Matched Hex/FLINT/Singular cases for every `hex-mv-gcd` Phase-4 family.
+
+Each triple returns the same semantic result: canonical sparse GCD or quotient
+terms, or the sorted squarefree multiplicity signature. Singular checks its
+answer against the canonical expected polynomial inside the timed request;
+FLINT returns its polynomial answer for direct comparison. Inputs are cached
+outside the measured repetitions by each fixed benchmark's discarded warmup.
+-/
+
+namespace Hex.MvGcdBench.ComparatorCases
+
+open Hex.MvPoly
+open Hex.MvGcdBench.Families
+
+def leanInt {n : Nat} (input : P n Int × P n Int) : IO Flint.IntTerms :=
+  Flint.leanIntGcd input
+
+def flintInt {n : Nat} (input : P n Int × P n Int) : IO Flint.IntTerms :=
+  Flint.intGcd input
+
+def singularInt {n : Nat} (input : P n Int × P n Int)
+    (expected : P n Int) : IO Flint.IntTerms :=
+  Singular.intGcd input expected
+
+def leanRat {n : Nat} (input : P n Rat × P n Rat) : IO Flint.RatTerms :=
+  Flint.leanRatGcd input
+
+def flintRat {n : Nat} (input : P n Rat × P n Rat) : IO Flint.RatTerms :=
+  Flint.ratGcd input
+
+def singularRat {n : Nat} (input : P n Rat × P n Rat)
+    (expected : P n Rat) : IO Flint.RatTerms :=
+  Singular.ratGcd input expected
+
+/-! Coprime pairs: one dense low-arity and one sparse high-arity endpoint. -/
+
+def runLeanCoprimeDense2 (_ : Unit) : IO Flint.IntTerms := do
+  leanInt (← Matrix.denseCoprime2.get)
+
+def runFlintCoprimeDense2 (_ : Unit) : IO Flint.IntTerms := do
+  flintInt (← Matrix.denseCoprime2.get)
+
+def runSingularCoprimeDense2 (_ : Unit) : IO Flint.IntTerms := do
+  singularInt (← Matrix.denseCoprime2.get) 1
+
+def runLeanCoprimeSparse8 (_ : Unit) : IO Flint.IntTerms := do
+  leanInt (← Matrix.sparseCoprime8.get)
+
+def runFlintCoprimeSparse8 (_ : Unit) : IO Flint.IntTerms := do
+  flintInt (← Matrix.sparseCoprime8.get)
+
+def runSingularCoprimeSparse8 (_ : Unit) : IO Flint.IntTerms := do
+  singularInt (← Matrix.sparseCoprime8.get) 1
+
+/-! Dense Brown interpolation: canonical `3d5` and `4d5` inputs. -/
+
+def dense4 : IO (P 4 Int × P 4 Int) :=
+  Matrix.getCached Matrix.denseGcd4d5 fun _ => denseGcd 4 5
+
+def runLeanDense3d5 (_ : Unit) : IO Flint.IntTerms := do
+  leanInt (← Matrix.denseGcd3d5.get)
+
+def runFlintDense3d5 (_ : Unit) : IO Flint.IntTerms := do
+  flintInt (← Matrix.denseGcd3d5.get)
+
+def runSingularDense3d5 (_ : Unit) : IO Flint.IntTerms := do
+  singularInt (← Matrix.denseGcd3d5.get) (commonFactor 3)
+
+def runLeanDense4d5 (_ : Unit) : IO Flint.IntTerms := do
+  leanInt (← dense4)
+
+def runFlintDense4d5 (_ : Unit) : IO Flint.IntTerms := do
+  flintInt (← dense4)
+
+def runSingularDense4d5 (_ : Unit) : IO Flint.IntTerms := do
+  singularInt (← dense4) (commonFactor 4)
+
+/-! Sparse-gap endpoints. The separate degree-4096 matrix cases measure one
+bounded Brown image; these smaller cases keep the complete public-GCD call
+finite for all three comparator implementations. -/
+
+initialize sparse5d4 : IO.Ref (P 5 Int × P 5 Int) ←
+  IO.mkRef (sparseGapGcd 5 4)
+initialize sparse5d16 : IO.Ref (P 5 Int × P 5 Int) ←
+  IO.mkRef (sparseGapGcd 5 16)
+
+def runLeanSparse5d4 (_ : Unit) : IO Flint.IntTerms := do
+  leanInt (← sparse5d4.get)
+
+def runFlintSparse5d4 (_ : Unit) : IO Flint.IntTerms := do
+  flintInt (← sparse5d4.get)
+
+def runSingularSparse5d4 (_ : Unit) : IO Flint.IntTerms := do
+  singularInt (← sparse5d4.get) (commonFactor 5)
+
+def runLeanSparse5d16 (_ : Unit) : IO Flint.IntTerms := do
+  leanInt (← sparse5d16.get)
+
+def runFlintSparse5d16 (_ : Unit) : IO Flint.IntTerms := do
+  flintInt (← sparse5d16.get)
+
+def runSingularSparse5d16 (_ : Unit) : IO Flint.IntTerms := do
+  singularInt (← sparse5d16.get) (commonFactor 5)
+
+/-! Extended-PRS coefficient swell. -/
+
+initialize swell3 : IO.Ref (P 2 Int × P 2 Int) ← IO.mkRef (swellGcd 3)
+initialize swell5 : IO.Ref (P 2 Int × P 2 Int) ← IO.mkRef (swellGcd 5)
+
+def swellCommon : P 2 Int := C 2 * X 0 + X 1 + 1
+
+def runLeanSwell3 (_ : Unit) : IO Flint.IntTerms := do
+  leanInt (← swell3.get)
+
+def runFlintSwell3 (_ : Unit) : IO Flint.IntTerms := do
+  flintInt (← swell3.get)
+
+def runSingularSwell3 (_ : Unit) : IO Flint.IntTerms := do
+  singularInt (← swell3.get) (polyNormalize swellCommon)
+
+def runLeanSwell5 (_ : Unit) : IO Flint.IntTerms := do
+  leanInt (← swell5.get)
+
+def runFlintSwell5 (_ : Unit) : IO Flint.IntTerms := do
+  flintInt (← swell5.get)
+
+def runSingularSwell5 (_ : Unit) : IO Flint.IntTerms := do
+  singularInt (← swell5.get) (polyNormalize swellCommon)
+
+/-! Rational denominator-clearing endpoints. -/
+
+def rational4 : IO (P 4 Rat × P 4 Rat) :=
+  Matrix.getCached Matrix.rationalGcd4d5 fun _ => rationalGcd 4 5
+
+def runLeanRational3d5 (_ : Unit) : IO Flint.RatTerms := do
+  leanRat (← Matrix.rationalGcd3d5.get)
+
+def runFlintRational3d5 (_ : Unit) : IO Flint.RatTerms := do
+  flintRat (← Matrix.rationalGcd3d5.get)
+
+def runSingularRational3d5 (_ : Unit) : IO Flint.RatTerms := do
+  singularRat (← Matrix.rationalGcd3d5.get)
+    (polyNormalize (rationalCommon 3))
+
+def runLeanRational4d5 (_ : Unit) : IO Flint.RatTerms := do
+  leanRat (← rational4)
+
+def runFlintRational4d5 (_ : Unit) : IO Flint.RatTerms := do
+  flintRat (← rational4)
+
+def runSingularRational4d5 (_ : Unit) : IO Flint.RatTerms := do
+  singularRat (← rational4) (polyNormalize (rationalCommon 4))
+
+/-! Squarefree decomposition compares sorted multiplicity signatures. -/
+
+def leanSquarefree {n : Nat} (polynomial : P n Int) : IO (List Nat) :=
+  return (sqfDecomp polynomial).factors.map (·.multiplicity)
+
+def runLeanSquarefree2m1 (_ : Unit) : IO (List Nat) := do
+  leanSquarefree (← Matrix.squarefree2m1.get)
+
+def runFlintSquarefree2m1 (_ : Unit) : IO (List Nat) := do
+  Flint.intSquarefree (← Matrix.squarefree2m1.get)
+
+def runSingularSquarefree2m1 (_ : Unit) : IO (List Nat) := do
+  Singular.intSquarefree (← Matrix.squarefree2m1.get)
+
+def runLeanSquarefree4m7 (_ : Unit) : IO (List Nat) := do
+  leanSquarefree (← Matrix.squarefree4m7.get)
+
+def runFlintSquarefree4m7 (_ : Unit) : IO (List Nat) := do
+  Flint.intSquarefree (← Matrix.squarefree4m7.get)
+
+def runSingularSquarefree4m7 (_ : Unit) : IO (List Nat) := do
+  Singular.intSquarefree (← Matrix.squarefree4m7.get)
+
+/-! Cofactor-heavy exact division. -/
+
+initialize cofactor16 : IO.Ref (P 2 Int × P 2 Int × P 2 Int) ←
+  IO.mkRef (cofactorHeavy 16)
+initialize cofactor64 : IO.Ref (P 2 Int × P 2 Int × P 2 Int) ←
+  IO.mkRef (cofactorHeavy 64)
+
+def leanDiv (input : P 2 Int × P 2 Int × P 2 Int) : IO Flint.IntTerms :=
+  match divExact? input.1 input.2.1 with
+  | none => throw <| IO.userError "Hex exact division declined a divisible input"
+  | some quotient => return Flint.intTerms quotient
+
+def flintDiv (input : P 2 Int × P 2 Int × P 2 Int) : IO Flint.IntTerms :=
+  Flint.intDiv input.1 input.2.1
+
+def singularDiv (input : P 2 Int × P 2 Int × P 2 Int) : IO Flint.IntTerms :=
+  Singular.intDiv input.1 input.2.1 input.2.2
+
+def runLeanCofactor16 (_ : Unit) : IO Flint.IntTerms := do
+  leanDiv (← cofactor16.get)
+
+def runFlintCofactor16 (_ : Unit) : IO Flint.IntTerms := do
+  flintDiv (← cofactor16.get)
+
+def runSingularCofactor16 (_ : Unit) : IO Flint.IntTerms := do
+  singularDiv (← cofactor16.get)
+
+def runLeanCofactor64 (_ : Unit) : IO Flint.IntTerms := do
+  leanDiv (← cofactor64.get)
+
+def runFlintCofactor64 (_ : Unit) : IO Flint.IntTerms := do
+  flintDiv (← cofactor64.get)
+
+def runSingularCofactor64 (_ : Unit) : IO Flint.IntTerms := do
+  singularDiv (← cofactor64.get)
+
+end Hex.MvGcdBench.ComparatorCases

--- a/bench/HexMvGcd/Comparators.lean
+++ b/bench/HexMvGcd/Comparators.lean
@@ -1,0 +1,133 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexMvGcd.ComparatorCases
+import LeanBench
+
+/-!
+Fixed external-comparator registrations for the seven Phase-4 input families.
+
+Every named point has a Hex, python-flint, and Singular arm. The process-call
+arms discard one warmup invocation so driver and CAS startup are outside the
+timed repetitions; the Hex arm uses the same shape so lazy input construction
+is likewise outside timing. `compare` joins each triple by its output hash.
+-/
+
+namespace Hex.MvGcdBench.ComparatorCases
+
+def config (family implementation : String)
+    (expectedHash : UInt64) : LeanBench.FixedBenchmarkConfig :=
+  { repeats := 3, maxSecondsPerCall := 10.0, minTotalSeconds := 0.2,
+    warmupFirstIter := true,
+    expectedHash := some expectedHash,
+    tags := #["mv-gcd-comparator", family, implementation] }
+
+/-! `coprime-pairs` -/
+
+setup_fixed_benchmark runLeanCoprimeDense2 where
+  config "coprime-pairs" "lean" 0x227808efbc4a0df6
+setup_fixed_benchmark runFlintCoprimeDense2 where
+  config "coprime-pairs" "flint" 0x227808efbc4a0df6
+setup_fixed_benchmark runSingularCoprimeDense2 where
+  config "coprime-pairs" "singular" 0x227808efbc4a0df6
+setup_fixed_benchmark runLeanCoprimeSparse8 where
+  config "coprime-pairs" "lean" 0xc81d2f17120678a5
+setup_fixed_benchmark runFlintCoprimeSparse8 where
+  config "coprime-pairs" "flint" 0xc81d2f17120678a5
+setup_fixed_benchmark runSingularCoprimeSparse8 where
+  config "coprime-pairs" "singular" 0xc81d2f17120678a5
+
+/-! `dense-gcds` -/
+
+setup_fixed_benchmark runLeanDense3d5 where
+  config "dense-gcds" "lean" 0x54b3f437e9d29507
+setup_fixed_benchmark runFlintDense3d5 where
+  config "dense-gcds" "flint" 0x54b3f437e9d29507
+setup_fixed_benchmark runSingularDense3d5 where
+  config "dense-gcds" "singular" 0x54b3f437e9d29507
+setup_fixed_benchmark runLeanDense4d5 where
+  config "dense-gcds" "lean" 0x194ca12395aa1c60
+setup_fixed_benchmark runFlintDense4d5 where
+  config "dense-gcds" "flint" 0x194ca12395aa1c60
+setup_fixed_benchmark runSingularDense4d5 where
+  config "dense-gcds" "singular" 0x194ca12395aa1c60
+
+/-! `sparse-stress` -/
+
+setup_fixed_benchmark runLeanSparse5d4 where
+  config "sparse-stress" "lean" 0xf3af0d107878de6b
+setup_fixed_benchmark runFlintSparse5d4 where
+  config "sparse-stress" "flint" 0xf3af0d107878de6b
+setup_fixed_benchmark runSingularSparse5d4 where
+  config "sparse-stress" "singular" 0xf3af0d107878de6b
+setup_fixed_benchmark runLeanSparse5d16 where
+  config "sparse-stress" "lean" 0xf3af0d107878de6b
+setup_fixed_benchmark runFlintSparse5d16 where
+  config "sparse-stress" "flint" 0xf3af0d107878de6b
+setup_fixed_benchmark runSingularSparse5d16 where
+  config "sparse-stress" "singular" 0xf3af0d107878de6b
+
+/-! `swell` -/
+
+setup_fixed_benchmark runLeanSwell3 where
+  config "swell" "lean" 0x3f55cf2c712015fc
+setup_fixed_benchmark runFlintSwell3 where
+  config "swell" "flint" 0x3f55cf2c712015fc
+setup_fixed_benchmark runSingularSwell3 where
+  config "swell" "singular" 0x3f55cf2c712015fc
+setup_fixed_benchmark runLeanSwell5 where
+  config "swell" "lean" 0x3f55cf2c712015fc
+setup_fixed_benchmark runFlintSwell5 where
+  config "swell" "flint" 0x3f55cf2c712015fc
+setup_fixed_benchmark runSingularSwell5 where
+  config "swell" "singular" 0x3f55cf2c712015fc
+
+/-! `rational` -/
+
+setup_fixed_benchmark runLeanRational3d5 where
+  config "rational" "lean" 0xe4e174072095f1f2
+setup_fixed_benchmark runFlintRational3d5 where
+  config "rational" "flint" 0xe4e174072095f1f2
+setup_fixed_benchmark runSingularRational3d5 where
+  config "rational" "singular" 0xe4e174072095f1f2
+setup_fixed_benchmark runLeanRational4d5 where
+  config "rational" "lean" 0xb0ea89a0bf1eb33c
+setup_fixed_benchmark runFlintRational4d5 where
+  config "rational" "flint" 0xb0ea89a0bf1eb33c
+setup_fixed_benchmark runSingularRational4d5 where
+  config "rational" "singular" 0xb0ea89a0bf1eb33c
+
+/-! `squarefree` -/
+
+setup_fixed_benchmark runLeanSquarefree2m1 where
+  config "squarefree" "lean" 0xde0a944a81313c66
+setup_fixed_benchmark runFlintSquarefree2m1 where
+  config "squarefree" "flint" 0xde0a944a81313c66
+setup_fixed_benchmark runSingularSquarefree2m1 where
+  config "squarefree" "singular" 0xde0a944a81313c66
+setup_fixed_benchmark runLeanSquarefree4m7 where
+  config "squarefree" "lean" 0x9834ad9417326d80
+setup_fixed_benchmark runFlintSquarefree4m7 where
+  config "squarefree" "flint" 0x9834ad9417326d80
+setup_fixed_benchmark runSingularSquarefree4m7 where
+  config "squarefree" "singular" 0x9834ad9417326d80
+
+/-! `cofactor-heavy` -/
+
+setup_fixed_benchmark runLeanCofactor16 where
+  config "cofactor-heavy" "lean" 0x7c3948af38b08ac0
+setup_fixed_benchmark runFlintCofactor16 where
+  config "cofactor-heavy" "flint" 0x7c3948af38b08ac0
+setup_fixed_benchmark runSingularCofactor16 where
+  config "cofactor-heavy" "singular" 0x7c3948af38b08ac0
+setup_fixed_benchmark runLeanCofactor64 where
+  config "cofactor-heavy" "lean" 0xb1205f7d916b1032
+setup_fixed_benchmark runFlintCofactor64 where
+  config "cofactor-heavy" "flint" 0xb1205f7d916b1032
+setup_fixed_benchmark runSingularCofactor64 where
+  config "cofactor-heavy" "singular" 0xb1205f7d916b1032
+
+end Hex.MvGcdBench.ComparatorCases

--- a/bench/HexMvGcd/Families.lean
+++ b/bench/HexMvGcd/Families.lean
@@ -93,16 +93,36 @@ def denseGcd (n degree : Nat) (hn : 0 < n := by omega) :
   let rightCofactor := X ⟨0, hn⟩ * leftCofactor + 1
   (common * leftCofactor, common * rightCofactor)
 
+/-- The nonintegral common factor used by the rational family. -/
+def rationalCommon (n : Nat) : P n Rat :=
+  (List.finRange n).foldl
+    (fun polynomial i =>
+      polynomial + C ((Int.ofNat (i.val + 1) : Rat) / 2) * X i) 1
+
 /-- The rational analogue of `denseGcd`, with nonintegral scalar content. -/
 def rationalGcd (n degree : Nat) (hn : 0 < n := by omega) :
     P n Rat × P n Rat :=
-  let common : P n Rat :=
-    (List.finRange n).foldl
-      (fun polynomial i =>
-        polynomial + C ((Int.ofNat (i.val + 1) : Rat) / 2) * X i) 1
+  let common := rationalCommon n
   let leftCofactor := denseBox (R := Rat) n degree
   let rightCofactor := X ⟨0, hn⟩ * leftCofactor + 1
   (common * leftCofactor, common * rightCofactor)
+
+/-- Bivariate PRS inputs whose nonmonic common factor and opposing large
+coefficients expose intermediate coefficient swell. -/
+def swellGcd (degree : Nat) : P 2 Int × P 2 Int :=
+  let x : P 2 Int := X 0
+  let y : P 2 Int := X 1
+  let common := C 2 * x + y + 1
+  (common * (x ^ degree + C 37 * y + 1),
+    common * (x ^ (degree + 1) - C 41 * y + 2))
+
+/-- Exact-division input with a small divisor and a dense large quotient. -/
+def cofactorHeavy (degree : Nat) : P 2 Int × P 2 Int × P 2 Int :=
+  let x : P 2 Int := X 0
+  let y : P 2 Int := X 1
+  let divisor := x + y + 1
+  let quotient := denseBox (R := Int) 2 degree + x * y + 2
+  (divisor * quotient, divisor, quotient)
 
 /-- A nonconstant linear factor which involves every available variable. -/
 def linearFactor (n salt : Nat) : P n Int :=

--- a/bench/HexMvGcdFlint.lean
+++ b/bench/HexMvGcdFlint.lean
@@ -23,7 +23,11 @@ namespace Hex.MvGcdBench.Flint
 open Hex
 open Hex.MvPoly
 
-abbrev P2 (R : Type) [Zero R] := MvPoly 2 R Mono.lex
+abbrev P (n : Nat) (R : Type) [Zero R] := MvPoly n R Mono.lex
+abbrev P2 (R : Type) [Zero R] := P 2 R
+
+abbrev IntTerms := List (List Nat × Int)
+abbrev RatTerms := List (List Nat × Rat)
 
 structure CoprimeInput where
   left : P2 Int
@@ -37,23 +41,34 @@ def prepCoprime (degree : Nat) : CoprimeInput :=
   { left := x ^ (degree + 1) + y + 1
     right := y ^ (degree + 1) + x + 2 }
 
-private def terms (p : P2 Int) : List (List Nat × Int) :=
+def intTerms {n : Nat} (p : P n Int) : IntTerms :=
   p.termsList.map fun term => (term.1.toList, term.2)
 
-private def termsJson (p : P2 Int) : Lean.Json :=
+def intTermsJson {n : Nat} (p : P n Int) : Lean.Json :=
   Lean.Json.arr <| (p.termsList.map fun term =>
     Lean.Json.arr #[
       Lean.Json.arr (term.1.toList.map (fun exponent =>
         Lean.Json.num (Lean.JsonNumber.fromNat exponent))).toArray,
       Lean.Json.num (Lean.JsonNumber.fromInt term.2)]).toArray
 
+def ratTerms {n : Nat} (p : P n Rat) : RatTerms :=
+  p.termsList.map fun term => (term.1.toList, term.2)
+
+def ratTermsJson {n : Nat} (p : P n Rat) : Lean.Json :=
+  Lean.Json.arr <| (p.termsList.map fun term =>
+    Lean.Json.arr #[
+      Lean.Json.arr (term.1.toList.map (fun exponent =>
+        Lean.Json.num (Lean.JsonNumber.fromNat exponent))).toArray,
+      Lean.Json.arr #[
+        Lean.Json.num (Lean.JsonNumber.fromInt term.2.num),
+        Lean.Json.num (Lean.JsonNumber.fromNat term.2.den)]]).toArray
+
 private def jsonError (context : String) (result : Except String α) : IO α :=
   match result with
   | .ok value => return value
   | .error msg => throw <| IO.userError s!"{context}: {msg}"
 
-private def jsonToTerms (nvars : Nat) (value : Lean.Json) :
-    IO (List (List Nat × Int)) := do
+def jsonToIntTerms (nvars : Nat) (value : Lean.Json) : IO IntTerms := do
   let encoded ← jsonError "FLINT multivariate result is not an array"
     value.getArr?
   let mut out : Array (List Nat × Int) := Array.mkEmpty encoded.size
@@ -81,23 +96,91 @@ private def jsonToTerms (nvars : Nat) (value : Lean.Json) :
     out := out.push (exponents.toList, coefficient)
   return out.toList
 
+def jsonToRatTerms (nvars : Nat) (value : Lean.Json) : IO RatTerms := do
+  let encoded ← jsonError "FLINT multivariate result is not an array"
+    value.getArr?
+  let mut out : Array (List Nat × Rat) := Array.mkEmpty encoded.size
+  for encodedTerm in encoded do
+    let pair ← jsonError "FLINT multivariate term is not an array"
+      encodedTerm.getArr?
+    let (exponentsValue, coefficientValue) ←
+      match pair.toList with
+      | [exponents, coefficient] => pure (exponents, coefficient)
+      | _ => throw (IO.userError
+          "FLINT multivariate term must contain exponents and coefficient")
+    let encodedExponents ← jsonError
+      "FLINT multivariate exponents are not an array" exponentsValue.getArr?
+    unless encodedExponents.size = nvars do
+      throw (IO.userError
+        s!"FLINT multivariate exponent arity {encodedExponents.size}; expected {nvars}")
+    let mut exponents : Array Nat := Array.mkEmpty nvars
+    for encodedExponent in encodedExponents do
+      exponents := exponents.push (← jsonError
+        "FLINT multivariate exponent is not a natural" encodedExponent.getNat?)
+    let encodedCoefficient ← jsonError
+      "FLINT multivariate rational coefficient is not an array"
+      coefficientValue.getArr?
+    let (numValue, denValue) ← match encodedCoefficient.toList with
+      | [num, den] => pure (num, den)
+      | _ => throw (IO.userError
+          "FLINT multivariate rational coefficient must contain numerator and denominator")
+    let num ← jsonError "FLINT rational numerator is not an integer" numValue.getInt?
+    let den ← jsonError "FLINT rational denominator is not a natural" denValue.getNat?
+    if hden : den = 0 then
+      throw <| IO.userError "FLINT rational denominator is zero"
+    else
+      let coefficient := Rat.normalize num den hden
+      if coefficient = 0 then
+        throw <| IO.userError "FLINT multivariate result contains a zero coefficient"
+      out := out.push (exponents.toList, coefficient)
+  return out.toList
+
+def leanIntGcd {n : Nat} (input : P n Int × P n Int) : IO IntTerms :=
+  return intTerms (gcd input.1 input.2)
+
+def intGcd {n : Nat} (input : P n Int × P n Int) : IO IntTerms := do
+  let result ← Hex.BenchOracle.Flint.runOp "fmpz_mpoly" "gcd" #[
+    ("nvars", Lean.Json.num (Lean.JsonNumber.fromNat n)),
+    ("a", intTermsJson input.1), ("b", intTermsJson input.2)]
+  jsonToIntTerms n result
+
+def intDiv {n : Nat} (dividend divisor : P n Int) : IO IntTerms := do
+  let result ← Hex.BenchOracle.Flint.runOp "fmpz_mpoly" "divexact" #[
+    ("nvars", Lean.Json.num (Lean.JsonNumber.fromNat n)),
+    ("a", intTermsJson dividend), ("b", intTermsJson divisor)]
+  jsonToIntTerms n result
+
+def intSquarefree {n : Nat} (polynomial : P n Int) : IO (List Nat) := do
+  let result ← Hex.BenchOracle.Flint.runOp "fmpz_mpoly" "squarefree" #[
+    ("nvars", Lean.Json.num (Lean.JsonNumber.fromNat n)),
+    ("a", intTermsJson polynomial)]
+  let values ← jsonError "FLINT squarefree result is not an array" result.getArr?
+  values.toList.mapM fun value =>
+    jsonError "FLINT squarefree multiplicity is not a natural" value.getNat?
+
+def leanRatGcd {n : Nat} (input : P n Rat × P n Rat) : IO RatTerms :=
+  return ratTerms (gcd input.1 input.2)
+
+def ratGcd {n : Nat} (input : P n Rat × P n Rat) : IO RatTerms := do
+  let result ← Hex.BenchOracle.Flint.runOp "fmpq_mpoly" "gcd" #[
+    ("nvars", Lean.Json.num (Lean.JsonNumber.fromNat n)),
+    ("a", ratTermsJson input.1), ("b", ratTermsJson input.2)]
+  jsonToRatTerms n result
+
 initialize coprime1 : IO.Ref CoprimeInput ← IO.mkRef (prepCoprime 1)
 
-def runLeanCoprime2 (_ : Unit) : IO (List (List Nat × Int)) := do
+def runLeanCoprime2 (_ : Unit) : IO IntTerms := do
   let input ← coprime1.get
-  return terms (gcd input.left input.right)
+  leanIntGcd (input.left, input.right)
 
-def runFlintCoprime2 (_ : Unit) : IO (List (List Nat × Int)) := do
+def runFlintCoprime2 (_ : Unit) : IO IntTerms := do
   let input ← coprime1.get
-  let result ← Hex.BenchOracle.Flint.runOp "fmpz_mpoly" "gcd" #[
-    ("nvars", Lean.Json.num (Lean.JsonNumber.fromNat 2)),
-    ("a", termsJson input.left), ("b", termsJson input.right)]
-  jsonToTerms 2 result
+  intGcd (input.left, input.right)
 
 /-- Persistent-driver framing/dispatch calibration without polynomial work. -/
-def runFlintMpolyOverhead (_ : Unit) : IO (List (List Nat × Int)) := do
+def runFlintMpolyOverhead (_ : Unit) : IO IntTerms := do
   let result ← Hex.BenchOracle.Flint.runOp "fmpz_mpoly" "overhead" #[]
-  jsonToTerms 2 result
+  jsonToIntTerms 2 result
 
 def leanCompareConfig (expectedHash : UInt64) : LeanBench.FixedBenchmarkConfig :=
   { repeats := 5, maxSecondsPerCall := 12.0, minTotalSeconds := 0.2,

--- a/bench/HexMvGcdSingular.lean
+++ b/bench/HexMvGcdSingular.lean
@@ -49,9 +49,9 @@ private def jsonError (context : String) (result : Except String α) : IO α :=
   | .ok value => pure value
   | .error error => throw <| IO.userError s!"{context}: {error}"
 
-private def runOp (op : String) (fields : Array (String × Json)) : IO Json := do
+def runOp (family op : String) (fields : Array (String × Json)) : IO Json := do
   let mut object : Array (String × Json) :=
-    #[("family", Json.str "integer_mpoly"), ("op", Json.str op)]
+    #[("family", Json.str family), ("op", Json.str op)]
   for field in fields do object := object.push field
   let replyLine ← Hex.BenchOracle.Flint.PersistentComparator.requestLine
     (← resolveDriver) (Json.mkObj object.toList).compress
@@ -72,26 +72,56 @@ private def runOp (op : String) (fields : Array (String × Json)) : IO Json := d
   | Except.error error => throw (IO.userError
       s!"singular_bench_driver missing/non-bool ok: {error}")
 
-private def termsJson (p : Flint.P2 Int) : Json :=
-  Json.arr <| (p.termsList.map fun term =>
-    Json.arr #[
-      Json.arr (term.1.toList.map (fun exponent =>
-        Json.num (Lean.JsonNumber.fromNat exponent))).toArray,
-      Json.num (Lean.JsonNumber.fromInt term.2)]).toArray
+private def expectTrue (context : String) (result : Json) : IO Unit := do
+  unless (← jsonError s!"{context} result is not a boolean" result.getBool?) do
+    throw <| IO.userError s!"{context} request returned false"
+
+def intGcd {n : Nat} (input : Flint.P n Int × Flint.P n Int)
+    (expected : Flint.P n Int) : IO Flint.IntTerms := do
+  let result ← runOp "integer_mpoly" "gcd_equals" #[
+    ("nvars", Json.num (Lean.JsonNumber.fromNat n)),
+    ("a", Flint.intTermsJson input.1), ("b", Flint.intTermsJson input.2),
+    ("expected", Flint.intTermsJson expected)]
+  expectTrue "Singular GCD" result
+  return Flint.intTerms expected
+
+def ratGcd {n : Nat} (input : Flint.P n Rat × Flint.P n Rat)
+    (expected : Flint.P n Rat) : IO Flint.RatTerms := do
+  let result ← runOp "rational_mpoly" "gcd_equals" #[
+    ("nvars", Json.num (Lean.JsonNumber.fromNat n)),
+    ("a", Flint.ratTermsJson input.1), ("b", Flint.ratTermsJson input.2),
+    ("expected", Flint.ratTermsJson expected)]
+  expectTrue "Singular rational GCD" result
+  return Flint.ratTerms expected
+
+def intDiv {n : Nat} (dividend divisor expected : Flint.P n Int) :
+    IO Flint.IntTerms := do
+  let result ← runOp "integer_mpoly" "div_equals" #[
+    ("nvars", Json.num (Lean.JsonNumber.fromNat n)),
+    ("a", Flint.intTermsJson dividend), ("b", Flint.intTermsJson divisor),
+    ("expected", Flint.intTermsJson expected)]
+  expectTrue "Singular exact division" result
+  return Flint.intTerms expected
+
+def intSquarefree {n : Nat} (polynomial : Flint.P n Int) : IO (List Nat) := do
+  let result ← runOp "integer_mpoly" "squarefree" #[
+    ("nvars", Json.num (Lean.JsonNumber.fromNat n)),
+    ("a", Flint.intTermsJson polynomial)]
+  let values ← jsonError "Singular squarefree result is not an array" result.getArr?
+  values.toList.mapM fun value =>
+    jsonError "Singular squarefree multiplicity is not a natural" value.getNat?
 
 def runOverhead (_ : Unit) : IO (List (List Nat × Int)) := do
-  let result ← runOp "overhead" #[]
-  unless (← jsonError "Singular overhead result is not a boolean" result.getBool?) do
-    throw <| IO.userError "Singular overhead request returned false"
+  let result ← runOp "integer_mpoly" "overhead" #[]
+  expectTrue "Singular overhead" result
   return []
 
 def runCoprime2 (_ : Unit) : IO (List (List Nat × Int)) := do
   let input ← Flint.coprime1.get
-  let result ← runOp "gcd_is_one" #[
+  let result ← runOp "integer_mpoly" "gcd_is_one" #[
     ("nvars", Json.num (Lean.JsonNumber.fromNat 2)),
-    ("a", termsJson input.left), ("b", termsJson input.right)]
-  unless (← jsonError "Singular coprime result is not a boolean" result.getBool?) do
-    throw <| IO.userError "Singular coprime request returned false"
+    ("a", Flint.intTermsJson input.left), ("b", Flint.intTermsJson input.right)]
+  expectTrue "Singular coprime" result
   return [([0, 0], 1)]
 
 def config (expectedHash : UInt64) : LeanBench.FixedBenchmarkConfig :=

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -294,8 +294,9 @@ lean_lib HexMvGcdKernelProbe where
 
 lean_lib HexMvGcdBenchSupport where
   srcDir := "bench"
-  globs := #[`HexMvGcd.Families, `HexMvGcd.Matrix, `HexMvGcdFlint,
-    `HexMvGcdSingular]
+  globs := #[`HexMvGcd.Families, `HexMvGcd.Matrix,
+    `HexMvGcd.ComparatorCases, `HexMvGcd.Comparators,
+    `HexMvGcdFlint, `HexMvGcdSingular]
 
 lean_lib HexMvPolyBenchSupport where
   srcDir := "bench"

--- a/libraries.yml
+++ b/libraries.yml
@@ -157,12 +157,12 @@ libraries:
     status: active
     phase4:
       comparators:
-        - tool: FLINT fmpz_mpoly_gcd via python-flint
+        - tool: FLINT fmpz_mpoly and fmpq_mpoly via python-flint
           class: informational
-          rationale: FLINT also dispatches to Zippel and sparse Hensel routes that this library does not implement; the coprime family is the like-for-like comparison.
-        - tool: Singular
+          rationale: The matched driver covers integer and rational GCD, exact division, and squarefree decomposition; FLINT also dispatches to Zippel and sparse Hensel routes that this library does not implement, so only the coprime-family expectation is like-for-like.
+        - tool: Singular gcd, quotient, and factorize
           class: informational
-          rationale: Singular likewise has sparse routes outside this SPEC, so its ratios diagnose representation and route coverage rather than gate release.
+          rationale: The persistent driver covers all seven families; Singular likewise has sparse routes outside this SPEC, so its ratios diagnose representation and route coverage rather than gate release.
       input_families:
         - name: coprime-pairs
           description: Dense and sparse coprime inputs in 2 to 8 variables, isolating the modular coprimality route.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -1240,5 +1240,11 @@
     "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
     "current_blob": "f9e1661e342a6ba74c2d50753a263b8e22769b51",
     "reason": "Additionally registers the build-only HexMvGcd Phase 4 shape-matrix support modules; hexbz_factor_service, its build flags, and every factorization runtime dependency remain unchanged."
+  },
+  {
+    "path": "lakefile.lean",
+    "baseline_blob": "a1b87406682dbf908d990f01676f326499b906e5",
+    "current_blob": "ca24d94a282d984be81fb1de20e578439cacf5b8",
+    "reason": "Additionally registers the build-only HexMvGcd Phase 4 shape-matrix and external-comparator support modules; hexbz_factor_service, its build flags, and every factorization runtime dependency remain unchanged."
   }
 ]

--- a/scripts/oracle/flint_bench_driver.py
+++ b/scripts/oracle/flint_bench_driver.py
@@ -81,12 +81,22 @@ degree (the same convention `Hex.DensePoly` uses in
 
 Request field ``nvars`` is the arity. ``a`` and ``b`` are sparse term lists
 ``[[[e₀, ..., eₙ₋₁], coefficient], ...]``. Results use the same encoding,
-with zero coefficients omitted and terms in FLINT's canonical lexicographic
-order.
+with zero coefficients omitted and terms reversed from FLINT's descending
+traversal into Hex's canonical ascending lexicographic traversal.
 
 * ``gcd`` — returns ``gcd(a, b)`` in FLINT's canonical integer normal form.
+* ``divexact`` — returns the exact quotient ``a / b`` and rejects a nonzero
+  remainder.
+* ``squarefree`` — returns the sorted multiplicities from FLINT's squarefree
+  factorisation of ``a``.
 * ``overhead`` — returns an empty term list without constructing a context;
   this is the steady-state framing / dispatch calibration.
+
+### `fmpq_mpoly` (multivariate rational polynomial Q[x₀, ..., xₙ₋₁])
+
+The sparse term shape is the same as ``fmpz_mpoly``, except that each
+coefficient is ``[numerator, denominator]`` in lowest terms. ``gcd`` returns
+the canonical monic rational GCD; ``overhead`` returns an empty term list.
 
 ### `fmpq_series` (fixed-precision rational power series)
 
@@ -400,7 +410,7 @@ def _fmpz_mpoly(ctx, req: dict[str, Any], field: str):
 def _fmpz_mpoly_encode(poly) -> list[list[Any]]:
     return [
         [[int(exponent) for exponent in powers], int(coefficient)]
-        for powers, coefficient in poly.terms()
+        for powers, coefficient in reversed(list(poly.terms()))
     ]
 
 
@@ -411,13 +421,119 @@ def _fmpz_mpoly_gcd(req: dict[str, Any]) -> list[list[Any]]:
     )
 
 
+def _fmpz_mpoly_divexact(req: dict[str, Any]) -> list[list[Any]]:
+    ctx = _fmpz_mpoly_context(req)
+    divisor = _fmpz_mpoly(ctx, req, "b")
+    if divisor == 0:
+        raise ValueError("fmpz_mpoly divisor is zero")
+    quotient, remainder = divmod(_fmpz_mpoly(ctx, req, "a"), divisor)
+    if remainder != 0:
+        raise ValueError("fmpz_mpoly division has a nonzero remainder")
+    return _fmpz_mpoly_encode(quotient)
+
+
+def _fmpz_mpoly_squarefree(req: dict[str, Any]) -> list[int]:
+    ctx = _fmpz_mpoly_context(req)
+    polynomial = _fmpz_mpoly(ctx, req, "a")
+    if polynomial == 0:
+        raise ValueError("fmpz_mpoly squarefree factorisation of zero")
+    _content, factors = polynomial.factor_squarefree()
+    return sorted(int(multiplicity) for _factor, multiplicity in factors)
+
+
 def _fmpz_mpoly_overhead(_req: dict[str, Any]) -> list[list[Any]]:
     return []
 
 
 _FMPZ_MPOLY_OPS: dict[str, Callable[[dict[str, Any]], Any]] = {
     "gcd": _fmpz_mpoly_gcd,
+    "divexact": _fmpz_mpoly_divexact,
+    "squarefree": _fmpz_mpoly_squarefree,
     "overhead": _fmpz_mpoly_overhead,
+}
+
+
+# ---------------------------------------------------------------------
+# `fmpq_mpoly` (Q[x₀, ..., xₙ₋₁])
+# ---------------------------------------------------------------------
+
+
+def _fmpq_mpoly_terms(value: Any, nvars: int, field: str):
+    if not isinstance(value, list):
+        raise ValueError(f"fmpq_mpoly field {field!r} must be a term list")
+    terms = {}
+    for index, term in enumerate(value):
+        if not isinstance(term, list) or len(term) != 2:
+            raise ValueError(
+                f"fmpq_mpoly field {field!r} term {index} must be "
+                "[exponents, [numerator, denominator]]"
+            )
+        exponents, coefficient = term
+        if not isinstance(exponents, list) or len(exponents) != nvars:
+            raise ValueError(
+                f"fmpq_mpoly field {field!r} term {index} has exponent length "
+                f"{len(exponents) if isinstance(exponents, list) else 'non-list'}; "
+                f"expected {nvars}"
+            )
+        powers = tuple(int(exponent) for exponent in exponents)
+        if any(exponent < 0 for exponent in powers):
+            raise ValueError(
+                f"fmpq_mpoly field {field!r} term {index} has a negative exponent"
+            )
+        if powers in terms:
+            raise ValueError(
+                f"fmpq_mpoly field {field!r} repeats exponent vector {powers}"
+            )
+        if not isinstance(coefficient, list) or len(coefficient) != 2:
+            raise ValueError(
+                f"fmpq_mpoly field {field!r} term {index} coefficient must be "
+                "[numerator, denominator]"
+            )
+        numerator, denominator = (int(value) for value in coefficient)
+        if denominator == 0:
+            raise ValueError("fmpq_mpoly coefficient denominator is zero")
+        rational = flint.fmpq(numerator, denominator)  # type: ignore[union-attr]
+        if rational != 0:
+            terms[powers] = rational
+    return terms
+
+
+def _fmpq_mpoly_context(req: dict[str, Any]):
+    nvars = int(req["nvars"])
+    if nvars < 0:
+        raise ValueError("fmpq_mpoly nvars must be nonnegative")
+    names = tuple(f"x{index}" for index in range(nvars))
+    return flint.fmpq_mpoly_ctx.get(names, "lex")  # type: ignore[union-attr]
+
+
+def _fmpq_mpoly(ctx, req: dict[str, Any], field: str):
+    return ctx.from_dict(_fmpq_mpoly_terms(req[field], ctx.nvars(), field))
+
+
+def _fmpq_mpoly_encode(poly) -> list[list[Any]]:
+    return [
+        [
+            [int(exponent) for exponent in powers],
+            [int(coefficient.p), int(coefficient.q)],
+        ]
+        for powers, coefficient in reversed(list(poly.terms()))
+    ]
+
+
+def _fmpq_mpoly_gcd(req: dict[str, Any]) -> list[list[Any]]:
+    ctx = _fmpq_mpoly_context(req)
+    return _fmpq_mpoly_encode(
+        _fmpq_mpoly(ctx, req, "a").gcd(_fmpq_mpoly(ctx, req, "b"))
+    )
+
+
+def _fmpq_mpoly_overhead(_req: dict[str, Any]) -> list[list[Any]]:
+    return []
+
+
+_FMPQ_MPOLY_OPS: dict[str, Callable[[dict[str, Any]], Any]] = {
+    "gcd": _fmpq_mpoly_gcd,
+    "overhead": _fmpq_mpoly_overhead,
 }
 
 
@@ -888,6 +1004,7 @@ _RCF_OPS: dict[str, Callable[[dict[str, Any]], Any]] = {
 _FAMILIES: dict[str, dict[str, Callable[[dict[str, Any]], Any]]] = {
     "fmpz_poly": _FMPZ_POLY_OPS,
     "fmpz_mpoly": _FMPZ_MPOLY_OPS,
+    "fmpq_mpoly": _FMPQ_MPOLY_OPS,
     "fmpq_series": _FMPQ_SERIES_OPS,
     "nmod_poly": _NMOD_POLY_OPS,
     "fmpz_mat": _FMPZ_MAT_OPS,

--- a/scripts/oracle/singular_bench_driver.py
+++ b/scripts/oracle/singular_bench_driver.py
@@ -3,10 +3,11 @@
 
 The outer process speaks the repository's one-JSON-request-per-line protocol.
 It keeps one quiet Singular subprocess alive and sends it a fresh polynomial
-GCD command for each request, so benchmark iterations do not include Singular
-startup.  The current family is deliberately narrow: it certifies that the
-declared integer inputs are coprime over ``Q[x_1, ..., x_n]``.  That is the
-like-for-like family named by ``HexMvGcd``'s informational comparator contract.
+command for each request, so benchmark iterations do not include Singular
+startup. Integer inputs are interpreted in ``Q[x_1, ..., x_n]``, matching
+Singular's canonical GCD normalization; rational inputs use the same ring.
+The supported operations cover the GCD, exact-division, and squarefree
+surfaces required by ``HexMvGcd``'s Phase-4 family matrix.
 """
 
 from __future__ import annotations
@@ -16,6 +17,14 @@ import os
 import subprocess
 import sys
 from typing import TextIO
+
+
+def _nonunit_multiplicities(encoded: str) -> list[int]:
+    """Decode `factorize`'s vector, omitting its coefficient-unit slot."""
+    if not encoded:
+        return []
+    multiplicities = [int(value.strip()) for value in encoded.split(",")]
+    return sorted(multiplicities[1:])
 
 
 def _terms(encoded: object, nvars: int, label: str) -> list[tuple[tuple[int, ...], int]]:
@@ -74,6 +83,76 @@ def _poly_expr(terms: list[tuple[tuple[int, ...], int]]) -> str:
     return "".join(pieces)
 
 
+def _rational_terms(
+    encoded: object, nvars: int, label: str
+) -> list[tuple[tuple[int, ...], tuple[int, int]]]:
+    if not isinstance(encoded, list):
+        raise ValueError(f"{label} terms must be a list")
+    out: list[tuple[tuple[int, ...], tuple[int, int]]] = []
+    seen: set[tuple[int, ...]] = set()
+    for index, term in enumerate(encoded):
+        if not isinstance(term, list) or len(term) != 2:
+            raise ValueError(f"{label} term {index} must contain exponents and coefficient")
+        exponents, coefficient = term
+        if not isinstance(exponents, list) or len(exponents) != nvars:
+            actual = len(exponents) if isinstance(exponents, list) else "non-list"
+            raise ValueError(
+                f"{label} term {index} exponent length {actual}; expected {nvars}"
+            )
+        if any(not isinstance(exponent, int) or isinstance(exponent, bool)
+               for exponent in exponents):
+            raise ValueError(f"{label} term {index} has a non-integer exponent")
+        if any(exponent < 0 for exponent in exponents):
+            raise ValueError(f"{label} term {index} has a negative exponent")
+        if not isinstance(coefficient, list) or len(coefficient) != 2:
+            raise ValueError(
+                f"{label} term {index} coefficient must be [numerator, denominator]"
+            )
+        numerator, denominator = coefficient
+        if any(not isinstance(value, int) or isinstance(value, bool)
+               for value in (numerator, denominator)):
+            raise ValueError(f"{label} term {index} has a non-integer rational part")
+        if denominator == 0:
+            raise ValueError(f"{label} term {index} denominator is zero")
+        if denominator < 0:
+            numerator, denominator = -numerator, -denominator
+        key = tuple(exponents)
+        if key in seen:
+            raise ValueError(f"{label} repeats exponent vector {key}")
+        seen.add(key)
+        if numerator != 0:
+            out.append((key, (numerator, denominator)))
+    return out
+
+
+def _rational_poly_expr(
+    terms: list[tuple[tuple[int, ...], tuple[int, int]]]
+) -> str:
+    if not terms:
+        return "0"
+    pieces: list[str] = []
+    for exponents, (numerator, denominator) in terms:
+        factors = [
+            f"x{index}" if exponent == 1 else f"x{index}^{exponent}"
+            for index, exponent in enumerate(exponents, start=1)
+            if exponent > 0
+        ]
+        monomial = "*".join(factors)
+        magnitude = abs(numerator)
+        scalar = str(magnitude) if denominator == 1 else f"({magnitude}/{denominator})"
+        if not monomial:
+            body = scalar
+        elif magnitude == denominator:
+            body = monomial
+        else:
+            body = f"{scalar}*{monomial}"
+        if not pieces:
+            pieces.append(body if numerator > 0 else f"-{body}")
+        else:
+            pieces.append(("+" if numerator > 0 else "-") + body)
+    return "".join(pieces)
+
+
 class SingularSession:
     def __init__(self, command: str) -> None:
         self._process = subprocess.Popen(
@@ -100,17 +179,16 @@ class SingularSession:
         raise RuntimeError("Singular closed stdout before the response sentinel")
 
     def _ensure_ring(self, nvars: int) -> None:
-        if self._nvars is None:
+        if self._nvars != nvars:
             variables = ",".join(f"x{index}" for index in range(1, nvars + 1))
-            sentinel = "__HEX_SINGULAR_RING_READY__"
+            self._serial += 1
+            ring_name = f"hex_ring_{self._serial}"
+            sentinel = f"__HEX_SINGULAR_RING_{self._serial}_READY__"
             self._request(
-                f'ring hex_ring=0,({variables}),lp; print("{sentinel}");', sentinel
+                f'ring {ring_name}=0,({variables}),lp; print("{sentinel}");',
+                sentinel,
             )
             self._nvars = nvars
-        elif self._nvars != nvars:
-            raise ValueError(
-                f"persistent Singular ring has {self._nvars} variables; requested {nvars}"
-            )
 
     def overhead(self) -> None:
         self._serial += 1
@@ -118,17 +196,62 @@ class SingularSession:
         self._request(f'print("{sentinel}");', sentinel)
 
     def gcd_is_one(self, nvars: int, left: str, right: str) -> bool:
+        return self.gcd_equals(nvars, left, right, "1")
+
+    def gcd_equals(self, nvars: int, left: str, right: str, expected: str) -> bool:
         self._ensure_ring(nvars)
         self._serial += 1
         yes = f"__HEX_SINGULAR_GCD_{self._serial}_YES__"
         no = f"__HEX_SINGULAR_GCD_{self._serial}_NO__"
         command = (
             f"poly hex_left={left}; poly hex_right={right}; "
+            f"poly hex_expected={expected}; "
             "poly hex_gcd=gcd(hex_left,hex_right); "
-            f'if (hex_gcd==1) {{ print("{yes}"); }} '
+            f'if (hex_gcd==hex_expected) {{ print("{yes}"); }} '
             f'else {{ print("{no}"); }} '
-            "kill hex_left; kill hex_right; kill hex_gcd;"
+            "kill hex_left; kill hex_right; kill hex_expected; kill hex_gcd;"
         )
+        return self._read_bool(command, yes, no, "GCD")
+
+    def div_equals(
+        self, nvars: int, dividend: str, divisor: str, expected: str
+    ) -> bool:
+        self._ensure_ring(nvars)
+        self._serial += 1
+        yes = f"__HEX_SINGULAR_DIV_{self._serial}_YES__"
+        no = f"__HEX_SINGULAR_DIV_{self._serial}_NO__"
+        command = (
+            f"poly hex_dividend={dividend}; poly hex_divisor={divisor}; "
+            f"poly hex_expected={expected}; "
+            "poly hex_quotient=hex_dividend/hex_divisor; "
+            f'if (hex_quotient==hex_expected && '
+            f'hex_quotient*hex_divisor==hex_dividend) {{ print("{yes}"); }} '
+            f'else {{ print("{no}"); }} '
+            "kill hex_dividend; kill hex_divisor; kill hex_expected; "
+            "kill hex_quotient;"
+        )
+        return self._read_bool(command, yes, no, "division")
+
+    def squarefree_multiplicities(self, nvars: int, polynomial: str) -> list[int]:
+        self._ensure_ring(nvars)
+        self._serial += 1
+        prefix = f"__HEX_SINGULAR_SQF_{self._serial}__"
+        command = (
+            f"poly hex_input={polynomial}; list hex_factors=factorize(hex_input); "
+            "intvec hex_multiplicities=hex_factors[2]; "
+            f'print("{prefix}"+string(hex_multiplicities)); '
+            "kill hex_input; kill hex_factors; kill hex_multiplicities;"
+        )
+        self._stdin.write(command + "\n")
+        self._stdin.flush()
+        for line in self._stdout:
+            answer = line.rstrip("\n").strip()
+            if answer.startswith(prefix):
+                encoded = answer[len(prefix):].strip()
+                return _nonunit_multiplicities(encoded)
+        raise RuntimeError("Singular closed stdout before the squarefree response")
+
+    def _read_bool(self, command: str, yes: str, no: str, label: str) -> bool:
         self._stdin.write(command + "\n")
         self._stdin.flush()
         for line in self._stdout:
@@ -137,25 +260,41 @@ class SingularSession:
                 return True
             if answer == no:
                 return False
-        raise RuntimeError("Singular closed stdout before the GCD response sentinel")
+        raise RuntimeError(f"Singular closed stdout before the {label} response sentinel")
 
 
-def _dispatch(request: dict[str, object], session: SingularSession) -> bool:
-    if request.get("family") != "integer_mpoly":
+def _dispatch(request: dict[str, object], session: SingularSession) -> bool | list[int]:
+    family = request.get("family")
+    if family not in {"integer_mpoly", "rational_mpoly"}:
         raise ValueError(f"unknown Singular family: {request.get('family')!r}")
     operation = request.get("op")
     if operation == "overhead":
         session.overhead()
         return True
-    if operation != "gcd_is_one":
+    if operation not in {"gcd_is_one", "gcd_equals", "div_equals", "squarefree"}:
         raise ValueError(f"unknown Singular integer_mpoly operation: {operation!r}")
     nvars = request.get("nvars")
     if not isinstance(nvars, int) or isinstance(nvars, bool) or nvars <= 0:
         raise ValueError("nvars must be a positive integer")
-    left = _poly_expr(_terms(request.get("a"), nvars, "a"))
-    right = _poly_expr(_terms(request.get("b"), nvars, "b"))
-    if not session.gcd_is_one(nvars, left, right):
-        raise ValueError("Singular computed a nonunit GCD for the coprime fixture")
+    parse = _terms if family == "integer_mpoly" else _rational_terms
+    render = _poly_expr if family == "integer_mpoly" else _rational_poly_expr
+    left = render(parse(request.get("a"), nvars, "a"))
+    if operation == "squarefree":
+        return session.squarefree_multiplicities(nvars, left)
+    right = render(parse(request.get("b"), nvars, "b"))
+    if operation == "gcd_is_one":
+        if not session.gcd_is_one(nvars, left, right):
+            raise ValueError("Singular computed a nonunit GCD for the coprime fixture")
+        return True
+    expected = render(parse(request.get("expected"), nvars, "expected"))
+    if operation == "gcd_equals" and not session.gcd_equals(
+        nvars, left, right, expected
+    ):
+        raise ValueError("Singular GCD differs from the expected canonical polynomial")
+    if operation == "div_equals" and not session.div_equals(
+        nvars, left, right, expected
+    ):
+        raise ValueError("Singular exact quotient differs from the expected polynomial")
     return True
 
 

--- a/scripts/oracle/test_flint_mpoly_bench.py
+++ b/scripts/oracle/test_flint_mpoly_bench.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import unittest
 from unittest import mock
+from fractions import Fraction
 
 from scripts.oracle import flint_bench_driver as driver
 
@@ -16,6 +17,18 @@ class _FakePoly:
     def gcd(self, other: "_FakePoly") -> "_FakePoly":
         del other
         return _FakePoly({(1, 0): 1, (0, 1): 1, (0, 0): 1})
+
+    def __eq__(self, other: object) -> bool:
+        if other == 0:
+            return not self._terms
+        return isinstance(other, _FakePoly) and self._terms == other._terms
+
+    def __divmod__(self, other: "_FakePoly") -> tuple["_FakePoly", "_FakePoly"]:
+        del other
+        return _FakePoly({(1, 0): 1, (0, 0): 2}), _FakePoly({})
+
+    def factor_squarefree(self):
+        return 1, [(_FakePoly({(1, 0): 1}), 3), (_FakePoly({(0, 1): 1}), 1)]
 
     def terms(self):
         return self._terms.items()
@@ -45,6 +58,49 @@ class _FakeFlint:
     fmpz_mpoly_ctx = _FakeContextFactory
 
 
+class _FakeRational:
+    def __init__(self, numerator: int, denominator: int = 1) -> None:
+        value = Fraction(numerator, denominator)
+        self.p = value.numerator
+        self.q = value.denominator
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, _FakeRational):
+            return (self.p, self.q) == (other.p, other.q)
+        if isinstance(other, int):
+            return self.p == other * self.q
+        return False
+
+
+class _FakeQPoly:
+    def __init__(self, terms) -> None:
+        self._terms = terms
+
+    def gcd(self, other: "_FakeQPoly") -> "_FakeQPoly":
+        del other
+        return _FakeQPoly({(1, 0): _FakeRational(1), (0, 0): _FakeRational(2, 3)})
+
+    def terms(self):
+        return self._terms.items()
+
+
+class _FakeQContext(_FakeContext):
+    def from_dict(self, terms) -> _FakeQPoly:
+        return _FakeQPoly(terms)
+
+
+class _FakeQContextFactory:
+    @classmethod
+    def get(cls, names: tuple[str, ...], ordering: str) -> _FakeQContext:
+        del ordering
+        return _FakeQContext(len(names))
+
+
+class _FakeFlintWithQ(_FakeFlint):
+    fmpq = _FakeRational
+    fmpq_mpoly_ctx = _FakeQContextFactory
+
+
 class FlintMpolyBenchTests(unittest.TestCase):
     def setUp(self) -> None:
         _FakeContextFactory.calls.clear()
@@ -64,7 +120,7 @@ class FlintMpolyBenchTests(unittest.TestCase):
             answer = driver._dispatch(request)
         self.assertEqual(
             answer,
-            [[[1, 0], 1], [[0, 1], 1], [[0, 0], 1]],
+            [[[0, 0], 1], [[0, 1], 1], [[1, 0], 1]],
         )
         self.assertEqual(_FakeContextFactory.calls, [(('x0', 'x1'), 'lex')])
 
@@ -73,6 +129,37 @@ class FlintMpolyBenchTests(unittest.TestCase):
             [[[1, 0], 0], [[0, 1], -3]], 2, "a"
         )
         self.assertEqual(terms, {(0, 1): -3})
+
+    def test_exact_division_and_squarefree_multiplicities(self) -> None:
+        base = {
+            "family": "fmpz_mpoly",
+            "nvars": 2,
+            "a": [[[2, 0], 1]],
+            "b": [[[1, 0], 1]],
+        }
+        with (
+            mock.patch.object(driver, "_require_flint"),
+            mock.patch.object(driver, "flint", _FakeFlint),
+        ):
+            quotient = driver._dispatch({**base, "op": "divexact"})
+            multiplicities = driver._dispatch({**base, "op": "squarefree"})
+        self.assertEqual(quotient, [[[0, 0], 2], [[1, 0], 1]])
+        self.assertEqual(multiplicities, [1, 3])
+
+    def test_rational_gcd_round_trips_reduced_coefficients(self) -> None:
+        request = {
+            "family": "fmpq_mpoly",
+            "op": "gcd",
+            "nvars": 2,
+            "a": [[[1, 0], [2, 4]], [[0, 0], [1, 3]]],
+            "b": [[[1, 0], [3, 6]], [[0, 0], [2, 3]]],
+        }
+        with (
+            mock.patch.object(driver, "_require_flint"),
+            mock.patch.object(driver, "flint", _FakeFlintWithQ),
+        ):
+            answer = driver._dispatch(request)
+        self.assertEqual(answer, [[[0, 0], [2, 3]], [[1, 0], [1, 1]]])
 
     def test_rejects_wrong_exponent_arity(self) -> None:
         with self.assertRaisesRegex(ValueError, "exponent length 1; expected 2"):

--- a/scripts/oracle/test_singular_mpoly_bench.py
+++ b/scripts/oracle/test_singular_mpoly_bench.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import unittest
+from unittest import mock
 
 from scripts.oracle import singular_bench_driver as driver
 
@@ -12,6 +13,9 @@ class _FakeSession:
     def __init__(self, answer: bool = True) -> None:
         self.answer = answer
         self.calls: list[tuple[int, str, str]] = []
+        self.equal_calls: list[tuple[int, str, str, str]] = []
+        self.div_calls: list[tuple[int, str, str, str]] = []
+        self.squarefree_calls: list[tuple[int, str]] = []
         self.overhead_calls = 0
 
     def overhead(self) -> None:
@@ -21,8 +25,38 @@ class _FakeSession:
         self.calls.append((nvars, left, right))
         return self.answer
 
+    def gcd_equals(self, nvars: int, left: str, right: str, expected: str) -> bool:
+        self.equal_calls.append((nvars, left, right, expected))
+        return self.answer
+
+    def div_equals(self, nvars: int, left: str, right: str, expected: str) -> bool:
+        self.div_calls.append((nvars, left, right, expected))
+        return self.answer
+
+    def squarefree_multiplicities(self, nvars: int, polynomial: str) -> list[int]:
+        self.squarefree_calls.append((nvars, polynomial))
+        return [3, 1, 2]
+
 
 class SingularMpolyBenchTests(unittest.TestCase):
+    def test_factorize_unit_is_not_a_squarefree_factor(self) -> None:
+        self.assertEqual(driver._nonunit_multiplicities("1,1,2"), [1, 2])
+
+    def test_persistent_session_switches_ring_arity(self) -> None:
+        session = driver.SingularSession.__new__(driver.SingularSession)
+        session._nvars = None
+        session._serial = 0
+        with mock.patch.object(session, "_request") as request:
+            session._ensure_ring(2)
+            session._ensure_ring(2)
+            session._ensure_ring(4)
+        self.assertEqual(request.call_count, 2)
+        self.assertIn("ring hex_ring_1=0,(x1,x2),lp", request.call_args_list[0].args[0])
+        self.assertIn(
+            "ring hex_ring_2=0,(x1,x2,x3,x4),lp",
+            request.call_args_list[1].args[0],
+        )
+
     def test_sparse_expression_and_dispatch(self) -> None:
         request = {
             "family": "integer_mpoly",
@@ -60,6 +94,46 @@ class SingularMpolyBenchTests(unittest.TestCase):
                 },
                 session,
             )
+
+    def test_rational_gcd_equality(self) -> None:
+        request = {
+            "family": "rational_mpoly",
+            "op": "gcd_equals",
+            "nvars": 2,
+            "a": [[[1, 0], [1, 2]], [[0, 0], [-2, 3]]],
+            "b": [[[0, 1], [3, 5]]],
+            "expected": [[[1, 0], [1, 1]], [[0, 0], [2, 3]]],
+        }
+        session = _FakeSession()
+        self.assertTrue(driver._dispatch(request, session))
+        self.assertEqual(
+            session.equal_calls,
+            [(2, "(1/2)*x1-(2/3)", "(3/5)*x2", "x1+(2/3)")],
+        )
+
+    def test_exact_division_equality(self) -> None:
+        request = {
+            "family": "integer_mpoly",
+            "op": "div_equals",
+            "nvars": 1,
+            "a": [[[2], 1], [[0], -1]],
+            "b": [[[1], 1], [[0], -1]],
+            "expected": [[[1], 1], [[0], 1]],
+        }
+        session = _FakeSession()
+        self.assertTrue(driver._dispatch(request, session))
+        self.assertEqual(session.div_calls, [(1, "x1^2-1", "x1-1", "x1+1")])
+
+    def test_squarefree_returns_multiplicity_signature(self) -> None:
+        request = {
+            "family": "integer_mpoly",
+            "op": "squarefree",
+            "nvars": 1,
+            "a": [[[3], 1], [[0], -1]],
+        }
+        session = _FakeSession()
+        self.assertEqual(driver._dispatch(request, session), [3, 1, 2])
+        self.assertEqual(session.squarefree_calls, [(1, "x1^3-1")])
 
     def test_rejects_duplicate_monomials(self) -> None:
         with self.assertRaisesRegex(ValueError, "repeats exponent vector"):


### PR DESCRIPTION
## Summary

- add matched Hex, python-flint, and Singular endpoints for all seven `HexMvGcd` Phase 4 input families
- compare canonical GCD/quotient terms or squarefree multiplicity signatures and pin the shared expected hashes
- extend the persistent FLINT and Singular drivers to integer/rational GCD, exact division, and squarefree decomposition
- document the comparator coverage and retain the degree-4096 bounded Brown-image cases separately from finite end-to-end sparse comparisons

## Validation

- `lake build` (10,309 jobs)
- `lake build hexmvgcd_bench`
- all 42 `mv-gcd-comparator` benchmark arms with expected hashes enabled
- `hexmvgcd_bench verify --tag mv-gcd-comparator`
- 17 focused FLINT/Singular driver tests
- Phase 4, source-line, copyright, freshness, and diff checks
