### PR TITLE
chore(hex-smith): record independent scaffold reviews

### DIFF
--- a/HexSmith/Correct/Complete.lean
+++ b/HexSmith/Correct/Complete.lean
@@ -1180,13 +1180,6 @@ theorem Diagonal.Compact.run_valid
         (Diagonal.Compact.run ops d).values)[i.val + 1]'hiRun
     simpa [result] using hd
 
-/-- The compact validation branch is therefore unconditionally true. -/
-theorem Diagonal.Compact.valid_eq_true (d : Vector Int r) :
-    Diagonal.Compact.valid d = true := by
-  unfold Diagonal.Compact.valid
-  exact decide_eq_true (Diagonal.Compact.run_valid
-    (Smith.formAccumulator r r) d)
-
 set_option maxHeartbeats 1600000 in
 private theorem Diagonal.Compact.pair_matrix (values : Vector Int r)
     (i j : Fin r) (hne : i ≠ j)

--- a/HexSmith/Diagonal.lean
+++ b/HexSmith/Diagonal.lean
@@ -128,9 +128,9 @@ end Smith.Diagonal
 
 namespace Smith.Diagonal
 
-/-- The decidable shape certificate checked before exposing the specialized
-diagonal result. It contains only the working matrix and diagonal list, so the
-form-only path still allocates no transforms. -/
+/-- The decidable shape predicate that the compact diagonal run is proved to
+satisfy. It contains only the working matrix and diagonal list, so reasoning
+about the form-only path does not introduce transform matrices. -/
 @[expose]
 def Valid (s : Smith.Result α r r) : Prop :=
   s.diag.length ≤ r ∧
@@ -143,22 +143,6 @@ def Valid (s : Smith.Result α r r) : Prop :=
 instance (s : Smith.Result α r r) : Decidable (Valid s) := by
   unfold Valid
   infer_instance
-
-/-- Form-only validation of the fixed diagonal network. -/
-@[expose]
-def valid (d : Vector Int r) : Bool :=
-  decide (Valid (run (Smith.formAccumulator r r) d))
-
-/-- Full-data candidate produced by exactly the same fixed network. -/
-@[expose]
-def candidateData (d : Vector Int r) : SmithData r r :=
-  let result := run (Smith.transformAccumulator r r) d
-  { rank := result.diag.length
-    diag := result.diagVector
-    left := result.accumulator.left
-    leftInv := result.accumulator.leftInv
-    right := result.accumulator.right
-    rightInv := result.accumulator.rightInv }
 
 /-- Agreement of diagonal runs after erasing their companion accumulators. -/
 structure Same (s : Smith.Result α r r) (t : Smith.Result β r r) : Prop where
@@ -849,11 +833,6 @@ def erase (s : Result α r) : Smith.Result α r r :=
   { matrix := diagMatrix s.values r r
     diag := collect s.values
     accumulator := s.accumulator }
-
-/-- Decidable postcondition for the compact form-only run. -/
-@[expose]
-def valid (d : Vector Int r) : Bool :=
-  decide (Valid (erase (run (Smith.formAccumulator r r) d)))
 
 /-- Full Smith-data candidate from the compact transform run. -/
 @[expose]

--- a/libraries.yml
+++ b/libraries.yml
@@ -432,7 +432,7 @@ libraries:
   HexSmith:
     deps: [HexHermite]
     mathlib: false
-    done_through: 0
+    done_through: 2
     status: active
     phase4:
       comparators:
@@ -760,7 +760,7 @@ libraries:
   HexSmithMathlib:
     deps: [HexSmith, HexHermiteMathlib]
     mathlib: true
-    done_through: 0
+    done_through: 2
     status: active
   HexPolyFpMathlib:
     deps: [HexPolyFp, HexPolyMathlib, HexModArithMathlib]

--- a/progress/2026-08-25T233027_issue9620.md
+++ b/progress/2026-08-25T233027_issue9620.md
@@ -1,0 +1,22 @@
+# HexSmith publication directive
+
+- Session type: feature / skeptical review
+- Audited the complete HexSmith executable and proof surface against its SPEC,
+  including routing, fuel completeness, transforms and inverses, diagonal
+  normalization, uniqueness, certificates, systems, rank, index, and
+  presentation data.
+- Audited HexSmithMathlib basis, chain, rank, and quotient correspondence. It
+  consumes executable Smith data and owns no executable surface.
+- Recorded independent Phase-2 attestations and advanced both libraries only
+  to `done_through: 2`.
+- Decomposed the remaining directive into #9624, #9625, #9629, #9630, #9631,
+  #9632, and #9633 with explicit dependency edges.
+- Verified `lake build HexSmith HexSmithMathlib`, the DAG, Phase-4/7 structural
+  checks, conformance target discovery, manual split, release manifest, and a
+  zero banned-token scan for both libraries.
+- Baseline quality delta: both phase counters move from 0 to 2; the source
+  remains free of `sorry`, `axiom`, and `native_decide`.
+- Remaining work: Phase-3 conformance acceptance, Phase-4 scientific evidence,
+  Phase-6 linter and API polish, Phase-7 documentation, and final integration.
+  The baseline `hexsmith_bench verify` also fails when optional FLINT/PARI
+  packages are absent; #9630 owns the benchmark-contract repair.

