### PR TITLE
chore: decompose HexIntFactor publication directive

### DIFF
--- a/progress/2026-08-25T232721Z_issue9619.md
+++ b/progress/2026-08-25T232721Z_issue9619.md
@@ -13,8 +13,16 @@
 - Audited the certificate/checker, partial and complete factorization,
   divisor, order, primitive-root, and Carmichael bodies against the SPEC.
 - Filed Phase-2 blockers #9639–#9643 for scan-based divisor algorithms and
-  silent factor-search candidate fallback, and made all five prerequisites of
-  the Phase-2 attestation issue #9627.
+  silent factor-search candidate fallback, then added #9646, #9650, and #9651
+  for the missing kernel probe, partial-checker invariants, and recursive
+  structural reduction. All are prerequisites of the Phase-2 attestation
+  issue #9627.
+- Split the missing Mathlib-free totient proof infrastructure into #9647 and
+  #9648, with the final algorithm correction #9641 depending on both.
+- Expanded #9639 and #9641 to cover the Mathlib correspondence proofs that
+  currently unfold the scan-based bodies, and expanded #9643 to cover both
+  complete and partial rejection paths plus the missing p-minus-one route
+  invariant.
 - Recorded the declaration-level findings on review issue #9622. No review
   token or phase counter was advanced.
 
@@ -28,11 +36,14 @@
 - Checker rejection in the aggregate search path must be proved impossible or
   represented distinctly; silently replacing it with empty partial data is not
   acceptable Phase-2 evidence.
+- Full conformance remains Phase 3, after Phase 2 as required by
+  `PLAN/Phase3.md`; focused regressions stay attached to each Phase-2 blocker,
+  while #9628 owns the complete per-operation and route-level contract.
 
 ## Remaining work
 
-- Resolve #9639–#9643, complete the independent route and Mathlib reviews, and
-  only then create the two Phase-2 review tokens through #9627.
+- Resolve every dependency recorded on #9627, complete the independent route
+  and Mathlib reviews, and only then create the two Phase-2 review tokens.
 - Complete the ordered Phase-3 through Phase-7 follow-ups and run the final
   acceptance gate #9638 before closing #9619.
 

--- a/progress/2026-08-25T232721Z_issue9619.md
+++ b/progress/2026-08-25T232721Z_issue9619.md
@@ -1,0 +1,43 @@
+# HexIntFactor publication-readiness directive
+
+- Date: 2026-08-25 23:27 UTC
+- Session type: feature / directive decomposition and skeptical review
+- Parent directive: #9619
+
+## Accomplished
+
+- Decomposed the publication-readiness directive into review, attestation,
+  conformance, performance, polish, documentation, and final-acceptance
+  follow-ups (#9622, #9623, #9626–#9628, and #9634–#9638), with explicit
+  dependency edges.
+- Audited the certificate/checker, partial and complete factorization,
+  divisor, order, primitive-root, and Carmichael bodies against the SPEC.
+- Filed Phase-2 blockers #9639–#9643 for scan-based divisor algorithms and
+  silent factor-search candidate fallback, and made all five prerequisites of
+  the Phase-2 attestation issue #9627.
+- Recorded the declaration-level findings on review issue #9622. No review
+  token or phase counter was advanced.
+
+## Decisions
+
+- The certificate support/multiplicity proofs and order/Carmichael proof route
+  match the advertised semantics in the reviewed scope.
+- `divisors`, `numDivisors`, `sigma`, `totient`, `squareDivisor`, and
+  `squarefreePart` are not publication-ready: their bodies scan values through
+  `n` instead of consuming the certified prime powers at the declared cost.
+- Checker rejection in the aggregate search path must be proved impossible or
+  represented distinctly; silently replacing it with empty partial data is not
+  acceptable Phase-2 evidence.
+
+## Remaining work
+
+- Resolve #9639–#9643, complete the independent route and Mathlib reviews, and
+  only then create the two Phase-2 review tokens through #9627.
+- Complete the ordered Phase-3 through Phase-7 follow-ups and run the final
+  acceptance gate #9638 before closing #9619.
+
+## Quality metrics
+
+- No source changes.
+- Review scope remains free of `sorry`, `axiom`, and `native_decide`.
+- Registry counters remain unchanged at 0.


### PR DESCRIPTION
## Summary

- decompose #9619 into worker-sized, dependency-ordered review through publication-acceptance follow-ups
- record an independent certificate/arithmetic API audit
- file and gate Phase 2 on blockers #9639–#9643
- leave both review tokens and registry counters untouched

## Verification

- `git diff --check`
- banned-token scan over `HexIntFactor` and `HexIntFactorMathlib`
- live dependency-edge audit on #9619 and #9627

Refs #9619.
Closes #9622.