### PR TITLE
fix(hermite): control HNF coefficient growth

### DIFF
--- a/HexHermite/Hermite.lean
+++ b/HexHermite/Hermite.lean
@@ -24,6 +24,17 @@ structure Result (α : Type) (n m : Nat) where
   pivots : List (Fin m)
   accumulator : α
 
+/-- Convert the stored pivot list to the dependent vector expected by
+`RowEchelonData`. -/
+@[expose]
+def Result.pivotVector (s : Result α n m) : Vector (Fin m) s.pivots.length :=
+  ⟨s.pivots.toArray, by simp⟩
+
+@[simp] theorem Result.pivotVector_get (s : Result α n m)
+    (i : Fin s.pivots.length) : s.pivotVector.get i = s.pivots.get i := by
+  change s.pivots.toArray[i.val] = s.pivots[i.val]
+  apply List.getElem_toArray
+
 /-- Search for the first nonzero entry at or below `start`. -/
 @[expose]
 def findPivot? (M : Matrix Int n m) (col : Fin m) (start : Nat) : Option (Fin n) :=
@@ -658,6 +669,105 @@ def run (ops : Accumulator α n) (A : Matrix Int n m) : Result α n m :=
   (List.finRange m).foldl (columnStep ops)
     { matrix := A, pivots := [], accumulator := ops.init }
 
+/-- Fraction-free row-profile state. The elimination matrix is used only to
+choose a row permutation and pivot columns; the Hermite computation itself
+still consists exclusively of unimodular integer row operations. -/
+structure Profile (n m : Nat) where
+  matrix : Matrix Int n m
+  row : Nat
+  previous : Int
+  swaps : List (Fin n × Fin n)
+  pivots : List (Fin m)
+
+/-- One rectangular fraction-free elimination update below a selected pivot. -/
+def profileEliminate (M : Matrix Int n m) (row : Fin n) (col : Fin m)
+    (previous : Int) : Matrix Int n m :=
+  let pivot := M[(row, col)]
+  Matrix.ofFn fun i j =>
+    if row.val < i.val then
+      if j = col then 0
+      else if col.val < j.val then
+        (pivot * M[(i, j)] - M[(i, col)] * M[(row, j)]) / previous
+      else M[(i, j)]
+    else M[(i, j)]
+
+/-- Extend a fraction-free row profile by one input column. -/
+def profileStep (s : Profile n m) (col : Fin m) : Profile n m :=
+  if hr : s.row < n then
+    match findPivot? s.matrix col s.row with
+    | none => s
+    | some found =>
+        let row : Fin n := ⟨s.row, hr⟩
+        let swapped := Matrix.rowSwap s.matrix row found
+        let pivot := swapped[(row, col)]
+        { matrix := profileEliminate swapped row col s.previous
+          row := s.row + 1
+          previous := pivot
+          swaps := s.swaps ++ [(row, found)]
+          pivots := s.pivots ++ [col] }
+  else s
+
+/-- A fraction-free row rank profile, represented as the row swaps needed to
+place independent rows first and their increasing pivot columns. -/
+def rankProfile (A : Matrix Int n m) : Profile n m :=
+  (List.finRange m).foldl profileStep
+    { matrix := A, row := 0, previous := 1, swaps := [], pivots := [] }
+
+/-- Normalize one nonzero pivot and reduce every entry above it. A zero entry
+is left alone, making the rank profile a checked optimization hint rather than
+a partiality assumption. -/
+def normalizeRow (ops : Accumulator α n) (s : Result α n m)
+    (col : Fin m) (pivot : Fin n) : Result α n m :=
+  if s.matrix[(pivot, col)] = 0 then s else
+    let s := signStep ops col pivot s
+    (List.finRange n).foldl (fun s row =>
+      if row.val < pivot.val then reduceStep ops col pivot row s else s) s
+
+/-- Clear one earlier pivot from the row currently being admitted, then
+restore the canonical residues above that pivot immediately. -/
+def clearPrior (ops : Accumulator α n) (pivots : List (Fin m))
+    (row : Fin n) (s : Result α n m) (pivot : Fin n) : Result α n m :=
+  if _hpr : pivot.val < row.val then
+    if hp : pivot.val < pivots.length then
+      let col := pivots.get ⟨pivot.val, hp⟩
+      normalizeRow ops (gcdStep ops col pivot row s) col pivot
+    else s
+  else s
+
+/-- Admit one profiled row into the growing principal Hermite block. -/
+def admitRow (ops : Accumulator α n) (pivots : List (Fin m))
+    (s : Result α n m) (row : Fin n) : Result α n m :=
+  let s := (List.finRange n).foldl (clearPrior ops pivots row) s
+  if hp : row.val < pivots.length then
+    normalizeRow ops s (pivots.get ⟨row.val, hp⟩) row
+  else s
+
+/-- Rank-profiled principal-block Hermite candidate. Each prefix is restored
+before another row is admitted, preventing uncontrolled suffix growth. -/
+@[expose]
+def principalCore (ops : Accumulator α n) (A : Matrix Int n m)
+    (profile : Profile n m) : Result α n m :=
+  let initial : Result α n m :=
+    { matrix := A, pivots := profile.pivots, accumulator := ops.init }
+  let permuted := profile.swaps.foldl (fun s swap =>
+    swapStep ops s swap.1 swap.2) initial
+  (List.finRange n).foldl (admitRow ops profile.pivots) permuted
+
+/-- Compute the row profile and run the principal-block candidate. -/
+@[expose]
+def principalRun (ops : Accumulator α n) (A : Matrix Int n m) : Result α n m :=
+  principalCore ops A (rankProfile A)
+
+/-- Use the bounded-growth candidate when its complete HNF shape checks;
+otherwise retain the proven column sweep as a total fallback. -/
+@[expose]
+def checkedRun (ops : Accumulator α n) (A : Matrix Int n m) : Result α n m :=
+  let candidate := principalRun ops A
+  if isHNFForm candidate.matrix candidate.pivots.length candidate.pivotVector then
+    candidate
+  else
+    run ops A
+
 /-- Shape invariant after processing the first `bound` columns. -/
 private structure PrefixForm (s : Result α n m) (bound : Nat) : Prop where
   rank_le_n : s.pivots.length ≤ n
@@ -940,6 +1050,61 @@ private theorem run_form (ops : Accumulator α n) (A : Matrix Int n m) :
     simpa using (@List.take_length (Fin m) (List.finRange m))
   simpa [prefixRun, run, ht] using h
 
+private theorem PrefixForm.hnfForm {s : Result α n m}
+    (h : PrefixForm s m) :
+    HNFForm s.matrix s.pivots.length s.pivotVector := by
+  refine ⟨h.rank_le_n, h.rank_le_bound, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · intro i j hij
+    simpa only [Result.pivotVector_get] using h.pivots_sorted i j hij
+  · intro i row hrow j hj
+    simp only [Result.pivotVector_get] at hj
+    change s.matrix[row][j] = 0
+    rw [← Matrix.getElem_pair_eq_nested]
+    exact h.leading i row hrow j hj
+  · intro i row hrow
+    rw [Result.pivotVector_get]
+    change 0 < s.matrix[row][s.pivots.get i]
+    rw [← Matrix.getElem_pair_eq_nested]
+    exact h.pivot_pos i row hrow
+  · intro i row hrow
+    rw [Result.pivotVector_get]
+    change s.matrix[row][s.pivots.get i] = 0
+    rw [← Matrix.getElem_pair_eq_nested]
+    exact h.below_zero i row hrow
+  · intro row hrow
+    apply Vector.ext
+    intro col hcol
+    simp only [Vector.getElem_zero]
+    change s.matrix[row][(⟨col, hcol⟩ : Fin m)] = 0
+    simpa only [Matrix.getElem_pair_eq_nested] using
+      h.zero_prefix row hrow ⟨col, hcol⟩ (by omega)
+  · intro i row hrow
+    rw [Result.pivotVector_get]
+    change 0 ≤ s.matrix[row][s.pivots.get i]
+    rw [← Matrix.getElem_pair_eq_nested]
+    exact (h.above_bounds i row hrow).1
+  · intro i row hrow pivotRow hpivotRow
+    rw [Result.pivotVector_get]
+    change s.matrix[row][s.pivots.get i] < s.matrix[pivotRow][s.pivots.get i]
+    rw [← Matrix.getElem_pair_eq_nested, ← Matrix.getElem_pair_eq_nested]
+    exact (h.above_bounds i row hrow).2 pivotRow hpivotRow
+
+private theorem checkedRun_form (ops : Accumulator α n) (A : Matrix Int n m) :
+    HNFForm (checkedRun ops A).matrix (checkedRun ops A).pivots.length
+      (checkedRun ops A).pivotVector := by
+  by_cases h : isHNFForm (principalRun ops A).matrix
+      (principalRun ops A).pivots.length (principalRun ops A).pivotVector = true
+  · have hc : checkedRun ops A = principalRun ops A := by
+      rw [checkedRun]
+      exact if_pos h
+    rw [hc]
+    exact (isHNFForm_iff _ _ _).mp h
+  · have hc : checkedRun ops A = run ops A := by
+      rw [checkedRun]
+      exact if_neg h
+    rw [hc]
+    exact (run_form ops A).hnfForm
+
 /-- Two accumulator runs agree on the computational form and pivot schedule. -/
 def Result.Same (s : Result α n m) (t : Result β n m) : Prop :=
   s.matrix = t.matrix ∧ s.pivots = t.pivots
@@ -999,6 +1164,67 @@ private theorem foldl_same {γ : Type}
       rw [List.foldl_cons, List.foldl_cons]
       apply ih (hstep x h)
 
