### PR TITLE
doc: correct stale HexGF2Mathlib and dependency-graph claims

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -673,35 +673,24 @@ the dimension argument, `L.factorCount + L.coeffWidth` "has type ℕ … of sort
 outParam Type but is expected to have type Type", because Mathlib's `Matrix`
 wants its first two arguments to be index types, not `Nat`.
 
-## `HexGF2Mathlib` defines a project-local `RingEquiv`/`TypeEquiv` shadowing Mathlib's
+## `HexGF2Mathlib` equivalences are Mathlib's `≃+*` (a project-local shadow used to exist)
 
-`HexGF2Mathlib/Basic.lean` declares its own minimal `structure RingEquiv`
-(fields `toFun`/`invFun`/`left_inv`/`right_inv`/`map_mul'`/`map_add'`, a CoeFun
-to `toFun`, and `symm`) **with the same `≃+*` notation** (`infixl:25 " ≃+* "`)
-and a `TypeEquiv` shadowing `Equiv`. So `HexGF2Mathlib.GF2n.equiv :
-GF2n … ≃+* GenericFiniteField` is **`HexGF2Mathlib.RingEquiv`, not Mathlib's**.
+`HexGF2Mathlib` once declared its own minimal `RingEquiv`/`TypeEquiv`
+structures reusing the `≃+*` notation, and older issue bodies or progress
+notes may still warn about `HexGF2Mathlib.RingEquiv.trans` not existing.
+That is no longer the situation: `HexGF2Mathlib/Basic.lean` states
+`GF2Poly.equiv : GF2Poly ≃+* FpPoly 2` with Mathlib's `RingEquiv`,
+`equivPolynomial` is built with `RingEquiv.trans`, and the `GF2n`/`GF2nPoly`
+field equivalences are Mathlib's too. Compose them with `RingEquiv.trans`
+and use the standard lemmas (`RingEquiv.symm_apply_apply`, `map_mul`,
+`map_add`) directly; no structure-literal repackaging is needed.
 
-Symptom when you forget: composing it with a Mathlib `RingEquiv` (e.g. a `cast`-
-based equiv on the generic Conway field) fails with `RingEquiv.trans`/`.trans`
-resolving to `HexGF2Mathlib.RingEquiv.trans` (which doesn't exist), or an
-"Application type mismatch" / "type mismatch" between two `≃+*` types that
-**print identically** (one is the custom struct, one is Mathlib's). `e.symm`,
-`e.map_mul'`, `e.symm_apply_apply` dot-notation resolves into the custom
-namespace too. Confirm early with `set_option pp.all true in #check e` — Mathlib's
-prints `@RingEquiv.{…}`, the custom one prints `@HexGF2Mathlib.RingEquiv.{…}`.
-
-Recipe to compose a custom `e : A ≃+*[Hex] B` with a Mathlib `g : B ≃+* C` into
-a Mathlib `A ≃+* C`: build the Mathlib structure literal directly,
-`{ toFun := fun x => g (e x), invFun := fun x => e.invFun (g.symm x), … }`, and
-discharge its fields from **`e`'s struct projections** (`e.left_inv`,
-`e.right_inv`, `e.map_mul'`, `e.map_add'` — `e` is a bare structure, no
-`MulHomClass`) and **`g`'s Mathlib lemmas** (`RingEquiv.symm_apply_apply`,
-`apply_symm_apply`, `map_mul`, `map_add`). Do **not** `RingEquiv.trans` across
-the boundary — the two `RingEquiv`s are different types. Inline `e`/`g`
-(no `let`): a `let`-bound equiv whose type mentions the heavy
-`GFqField.FiniteField`/`GenericFiniteField` carrier blows the `whnf` heartbeat
-budget (same trap as the `set d := toMonicLiftData` warning above); name a thin
-`private def` for the repackaged `e` if you must, but reference it inline.
+One piece of the old advice still applies: inline the equivalences at use
+sites rather than `let`-binding them. A `let`-bound equiv whose type
+mentions the heavy `GFqField.FiniteField`/`GenericFiniteField` carrier
+blows the `whnf` heartbeat budget (same trap as the
+`set d := toMonicLiftData` warning above); name a thin `private def` if you
+must, but reference it inline.
 
 ### `GF2Poly` multiplication is carryless with no exported coeff-convolution
 

--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -146,9 +146,9 @@ Each library with its immediate dependencies:
 - **hex-hensel**: hex-poly-fp, hex-poly-z, hex-basic
 - **hex-conway**: hex-berlekamp
 - **hex-gfq-ring**: hex-poly-fp
-- **hex-gfq-field**: hex-gfq-ring, hex-finite-field
+- **hex-gfq-field**: hex-gfq-ring, hex-berlekamp, hex-finite-field
 - **hex-gfq**: hex-gfq-field, hex-conway, hex-gf2
-- **hex-gf2**: hex-poly, hex-basic, hex-finite-field
+- **hex-gf2**: hex-basic, hex-finite-field
 - **hex-berlekamp-zassenhaus**: hex-berlekamp, hex-hensel, hex-lll
 - **hex-summation**: hex-poly, hex-mv-poly, hex-resultant, hex-matrix, hex-row-reduce, hex-berlekamp-zassenhaus, hex-basic
 
@@ -193,7 +193,7 @@ Mathlib companion libraries (each also depends on Mathlib):
 - **hex-berlekamp-mathlib**: hex-berlekamp, hex-poly-mathlib, hex-mod-arith-mathlib, hex-poly-fp-mathlib
 - **hex-hensel-mathlib**: hex-hensel, hex-poly-mathlib
 - **hex-gf2-mathlib**: hex-gf2, hex-poly-fp, hex-gfq-field, hex-poly-fp-mathlib
-- **hex-gfq-mathlib**: hex-gfq
+- **hex-gfq-mathlib**: hex-gfq, hex-gf2-mathlib
 - **hex-berlekamp-zassenhaus-mathlib**: hex-berlekamp-zassenhaus, hex-poly-z-mathlib
 - **hex-summation-mathlib**: hex-summation
 


### PR DESCRIPTION
This PR correct two documentation leftovers from the finite-field batch. The hex-lean-mathlib-boundary skill still described HexGF2Mathlib's project-local `RingEquiv`/`TypeEquiv` shadow and warned that `HexGF2Mathlib.RingEquiv.trans` does not exist; the library has used Mathlib's `≃+*` throughout since the correspondence rewrite, so the section now states the current situation and keeps only the still-valid advice about inlining heavy-carrier equivalences. In the central SPEC index's dependency section, three current-fact lines are corrected against `libraries.yml` (hex-gf2 no longer depends on hex-poly, hex-gfq-field also depends on hex-berlekamp, hex-gfq-mathlib also depends on hex-gf2-mathlib); the prospective `hex-finite-field` entries describe the planned graph and are left alone.

🤖 Prepared with Claude Code