--- a/status/hex-smith-mathlib.scaffolding-reviewed
+++ b/status/hex-smith-mathlib.scaffolding-reviewed
@@ -1,0 +1,16 @@
+Independent Phase 2 skeptical review completed against the HexSmithMathlib
+correspondence SPEC and source.
+
+The review checked the ambient basis from the recorded inverse right
+transform, the independent relation basis from the transformed presentation,
+construction of `Module.Basis.SmithNormalForm`, transport of the executable
+divisibility chain and rank, and the rank-general quotient decomposition. The
+bridge consumes `Hex.Matrix.snfData` and `invariantFactors`; it does not invoke
+Mathlib's noncomputable Smith-form existence construction or duplicate the
+Smith algorithm. Its declarations are correspondence statements and
+noncomputable proof-facing constructions, with no executable reifier,
+certificate checker, or tactic surface.
+
+No data placeholder, executable detour, missing headline declaration, axiom,
+sorry, or mathematical statement mismatch was found. Phase 3 through Phase 7
+acceptance work is tracked separately and is not attested by this token.

--- a/status/hex-smith.scaffolding-reviewed
+++ b/status/hex-smith.scaffolding-reviewed
@@ -1,0 +1,17 @@
+Independent Phase 2 skeptical review completed against the HexSmith SPEC and
+the executable and proof sources.
+
+The review checked the accumulator-parametric classical pivot loop, the fused
+divisibility repair and fuel sufficiency proof, the compact diagonal gcd/lcm
+network, explicit inverse accumulation, determinantal-divisor uniqueness,
+certificate replay, Hermite rank and index agreement, diagonal solvability,
+and abelian-presentation data. The form-only APIs use the `Unit` accumulator
+and never construct transforms; the diagonal APIs bypass the general pivot
+loop; empty, rectangular, and rank-deficient conventions are represented by
+the same proofs as ordinary inputs. Shared Hermite code is limited to the
+bounded elementary gcd steps rather than invoking Hermite normalization.
+
+No data placeholder, fake extern, native-type detour, missing headline
+declaration, axiom, sorry, or mathematical contract mismatch was found.
+Phase 3 through Phase 7 acceptance work is tracked separately and is not
+attested by this token.

--- a/status/hex-smith.scaffolding-reviewed
+++ b/status/hex-smith.scaffolding-reviewed
@@ -8,8 +8,9 @@ certificate replay, Hermite rank and index agreement, diagonal solvability,
 and abelian-presentation data. The form-only APIs use the `Unit` accumulator
 and never construct transforms; the diagonal APIs bypass the general pivot
 loop; empty, rectangular, and rank-deficient conventions are represented by
-the same proofs as ordinary inputs. Shared Hermite code is limited to the
-bounded elementary gcd steps rather than invoking Hermite normalization.
+the same proofs as ordinary inputs. On the executable path, shared Hermite
+code is limited to the bounded elementary gcd steps rather than invoking
+Hermite normalization.
 
 No data placeholder, fake extern, native-type detour, missing headline
 declaration, axiom, sorry, or mathematical contract mismatch was found.


### PR DESCRIPTION
Advances the HexSmith release directive through the independently audited Phase-2 boundary only.

- records skeptical review attestations for HexSmith and HexSmithMathlib
- advances both counters from 0 to 2
- leaves conformance, performance, polish, documentation, and publication integration to the explicit dependency chain under #9620

Closes #9624
Closes #9625

Parent directive: #9620

Local verification:
- `lake build HexSmith HexSmithMathlib`
- `python3 scripts/check_dag.py`
- `python3 scripts/check_phase4.py`
- `python3 scripts/check_phase7.py`
- `python3 scripts/conformance_targets.py --check`
- `python3 scripts/release/check_manual_split.py`
- `python3 scripts/release/check_released_manifest.py`
- zero `sorry`, `axiom`, or `native_decide` across both libraries