### PR TITLE
doc: deepen the HexBasic manual chapter

### DIFF
--- a/HexBasic.lean
+++ b/HexBasic.lean
@@ -34,5 +34,8 @@ across supported Lean versions (`HexBasic.Conditional`).
 It also holds the shared exact-division contract (`HexBasic.ExactDiv`): the
 total `exactDiv` wrapper with deterministic division by zero, the
 `ExactDivLaws` package, and the coefficient-independent cancellation lemmas
-that fraction-free algorithms in `hex-resultant` and `hex-bareiss` both need.
+that the fraction-free algorithms in `hex-resultant`, `hex-mv-gcd` and
+`hex-poly-smith` share. (`hex-bareiss` solves the same problem one layer down,
+against `HexArith.Int.exactDiv` on a fixed carrier, and does not depend on this
+library.)
 -/

--- a/HexManual/Chapters/HexBasic.lean
+++ b/HexManual/Chapters/HexBasic.lean
@@ -39,10 +39,22 @@ compatibility lemmas. Everything is Mathlib-free and executable in Lean.
 tag := "hex-basic-containers"
 %%%
 
-Lean's standard array tabulator is efficient in compiled code, but one of its
-implementation helpers is opaque across module boundaries. The primed Hex
-versions use an exposed list tabulation for kernel reduction and redirect
-compiled code back to the standard implementations with `@[csimp]`.
+Hex certificate checking runs `decide +kernel` over concrete arrays and
+vectors, so the kernel has to reduce both array construction and array
+equality. Under Lean's module system it does not, for three separate reasons.
+{name}`Array.ofFn` delegates to an unexposed `ofFn.go`; core's
+{name}`Array.instDecidableEq` delegates to an unexposed
+{name}`Array.instDecidableEqImpl`; and {name}`Vector` gets its equality from
+`deriving DecidableEq`, whose generated `decEq` is likewise unexposed. In each
+case the callee's body is unavailable downstream, so reduction stalls on a term
+the kernel can see but cannot unfold.
+
+The workaround is the same in all three cases. Route through {name}`List`,
+which is fully exposed and does reduce, and attach a `@[csimp]` lemma sending
+compiled code back to the core definition. The list detour is then paid only in
+the kernel, which is the one place it buys anything: {name}`Array.toList` is an
+`O(n)` conversion that allocates in full and gives up early exit, so it is the
+wrong shape for compiled code.
 
 {docstring Hex.Array.ofFn'}
 
@@ -50,8 +62,31 @@ compiled code back to the standard implementations with `@[csimp]`.
 
 The accompanying simplification lemmas identify the primed constructors with
 their standard counterparts, so ordinary container lemmas remain available.
-`HexBasic` also provides kernel-reducible equality for arrays and vectors and
-the usual pointwise laws for {name}`Vector.modify`.
+
+{docstring Hex.instDecidableEqArray}
+
+{docstring Hex.instDecidableEqVector}
+
+Both instances are `scoped`, so they take effect under `open scoped Hex` and
+nowhere else, and never leak into a consumer that has not asked for them. A
+module that forgets to open the scope gets a stuck `decide`, which is a loud
+failure rather than a silent change of meaning.
+
+These four definitions are shims, not API this library wants to own. When
+[leanprover/lean4#14270](https://github.com/leanprover/lean4/pull/14270)
+lands and the toolchain moves past it, core's own `ofFn` and equality reduce
+in the kernel, the primed constructors and the priority instances go away, and
+callers move back to the standard names. `HexBasic.ModuleBoundaryTests` is
+what makes that removal checkable: it sits in a *separate* module from the
+definitions it exercises, because a same-module test passes whether or not the
+workaround is present and so proves nothing.
+
+`HexBasic` also supplies an entrywise vector update with the pointwise read
+law its callers reason with.
+
+{docstring Vector.modify}
+
+{docstring Vector.getElem_modify}
 
 # Ordered-map traversal and merging
 %%%
@@ -128,11 +163,58 @@ end HexBasicChapter
 tag := "hex-basic-folds"
 %%%
 
-The `List.foldl` lemmas expose algebraic transformations used repeatedly by
-coefficient convolutions and finite sums: congruence, permutation invariance,
-distribution over addition and subtraction, and bounds for additive or
-maximum folds. Small conditional and list lemmas carry stable Hex names where
-the supported Lean versions differ.
+Nearly every library above this one reduces a list with a single operation:
+`xs.foldl (fun acc x => acc + f x) z` for a coefficient convolution or a finite
+sum, and its multiplicative twin for a product. A Mathlib-free library cannot
+reach for `Finset.sum`, and the core lemmas about associative folds require
+`Std.Associative` and `Std.LawfulIdentity` instances that a bare
+`Lean.Grind.Semiring` does not carry. `HexBasic.Fold` supplies those instances
+file-locally and states the algebra the libraries actually use, so the same
+rearrangement is proved once rather than in each consumer.
+
+The two most-used shapes pull the running accumulator out of a fold and factor
+a scalar through one.
+
+{docstring List.foldl_add_eq_add_foldl}
+
+{docstring List.foldl_add_mul_left}
+
+Reordering and reassociation matter because a sum indexed by an ordered map's
+keys has no canonical order, and because coefficient convolutions are naturally
+written as nested sums.
+
+{docstring List.foldl_add_perm}
+
+{docstring List.foldl_add_comm}
+
+Bounds on `Nat` folds carry the degree and size arguments that termination and
+size reasoning need.
+
+{docstring List.le_foldl_max_of_mem}
+
+```lean
+namespace HexBasicFolds
+
+-- The fold shape the lemmas above talk about.
+def sum2 (z : Int) (xs : List Int) : Int :=
+  xs.foldl (fun a i => a + 2 * i) z
+
+-- The sum itself.
+#guard sum2 0 [1, 2, 3] = 12
+-- Reordering the list does not change it.
+#guard sum2 0 [3, 1, 2] = 12
+-- A nonzero start shifts it by exactly that much.
+#guard sum2 5 [1, 2, 3] = 17
+
+end HexBasicFolds
+```
+
+The conditional lemmas are naming rather than mathematics:
+{name}`Hex.ite_eq_left` and its siblings give `if`-reduction stable Hex names
+across the Lean versions the project supports, so an upstream rename is
+absorbed here instead of rippling through the algebra libraries. `HexBasic`
+also carries the handful of duplicate-freeness and lexicographic-comparison
+list lemmas that the canonical-form libraries share.
 
 # Verification boundary
 %%%
@@ -144,3 +226,35 @@ exercise array construction, vector updates, tree-map operations, exact
 division, and deterministic randomness after importing the public umbrella,
 so accidental opacity is caught by the ordinary build. `HexBasic` uses no
 external oracle and introduces no native runtime dependency.
+
+# Cross-references
+%%%
+tag := "hex-basic-cross-references"
+%%%
+
+`HexBasic` has no dependencies: it imports only Lean and Std, and sits at the
+root of the library graph. Nothing depends on all of it, which is the point;
+each consumer takes the one or two modules it needs.
+
+* The {name}`Std.ExtTreeMap` merges are what
+  {ref "hex-mv-poly"}[`HexMvPoly`] builds its canonical sparse representation
+  on, with `HexMvHensel` reusing the same traversals.
+* The kernel-reducible containers are taken by the libraries whose
+  certificates are checked by `decide +kernel` over concrete arrays:
+  {ref "hex-mv-poly"}[`HexMvPoly`],
+  {ref "hex-sparse-poly"}[`HexSparsePoly`],
+  {ref "hex-berlekamp-zassenhaus"}[`HexBerlekampZassenhaus`], and
+  {ref "hex-real-roots"}[`HexRealRoots`].
+* The exact-division contract is shared by the fraction-free algorithms:
+  {ref "hex-resultant"}[`HexResultant`], `HexMvGcd`, and
+  {ref "hex-poly-smith"}[`HexPolySmith`] each cancel a known nonzero factor
+  through {name}`Hex.ExactDivLaws` rather than carrying their own division
+  hypothesis. {ref "hex-bareiss"}[`HexBareiss`] solves the same problem one
+  layer down, against `HexArith.Int.exactDiv` on a fixed carrier.
+* The fold algebra travels with the multivariate stack, where sums are indexed
+  by a map's keys: {ref "hex-mv-poly"}[`HexMvPoly`], `HexMvGcd`,
+  `HexMvHensel`, and {ref "hex-resultant"}[`HexResultant`].
+* `HexBasic` has no Mathlib companion, and needs none. Nothing here states a
+  correspondence: these are Lean and Std facts that happen not to be upstream
+  yet. The Mathlib bridges live in the consuming libraries' `*Mathlib`
+  counterparts, which import both this library and Mathlib.

--- a/progress/20260825T230315Z_hex-basic-phase-7.md
+++ b/progress/20260825T230315Z_hex-basic-phase-7.md
@@ -1,0 +1,47 @@
+# HexBasic Phase 7
+
+## Accomplished
+
+- Established that `HexBasic` was already recorded at `done_through: 7`. The
+  chapter `HexManual/Chapters/HexBasic.lean` landed in `54c31f693`
+  (PR #9549) together with the `libraries.yml` bump, so `scripts/check_phase7.py`,
+  `scripts/release/check_manual_split.py` and `scripts/check_dag.py` were already
+  green on `origin/main` before this branch. No `libraries.yml` change was needed.
+- Confirmed the two structural claims that keep `HexBasic`'s Phase 7 scope
+  small: `PLAN/Phase7.md`'s anchor table has no `hex-basic` row (the four
+  tutorials anchor to `hex-gf2`, `hex-berlekamp`, `hex-berlekamp-zassenhaus`
+  and `hex-lll`), and `scripts/release/released.yml` marks `leanprover/hex-basic`
+  `readme: false`, so there is no monorepo `HexBasic/README.md` obligation.
+- Deepened the chapter where it was thinnest against the `PLAN/Phase7.md`
+  authoring criteria. The kernel-reducible containers section now names all
+  three module-system exposure gaps it works around, pulls the two `scoped`
+  `DecidableEq` instances, explains why they are `scoped`, and states the
+  removal plan for when leanprover/lean4#14270 lands, with
+  `HexBasic.ModuleBoundaryTests` identified as what makes that removal
+  checkable. The fold section, previously a single paragraph with no source
+  pulls, now embeds five representative `List.foldl` lemmas and a worked
+  `#guard` block. A `Cross-references` section was added, matching the house
+  shape used by the other released chapters.
+- Checked every consumer claim in that new section against the import graph
+  rather than against the umbrella docstring, which is stale on this point:
+  `HexPoly` and `HexPolyFp` do not depend on `HexBasic` at all, `HexSparsePoly`
+  takes only the containers, and `HexBareiss` uses `HexArith.Int.exactDiv`
+  rather than `Hex.ExactDivLaws`. Corrected the `HexBasic.lean` umbrella
+  docstring, which named `hex-bareiss` as an exact-division consumer even
+  though it does not depend on this library.
+
+## Current frontier
+
+`lake build HexManual` is green with the revised chapter: every `{docstring}`
+resolves, the code block stays inside the 60-column cap, and the `#guard`s
+evaluate. `lake exe hexmanual` renders, so the new cross-chapter `{ref}`s all
+resolve to real pages. `HexBasic` needs nothing further for Release 1.
+
+## Next step
+
+`HexBerlekamp` is the other library flagged as a Release 1 `done_through` gap;
+it sits at `4`, so it needs Phases 5 and 6 before its chapter is in scope.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR fill in the two places the `HexBasic` reference chapter was thinnest against the `PLAN/Phase7.md` authoring criteria. The kernel-reducible containers section now names all three module-system exposure gaps it works around, pulls the two `scoped` `DecidableEq` instances, says why they are `scoped`, and states the removal plan for when https://github.com/leanprover/lean4/pull/14270 lands, with `HexBasic.ModuleBoundaryTests` identified as what makes that removal checkable. The fold section, previously a paragraph with no source pulls, embeds five representative `List.foldl` lemmas and a worked `#guard` block. A `Cross-references` section is added in the shape the other released chapters use.

Its consumer claims are checked against the import graph rather than restated from prose, which the umbrella docstring was stale about: `hex-bareiss` does not depend on `hex-basic` and cancels through `HexArith.Int.exactDiv` instead, so the docstring is corrected to name the actual consumers.

`HexBasic` was already recorded at `done_through: 7`, so `libraries.yml` and the `HexManual.lean` wiring are unchanged.

🤖 Prepared with Claude Code