+private theorem normalizeRow_same (ops : Accumulator α n)
+    (ops' : Accumulator β n) {s : Result α n m} {t : Result β n m}
+    (h : s.Same t) (col : Fin m) (pivot : Fin n) :
+    (normalizeRow ops s col pivot).Same (normalizeRow ops' t col pivot) := by
+  rcases s with ⟨matrix, pivots, acc⟩
+  rcases t with ⟨matrix', pivots', acc'⟩
+  simp only [Result.Same] at h
+  rcases h with ⟨rfl, rfl⟩
+  rw [normalizeRow, normalizeRow]
+  split
+  · exact ⟨rfl, rfl⟩
+  · apply foldl_same
+    · exact signStep_same ops ops' ⟨rfl, rfl⟩ col pivot
+    · intro state state' row hstate
+      split
+      · exact reduceStep_same ops ops' hstate col pivot row
+      · exact hstate
+
+private theorem clearPrior_same (ops : Accumulator α n)
+    (ops' : Accumulator β n) (pivots : List (Fin m)) (row : Fin n)
+    {s : Result α n m} {t : Result β n m} (h : s.Same t) (pivot : Fin n) :
+    (clearPrior ops pivots row s pivot).Same
+      (clearPrior ops' pivots row t pivot) := by
+  rw [clearPrior, clearPrior]
+  split
+  · split
+    · exact normalizeRow_same ops ops'
+        (gcdStep_same ops ops' h _ pivot row) _ pivot
+    · exact h
+  · exact h
+
+private theorem admitRow_same (ops : Accumulator α n)
+    (ops' : Accumulator β n) (pivots : List (Fin m))
+    {s : Result α n m} {t : Result β n m} (h : s.Same t) (row : Fin n) :
+    (admitRow ops pivots s row).Same (admitRow ops' pivots t row) := by
+  rw [admitRow, admitRow]
+  have hc := foldl_same (clearPrior ops pivots row) (clearPrior ops' pivots row)
+    (List.finRange n) h (fun pivot hp => clearPrior_same ops ops' pivots row hp pivot)
+  split
+  · exact normalizeRow_same ops ops' hc _ row
+  · exact hc
+
+private theorem principalRun_same (ops : Accumulator α n)
+    (ops' : Accumulator β n) (A : Matrix Int n m) :
+    (principalRun ops A).Same (principalRun ops' A) := by
+  rw [principalRun, principalRun, principalCore, principalCore]
+  let profile := rankProfile A
+  have hp :
+      (profile.swaps.foldl (fun s swap => swapStep ops s swap.1 swap.2)
+        { matrix := A, pivots := profile.pivots, accumulator := ops.init }).Same
+      (profile.swaps.foldl (fun s swap => swapStep ops' s swap.1 swap.2)
+        { matrix := A, pivots := profile.pivots, accumulator := ops'.init }) := by
+    exact foldl_same _ _ profile.swaps ⟨rfl, rfl⟩ (by
+      intro state state' swap hs
+      exact swapStep_same ops ops' hs swap.1 swap.2)
+  have hr := foldl_same (admitRow ops profile.pivots)
+    (admitRow ops' profile.pivots) (List.finRange n) hp (by
+      intro state state' row hs
+      exact admitRow_same ops ops' profile.pivots hs row)
+  exact hr
+
 private theorem clearColumn_same (ops : Accumulator α n) (ops' : Accumulator β n)
     {s : Result α n m} {t : Result β n m} (h : s.Same t)
     (col : Fin m) (pivotRow found : Fin n) :
@@ -1054,10 +1280,177 @@ theorem run_pivots_agree (ops : Accumulator α n) (ops' : Accumulator β n)
     { matrix := A, pivots := [], accumulator := ops'.init }) ⟨rfl, rfl⟩
       (fun col h => columnStep_same ops ops' h col)).2
 
+private theorem checkedRun_same (ops : Accumulator α n)
+    (ops' : Accumulator β n) (A : Matrix Int n m) :
+    (checkedRun ops A).Same (checkedRun ops' A) := by
+  have hp := principalRun_same ops ops' A
+  have hc : isHNFForm (principalRun ops A).matrix
+      (principalRun ops A).pivots.length (principalRun ops A).pivotVector =
+      isHNFForm (principalRun ops' A).matrix
+        (principalRun ops' A).pivots.length (principalRun ops' A).pivotVector := by
+    rcases hpo : principalRun ops A with ⟨matrix, pivots, acc⟩
+    rcases hpo' : principalRun ops' A with ⟨matrix', pivots', acc'⟩
+    rw [hpo, hpo'] at hp
+    simp only [Result.Same, Result.pivotVector] at hp ⊢
+    rcases hp with ⟨rfl, rfl⟩
+    rfl
+  rw [checkedRun, checkedRun, hc]
+  split
+  · exact hp
+  · exact ⟨run_matrix_agree ops ops' A, run_pivots_agree ops ops' A⟩
+
+theorem checkedRun_matrix_agree (ops : Accumulator α n)
+    (ops' : Accumulator β n) (A : Matrix Int n m) :
+    (checkedRun ops A).matrix = (checkedRun ops' A).matrix :=
+  (checkedRun_same ops ops' A).1
+
+theorem checkedRun_pivots_agree (ops : Accumulator α n)
+    (ops' : Accumulator β n) (A : Matrix Int n m) :
+    (checkedRun ops A).pivots = (checkedRun ops' A).pivots :=
+  (checkedRun_same ops ops' A).2
+
 /-- A relation between accumulator runs that also tracks a homomorphism on
 the companion state. -/
 private def Result.Mapped (f : α → β) (s : Result α n m) (t : Result β n m) : Prop :=
   s.matrix = t.matrix ∧ s.pivots = t.pivots ∧ f s.accumulator = t.accumulator
+
+private structure Accumulator.Hom (f : α → β)
+    (ops : Accumulator α n) (ops' : Accumulator β n) : Prop where
+  init : f ops.init = ops'.init
+  swap : ∀ a i k, f (ops.swap a i k) = ops'.swap (f a) i k
+  combine : ∀ a i k x y z w,
+    f (ops.combine a i k x y z w) = ops'.combine (f a) i k x y z w
+  negate : ∀ a i, f (ops.negate a i) = ops'.negate (f a) i
+  add : ∀ a i k c, f (ops.add a i k c) = ops'.add (f a) i k c
+
+private theorem swapStep_mapped (f : α → β) (ops : Accumulator α n)
+    (ops' : Accumulator β n) (hom : ops.Hom f ops')
+    {s : Result α n m} {t : Result β n m} (h : s.Mapped f t) (i k : Fin n) :
+    (swapStep ops s i k).Mapped f (swapStep ops' t i k) := by
+  rcases s with ⟨matrix, pivots, acc⟩
+  rcases t with ⟨matrix', pivots', acc'⟩
+  simp only [Result.Mapped] at h ⊢
+  rcases h with ⟨rfl, rfl, rfl⟩
+  rw [swapStep, swapStep]
+  split
+  · exact ⟨rfl, rfl, rfl⟩
+  · exact ⟨rfl, rfl, hom.swap acc i k⟩
+
+private theorem gcdStep_mapped (f : α → β) (ops : Accumulator α n)
+    (ops' : Accumulator β n) (hom : ops.Hom f ops')
+    {s : Result α n m} {t : Result β n m} (h : s.Mapped f t)
+    (col : Fin m) (i k : Fin n) :
+    (gcdStep ops col i k s).Mapped f (gcdStep ops' col i k t) := by
+  rcases s with ⟨matrix, pivots, acc⟩
+  rcases t with ⟨matrix', pivots', acc'⟩
+  simp only [Result.Mapped] at h ⊢
+  rcases h with ⟨rfl, rfl, rfl⟩
+  rw [gcdStep, gcdStep]
+  split
+  · exact ⟨rfl, rfl, rfl⟩
+  · exact ⟨rfl, rfl, hom.combine acc i k _ _ _ _⟩
+
+private theorem signStep_mapped (f : α → β) (ops : Accumulator α n)
+    (ops' : Accumulator β n) (hom : ops.Hom f ops')
+    {s : Result α n m} {t : Result β n m} (h : s.Mapped f t)
+    (col : Fin m) (i : Fin n) :
+    (signStep ops col i s).Mapped f (signStep ops' col i t) := by
+  rcases s with ⟨matrix, pivots, acc⟩
+  rcases t with ⟨matrix', pivots', acc'⟩
+  simp only [Result.Mapped] at h ⊢
+  rcases h with ⟨rfl, rfl, rfl⟩
+  rw [signStep, signStep]
+  split
+  · exact ⟨rfl, rfl, hom.negate acc i⟩
+  · exact ⟨rfl, rfl, rfl⟩
+
+private theorem reduceStep_mapped (f : α → β) (ops : Accumulator α n)
+    (ops' : Accumulator β n) (hom : ops.Hom f ops')
+    {s : Result α n m} {t : Result β n m} (h : s.Mapped f t)
+    (col : Fin m) (i k : Fin n) :
+    (reduceStep ops col i k s).Mapped f (reduceStep ops' col i k t) := by
+  rcases s with ⟨matrix, pivots, acc⟩
+  rcases t with ⟨matrix', pivots', acc'⟩
+  simp only [Result.Mapped] at h ⊢
+  rcases h with ⟨rfl, rfl, rfl⟩
+  rw [reduceStep, reduceStep]
+  split
+  · exact ⟨rfl, rfl, rfl⟩
+  · exact ⟨rfl, rfl, hom.add acc i k _⟩
+
+private theorem foldl_mapped (f : α → β) {γ : Type}
+    (fstep : Result α n m → γ → Result α n m)
+    (gstep : Result β n m → γ → Result β n m) (xs : List γ)
+    {s : Result α n m} {t : Result β n m} (h : s.Mapped f t)
+    (hstep : ∀ {s t} x, s.Mapped f t → (fstep s x).Mapped f (gstep t x)) :
+    (xs.foldl fstep s).Mapped f (xs.foldl gstep t) := by
+  induction xs generalizing s t with
+  | nil => exact h
+  | cons x xs ih =>
+      rw [List.foldl_cons, List.foldl_cons]
+      exact ih (hstep x h)
+
+private theorem normalizeRow_mapped (f : α → β) (ops : Accumulator α n)
+    (ops' : Accumulator β n) (hom : ops.Hom f ops')
+    {s : Result α n m} {t : Result β n m} (h : s.Mapped f t)
+    (col : Fin m) (pivot : Fin n) :
+    (normalizeRow ops s col pivot).Mapped f (normalizeRow ops' t col pivot) := by
+  rcases s with ⟨matrix, pivots, acc⟩
+  rcases t with ⟨matrix', pivots', acc'⟩
+  simp only [Result.Mapped] at h
+  rcases h with ⟨rfl, rfl, rfl⟩
+  rw [normalizeRow, normalizeRow]
+  split
+  · exact ⟨rfl, rfl, rfl⟩
+  · apply foldl_mapped f
+    · exact signStep_mapped f ops ops' hom ⟨rfl, rfl, rfl⟩ col pivot
+    · intro state state' row hs
+      split
+      · exact reduceStep_mapped f ops ops' hom hs col pivot row
+      · exact hs
+
+private theorem clearPrior_mapped (f : α → β) (ops : Accumulator α n)
+    (ops' : Accumulator β n) (hom : ops.Hom f ops') (pivots : List (Fin m))
+    (row : Fin n) {s : Result α n m} {t : Result β n m} (h : s.Mapped f t)
+    (pivot : Fin n) :
+    (clearPrior ops pivots row s pivot).Mapped f
+      (clearPrior ops' pivots row t pivot) := by
+  rw [clearPrior, clearPrior]
+  split
+  · split
+    · exact normalizeRow_mapped f ops ops' hom
+        (gcdStep_mapped f ops ops' hom h _ pivot row) _ pivot
+    · exact h
+  · exact h
+
+private theorem admitRow_mapped (f : α → β) (ops : Accumulator α n)
+    (ops' : Accumulator β n) (hom : ops.Hom f ops') (pivots : List (Fin m))
+    {s : Result α n m} {t : Result β n m} (h : s.Mapped f t) (row : Fin n) :
+    (admitRow ops pivots s row).Mapped f (admitRow ops' pivots t row) := by
+  rw [admitRow, admitRow]
+  have hc := foldl_mapped f (clearPrior ops pivots row) (clearPrior ops' pivots row)
+    (List.finRange n) h (fun pivot hp =>
+      clearPrior_mapped f ops ops' hom pivots row hp pivot)
+  split
+  · exact normalizeRow_mapped f ops ops' hom hc _ row
+  · exact hc
+
+private theorem principalRun_accumulator_map (f : α → β)
+    (ops : Accumulator α n) (ops' : Accumulator β n) (hom : ops.Hom f ops')
+    (A : Matrix Int n m) :
+    f (principalRun ops A).accumulator = (principalRun ops' A).accumulator := by
+  rw [principalRun, principalRun, principalCore, principalCore]
+  let profile := rankProfile A
+  have hp := foldl_mapped f _ _ profile.swaps
+    (show ({ matrix := A, pivots := profile.pivots, accumulator := ops.init } :
+        Result α n m).Mapped f
+      { matrix := A, pivots := profile.pivots, accumulator := ops'.init } from
+        ⟨rfl, rfl, hom.init⟩)
+    (fun swap hs => swapStep_mapped f ops ops' hom hs swap.1 swap.2)
+  have hr := foldl_mapped f (admitRow ops profile.pivots)
+    (admitRow ops' profile.pivots) (List.finRange n) hp (fun row hs =>
+      admitRow_mapped f ops ops' hom profile.pivots hs row)
+  exact hr.2.2
 
 private theorem run_accumulator_map (f : α → β)
     (ops : Accumulator α n) (ops' : Accumulator β n)
@@ -1178,6 +1571,27 @@ private theorem run_accumulator_map (f : α → β)
     ⟨rfl, rfl, hinit⟩ (fun col h => column_mapped h col)
   exact result.2.2
 
+private theorem checkedRun_accumulator_map (f : α → β)
+    (ops : Accumulator α n) (ops' : Accumulator β n)
+    (hom : ops.Hom f ops') (A : Matrix Int n m) :
+    f (checkedRun ops A).accumulator = (checkedRun ops' A).accumulator := by
+  have hs := principalRun_same ops ops' A
+  have hc : isHNFForm (principalRun ops A).matrix
+      (principalRun ops A).pivots.length (principalRun ops A).pivotVector =
+      isHNFForm (principalRun ops' A).matrix
+        (principalRun ops' A).pivots.length (principalRun ops' A).pivotVector := by
+    rcases hpo : principalRun ops A with ⟨matrix, pivots, acc⟩
+    rcases hpo' : principalRun ops' A with ⟨matrix', pivots', acc'⟩
+    rw [hpo, hpo'] at hs
+    simp only [Result.Same, Result.pivotVector] at hs ⊢
+    rcases hs with ⟨rfl, rfl⟩
+    rfl
+  rw [checkedRun, checkedRun, hc]
+  split
+  · exact principalRun_accumulator_map f ops ops' hom A
+  · exact run_accumulator_map f ops ops' hom.init hom.swap hom.combine
+      hom.negate hom.add A
+
 /-- Projecting the transform from the inverse-tracking path agrees with the
 transform-only path. -/
 theorem run_inverse_transform (A : Matrix Int n m) :
@@ -1190,16 +1604,16 @@ theorem run_inverse_transform (A : Matrix Int n m) :
   · intros; rfl
   · intros; rfl
 
-/-- Convert the stored pivot list to the dependent vector expected by
-`RowEchelonData`. -/
-@[expose]
-def Result.pivotVector (s : Result α n m) : Vector (Fin m) s.pivots.length :=
-  ⟨s.pivots.toArray, by simp⟩
-
-@[simp] theorem Result.pivotVector_get (s : Result α n m)
-    (i : Fin s.pivots.length) : s.pivotVector.get i = s.pivots.get i := by
-  change s.pivots.toArray[i.val] = s.pivots[i.val]
-  apply List.getElem_toArray
+private theorem checkedRun_inverse_transform (A : Matrix Int n m) :
+    (checkedRun (inverseAccumulator n) A).accumulator.transform =
+      (checkedRun (transformAccumulator n) A).accumulator := by
+  apply checkedRun_accumulator_map (fun p : TransformPair n => p.transform)
+  exact
+    { init := rfl
+      swap := by intros; rfl
+      combine := by intros; rfl
+      negate := by intros; rfl
+      add := by intros; rfl }
 
 /-- The bounded sweep creates no more than one pivot per row. -/
 theorem run_rank_le (ops : Accumulator α n) (A : Matrix Int n m) :
@@ -1214,6 +1628,10 @@ theorem run_rank_le (ops : Accumulator α n) (A : Matrix Int n m) :
       rw [List.foldl_cons]
       apply ih
       exact columnStep_rank_le ops s col hinit
+
+theorem checkedRun_rank_le (ops : Accumulator α n) (A : Matrix Int n m) :
+    (checkedRun ops A).pivots.length ≤ n :=
+  (checkedRun_form ops A).1
 
 /-- The transform accumulator always maps the original input to the current
 working matrix. -/
@@ -1307,6 +1725,117 @@ private theorem run_transform (A : Matrix Int n m) :
     exact Matrix.identity_mul A) (by
     intro state col h
     exact column_preserves h col)
+
+private theorem transformSwap {s : Result (Matrix Int n n) n m}
+    {A : Matrix Int n m} (h : s.Transforms A) (i k : Fin n) :
+    (swapStep (transformAccumulator n) s i k).Transforms A := by
+  rw [swapStep]
+  split
+  · exact h
+  · change Matrix.rowSwap s.accumulator i k * A = Matrix.rowSwap s.matrix i k
+    rw [Matrix.rowSwap_mul, h]
+
+private theorem transformGcd {s : Result (Matrix Int n n) n m}
+    {A : Matrix Int n m} (h : s.Transforms A) (col : Fin m) (i k : Fin n) :
+    (gcdStep (transformAccumulator n) col i k s).Transforms A := by
+  rw [gcdStep]
+  split
+  · exact h
+  · change combineRows s.accumulator i k _ _ _ _ * A =
+        combineRows s.matrix i k _ _ _ _
+    rw [combineRows_mul, h]
+
+private theorem transformSign {s : Result (Matrix Int n n) n m}
+    {A : Matrix Int n m} (h : s.Transforms A) (col : Fin m) (i : Fin n) :
+    (signStep (transformAccumulator n) col i s).Transforms A := by
+  rw [signStep]
+  split
+  · change Matrix.rowScale s.accumulator i (-1) * A = Matrix.rowScale s.matrix i (-1)
+    rw [Matrix.rowScale_mul, h]
+  · exact h
+
+private theorem transformReduce {s : Result (Matrix Int n n) n m}
+    {A : Matrix Int n m} (h : s.Transforms A) (col : Fin m) (i k : Fin n) :
+    (reduceStep (transformAccumulator n) col i k s).Transforms A := by
+  rw [reduceStep]
+  split
+  · exact h
+  · change Matrix.rowAdd s.accumulator i k _ * A = Matrix.rowAdd s.matrix i k _
+    rw [Matrix.rowAdd_mul, h]
+
+private theorem transformFold {A : Matrix Int n m} {γ : Type}
+    (step : Result (Matrix Int n n) n m → γ → Result (Matrix Int n n) n m)
+    (xs : List γ) {s : Result (Matrix Int n n) n m} (h : s.Transforms A)
+    (hstep : ∀ {s} x, s.Transforms A → (step s x).Transforms A) :
+    (xs.foldl step s).Transforms A := by
+  induction xs generalizing s with
+  | nil => exact h
+  | cons x xs ih =>
+      rw [List.foldl_cons]
+      exact ih (hstep x h)
+
+private theorem transformNormalize {s : Result (Matrix Int n n) n m}
+    {A : Matrix Int n m} (h : s.Transforms A) (col : Fin m) (pivot : Fin n) :
+    (normalizeRow (transformAccumulator n) s col pivot).Transforms A := by
+  rw [normalizeRow]
+  split
+  · exact h
+  · exact transformFold _ (List.finRange n) (transformSign h col pivot) (by
+      intro state row hs
+      split
+      · exact transformReduce hs col pivot row
+      · exact hs)
+
+private theorem transformClear (pivots : List (Fin m)) (row : Fin n)
+    {s : Result (Matrix Int n n) n m} {A : Matrix Int n m} (h : s.Transforms A)
+    (pivot : Fin n) :
+    (clearPrior (transformAccumulator n) pivots row s pivot).Transforms A := by
+  rw [clearPrior]
+  split
+  · split
+    · exact transformNormalize (transformGcd h _ pivot row) _ pivot
+    · exact h
+  · exact h
+
+private theorem transformAdmit (pivots : List (Fin m))
+    {s : Result (Matrix Int n n) n m} {A : Matrix Int n m} (h : s.Transforms A)
+    (row : Fin n) :
+    (admitRow (transformAccumulator n) pivots s row).Transforms A := by
+  rw [admitRow]
+  have hc := transformFold (clearPrior (transformAccumulator n) pivots row)
+    (List.finRange n) h (fun pivot hs => transformClear pivots row hs pivot)
+  split
+  · exact transformNormalize hc _ row
+  · exact hc
+
+private theorem principalCore_transform (A : Matrix Int n m) (profile : Profile n m) :
+    let initial : Result (Matrix Int n n) n m :=
+      { matrix := A, pivots := profile.pivots, accumulator := Matrix.identity n }
+    let permuted := profile.swaps.foldl
+      (fun s swap => swapStep (transformAccumulator n) s swap.1 swap.2) initial
+    ((List.finRange n).foldl
+      (admitRow (transformAccumulator n) profile.pivots) permuted).Transforms A := by
+  dsimp only
+  apply transformFold
+  · apply transformFold
+    · exact Matrix.identity_mul A
+    · intro state swap hs
+      exact transformSwap hs swap.1 swap.2
+  · intro state row hs
+    exact transformAdmit profile.pivots hs row
+
+private theorem principalRun_transform (A : Matrix Int n m) :
+    (principalRun (transformAccumulator n) A).Transforms A := by
+  change (principalCore (transformAccumulator n) A (rankProfile A)).Transforms A
+  exact principalCore_transform A (rankProfile A)
+
+private theorem checkedRun_transform (A : Matrix Int n m) :
+    (checkedRun (transformAccumulator n) A).accumulator * A =
+      (checkedRun (transformAccumulator n) A).matrix := by
+  rw [checkedRun]
+  split
+  · exact principalRun_transform A
+  · exact run_transform A
 
 set_option maxHeartbeats 800000 in
 /-- The explicit inverse accumulator remains a right inverse of its transform. -/
@@ -1411,6 +1940,136 @@ private theorem run_inverse_mul (A : Matrix Int n m) :
     intro state col h
     exact column_preserves h col)
 
+private def Result.Invertible (s : Result (TransformPair n) n m) : Prop :=
+  s.accumulator.transform * s.accumulator.inverse = Matrix.identity n
+
+private theorem inverseSwap {s : Result (TransformPair n) n m}
+    (h : s.Invertible) (i k : Fin n) :
+    (swapStep (inverseAccumulator n) s i k).Invertible := by
+  rw [swapStep]
+  split
+  · exact h
+  · change Matrix.rowSwap s.accumulator.transform i k *
+        Matrix.colSwap s.accumulator.inverse i k = Matrix.identity n
+    rw [Matrix.rowSwap_mul, mul_colSwap, h, swap_inverse_identity]
+
+private theorem inverseGcd {s : Result (TransformPair n) n m}
+    (h : s.Invertible) (col : Fin m) (i k : Fin n) (hik : i ≠ k) :
+    (gcdStep (inverseAccumulator n) col i k s).Invertible := by
+  rw [gcdStep]
+  split
+  · exact h
+  · rename_i hb
+    let a := s.matrix[(i, col)]
+    let b := s.matrix[(k, col)]
+    rcases hc : gcdCoeffs a b with ⟨x, y, z, w⟩
+    have hdet := gcdCoeffs_det (a := a) (b := b) hb
+    rw [hc] at hdet
+    dsimp only at hdet
+    dsimp [a, b] at hc
+    dsimp only
+    rw [hc]
+    change combineRows s.accumulator.transform i k x y z w *
+        combineCols s.accumulator.inverse i k w (-z) (-y) x = Matrix.identity n
+    rw [combineRows_mul, mul_combineCols, h,
+      combine_inverse_identity i k hik x y z w hdet]
+
+private theorem inverseSign {s : Result (TransformPair n) n m}
+    (h : s.Invertible) (col : Fin m) (i : Fin n) :
+    (signStep (inverseAccumulator n) col i s).Invertible := by
+  rw [signStep]
+  split
+  · change Matrix.rowScale s.accumulator.transform i (-1) *
+        Matrix.colScale s.accumulator.inverse i (-1) = Matrix.identity n
+    rw [Matrix.rowScale_mul, mul_colScale, h, negate_inverse_identity]
+  · exact h
+
+private theorem inverseReduce {s : Result (TransformPair n) n m}
+    (h : s.Invertible) (col : Fin m) (i k : Fin n) (hik : i ≠ k) :
+    (reduceStep (inverseAccumulator n) col i k s).Invertible := by
+  rw [reduceStep]
+  split
+  · exact h
+  · change Matrix.rowAdd s.accumulator.transform i k _ *
+        Matrix.colAdd s.accumulator.inverse k i (-_) = Matrix.identity n
+    rw [Matrix.rowAdd_mul, Matrix.mul_colAdd, h]
+    exact add_inverse_identity i k hik _
+
+private theorem inverseFold {γ : Type}
+    (step : Result (TransformPair n) n m → γ → Result (TransformPair n) n m)
+    (xs : List γ) {s : Result (TransformPair n) n m} (h : s.Invertible)
+    (hstep : ∀ {s} x, s.Invertible → (step s x).Invertible) :
+    (xs.foldl step s).Invertible := by
+  induction xs generalizing s with
+  | nil => exact h
+  | cons x xs ih =>
+      rw [List.foldl_cons]
+      exact ih (hstep x h)
+
+private theorem inverseNormalize {s : Result (TransformPair n) n m}
+    (h : s.Invertible) (col : Fin m) (pivot : Fin n) :
+    (normalizeRow (inverseAccumulator n) s col pivot).Invertible := by
+  rw [normalizeRow]
+  split
+  · exact h
+  · exact inverseFold _ (List.finRange n) (inverseSign h col pivot) (by
+      intro state row hs
+      split
+      · exact inverseReduce hs col pivot row (by omega)
+      · exact hs)
+
+private theorem inverseClear (pivots : List (Fin m)) (row : Fin n)
+    {s : Result (TransformPair n) n m} (h : s.Invertible) (pivot : Fin n) :
+    (clearPrior (inverseAccumulator n) pivots row s pivot).Invertible := by
+  rw [clearPrior]
+  split
+  · rename_i hpr
+    split
+    · exact inverseNormalize (inverseGcd h _ pivot row (by omega)) _ pivot
+    · exact h
+  · exact h
+
+private theorem inverseAdmit (pivots : List (Fin m))
+    {s : Result (TransformPair n) n m} (h : s.Invertible) (row : Fin n) :
+    (admitRow (inverseAccumulator n) pivots s row).Invertible := by
+  rw [admitRow]
+  have hc := inverseFold (clearPrior (inverseAccumulator n) pivots row)
+    (List.finRange n) h (fun pivot hs => inverseClear pivots row hs pivot)
+  split
+  · exact inverseNormalize hc _ row
+  · exact hc
+
+private theorem principalCore_inverse (A : Matrix Int n m) (profile : Profile n m) :
+    let initial : Result (TransformPair n) n m :=
+      { matrix := A, pivots := profile.pivots
+        accumulator := ⟨Matrix.identity n, Matrix.identity n⟩ }
+    let permuted := profile.swaps.foldl
+      (fun s swap => swapStep (inverseAccumulator n) s swap.1 swap.2) initial
+    ((List.finRange n).foldl
+      (admitRow (inverseAccumulator n) profile.pivots) permuted).Invertible := by
+  dsimp only
+  apply inverseFold
+  · apply inverseFold
+    · exact Matrix.identity_mul _
+    · intro state swap hs
+      exact inverseSwap hs swap.1 swap.2
+  · intro state row hs
+    exact inverseAdmit profile.pivots hs row
+
+private theorem principalRun_inverse_mul (A : Matrix Int n m) :
+    (principalRun (inverseAccumulator n) A).Invertible := by
+  change (principalCore (inverseAccumulator n) A (rankProfile A)).Invertible
+  exact principalCore_inverse A (rankProfile A)
+
+private theorem checkedRun_inverse_mul (A : Matrix Int n m) :
+    (checkedRun (inverseAccumulator n) A).accumulator.transform *
+        (checkedRun (inverseAccumulator n) A).accumulator.inverse =
+      Matrix.identity n := by
+  rw [checkedRun]
+  split
+  · exact principalRun_inverse_mul A
+  · exact run_inverse_mul A
+
 end Hermite
 
 /-- Hermite data with the inverse transform accumulated on the value path. -/
@@ -1421,23 +2080,24 @@ structure HermiteData (n m : Nat) where
 /-- The Hermite normal form of `A`. Does not compute the transform. -/
 @[expose]
 def hnf (A : Matrix Int n m) : Matrix Int n m :=
-  (Hermite.run (Hermite.formAccumulator n) A).matrix
+  (Hermite.checkedRun (Hermite.formAccumulator n) A).matrix
 
 /-- The number of nonzero rows of `hnf A`. -/
 @[expose]
 def hnfRank (A : Matrix Int n m) : Nat :=
-  (Hermite.run (Hermite.formAccumulator n) A).pivots.length
+  (Hermite.checkedRun (Hermite.formAccumulator n) A).pivots.length
 
 /-- The nonzero rows of `hnf A`. -/
 @[expose]
 def hnfBasis (A : Matrix Int n m) : Matrix Int (hnfRank A) m :=
   Matrix.ofFn fun i j =>
-    (hnf A)[(Fin.castLE (Hermite.run_rank_le (Hermite.formAccumulator n) A) i, j)]
+    (hnf A)[(Fin.castLE (Hermite.checkedRun_rank_le
+      (Hermite.formAccumulator n) A) i, j)]
 
 /-- Hermite form with rank, pivot columns, and left transform. -/
 @[expose]
 def hnfData (A : Matrix Int n m) : RowEchelonData Int n m :=
-  let result := Hermite.run (Hermite.transformAccumulator n) A
+  let result := Hermite.checkedRun (Hermite.transformAccumulator n) A
   { rank := result.pivots.length
     echelon := result.matrix
     transform := result.accumulator
@@ -1446,24 +2106,24 @@ def hnfData (A : Matrix Int n m) : RowEchelonData Int n m :=
 /-- The accumulated left transform carries the input to the reported form. -/
 theorem hnfData_transform_mul (A : Matrix Int n m) :
     (hnfData A).transform * A = (hnfData A).echelon := by
-  exact Hermite.run_transform A
+  exact Hermite.checkedRun_transform A
 
 /-- The form-only and transform paths run the same matrix schedule. -/
 theorem hnf_eq_hnfData_echelon (A : Matrix Int n m) :
     hnf A = (hnfData A).echelon := by
-  exact Hermite.run_matrix_agree (Hermite.formAccumulator n)
+  exact Hermite.checkedRun_matrix_agree (Hermite.formAccumulator n)
     (Hermite.transformAccumulator n) A
 
 /-- The form-only and transform paths report the same rank. -/
 theorem hnfRank_eq (A : Matrix Int n m) :
     hnfRank A = (hnfData A).rank := by
-  exact congrArg List.length (Hermite.run_pivots_agree
+  exact congrArg List.length (Hermite.checkedRun_pivots_agree
     (Hermite.formAccumulator n) (Hermite.transformAccumulator n) A)
 
 /-- Hermite data with both transform and inverse accumulated in one sweep. -/
 @[expose]
 def hnfWithInv (A : Matrix Int n m) : HermiteData n m :=
-  let result := Hermite.run (Hermite.inverseAccumulator n) A
+  let result := Hermite.checkedRun (Hermite.inverseAccumulator n) A
   { rowData :=
       { rank := result.pivots.length
         echelon := result.matrix
@@ -1474,16 +2134,16 @@ def hnfWithInv (A : Matrix Int n m) : HermiteData n m :=
 /-- The inverse-tracking path returns the same row data as `hnfData`. -/
 theorem hnfWithInv_data (A : Matrix Int n m) :
     (hnfWithInv A).rowData = hnfData A := by
-  let ri := Hermite.run (Hermite.inverseAccumulator n) A
-  let rt := Hermite.run (Hermite.transformAccumulator n) A
+  let ri := Hermite.checkedRun (Hermite.inverseAccumulator n) A
+  let rt := Hermite.checkedRun (Hermite.transformAccumulator n) A
   have hm : ri.matrix = rt.matrix :=
-    Hermite.run_matrix_agree (Hermite.inverseAccumulator n)
+    Hermite.checkedRun_matrix_agree (Hermite.inverseAccumulator n)
       (Hermite.transformAccumulator n) A
   have hp : ri.pivots = rt.pivots :=
-    Hermite.run_pivots_agree (Hermite.inverseAccumulator n)
+    Hermite.checkedRun_pivots_agree (Hermite.inverseAccumulator n)
       (Hermite.transformAccumulator n) A
   have hu : ri.accumulator.transform = rt.accumulator :=
-    Hermite.run_inverse_transform A
+    Hermite.checkedRun_inverse_transform A
   change
     RowEchelonData.mk ri.pivots.length ri.matrix ri.accumulator.transform
       ri.pivotVector =
@@ -1500,7 +2160,7 @@ theorem hnfWithInv_data (A : Matrix Int n m) :
 theorem hnfWithInv_mul_inv (A : Matrix Int n m) :
     (hnfWithInv A).rowData.transform * (hnfWithInv A).inverse =
       Matrix.identity n := by
-  exact Hermite.run_inverse_mul A
+  exact Hermite.checkedRun_inverse_mul A
 
 /-- The explicitly accumulated inverse is also a left inverse of the transform. -/
 theorem hnfWithInv_inv_mul (A : Matrix Int n m) :
@@ -1516,9 +2176,10 @@ theorem hnfWithInv_transform_mul (A : Matrix Int n m) :
 
 /-- The executable Hermite sweep satisfies the complete row-HNF contract. -/
 theorem hnfData_isHNF (A : Matrix Int n m) : IsHNF A (hnfData A) := by
-  let s := Hermite.run (Hermite.transformAccumulator n) A
-  have hs : Hermite.PrefixForm s m :=
-    Hermite.run_form (Hermite.transformAccumulator n) A
+  let s := Hermite.checkedRun (Hermite.transformAccumulator n) A
+  have hs : HNFForm s.matrix s.pivots.length s.pivotVector :=
+    Hermite.checkedRun_form (Hermite.transformAccumulator n) A
+  rcases hs with ⟨hrn, hrm, hsorted, hleading, hpos, hbelow, hzero, hnonneg, hlt⟩
   have hleft : (hnfWithInv A).inverse * (hnfData A).transform =
       Matrix.identity n := by
     rw [← hnfWithInv_data A]
@@ -1533,17 +2194,14 @@ theorem hnfData_isHNF (A : Matrix Int n m) : IsHNF A (hnfData A) := by
       transform := s.accumulator
       pivotCols := s.pivotVector }
   let pivotRow : Fin s.pivots.length → Fin n := fun i =>
-    ⟨i.val, Nat.lt_of_lt_of_le i.isLt hs.rank_le_n⟩
-  have pivotGet (i : Fin s.pivots.length) :
-      s.pivotVector.get i = s.pivots.get i :=
-    Hermite.Result.pivotVector_get s i
+    ⟨i.val, Nat.lt_of_lt_of_le i.isLt hrn⟩
   refine
     { toIsEchelonForm :=
         { transform_mul := hnfData_transform_mul A
           transform_inv := ⟨(hnfWithInv A).inverse, ?_⟩
           transform_right_inv := ⟨(hnfWithInv A).inverse, ?_⟩
-          rank_le_n := hs.rank_le_n
-          rank_le_m := hs.rank_le_bound
+          rank_le_n := hrn
+          rank_le_m := hrm
           pivotCols_sorted := ?_
           below_pivot_zero := ?_
           zero_row := ?_ }
@@ -1554,36 +2212,20 @@ theorem hnfData_isHNF (A : Matrix Int n m) : IsHNF A (hnfData A) := by
   · exact hleft
   · exact hright
   · intro i j hij
-    change s.pivotVector.get i < s.pivotVector.get j
-    rw [Hermite.Result.pivotVector_get, Hermite.Result.pivotVector_get]
-    exact hs.pivots_sorted i j hij
+    exact hsorted i j hij
   · intro i row hir
-    change s.matrix[row][s.pivotVector.get i] = 0
-    rw [← Matrix.getElem_pair_eq_nested, pivotGet]
-    exact hs.below_zero i row hir
+    change (s.matrix.getRow row).get (s.pivotVector.get i) = 0
+    exact hbelow i row hir
   · intro row hr
-    apply Vector.ext
-    intro j hj
-    simp only [Vector.getElem_zero]
-    change s.matrix[row][(⟨j, hj⟩ : Fin m)] = 0
-    simpa only [Matrix.getElem_pair_eq_nested] using
-      hs.zero_prefix row hr ⟨j, hj⟩ (by omega)
+    exact hzero row hr
   · intro i j hj
-    change s.matrix[pivotRow i][j] = 0
-    simpa only [Hermite.Result.pivotVector_get, Matrix.getElem_pair_eq_nested] using
-      hs.leading i (pivotRow i) rfl j hj
+    change (s.matrix.getRow (pivotRow i)).get j = 0
+    exact hleading i (pivotRow i) rfl j hj
   · intro i
-    change 0 < s.matrix[pivotRow i][s.pivotVector.get i]
-    rw [← Matrix.getElem_pair_eq_nested, pivotGet]
-    exact hs.pivot_pos i (pivotRow i) rfl
+    exact hpos i (pivotRow i) rfl
   · intro i row hir
-    change 0 ≤ s.matrix[row][s.pivotVector.get i]
-    rw [← Matrix.getElem_pair_eq_nested, pivotGet]
-    exact (hs.above_bounds i row hir).1
+    exact hnonneg i row hir
   · intro i row hir
-    change s.matrix[row][s.pivotVector.get i] <
-      s.matrix[pivotRow i][s.pivotVector.get i]
-    rw [← Matrix.getElem_pair_eq_nested, ← Matrix.getElem_pair_eq_nested, pivotGet]
-    exact (hs.above_bounds i row hir).2 (pivotRow i) rfl
+    exact hlt i row hir (pivotRow i) rfl
 
 end Hex.Matrix

--- a/HexHermite/Lattice.lean
+++ b/HexHermite/Lattice.lean
@@ -347,7 +347,7 @@ def latticeContains (A : Matrix Int n m) (v : Vector Int m) : Bool :=
 /-- The rows of the transform corresponding to zero HNF rows. -/
 @[expose]
 def kernelBasis (A : Matrix Int n m) : Matrix Int (n - hnfRank A) n :=
-  let hr := Hermite.run_rank_le (Hermite.formAccumulator n) A
+  let hr := Hermite.checkedRun_rank_le (Hermite.formAccumulator n) A
   Matrix.ofFn fun i j =>
     let row : Fin n := ⟨hnfRank A + i.val, by omega⟩
     (hnfData A).transform[(row, j)]
@@ -355,8 +355,8 @@ def kernelBasis (A : Matrix Int n m) : Matrix Int (n - hnfRank A) n :=
 /-- Positive HNF pivot values in pivot-column order. -/
 @[expose]
 def pivots (A : Matrix Int n m) : Vector Nat (hnfRank A) :=
-  let result := Hermite.run (Hermite.formAccumulator n) A
-  have hr := Hermite.run_rank_le (Hermite.formAccumulator n) A
+  let result := Hermite.checkedRun (Hermite.formAccumulator n) A
+  have hr := Hermite.checkedRun_rank_le (Hermite.formAccumulator n) A
   Vector.ofFn fun i =>
     let row : Fin n := Fin.castLE hr i
     (result.matrix[(row, result.pivotVector.get i)]).natAbs
@@ -406,23 +406,23 @@ theorem row_mul_eq_vecMul (M : Matrix Int n' n) (N : Matrix Int n m)
 
 private theorem basis_mul_form (A : Matrix Int n m) :
     let P : Matrix Int (hnfRank A) n := Matrix.ofFn fun i j =>
-      if Fin.castLE (Hermite.run_rank_le (Hermite.formAccumulator n) A) i = j
+      if Fin.castLE (Hermite.checkedRun_rank_le (Hermite.formAccumulator n) A) i = j
         then 1 else 0
     P * hnf A = hnfBasis A := by
   dsimp only
   let P : Matrix Int (hnfRank A) n := Matrix.ofFn fun i j =>
-    if Fin.castLE (Hermite.run_rank_le (Hermite.formAccumulator n) A) i = j
+    if Fin.castLE (Hermite.checkedRun_rank_le (Hermite.formAccumulator n) A) i = j
       then 1 else 0
   apply Matrix.ext_getElem
   intro i j
   have hrow : Matrix.row P i = Vector.ofFn fun k : Fin n =>
-      if Fin.castLE (Hermite.run_rank_le (Hermite.formAccumulator n) A) i = k
+      if Fin.castLE (Hermite.checkedRun_rank_le (Hermite.formAccumulator n) A) i = k
         then 1 else 0 := by
     apply Vector.ext
     intro k hk
     let kk : Fin n := ⟨k, hk⟩
     have hp : (Matrix.row P i)[kk] =
-        (if Fin.castLE (Hermite.run_rank_le (Hermite.formAccumulator n) A) i = kk
+        (if Fin.castLE (Hermite.checkedRun_rank_le (Hermite.formAccumulator n) A) i = kk
           then 1 else 0) := by
       rw [Matrix.getElem_row]
       simp only [P, Matrix.getElem_ofFn]
@@ -433,7 +433,7 @@ private theorem basis_mul_form (A : Matrix Int n m) :
   calc
     (P * hnf A)[i][j] =
         (hnf A)[Fin.castLE
-          (Hermite.run_rank_le (Hermite.formAccumulator n) A) i][j] := hentry
+          (Hermite.checkedRun_rank_le (Hermite.formAccumulator n) A) i][j] := hentry
     _ = (hnfBasis A)[i][j] := by
       simp only [hnfBasis, Matrix.getElem_ofFn,
         Matrix.getElem_pair_eq_nested]
@@ -505,7 +505,7 @@ lattice. -/
 theorem hnfBasis_memLattice_iff (A : Matrix Int n m) (v : Vector Int m) :
     (hnfBasis A).memLattice v ↔ A.memLattice v := by
   let P : Matrix Int (hnfRank A) n := Matrix.ofFn fun i j =>
-    if Fin.castLE (Hermite.run_rank_le (Hermite.formAccumulator n) A) i = j
+    if Fin.castLE (Hermite.checkedRun_rank_le (Hermite.formAccumulator n) A) i = j
       then 1 else 0
   let Q : Matrix Int n (hnfRank A) := Matrix.ofFn fun i j =>
     if i.val = j.val then 1 else 0
@@ -629,11 +629,11 @@ private theorem dotProduct_drop_of_head_zero {R : Type} [Lean.Grind.Ring R]
 
 private theorem vecMul_kernelBasis (A : Matrix Int n m) (d : Vector Int n)
     (hz : ∀ i : Fin (hnfRank A),
-      d[Fin.castLE (Hermite.run_rank_le (Hermite.formAccumulator n) A) i] = 0) :
+      d[Fin.castLE (Hermite.checkedRun_rank_le (Hermite.formAccumulator n) A) i] = 0) :
     vecMul (d.drop (hnfRank A)) (kernelBasis A) =
       vecMul d (hnfData A).transform := by
   let r := hnfRank A
-  have hr : r ≤ n := Hermite.run_rank_le (Hermite.formAccumulator n) A
+  have hr : r ≤ n := Hermite.checkedRun_rank_le (Hermite.formAccumulator n) A
   apply Vector.ext
   intro j hj
   let col : Fin n := ⟨j, hj⟩
@@ -703,7 +703,7 @@ theorem kernelBasis_complete {A : Matrix Int n m} {x : Vector Int n} :
         hform.toIsEchelonForm.vecMul_transformInv_transpose hinv x
       _ = 0 := hx
   have hr : hnfRank A ≤ n :=
-    Hermite.run_rank_le (Hermite.formAccumulator n) A
+    Hermite.checkedRun_rank_le (Hermite.formAccumulator n) A
   have hz : ∀ i : Fin (hnfRank A), d[Fin.castLE hr i] = 0 := by
     intro i
     have hi : i.val < D.rank := by
@@ -742,7 +742,7 @@ theorem kernelBasis_independent {A : Matrix Int n m}
     vecMul c (kernelBasis A) = 0 → c = 0 := by
   intro hc
   let r := hnfRank A
-  have hr : r ≤ n := Hermite.run_rank_le (Hermite.formAccumulator n) A
+  have hr : r ≤ n := Hermite.checkedRun_rank_le (Hermite.formAccumulator n) A
   let d : Vector Int n := Vector.ofFn fun i =>
     if h : i.val < r then 0 else c[i.val - r]'(by omega)
   have hz : ∀ i : Fin r, d[Fin.castLE hr i] = 0 := by
@@ -865,20 +865,20 @@ theorem latticeIndex_eq_det (A : Matrix Int n n) :
         rw [Vector.getElem_toList, List.getElem_ofFn]
         unfold pivots
         rw [Vector.getElem_ofFn]
-        let rs := Hermite.run (Hermite.formAccumulator n) A
-        let rt := Hermite.run (Hermite.transformAccumulator n) A
+        let rs := Hermite.checkedRun (Hermite.formAccumulator n) A
+        let rt := Hermite.checkedRun (Hermite.transformAccumulator n) A
         have hm : rs.matrix = rt.matrix :=
-          Hermite.run_matrix_agree (Hermite.formAccumulator n)
+          Hermite.checkedRun_matrix_agree (Hermite.formAccumulator n)
             (Hermite.transformAccumulator n) A
         have hp : rs.pivots = rt.pivots :=
-          Hermite.run_pivots_agree (Hermite.formAccumulator n)
+          Hermite.checkedRun_pivots_agree (Hermite.formAccumulator n)
             (Hermite.transformAccumulator n) A
         have hkR : k < hnfRank A := by rw [hfull]; exact hk
         let is : Fin rs.pivots.length := ⟨k, by simpa [rs, hnfRank] using hkR⟩
         let it : Fin rt.pivots.length :=
           Fin.cast (congrArg List.length hp) is
         have hrow : Fin.castLE
-            (Hermite.run_rank_le (Hermite.formAccumulator n) A)
+            (Hermite.checkedRun_rank_le (Hermite.formAccumulator n) A)
             (⟨k, hkR⟩ : Fin (hnfRank A)) = i := Fin.ext rfl
         have hit : it = Fin.cast hrD.symm i := Fin.ext rfl
         have hcolS : rs.pivotVector.get is = i := by
@@ -891,7 +891,7 @@ theorem latticeIndex_eq_det (A : Matrix Int n n) :
               simp [D, rt, hnfData]
             _ = i := hcol
         change rs.matrix[(Fin.castLE
-          (Hermite.run_rank_le (Hermite.formAccumulator n) A)
+          (Hermite.checkedRun_rank_le (Hermite.formAccumulator n) A)
           (⟨k, hkR⟩ : Fin (hnfRank A)),
           rs.pivotVector.get is)].natAbs = D.echelon[i][i].natAbs
         rw [hrow, hcolS, hm]

--- a/HexHermite/README.md
+++ b/HexHermite/README.md
@@ -48,7 +48,9 @@ The Mathlib-free contract `IsHNF` combines the shared row-echelon transform
 contract with positive pivots and canonical reduced residues. The executable
 shape checker and packed certificate have a proved soundness theorem. The form,
 transform, and inverse paths share one deterministic accumulator-parametric
-elimination schedule, with proved form/rank/data agreement.
+rank-profiled principal-block schedule, with proved form/rank/data agreement.
+Every candidate is checked against the complete HNF shape contract; the earlier
+total column sweep remains as a fallback.
 
 # Contributing
 

--- a/HexHermite/SPEC/hex-hermite.md
+++ b/HexHermite/SPEC/hex-hermite.md
@@ -275,47 +275,31 @@ while the intermediate matrices are not. This is the classical
 observation that makes integer elimination a different subject from
 elimination over a field.
 
-Three responses are standard. V1 takes the first and records objective
-triggers for specifying the other two later.
+The public path now uses a rank-profiled principal-block sweep inspired by
+Kannan--Bachem. A rectangular fraction-free elimination first records
+increasing pivot columns and only the row swaps needed to put independent rows
+first. Those data are a scheduling hint: the actual HNF computation starts
+again from `A` and uses only unimodular integer row operations. It admits the
+profiled rows one at a time, clears each earlier pivot from the new row, and
+immediately restores the canonical residues above that pivot before admitting
+the next row. Keeping the active principal prefix in HNF prevents the explosive
+growth seen when a column sweep repeatedly mixes a reduced prefix with an
+uncontrolled suffix.
 
-**The default is total, and is the one the public `hnf` runs.** Process
-the columns left to right, and after each new pivot is fixed, reduce
-every entry above it immediately rather than at the end. Reducing eagerly
-is what keeps the already-processed part of the matrix bounded by its own
-pivots instead of letting it accumulate across the run. The rows not yet
-consumed are not bounded by anything, which is the honest statement, and
-is why the input families under "Benchmarking" measure entry size and not
-only time.
+The control flow remains entirely bounded by `n` and `m`. Fraction-free
+profiling scans the columns and updates the trailing rectangle; the principal
+sweep is a fixed nest over rows and earlier pivots. The schedule is
+parameterised by a companion accumulator: `Unit` for `hnf`, `U` for `hnfData`,
+and `(U, W)` for `hnfWithInv`. The matrix, transform, and inverse paths have
+proved schedule agreement, `U * A = H`, and `U * W = W * U = I`.
 
-The control flow is entirely bounded. For each of the `m` columns, scan the
-rows at or below the current pivot row. If they are all zero, advance only
-the column. Otherwise move the first nonzero entry to the pivot row, then
-fold the 2x2 `extGcd` step once over each lower row. Each application clears
-that row's entry in the pivot column; later applications touch only the pivot
-row and a later row, so an entry already cleared is not reintroduced. Negate
-the pivot row if the resulting pivot is negative, then use a final fixed scan
-to reduce the entries above it and advance both the pivot row and column. Thus
-the implementation is nested structural iteration over
-the remaining columns and rows (or equivalent fuel bounded by `m` and `n`),
-with no value-dependent recursive call and no unreachable exhaustion branch.
-Implement this as one loop parameterised by a companion accumulator: `Unit`
-for `hnf`, `U` for `hnfData`, and `(U, W)` for `hnfWithInv`. The accumulator's
-row-step operation is inlined, so the `Unit` instantiation allocates no matrix.
-The shared loop makes the schedule and pivot selection identical and lets the
-agreement theorems follow from accumulator-parametric step lemmas rather than
-three independent correctness inductions.
-
-This is deliberately *not* called Kannan-Bachem. Kannan-Bachem maintains
-Hermite normal forms of leading *nonsingular* minors and reorders rows
-and columns to produce them, and its entry bound is a cofactor bound that
-holds for that arrangement. Its FLINT analogue `hnf_minors` carries a
-rank precondition. The public `hnf` here takes arbitrary rectangular and
-rank-deficient input, where a leading minor determinant can be zero and
-the bound says nothing. Specifying rank-profile preprocessing, the
-full-rank subproblem it produces, and the reconstruction of the zero rows
-and the transform is real work and is listed under "Open questions" as
-the optimisation to measure against the total algorithm, not smuggled in
-as the default.
+The profile is intentionally not trusted as a proof. `checkedRun` checks every
+entry-level HNF clause on the candidate and falls back to the earlier total
+column sweep if the check fails. The candidate's certificate still follows
+from the proved elementary-row-operation invariants; the Boolean check supplies
+only its canonical HNF shape. This makes rectangular and rank-deficient inputs
+total while leaving a future proof of fraction-free rank-profile correctness
+free to remove the fallback without changing the public API.
 
 **The modular variant is not a v1 declaration.** For square
 nonsingular `A` with `d = |det A|`, the row lattice `L` contains `d·ℤⁿ`
@@ -349,6 +333,25 @@ constraint on a real input family, because the dependency is heavy
 (`hex-lll` pulls in `hex-gram-schmidt`) and the payoff is
 input-dependent. The threshold that would justify adding it is written
 down under "Benchmarking".
+
+### Research references
+
+These are the three algorithmic branches to revisit if the guarded principal
+sweep needs stronger worst-case guarantees or a different growth strategy:
+
+- Ravindran Kannan and Achim Bachem, [*Polynomial Algorithms for Computing the
+  Smith and Hermite Normal Forms of an Integer Matrix*](https://people.tamu.edu/~rojas/kannanbachemhermitesmith79.pdf),
+  SIAM Journal on Computing 8(4), 1979. This is the reference for the
+  polynomial-time principal-minor arrangement that motivated the current
+  rank-profiled prefix schedule.
+- George Havas, Bohdan S. Majewski, and Keith R. Matthews, [*Extended GCD and
+  Hermite Normal Form Algorithms via Lattice Basis Reduction*](https://staff.itee.uq.edu.au/havas/1998hmm.pdf),
+  Experimental Mathematics 7(2), 1998. This is the LLL-based growth-control
+  alternative.
+- Arne Storjohann and George Labahn, [*Asymptotically Fast Computation of
+  Hermite Normal Forms of Integer Matrices*](https://doi.org/10.1145/236869.237083),
+  ISSAC 1996. This is the reference point for a future asymptotically fast
+  implementation rather than an incremental optimisation of this sweep.
 
 **The transform costs more than the form.** `U` is larger than `H`, often
 much larger, and computing it is the dominant cost on hard inputs. This
@@ -683,9 +686,9 @@ derived. See "Benchmarking".
 
 | operation | algorithm | matrix updates and `extGcd` calls | operand size |
 |---|---|---|---|
-| `hnf` | column sweep with eager reduction above each pivot | `O(r · n · m)` | processed part bounded by its own pivots, unprocessed part unbounded |
-| `hnfData` | `hnf` plus accumulation of `U` only | `+ O(r · n²)` | `U` may be much larger than `H` |
-| `hnfWithInv` | `hnfData` plus right-updates of `W = U⁻¹` | `+ O(r · n²)` beyond `hnfData` | `U`'s and `W`'s |
+| `hnf` | fraction-free rank profile, then guarded principal-block sweep | `O(r · n · m)` profile-entry updates; at most `O(n · r²)` scheduled row-reduction checks and `O(n · r)` gcd steps, each nontrivial row update touching `m` entries | active principal prefixes are eagerly reduced; dependent rows are also cleared; the candidate is shape-checked, with the column sweep as fallback |
+| `hnfData` | the same schedule plus accumulation of `U` | at most `O(n · r² · (m + n) + r · n · m)` integer operations | `U` may be much larger than `H` |
+| `hnfWithInv` | `hnfData` plus right-updates of `W = U⁻¹` | at most another `O(n² · r²)` integer operations | `U`'s and `W`'s |
 | `latticeCoeffs` | `hnfData`, forward pivot solve, residual check, one `vecMul` through `U` | as `hnfData`, plus `O(n · m)` | bounded by `H`, `U`, and the residual |
 | `latticeContains` | `latticeCoeffs` followed by `Option.isSome` | as `latticeCoeffs` | as `latticeCoeffs` |
 | `kernelBasis` | `hnfData` plus a row slice of `U` | as `hnfData`, plus `O((n-r) · n)` | `U`'s |
@@ -902,14 +905,11 @@ the first and third dependencies.
   public entry point starts with a complete square DKT recurrence and
   `hnfSquare_eq_hnf`; rectangular generalisation is a later extension, not a
   premise hidden in that first API.
-- **Whether the rank-profile preprocessing is worth writing.** The
-  default algorithm is total but its unprocessed rows are unbounded. The
-  Kannan-Bachem arrangement bounds them, at the cost of rank-profile
-  preprocessing, a full-rank subproblem, and reconstruction of the zero
-  rows and the transform. That is a real algorithm to specify, not a
-  variant of the default, and it should be specified only if the entry
-  instrumentation under "Benchmarking" shows the unprocessed rows are
-  what hurts.
+- **Whether to prove the rank profile directly.** The current profile is a
+  checked optimisation hint: failure of the complete HNF shape check selects
+  the proved column sweep. A direct proof that fraction-free profiling finds
+  exactly the independent rows and pivot columns would make the fallback
+  unreachable and would support sharper bit-complexity analysis.
 - **Kernel reduction.** Nothing in this SPEC is on a `decide +kernel`
   path today. If the Hermite certificate is ever checked in the kernel,
   the exposure analysis in the `hex-mv-poly` SPEC applies verbatim, and

--- a/HexHermite/Unique.lean
+++ b/HexHermite/Unique.lean
@@ -978,9 +978,9 @@ theorem hnfBasis_eq_of_memLattice (A : Matrix Int n m) (B : Matrix Int n' m)
   simp only [hnfBasis, Matrix.getElem_ofFn, Matrix.getElem_pair_eq_nested]
   rw [hnf_eq_hnfData_echelon A, hnf_eq_hnfData_echelon B]
   let rowA : Fin n := Fin.castLE
-    (Hermite.run_rank_le (Hermite.formAccumulator n) A) i
+    (Hermite.checkedRun_rank_le (Hermite.formAccumulator n) A) i
   let rowB : Fin n' := Fin.castLE
-    (Hermite.run_rank_le (Hermite.formAccumulator n') B) ib
+    (Hermite.checkedRun_rank_le (Hermite.formAccumulator n') B) ib
   have hrowA : rowA = hA.toIsEchelonForm.pivotRow ⟨i.val, hiD⟩ := Fin.ext rfl
   have hrowB : rowB = hB.toIsEchelonForm.pivotRow ⟨ib.val, hiE⟩ := Fin.ext rfl
   change D.echelon[rowA][j] = E.echelon[rowB][j]

--- a/SPEC/Libraries/hex-hermite.md
+++ b/SPEC/Libraries/hex-hermite.md
@@ -275,47 +275,31 @@ while the intermediate matrices are not. This is the classical
 observation that makes integer elimination a different subject from
 elimination over a field.
 
-Three responses are standard. V1 takes the first and records objective
-triggers for specifying the other two later.
+The public path now uses a rank-profiled principal-block sweep inspired by
+Kannan--Bachem. A rectangular fraction-free elimination first records
+increasing pivot columns and only the row swaps needed to put independent rows
+first. Those data are a scheduling hint: the actual HNF computation starts
+again from `A` and uses only unimodular integer row operations. It admits the
+profiled rows one at a time, clears each earlier pivot from the new row, and
+immediately restores the canonical residues above that pivot before admitting
+the next row. Keeping the active principal prefix in HNF prevents the explosive
+growth seen when a column sweep repeatedly mixes a reduced prefix with an
+uncontrolled suffix.
 
-**The default is total, and is the one the public `hnf` runs.** Process
-the columns left to right, and after each new pivot is fixed, reduce
-every entry above it immediately rather than at the end. Reducing eagerly
-is what keeps the already-processed part of the matrix bounded by its own
-pivots instead of letting it accumulate across the run. The rows not yet
-consumed are not bounded by anything, which is the honest statement, and
-is why the input families under "Benchmarking" measure entry size and not
-only time.
+The control flow remains entirely bounded by `n` and `m`. Fraction-free
+profiling scans the columns and updates the trailing rectangle; the principal
+sweep is a fixed nest over rows and earlier pivots. The schedule is
+parameterised by a companion accumulator: `Unit` for `hnf`, `U` for `hnfData`,
+and `(U, W)` for `hnfWithInv`. The matrix, transform, and inverse paths have
+proved schedule agreement, `U * A = H`, and `U * W = W * U = I`.
 
-The control flow is entirely bounded. For each of the `m` columns, scan the
-rows at or below the current pivot row. If they are all zero, advance only
-the column. Otherwise move the first nonzero entry to the pivot row, then
-fold the 2x2 `extGcd` step once over each lower row. Each application clears
-that row's entry in the pivot column; later applications touch only the pivot
-row and a later row, so an entry already cleared is not reintroduced. Negate
-the pivot row if the resulting pivot is negative, then use a final fixed scan
-to reduce the entries above it and advance both the pivot row and column. Thus
-the implementation is nested structural iteration over
-the remaining columns and rows (or equivalent fuel bounded by `m` and `n`),
-with no value-dependent recursive call and no unreachable exhaustion branch.
-Implement this as one loop parameterised by a companion accumulator: `Unit`
-for `hnf`, `U` for `hnfData`, and `(U, W)` for `hnfWithInv`. The accumulator's
-row-step operation is inlined, so the `Unit` instantiation allocates no matrix.
-The shared loop makes the schedule and pivot selection identical and lets the
-agreement theorems follow from accumulator-parametric step lemmas rather than
-three independent correctness inductions.
-
-This is deliberately *not* called Kannan-Bachem. Kannan-Bachem maintains
-Hermite normal forms of leading *nonsingular* minors and reorders rows
-and columns to produce them, and its entry bound is a cofactor bound that
-holds for that arrangement. Its FLINT analogue `hnf_minors` carries a
-rank precondition. The public `hnf` here takes arbitrary rectangular and
-rank-deficient input, where a leading minor determinant can be zero and
-the bound says nothing. Specifying rank-profile preprocessing, the
-full-rank subproblem it produces, and the reconstruction of the zero rows
-and the transform is real work and is listed under "Open questions" as
-the optimisation to measure against the total algorithm, not smuggled in
-as the default.
+The profile is intentionally not trusted as a proof. `checkedRun` checks every
+entry-level HNF clause on the candidate and falls back to the earlier total
+column sweep if the check fails. The candidate's certificate still follows
+from the proved elementary-row-operation invariants; the Boolean check supplies
+only its canonical HNF shape. This makes rectangular and rank-deficient inputs
+total while leaving a future proof of fraction-free rank-profile correctness
+free to remove the fallback without changing the public API.
 
 **The modular variant is not a v1 declaration.** For square
 nonsingular `A` with `d = |det A|`, the row lattice `L` contains `d·ℤⁿ`
@@ -349,6 +333,25 @@ constraint on a real input family, because the dependency is heavy
 (`hex-lll` pulls in `hex-gram-schmidt`) and the payoff is
 input-dependent. The threshold that would justify adding it is written
 down under "Benchmarking".
+
+### Research references
+
+These are the three algorithmic branches to revisit if the guarded principal
+sweep needs stronger worst-case guarantees or a different growth strategy:
+
+- Ravindran Kannan and Achim Bachem, [*Polynomial Algorithms for Computing the
+  Smith and Hermite Normal Forms of an Integer Matrix*](https://people.tamu.edu/~rojas/kannanbachemhermitesmith79.pdf),
+  SIAM Journal on Computing 8(4), 1979. This is the reference for the
+  polynomial-time principal-minor arrangement that motivated the current
+  rank-profiled prefix schedule.
+- George Havas, Bohdan S. Majewski, and Keith R. Matthews, [*Extended GCD and
+  Hermite Normal Form Algorithms via Lattice Basis Reduction*](https://staff.itee.uq.edu.au/havas/1998hmm.pdf),
+  Experimental Mathematics 7(2), 1998. This is the LLL-based growth-control
+  alternative.
+- Arne Storjohann and George Labahn, [*Asymptotically Fast Computation of
+  Hermite Normal Forms of Integer Matrices*](https://doi.org/10.1145/236869.237083),
+  ISSAC 1996. This is the reference point for a future asymptotically fast
+  implementation rather than an incremental optimisation of this sweep.
 
 **The transform costs more than the form.** `U` is larger than `H`, often
 much larger, and computing it is the dominant cost on hard inputs. This
@@ -681,9 +684,9 @@ derived. See "Benchmarking".
 
 | operation | algorithm | matrix updates and `extGcd` calls | operand size |
 |---|---|---|---|
-| `hnf` | column sweep with eager reduction above each pivot | `O(r · n · m)` | processed part bounded by its own pivots, unprocessed part unbounded |
-| `hnfData` | `hnf` plus accumulation of `U` only | `+ O(r · n²)` | `U` may be much larger than `H` |
-| `hnfWithInv` | `hnfData` plus right-updates of `W = U⁻¹` | `+ O(r · n²)` beyond `hnfData` | `U`'s and `W`'s |
+| `hnf` | fraction-free rank profile, then guarded principal-block sweep | `O(r · n · m)` profile-entry updates; at most `O(n · r²)` scheduled row-reduction checks and `O(n · r)` gcd steps, each nontrivial row update touching `m` entries | active principal prefixes are eagerly reduced; dependent rows are also cleared; the candidate is shape-checked, with the column sweep as fallback |
+| `hnfData` | the same schedule plus accumulation of `U` | at most `O(n · r² · (m + n) + r · n · m)` integer operations | `U` may be much larger than `H` |
+| `hnfWithInv` | `hnfData` plus right-updates of `W = U⁻¹` | at most another `O(n² · r²)` integer operations | `U`'s and `W`'s |
 | `latticeCoeffs` | `hnfData`, forward pivot solve, residual check, one `vecMul` through `U` | as `hnfData`, plus `O(n · m)` | bounded by `H`, `U`, and the residual |
 | `latticeContains` | `latticeCoeffs` followed by `Option.isSome` | as `latticeCoeffs` | as `latticeCoeffs` |
 | `kernelBasis` | `hnfData` plus a row slice of `U` | as `hnfData`, plus `O((n-r) · n)` | `U`'s |
@@ -934,14 +937,11 @@ the first and third dependencies.
   public entry point starts with a complete square DKT recurrence and
   `hnfSquare_eq_hnf`; rectangular generalisation is a later extension, not a
   premise hidden in that first API.
-- **Whether the rank-profile preprocessing is worth writing.** The
-  default algorithm is total but its unprocessed rows are unbounded. The
-  Kannan-Bachem arrangement bounds them, at the cost of rank-profile
-  preprocessing, a full-rank subproblem, and reconstruction of the zero
-  rows and the transform. That is a real algorithm to specify, not a
-  variant of the default, and it should be specified only if the entry
-  instrumentation under "Benchmarking" shows the unprocessed rows are
-  what hurts.
+- **Whether to prove the rank profile directly.** The current profile is a
+  checked optimisation hint: failure of the complete HNF shape check selects
+  the proved column sweep. A direct proof that fraction-free profiling finds
+  exactly the independent rows and pivot columns would make the fallback
+  unreachable and would support sharper bit-complexity analysis.
 - **Kernel reduction.** Nothing in this SPEC is on a `decide +kernel`
   path today. If the Hermite certificate is ever checked in the kernel,
   the exposure analysis in the `hex-mv-poly` SPEC applies verbatim, and

--- a/bench/HexHermite/Bench.lean
+++ b/bench/HexHermite/Bench.lean
@@ -105,17 +105,65 @@ private def growthColumn (s : GrowthState n m) (col : Fin m) : GrowthState n m :
         { next with result := { next.result with pivots := next.result.pivots ++ [col] } }
   else s
 
+private def growthNormalize (s : GrowthState n m) (col : Fin m)
+    (pivot : Fin n) : GrowthState n m :=
+  if s.result.matrix[(pivot, col)] = 0 then s else
+    let ops := Matrix.Hermite.formAccumulator n
+    let s := observe (Matrix.Hermite.signStep ops col pivot s.result) s.peak
+    (List.finRange n).foldl (fun s row =>
+      if row.val < pivot.val then
+        observe (Matrix.Hermite.reduceStep ops col pivot row s.result) s.peak
+      else s) s
+
+private def growthPrior (pivots : List (Fin m)) (row : Fin n)
+    (s : GrowthState n m) (pivot : Fin n) : GrowthState n m :=
+  if pivot.val < row.val then
+    if hp : pivot.val < pivots.length then
+      let col := pivots.get ⟨pivot.val, hp⟩
+      let next := Matrix.Hermite.gcdStep (Matrix.Hermite.formAccumulator n)
+        col pivot row s.result
+      growthNormalize (observe next s.peak) col pivot
+    else s
+  else s
+
+private def growthAdmit (pivots : List (Fin m)) (s : GrowthState n m)
+    (row : Fin n) : GrowthState n m :=
+  let s := (List.finRange n).foldl (growthPrior pivots row) s
+  if hp : row.val < pivots.length then
+    growthNormalize s (pivots.get ⟨row.val, hp⟩) row
+  else s
+
+private def principalGrowth (A : Matrix Int n m) : GrowthState n m :=
+  let profile := Matrix.Hermite.rankProfile A
+  let initial : GrowthState n m :=
+    { result :=
+        { matrix := A, pivots := profile.pivots
+          accumulator := (Matrix.Hermite.formAccumulator n).init }
+      peak := matrixBits A }
+  let permuted := profile.swaps.foldl (fun s swap =>
+    observe (Matrix.Hermite.swapStep (Matrix.Hermite.formAccumulator n)
+      s.result swap.1 swap.2) s.peak) initial
+  (List.finRange n).foldl (growthAdmit profile.pivots) permuted
+
+private def columnGrowth (A : Matrix Int n m) : GrowthState n m :=
+  let initial : GrowthState n m :=
+    { result :=
+        { matrix := A, pivots := []
+          accumulator := (Matrix.Hermite.formAccumulator n).init }
+      peak := matrixBits A }
+  (List.finRange m).foldl growthColumn initial
+
 /-- Scan the working matrix after every elementary update and return the peak
 coefficient bit-size. This runner is intentionally separate from timed
 benchmarks so instrumentation does not perturb ordinary timings. -/
 def peakBits (input : Input) : Nat :=
   let A := matrix input
-  let initial : GrowthState input.rows input.cols :=
-    { result :=
-        { matrix := A, pivots := []
-          accumulator := (Matrix.Hermite.formAccumulator input.rows).init }
-      peak := matrixBits A }
-  ((List.finRange input.cols).foldl growthColumn initial).peak
+  let candidate := principalGrowth A
+  if Matrix.isHNFForm candidate.result.matrix candidate.result.pivots.length
+      candidate.result.pivotVector then
+    candidate.peak
+  else
+    (columnGrowth A).peak
 
 /-- Peak-versus-output growth data for the predeclared badly-conditioned
 family. -/
@@ -288,34 +336,32 @@ def runPariOverhead (_ : Unit) : IO Int := do
   | .ok value => return value
   | .error error => throw <| IO.userError s!"invalid PARI overhead reply: {error}"
 
-/- Cost-model derivation: the square dense family scans `n` columns, clears
-`O(n)` rows per pivot, and each elementary row update touches `O(n)` entries,
-giving `O(n³)` integer operations. -/
-setup_benchmark runDense n => n ^ 3 with prep := dense where {
+/- Cost-model derivation: rank profiling is cubic on square input. In the
+principal sweep, restoring all earlier prefixes after each admitted row has
+`O(n³)` scheduled reduction checks, with each nontrivial row update touching
+`O(n)` entries; the conservative worst-case model is therefore `O(n⁴)`. -/
+setup_benchmark runDense n => n ^ 4 with prep := dense where {
   paramFloor := 20, paramCeiling := 80, paramSchedule := .custom #[20, 32, 48, 64, 80]
   targetInnerNanos := 2_000_000_000
   maxSecondsPerCall := 10.0
 }
-/- Cost-model derivation: rank deficiency changes which pivots are found but
-not the worst-case column, row-clear, and row-width loops, so the square
-family remains `O(n³)` integer operations. -/
-setup_benchmark runDeficient n => n ^ 3 with prep := deficient where {
+/- Cost-model derivation: rank deficiency lowers the active rank in practice,
+but the dimension-only upper model retains the square `O(n⁴)` bound. -/
+setup_benchmark runDeficient n => n ^ 4 with prep := deficient where {
   paramFloor := 20, paramCeiling := 80, paramSchedule := .custom #[20, 32, 48, 64, 80]
   targetInnerNanos := 2_000_000_000
   maxSecondsPerCall := 10.0
 }
-/- Cost-model derivation: the tall family has `4n` rows and `n` columns;
-clearing `O(n)` rows with `O(n)`-wide updates for each of `n` columns is still
-`O(n³)` integer operations because the aspect ratio is fixed. -/
-setup_benchmark runTall n => n ^ 3 with prep := tall where {
+/- Cost-model derivation: the tall family has `4n` rows and `n` columns. Its
+fixed aspect ratio leaves the conservative principal-sweep model `O(n⁴)`. -/
+setup_benchmark runTall n => n ^ 4 with prep := tall where {
   paramFloor := 8, paramCeiling := 24, paramSchedule := .custom #[8, 12, 16, 20, 24]
   targetInnerNanos := 2_000_000_000
   maxSecondsPerCall := 10.0
 }
-/- Cost-model derivation: conjugation changes coefficient growth but retains
-the square `n`-column by `n`-row clearing structure with `n`-wide updates, so
-the declared operation-count model is `O(n³)`. -/
-setup_benchmark runConjugate n => n ^ 3 with prep := conjugate where {
+/- Cost-model derivation: conjugation changes coefficient growth but not the
+conservative square principal-sweep upper model `O(n⁴)`. -/
+setup_benchmark runConjugate n => n ^ 4 with prep := conjugate where {
   paramFloor := 20, paramCeiling := 80, paramSchedule := .custom #[20, 32, 48, 64, 80]
   targetInnerNanos := 2_000_000_000
   maxSecondsPerCall := 10.0

--- a/conformance/HexHermite/Conformance.lean
+++ b/conformance/HexHermite/Conformance.lean
@@ -77,6 +77,24 @@ hand-derived row-HNF values. -/
 #guard hnf alreadyHNF = alreadyHNF
 #guard hnf (hnf rectangular) = hnf rectangular
 
+/- The rank-profiled candidate itself, rather than only its guarded fallback,
+passes the complete HNF shape checker on every structural fixture family. -/
+private def principalPasses (A : Matrix Int n m) : Bool :=
+  let result := Hermite.principalRun (Hermite.formAccumulator n) A
+  isHNFForm result.matrix result.pivots.length result.pivotVector
+
+#guard principalPasses empty00
+#guard principalPasses empty03
+#guard principalPasses empty30
+#guard principalPasses negativeLast
+#guard principalPasses rankDeficient
+#guard principalPasses rectangular
+#guard principalPasses zeroLeft
+#guard principalPasses tall
+#guard principalPasses wide
+#guard principalPasses alreadyHNF
+#guard principalPasses pivotOne
+
 /- Rank and basis observers, including equal lattices presented with different
 numbers of rows. -/
 #guard hnfRank empty03 = 0


### PR DESCRIPTION
## Summary

- add a rectangular fraction-free rank profile and principal-block HNF schedule
- validate the candidate against the full HNF shape and retain the proved column sweep as a total fallback
- prove transform, inverse, rank, and accumulator agreement for the guarded public path
- extend conformance and coefficient-growth instrumentation
- document Kannan–Bachem, Havas–Majewski–Matthews, and Storjohann–Labahn as future reference points

## Experimental result

On the fixed bounded family, peak/output coefficient sizes remained 7/5, 9/6, 10/6, 11/7, and 11/7 bits for dimensions 20, 32, 48, 64, and 80.

## Validation

- lake build
- lake build HexHermite HexConformance hexhermite_bench after rebasing onto current main (10,177 jobs)
- fixture regeneration diff
- git diff --check

Follow-up to #9588. This PR implements and verifies the growth-control mechanism; it does not by itself claim the dedicated three-trial Phase-4 publication ladder.