### PR TITLE
polish: advance HexBerlekamp through Phase 7

### DIFF
--- a/HexBerlekamp/BerlekampMatrix.lean
+++ b/HexBerlekamp/BerlekampMatrix.lean
@@ -137,9 +137,9 @@ private theorem array_toList_getD {α : Type}
       rw [List.getD_eq_getElem?_getD]
       unfold Array.getD Array.size Array.getInternal
       by_cases hlt : i < data.length
-      · rw [dif_pos hlt]
+      · rw [dite_eq_left hlt]
         simp [List.getElem?_eq_getElem hlt]
-      · rw [dif_neg hlt]
+      · rw [dite_eq_right hlt]
         simp [List.getElem?_eq_none_iff.mpr (Nat.le_of_not_gt hlt)]
 
 private theorem list_getD_map_range
@@ -373,7 +373,6 @@ private theorem powModMonic_column_size_le
 /-- `composeCoeffPowerSumUpTo` written with the last term appended on the
 right. -/
 private theorem composeCoeffPowerSumUpTo_succ_right
-    [ZMod64.PrimeModulus p]
     (coeff : Nat → ZMod64 p) (q : FpPoly p) (n : Nat) :
     ∀ base,
       FpPoly.composeCoeffPowerSumUpTo coeff (n + 1) base q =
@@ -397,7 +396,6 @@ private theorem composeCoeffPowerSumUpTo_succ_right
 /-- `composeCoeffPowerSumUpTo … n 0 q` viewed as the `List.finRange n`-foldl
 sum `Σ_{j < n} C(coeff j) · linearPow q j`. -/
 private theorem composeCoeffPowerSumUpTo_eq_foldl_finRange
-    [ZMod64.PrimeModulus p]
     (coeff : Nat → ZMod64 p) (q : FpPoly p) (n : Nat) :
     FpPoly.composeCoeffPowerSumUpTo coeff n 0 q =
       (List.finRange n).foldl
@@ -709,7 +707,7 @@ private theorem vector_sub_eq_zero_iff_eq [Lean.Grind.Ring R] (u v : Vector R n)
 fixed-space equation `Q_f * v = v`. -/
 theorem isFixedSpaceKernelVector_iff_berlekampMatrix_mulVec_eq
     (f : FpPoly p) (hmonic : DensePoly.Monic f)
-    [ZMod64.PrimeModulus p] (v : Vector (ZMod64 p) (basisSize f)) :
+    (v : Vector (ZMod64 p) (basisSize f)) :
     IsFixedSpaceKernelVector f hmonic v ↔
       Matrix.mulVec (berlekampMatrix f hmonic) v = v := by
   unfold IsFixedSpaceKernelVector

--- a/HexBerlekamp/DelayedKernel.lean
+++ b/HexBerlekamp/DelayedKernel.lean
@@ -204,7 +204,7 @@ private theorem delayedDotLoop_eq_foldl (ctx : Hex.BarrettCtx p) (u v : Vector (
           (BarrettCtx.accStep ctx.toUInt64Ctx) (lo, hi, count)).2.1 := by
   fun_induction delayedDotLoop ctx u v i lo hi count with
   | case1 i lo hi count h hwin ih =>
-    -- Flush step: the fold's `accStep` takes the `if_pos` branch.
+    -- Flush step: the fold's `accStep` takes the `ite_eq_left` branch.
     have hcomb :
         (((List.finRange m).drop i).map (fun j => u[j].toUInt64 * v[j].toUInt64)).foldl
             (BarrettCtx.accStep ctx.toUInt64Ctx) (lo, hi, count) =
@@ -215,7 +215,7 @@ private theorem delayedDotLoop_eq_foldl (ctx : Hex.BarrettCtx p) (u v : Vector (
               (lo + u[i].toUInt64 * v[i].toUInt64)
               (hi + (if lo + u[i].toUInt64 * v[i].toUInt64 < lo then 1 else 0)), 0, 0) := by
       rw [List.drop_eq_getElem_cons (by simpa using h), List.map_cons, List.foldl_cons,
-        BarrettCtx.accStep_eq_inline, if_pos hwin]
+        BarrettCtx.accStep_eq_inline, ite_eq_left hwin]
       simp only [List.getElem_finRange, Fin.getElem_fin, Fin.val_cast]
     exact ih.trans (congrArg
       (fun s : UInt64 × UInt64 × Nat =>
@@ -223,7 +223,7 @@ private theorem delayedDotLoop_eq_foldl (ctx : Hex.BarrettCtx p) (u v : Vector (
           s.1 s.2.1)
       hcomb).symm
   | case2 i lo hi count h hwin ih =>
-    -- In-window step: the fold's `accStep` takes the `if_neg` branch.
+    -- In-window step: the fold's `accStep` takes the `ite_eq_right` branch.
     have hcomb :
         (((List.finRange m).drop i).map (fun j => u[j].toUInt64 * v[j].toUInt64)).foldl
             (BarrettCtx.accStep ctx.toUInt64Ctx) (lo, hi, count) =
@@ -234,7 +234,7 @@ private theorem delayedDotLoop_eq_foldl (ctx : Hex.BarrettCtx p) (u v : Vector (
               hi + (if lo + u[i].toUInt64 * v[i].toUInt64 < lo then 1 else 0),
               count + 1) := by
       rw [List.drop_eq_getElem_cons (by simpa using h), List.map_cons, List.foldl_cons,
-        BarrettCtx.accStep_eq_inline, if_neg hwin]
+        BarrettCtx.accStep_eq_inline, ite_eq_right hwin]
       simp only [List.getElem_finRange, Fin.getElem_fin, Fin.val_cast]
     exact ih.trans (congrArg
       (fun s : UInt64 × UInt64 × Nat =>
@@ -266,12 +266,15 @@ private theorem delayedDotRun_eq_loop (ctx : Hex.BarrettCtx p) (u v : Vector (ZM
   | case1 i lo hi h ih =>
     intro count hcount
     have hne : ¬ (count + 1 = BarrettCtx.barrettWindow) := by omega
-    rw [delayedDotLoop, dif_pos h, if_neg hne]
+    rw [delayedDotLoop, dite_eq_left h, ite_eq_right hne]
     exact ih (count + 1) (by omega)
   | case2 i lo hi h =>
     intro count _
-    rw [delayedDotLoop, dif_neg h]
+    rw [delayedDotLoop, dite_eq_right h]
 
+/-- The reference delayed dot product agrees with the windowed implementation,
+registered `@[csimp]` so compiled code runs `delayedDotImpl` while proofs keep
+reasoning about `delayedDot`. -/
 @[csimp] theorem delayedDot_eq_impl : @delayedDot = @delayedDotImpl := by
   funext p inst m ctx u v
   -- The loop from the empty start state computes exactly `foldReduce` (the
@@ -286,11 +289,11 @@ private theorem delayedDotRun_eq_loop (ctx : Hex.BarrettCtx p) (u v : Vector (ZM
     calc delayedDot ctx u v
         = ZMod64.ofNat p (delayedDotRun ctx u v 0 0 0).toNat :=
           congrArg (fun w : UInt64 => ZMod64.ofNat p w.toNat) (hrun.trans hloop).symm
-      _ = delayedDotImpl ctx u v := by rw [delayedDotImpl, if_pos hm]
+      _ = delayedDotImpl ctx u v := by rw [delayedDotImpl, ite_eq_left hm]
   · calc delayedDot ctx u v
         = ZMod64.ofNat p (delayedDotLoop ctx u v 0 0 0 0).toNat :=
           congrArg (fun w : UInt64 => ZMod64.ofNat p w.toNat) hloop.symm
-      _ = delayedDotImpl ctx u v := by rw [delayedDotImpl, if_neg hm]
+      _ = delayedDotImpl ctx u v := by rw [delayedDotImpl, ite_eq_right hm]
 
 /-- **Correctness of the delayed dot product.** The periodically-reduced dot
 product equals the naive `Vector.dotProduct` on `ZMod64 p`: reduction modulo `p`

--- a/HexBerlekamp/DistinctDegree.lean
+++ b/HexBerlekamp/DistinctDegree.lean
@@ -226,52 +226,27 @@ theorem distinctDegreeCandidate_spec
 /-- `1 * a = a`: left identity for `FpPoly` multiplication, from commutativity
 and the right unit law. -/
 private theorem one_mul_poly
-    [ZMod64.PrimeModulus p]
     (a : FpPoly p) :
     (1 : FpPoly p) * a = a :=
   (DensePoly.mul_comm_poly (1 : FpPoly p) a).trans (DensePoly.mul_one_right_poly a)
 
-/-- `factorProduct` of a cons is the head times the `factorProduct` of the
-tail. -/
-private theorem factorProduct_cons_eq
-    [ZMod64.PrimeModulus p]
-    (x : FpPoly p) (xs : List (FpPoly p)) :
-    factorProduct (x :: xs) = x * factorProduct xs := by
-  show xs.foldl (fun acc factor => acc * factor) (1 * x)
-    = x * xs.foldl (fun acc factor => acc * factor) 1
-  rw [one_mul_poly x]
-  exact List.foldl_mul_eq_mul_foldl xs id x
-
-/-- `factorProduct` distributes over list append. -/
-private theorem factorProduct_append
-    [ZMod64.PrimeModulus p]
-    (xs ys : List (FpPoly p)) :
-    factorProduct (xs ++ ys) = factorProduct xs * factorProduct ys := by
-  induction xs with
-  | nil =>
-      simp [factorProduct]
-  | cons x xs ih =>
-      rw [List.cons_append, factorProduct_cons_eq, factorProduct_cons_eq, ih]
-      exact (DensePoly.mul_assoc_poly x (factorProduct xs) (factorProduct ys)).symm
-
 /-- Bucket products distribute over list append in stored bucket order. -/
 theorem degreeBucketProduct_append
-    [ZMod64.PrimeModulus p]
     (buckets₁ buckets₂ : List (DegreeBucket p)) :
     degreeBucketProduct (buckets₁ ++ buckets₂) =
       degreeBucketProduct buckets₁ * degreeBucketProduct buckets₂ := by
   simp [degreeBucketProduct, degreeBucketFactors_append, factorProduct_append]
 
-/-- The product of a singleton bucket list is its recorded factor. -/
-@[simp, grind =] theorem degreeBucketProduct_singleton
-    [ZMod64.PrimeModulus p]
+/-- The product of a singleton bucket list is its recorded factor.
+Not `@[simp]`: `simp` already closes it from `degreeBucketProduct_cons`,
+`degreeBucketProduct_nil`, and `FpPoly.mul_one`. -/
+theorem degreeBucketProduct_singleton
     (bucket : DegreeBucket p) :
     degreeBucketProduct [bucket] = bucket.factor := by
   simp [degreeBucketProduct, degreeBucketFactors, factorProduct]
 
 /-- Pull the first bucket factor out of a bucket product. -/
 @[simp, grind =] theorem degreeBucketProduct_cons
-    [ZMod64.PrimeModulus p]
     (bucket : DegreeBucket p) (buckets : List (DegreeBucket p)) :
     degreeBucketProduct (bucket :: buckets) =
       bucket.factor * degreeBucketProduct buckets := by
@@ -287,7 +262,6 @@ private theorem degreeBucketProduct_appendBucket?_none
 /-- Appending `some bucket` multiplies the bucket product on the right by that
 bucket's recorded factor. -/
 private theorem degreeBucketProduct_appendBucket?_some
-    [ZMod64.PrimeModulus p]
     (buckets : List (DegreeBucket p)) (bucket : DegreeBucket p) :
     degreeBucketProduct (appendBucket? buckets (some bucket)) =
       degreeBucketProduct buckets * bucket.factor := by
@@ -302,7 +276,6 @@ private def optionalBucketProduct : Option (DegreeBucket p) → FpPoly p
 /-- Appending an optional bucket multiplies the bucket product on the right by
 `optionalBucketProduct`, unifying the `none` and `some` cases. -/
 private theorem degreeBucketProduct_appendBucket?
-    [ZMod64.PrimeModulus p]
     (buckets : List (DegreeBucket p)) (bucket? : Option (DegreeBucket p)) :
     degreeBucketProduct (appendBucket? buckets bucket?) =
       degreeBucketProduct buckets * optionalBucketProduct bucket? := by
@@ -332,17 +305,6 @@ private theorem gcd_mul_div_eq
       ((residual / DensePoly.gcd residual diff) *
         DensePoly.gcd residual diff)).symm.trans hspec)
 
-/-- The degree-`d` candidate divides `residual`: candidate times
-`residual / candidate` recovers `residual`. -/
-private theorem distinctDegreeCandidate_mul_div_eq
-    [ZMod64.PrimeModulus p]
-    (f : FpPoly p) (hmonic : DensePoly.Monic f)
-    (residual : FpPoly p) (d : Nat) :
-    distinctDegreeCandidate f hmonic residual d *
-        (residual / distinctDegreeCandidate f hmonic residual d) = residual := by
-  rw [distinctDegreeCandidate_spec]
-  exact gcd_mul_div_eq residual (frobeniusDiffMod f hmonic d)
-
 /-- A product with a non-unit right factor is non-unit, since any divisor of a
 unit is a unit. -/
 private theorem isUnitPolynomial_mul_eq_false_of_right
@@ -361,7 +323,6 @@ private theorem isUnitPolynomial_mul_eq_false_of_right
 /-- `finishDegreePower` preserves the running product when `acc` is non-unit:
 the emitted bucket factor times the returned residual equals `acc * residual`. -/
 private theorem finishDegreePower_product_nonunit
-    [ZMod64.PrimeModulus p]
     (d : Nat) (residual acc : FpPoly p)
     (hacc : isUnitPolynomial acc = false) :
     let result := finishDegreePower (p := p) d residual acc
@@ -369,21 +330,6 @@ private theorem finishDegreePower_product_nonunit
   unfold finishDegreePower
   rw [hacc]
   cases isUnitPolynomial residual <;> simp [optionalBucketProduct]
-
-/-- `1 ≠ 0` in `ZMod64 p` for a prime modulus, since `p ≥ 2` makes
-`1 % p = 1`. -/
-private theorem zmod_one_ne_zero_local
-    [ZMod64.PrimeModulus p] :
-    (1 : ZMod64 p) ≠ 0 := by
-  intro h
-  have htoNat : (1 : ZMod64 p).toNat = (0 : ZMod64 p).toNat :=
-    congrArg ZMod64.toNat h
-  rw [show ((1 : ZMod64 p).toNat) = 1 % p from ZMod64.toNat_one,
-      show ((0 : ZMod64 p).toNat) = 0 from ZMod64.toNat_zero,
-      Nat.mod_eq_of_lt (by
-        have h2 : 2 ≤ p := (ZMod64.PrimeModulus.prime (p := p)).two_le
-        omega : 1 < p)] at htoNat
-  exact absurd htoNat (by omega)
 
 /-- The constant polynomial `1` is a unit (degree `0`). -/
 private theorem isUnitPolynomial_one
@@ -394,7 +340,7 @@ private theorem isUnitPolynomial_one
     | some 0 => true
     | _ => false) = true
   have hcoeffs : (DensePoly.C (1 : ZMod64 p)).coeffs = #[(1 : ZMod64 p)] :=
-    DensePoly.coeffs_C_of_ne_zero zmod_one_ne_zero_local
+    DensePoly.coeffs_C_of_ne_zero (ZMod64.one_ne_zero_of_prime (ZMod64.PrimeModulus.prime (p := p)))
   simp [DensePoly.degree?, DensePoly.size, hcoeffs]
 
 /-- `finishDegreePower` from unit accumulator `1` preserves `residual`: the
@@ -999,7 +945,6 @@ private theorem distinctDegreeLoop_bucket_positive_degrees
           (appendBucket? buckets powerResult.1) (by omega) happend bucket hmem
 
 private theorem distinctDegreeFactor_bucket_positive_degrees
-    [ZMod64.PrimeModulus p]
     (f : FpPoly p) (hmonic : DensePoly.Monic f) :
     ∀ bucket ∈ (distinctDegreeFactor f hmonic).buckets, 0 < bucket.degree := by
   unfold distinctDegreeFactor

--- a/HexBerlekamp/Factor.lean
+++ b/HexBerlekamp/Factor.lean
@@ -218,7 +218,7 @@ theorem splitFactorCached_eq
     splitFactorCached f witness (witness % f) c = splitFactorAt f witness c := by
   unfold splitFactorCached
   by_cases hfast : 2 ≤ f.size ∧ f.size < witness.size
-  · rw [if_pos hfast]
+  · rw [ite_eq_left hfast]
     rw [FpPoly.gcdAuxCached_eq]
     have hf : f.isZero = false :=
       (DensePoly.isZero_eq_false_iff f).mpr (by omega)
@@ -231,7 +231,7 @@ theorem splitFactorCached_eq
     unfold splitFactorAt
     rw [DensePoly.gcd_eq_aux_mod f (witness - FpPoly.C c) hf hshiftLt,
       hshiftSize, sub_C_mod_eq f witness c hfast.1]
-  · rw [if_neg hfast]
+  · rw [ite_eq_right hfast]
 
 /-- `true` exactly when the gcd candidate is nonconstant and strictly smaller
 than `f` in size (i.e. strictly smaller in degree). Strict size suffices to
@@ -288,7 +288,7 @@ private theorem cachedSplitAux_eq
       let factor := splitFactorAt f witness splitConstant
       by_cases hnon : isNontrivialSplitFactor f factor
       · simp [splitConstant, factor, hnon]
-      · simp only [splitConstant, factor, hnon, Bool.false_eq_true, if_false]
+      · simp only [splitConstant, factor, hnon, Bool.false_eq_true, ite_false]
         exact ih (c + 1)
 
 /--
@@ -328,8 +328,8 @@ private theorem kernelWitnessSplitAux_of_some
     kernelWitnessSplitAux f witness p 0 = some r := by
   unfold kernelWitnessSplit? at hsplit
   by_cases hguard : (witness % f).size ≤ 1
-  · rw [if_pos hguard] at hsplit; exact absurd hsplit (by simp)
-  · rw [if_neg hguard] at hsplit
+  · rw [ite_eq_left hguard] at hsplit; exact absurd hsplit (by simp)
+  · rw [ite_eq_right hguard] at hsplit
     rw [cachedSplitAux_eq] at hsplit
     exact hsplit
 
@@ -864,7 +864,7 @@ private theorem isNontrivialSplitFactor_false_of_mod_size_le_one
     rw [DensePoly.coeff_sub_ring]
     have h1 : (witness % f).coeff i = 0 :=
       DensePoly.coeff_eq_zero_of_size_le (witness % f) (by omega)
-    have h2 : (FpPoly.C c).coeff i = 0 := by rw [FpPoly.coeff_C, if_neg (by omega)]
+    have h2 : (FpPoly.C c).coeff i = 0 := by rw [FpPoly.coeff_C, ite_eq_right (by omega)]
     rw [h1, h2]; grind
   by_cases hs0 : (witness % f - FpPoly.C c) = 0
   · -- `c` matches the constant residue: `f ∣ witness - c`, so the gcd is `~ f`.
@@ -925,7 +925,7 @@ private theorem kernelWitnessSplitAux_none_of_mod_size_le_one
       have hnon : isNontrivialSplitFactor f
           (splitFactorAt f witness (ZMod64.ofNat p c)) = false :=
         isNontrivialSplitFactor_false_of_mod_size_le_one f witness hconst (ZMod64.ofNat p c)
-      simp only [hnon, Bool.false_eq_true, if_false]
+      simp only [hnon, Bool.false_eq_true, ite_false]
       exact ih (c + 1)
 
 /--
@@ -956,7 +956,7 @@ theorem kernelWitnessSplit?_some_of_nontrivial_splitFactorAt
         (splitFactorAt f witness (ZMod64.ofNat p (0 + c.toNat))) = true := by
     rw [Nat.zero_add, hc_eq]; exact hnontriv
   unfold kernelWitnessSplit?
-  rw [if_neg hguard]
+  rw [ite_eq_right hguard]
   rw [cachedSplitAux_eq]
   exact kernelWitnessSplitAux_some_of_nontrivial_offset f witness p 0 c.toNat hc_lt hnon
 
@@ -1024,8 +1024,8 @@ private theorem kernelWitnessSplitAux_none_scale
       · simp [splitConstant, factorG, hnon] at h
       · have hnonSG : ¬ isNontrivialSplitFactor (DensePoly.scale c g) factorSG := by
           rw [hcong]; exact hnon
-        simp only [splitConstant, factorG, hnon, Bool.false_eq_true, if_false] at h
-        simp only [splitConstant, factorSG, hnonSG, Bool.false_eq_true, if_false]
+        simp only [splitConstant, factorG, hnon, Bool.false_eq_true, ite_false] at h
+        simp only [splitConstant, factorSG, hnonSG, Bool.false_eq_true, ite_false]
         exact ih (start + 1) h
 
 /-- Transport of a failed Berlekamp split search across a unit scaling: if no
@@ -1045,15 +1045,15 @@ theorem kernelWitnessSplit?_none_scale
     · exact kernelWitnessSplitAux_none_of_mod_size_le_one g witness hguard p 0
     · have h' := h
       unfold kernelWitnessSplit? at h'
-      rw [if_neg hguard] at h'
+      rw [ite_eq_right hguard] at h'
       rw [cachedSplitAux_eq] at h'
       exact h'
   have haux_sg : kernelWitnessSplitAux (DensePoly.scale c g) witness p 0 = none :=
     kernelWitnessSplitAux_none_scale hc g witness p 0 haux_g
   unfold kernelWitnessSplit?
   by_cases hguard2 : (witness % DensePoly.scale c g).size ≤ 1
-  · rw [if_pos hguard2]
-  · rw [if_neg hguard2, cachedSplitAux_eq]; exact haux_sg
+  · rw [ite_eq_left hguard2]
+  · rw [ite_eq_right hguard2, cachedSplitAux_eq]; exact haux_sg
 
 private theorem splitWithWitnesses?_product_spec
     [ZMod64.PrimeModulus p]
@@ -1076,7 +1076,6 @@ private theorem splitWithWitnesses?_product_spec
       exact ih h
 
 private theorem one_mul_poly
-    [ZMod64.PrimeModulus p]
     (a : FpPoly p) :
     (1 : FpPoly p) * a = a :=
   (DensePoly.mul_comm_poly (1 : FpPoly p) a).trans (DensePoly.mul_one_right_poly a)
@@ -1087,7 +1086,6 @@ product. Useful for downstream proofs that reason about `factorProduct` without
 unfolding the underlying `List.foldl`.
 -/
 theorem factorProduct_cons
-    [ZMod64.PrimeModulus p]
     (x : FpPoly p) (xs : List (FpPoly p)) :
     factorProduct (x :: xs) = x * factorProduct xs := by
   show xs.foldl (fun acc factor => acc * factor) (1 * x)
@@ -1096,8 +1094,7 @@ theorem factorProduct_cons
   exact List.foldl_mul_eq_mul_foldl xs id x
 
 /-- `factorProduct` distributes over list append. -/
-private theorem factorProduct_append
-    [ZMod64.PrimeModulus p]
+theorem factorProduct_append
     (xs ys : List (FpPoly p)) :
     factorProduct (xs ++ ys) = factorProduct xs * factorProduct ys := by
   induction xs with
@@ -1123,9 +1120,9 @@ private theorem factorProduct_fullySplit
   | succ fuel ih =>
       rw [fullySplit]
       by_cases hsize : f.size ≤ 2
-      · rw [if_pos hsize, factorProduct_cons, factorProduct_nil]
+      · rw [ite_eq_left hsize, factorProduct_cons, factorProduct_nil]
         exact DensePoly.mul_one_right_poly f
-      · rw [if_neg hsize]
+      · rw [ite_eq_right hsize]
         cases hsplit : splitWithWitnesses? f witnesses with
         | none =>
             rw [factorProduct_cons, factorProduct_nil]
@@ -1179,9 +1176,9 @@ private theorem fullySplit_ne_nil
   | succ fuel ih =>
       rw [fullySplit]
       by_cases hsize : f.size ≤ 2
-      · rw [if_pos hsize]
+      · rw [ite_eq_left hsize]
         exact List.cons_ne_nil f []
-      · rw [if_neg hsize]
+      · rw [ite_eq_right hsize]
         cases hsplit : splitWithWitnesses? f witnesses with
         | none => exact List.cons_ne_nil f []
         | some split =>
@@ -1305,6 +1302,8 @@ private theorem kernelWitnessSplitAux_factor_pos_degree
       · simp [splitConstant, factor, hnon] at hsplit
         exact ih (c + 1) hsplit
 
+/-- A successful kernel-witness split returns a factor of positive degree, so
+the recursive splitter always makes progress. -/
 theorem kernelWitnessSplit_factor_pos_degree
     [ZMod64.PrimeModulus p]
     (f witness : FpPoly p) (r : SplitResult p)
@@ -1469,7 +1468,7 @@ theorem kernelWitnessSplit?_none_of_berlekampFactor_factors_length_le_one
               = fullySplit ((fixedSpaceKernel f hmonic).toList) f.size split.factor
                 ++ fullySplit ((fixedSpaceKernel f hmonic).toList) f.size split.cofactor := by
             rw [berlekampFactor_factors_of_rootFactors_none f hmonic hr]
-            rw [fullySplit, if_neg hsize, hsp]
+            rw [fullySplit, ite_eq_right hsize, hsp]
           rw [hfac_eq, List.length_append] at hsmall
           have h1 :
               0 < (fullySplit ((fixedSpaceKernel f hmonic).toList)
@@ -1511,7 +1510,6 @@ private theorem splitWithWitnesses?_cofactor_size_lt
 
 /-- An element of a list of `FpPoly p` divides the product of the list. -/
 private theorem dvd_factorProduct_of_mem
-    [ZMod64.PrimeModulus p]
     (xs : List (FpPoly p)) {g : FpPoly p} (hg : g ∈ xs) :
     g ∣ factorProduct xs := by
   induction xs with
@@ -1533,7 +1531,6 @@ private theorem dvd_factorProduct_of_mem
 /-- Two distinct elements of a `Nodup` list of `FpPoly p` have a product that
 divides the list's product. -/
 theorem mul_dvd_factorProduct_of_mem_of_ne
-    [ZMod64.PrimeModulus p]
     {xs : List (FpPoly p)} (h_nodup : xs.Nodup)
     {a b : FpPoly p} (ha : a ∈ xs) (hb : b ∈ xs) (hab : a ≠ b) :
     a * b ∣ factorProduct xs := by
@@ -1577,7 +1574,6 @@ theorem mul_dvd_factorProduct_of_mem_of_ne
 
 /-- A polynomial that divides both `a` and `b` squares-divides `a * b`. -/
 private theorem squared_dvd_of_dvd_dvd
-    [ZMod64.PrimeModulus p]
     {a b g : FpPoly p} (hga : g ∣ a) (hgb : g ∣ b) :
     g * g ∣ a * b := by
   rcases hga with ⟨a', ha'⟩
@@ -1596,7 +1592,6 @@ private theorem squared_dvd_of_dvd_dvd
 
 /-- `factorProduct rest` divides `factorProduct (fac :: rest)`. -/
 private theorem factorProduct_tail_dvd_cons
-    [ZMod64.PrimeModulus p]
     (fac : FpPoly p) (rest : List (FpPoly p)) :
     factorProduct rest ∣ factorProduct (fac :: rest) := by
   rw [factorProduct_cons]
@@ -1737,7 +1732,6 @@ divides two distinct positions.  This is a direct consequence of the
 no-squared invariant and the fact that any two list entries multiply to a
 factor of `factorProduct`. -/
 private theorem factorProduct_pairwise_no_common_pos_divisor
-    [ZMod64.PrimeModulus p]
     (factors : List (FpPoly p))
     (h_no_squared : ∀ g : FpPoly p,
         g * g ∣ factorProduct factors → ¬ (0 < g.degree?.getD 0)) :

--- a/HexBerlekamp/FactorPolyElab.lean
+++ b/HexBerlekamp/FactorPolyElab.lean
@@ -203,6 +203,8 @@ input types), usable as
 `obtain ⟨scalar, factors, factors_mul, factors_irred⟩ := factor_poly f`. -/
 syntax (name := factorPolyTerm) "factor_poly" term:max : term
 
+/-- Term elaborator for `factor_poly f`: runs the search in compiled code and
+returns the checked certificate term. -/
 @[term_elab factorPolyTerm] meta def elabFactorPoly : Term.TermElab :=
   fun stx expectedType? => do
     match stx with
@@ -266,6 +268,8 @@ meta def introFactored (e : Expr) : Tactic.TacticM Unit := do
 `factors_irred` hypotheses stated over them. -/
 syntax (name := factorPolyTac) "factor_poly" term:max : tactic
 
+/-- Tactic elaborator for `factor_poly f`: elaborates the certificate and
+introduces its four fields into the local context. -/
 @[tactic factorPolyTac] meta def evalFactorPolyTac : Tactic.Tactic :=
   fun stx => do
     match stx with

--- a/HexBerlekamp/Irreducibility.lean
+++ b/HexBerlekamp/Irreducibility.lean
@@ -109,6 +109,7 @@ Each witness proves coprimality of `f` and
 structure IrreducibilityCertificate where
   /-- The characteristic of the finite field. -/
   p : Nat
+  /-- The modulus bound, carried so the certificate is self-describing. -/
   [bounds : ZMod64.Bounds p]
   /-- The degree claimed for the polynomial under test. -/
   n : Nat
@@ -321,27 +322,14 @@ theorem rabinDividesTest_spec (f : FpPoly p) (hmonic : DensePoly.Monic f) :
       (frobeniusDiffMod f hmonic (basisSize f)).isZero := by
   rfl
 
-private theorem zmod64_one_ne_zero_of_prime
-    (hp : Hex.Nat.Prime p) :
-    (1 : ZMod64 p) ≠ 0 := by
-  intro hone
-  have hnat : (1 : ZMod64 p).toNat = (0 : ZMod64 p).toNat :=
-    congrArg ZMod64.toNat hone
-  change (ZMod64.one : ZMod64 p).toNat = (ZMod64.zero : ZMod64 p).toNat at hnat
-  have hp_gt : 1 < p := by
-    have htwo : 2 ≤ p := Hex.Nat.Prime.two_le hp
-    omega
-  rw [ZMod64.toNat_one, ZMod64.toNat_zero, Nat.mod_eq_of_lt hp_gt] at hnat
-  omega
-
 private theorem fp_one_ne_zero [ZMod64.PrimeModulus p] :
     (1 : FpPoly p) ≠ 0 := by
   intro hone
   have hcoeff := congrArg (fun f : FpPoly p => f.coeff 0) hone
   change (DensePoly.C (1 : ZMod64 p)).coeff 0 = (0 : FpPoly p).coeff 0 at hcoeff
   rw [DensePoly.coeff_C, DensePoly.coeff_zero] at hcoeff
-  simp only [if_true] at hcoeff
-  exact zmod64_one_ne_zero_of_prime (ZMod64.PrimeModulus.prime (p := p)) hcoeff
+  simp only [ite_true] at hcoeff
+  exact ZMod64.one_ne_zero_of_prime (ZMod64.PrimeModulus.prime (p := p)) hcoeff
 
 private theorem eq_zero_of_size_eq_zero (f : FpPoly p) (hsize : f.size = 0) :
     f = 0 := by

--- a/HexBerlekamp/IrreducibilityElab.lean
+++ b/HexBerlekamp/IrreducibilityElab.lean
@@ -118,6 +118,8 @@ meta def elabIrreducibilityArgument (stx : Syntax) (t : Syntax)
 types). -/
 syntax (name := irreducibilityTerm) "irreducibility" term:max : term
 
+/-- Term elaborator for `irreducibility f`: runs the Rabin test in compiled
+code and returns the checked irreducibility proof term. -/
 @[term_elab irreducibilityTerm] meta def elabIrreducibility : Term.TermElab :=
   fun stx expectedType? => do
     match stx with
@@ -155,6 +157,8 @@ the form `… .Irreducible e`; `irreducibility f` adds the proof as `this`;
 syntax (name := irreducibilityTac)
   "irreducibility" (atomic(ident " : "))? (term:max)? : tactic
 
+/-- Tactic elaborator for `irreducibility`: closes an `Irreducible` goal, or
+adds the proof to the local context under `this` or a caller-chosen name. -/
 @[tactic irreducibilityTac] meta def evalIrreducibilityTac : Tactic.Tactic :=
   fun stx => do
     match stx with

--- a/HexBerlekamp/LinearFactors.lean
+++ b/HexBerlekamp/LinearFactors.lean
@@ -41,17 +41,6 @@ variable {p : Nat} [ZMod64.Bounds p]
 def primeFieldLinearFactor (c : ZMod64 p) : FpPoly p :=
   FpPoly.X - FpPoly.C c
 
-private theorem zmod64_one_ne_zero_of_prime [ZMod64.PrimeModulus p] :
-    (1 : ZMod64 p) ≠ (0 : ZMod64 p) := by
-  intro h
-  have h2 : 2 ≤ p := Hex.Nat.Prime.two_le (ZMod64.PrimeModulus.prime (p := p))
-  have htoNat : (1 : ZMod64 p).toNat = (0 : ZMod64 p).toNat :=
-    congrArg ZMod64.toNat h
-  rw [show ((1 : ZMod64 p).toNat) = 1 % p from ZMod64.toNat_one,
-      show ((0 : ZMod64 p).toNat) = 0 from ZMod64.toNat_zero,
-      Nat.mod_eq_of_lt (by omega : 1 < p)] at htoNat
-  exact absurd htoNat (by omega)
-
 /-- The listed prime-field linear factors are genuinely degree-one candidates. -/
 theorem primeFieldLinearFactor_coeff_one (c : ZMod64 p) :
     (primeFieldLinearFactor c).coeff 1 = (1 : ZMod64 p) := by
@@ -69,7 +58,7 @@ theorem primeFieldLinearFactor_ne_zero
   have hcoeff := congrArg (fun f : FpPoly p => f.coeff 1) hzero
   change (primeFieldLinearFactor c).coeff 1 = (0 : FpPoly p).coeff 1 at hcoeff
   rw [primeFieldLinearFactor_coeff_one c, DensePoly.coeff_zero] at hcoeff
-  exact zmod64_one_ne_zero_of_prime hcoeff
+  exact ZMod64.one_ne_zero_of_prime (ZMod64.PrimeModulus.prime (p := p)) hcoeff
 
 /-- The high coefficients of a prime-field linear factor vanish. -/
 private theorem primeFieldLinearFactor_coeff_high (c : ZMod64 p) {n : Nat}
@@ -88,7 +77,7 @@ theorem primeFieldLinearFactor_size [ZMod64.PrimeModulus p] (c : ZMod64 p) :
     (primeFieldLinearFactor c).size = 2 := by
   have h_coeff_1_ne : (primeFieldLinearFactor c).coeff 1 ≠ 0 := by
     rw [primeFieldLinearFactor_coeff_one c]
-    exact zmod64_one_ne_zero_of_prime
+    exact ZMod64.one_ne_zero_of_prime (ZMod64.PrimeModulus.prime (p := p))
   have h_lower : 2 ≤ (primeFieldLinearFactor c).size := by
     apply Classical.byContradiction
     intro h
@@ -310,7 +299,7 @@ theorem fpPoly_one_ne_zero [ZMod64.PrimeModulus p] : (1 : FpPoly p) ≠ 0 := by
     rw [DensePoly.coeff_C]
     simp
   rw [hone_coeff] at hcoeff
-  exact zmod64_one_ne_zero_of_prime hcoeff
+  exact ZMod64.one_ne_zero_of_prime (ZMod64.PrimeModulus.prime (p := p)) hcoeff
 
 /-- The constant polynomial `1` over a prime modulus has size `1`. -/
 theorem fpPoly_one_size [ZMod64.PrimeModulus p] : (1 : FpPoly p).size = 1 := by
@@ -460,7 +449,7 @@ theorem primeFieldLinearFactor_dvd_of_mem_rootsIn
 /-! # Reconstruction from a complete root list -/
 
 /-- A size-one monic polynomial is `1`. -/
-private theorem eq_one_of_size_one_of_monic [ZMod64.PrimeModulus p]
+private theorem eq_one_of_size_one_of_monic
     (q : FpPoly p) (hsize : q.size = 1) (hmonic : DensePoly.Monic q) :
     q = 1 := by
   have hlead : q.coeff 0 = (1 : ZMod64 p) := by

--- a/HexBerlekamp/PackedKernel.lean
+++ b/HexBerlekamp/PackedKernel.lean
@@ -75,7 +75,7 @@ where their product is exact for any `UInt32` inputs. -/
 variable {p : Nat} [ZMod64.Bounds p]
 
 /-- The modulus as a packed word. -/
-@[inline] def modWord (p : Nat) [ZMod64.Bounds p] : UInt32 :=
+@[inline] def modWord (p : Nat) : UInt32 :=
   UInt32.ofNat p
 
 /-- Read a packed word as a residue. -/
@@ -86,20 +86,29 @@ variable {p : Nat} [ZMod64.Bounds p]
 @[inline] def ofZMod (a : ZMod64 p) : UInt32 :=
   a.val.toUInt32
 
+/-- A residue is below `2 ^ 32`, so `ofZMod` loses nothing: `ZMod64.Bounds`
+caps the modulus at `2 ^ 31`. -/
 theorem toNat_lt_two_pow_32 (a : ZMod64 p) : a.toNat < 2 ^ 32 :=
   Nat.lt_trans a.isLt (Nat.lt_trans (ZMod64.Bounds.pLtR (p := p)) (by decide))
 
+/-- Packing a residue preserves its numeral. -/
 @[simp] theorem toNat_ofZMod (a : ZMod64 p) : (ofZMod a).toNat = a.toNat := by
   show (a.val.toUInt32).toNat = a.toNat
   rw [UInt64.toNat_toUInt32]
   exact Nat.mod_eq_of_lt (toNat_lt_two_pow_32 a)
 
+/-- `ofZMod` is a section of `toZMod`: packing then reading recovers the
+residue. -/
 @[simp] theorem toZMod_ofZMod (a : ZMod64 p) : toZMod p (ofZMod a) = a := by
   rw [toZMod, toNat_ofZMod, ZMod64.ofNat_toNat]
 
-@[simp] theorem toNat_toZMod (a : UInt32) : (toZMod p a).toNat = a.toNat % p := by
+/-- Reading an arbitrary packed word canonicalizes it modulo `p`.
+Not `@[simp]`: `ZMod64.toNat_eq_val` rewrites the `ZMod64.toNat` head of the
+left-hand side, so this shape is not simp-normal. -/
+theorem toNat_toZMod (a : UInt32) : (toZMod p a).toNat = a.toNat % p := by
   simp [toZMod]
 
+/-- The packed modulus word carries the modulus faithfully. -/
 @[simp] theorem toNat_modWord : (modWord p).toNat = p := by
   show (UInt32.ofNat p).toNat = p
   rw [UInt32.toNat_ofNat']
@@ -121,6 +130,9 @@ theorem toNat_toZMod_of_lt {a : UInt32} (h : a.toNat < p) :
 
 /-! ## Correctness of the packed operations -/
 
+/-- `mulMod` computes the modular product of its operands as naturals. The
+`UInt64` widening keeps the unreduced product exact for arbitrary `UInt32`
+inputs, so no reducedness hypothesis is needed. -/
 theorem toNat_mulMod {q a b : UInt32} (hq : q.toNat = p) :
     (mulMod q a b).toNat = (a.toNat * b.toNat) % p := by
   have hprod : (a.toUInt64 * b.toUInt64).toNat = a.toNat * b.toNat := by
@@ -138,10 +150,14 @@ theorem toNat_mulMod {q a b : UInt32} (hq : q.toNat = p) :
   exact Nat.mod_eq_of_lt
     (Nat.lt_trans (Nat.mod_lt _ (ZMod64.Bounds.pPos (p := p))) (pLt32 (p := p)))
 
+/-- `mulMod` returns a reduced residue. -/
 theorem mulMod_lt {q a b : UInt32} (hq : q.toNat = p) : (mulMod q a b).toNat < p := by
   rw [toNat_mulMod hq]
   exact Nat.mod_lt _ (ZMod64.Bounds.pPos (p := p))
 
+/-- `addMod` computes the modular sum of two reduced operands. Reducedness is
+required: the single conditional subtraction only canonicalizes a sum that is
+below `2 * p`. -/
 theorem toNat_addMod {q a b : UInt32} (hq : q.toNat = p)
     (ha : a.toNat < p) (hb : b.toNat < p) :
     (addMod q a b).toNat = (a.toNat + b.toNat) % p := by
@@ -151,11 +167,11 @@ theorem toNat_addMod {q a b : UInt32} (hq : q.toNat = p)
     exact Nat.mod_eq_of_lt (by omega)
   unfold addMod
   by_cases hlt : a + b < q
-  · rw [if_pos hlt]
+  · rw [ite_eq_left hlt]
     have hlt' : (a + b).toNat < q.toNat := UInt32.lt_iff_toNat_lt.mp hlt
     rw [hq, hsum] at hlt'
     rw [hsum, Nat.mod_eq_of_lt hlt']
-  · rw [if_neg hlt]
+  · rw [ite_eq_right hlt]
     have hge : p ≤ a.toNat + b.toNat :=
       Nat.le_of_not_lt fun hcon =>
         hlt (UInt32.lt_iff_toNat_lt.mpr (by rw [hq, hsum]; exact hcon))
@@ -165,22 +181,25 @@ theorem toNat_addMod {q a b : UInt32} (hq : q.toNat = p)
       Nat.add_mod_right, Nat.mod_eq_of_lt (by omega : a.toNat + b.toNat - p < 2 ^ 32)]
     rw [Nat.mod_eq_sub_mod hge, Nat.mod_eq_of_lt (by omega)]
 
+/-- `addMod` returns a reduced residue when both operands are reduced. -/
 theorem addMod_lt {q a b : UInt32} (hq : q.toNat = p)
     (ha : a.toNat < p) (hb : b.toNat < p) : (addMod q a b).toNat < p := by
   rw [toNat_addMod hq ha hb]
   exact Nat.mod_lt _ (ZMod64.Bounds.pPos (p := p))
 
+/-- `negMod` computes the modular negation of a reduced operand. The `a == 0`
+branch is what makes the result reduced rather than `p`. -/
 theorem toNat_negMod {q a : UInt32} (hq : q.toNat = p) (ha : a.toNat < p) :
     (negMod q a).toNat = (p - a.toNat) % p := by
   have hp32 : p < 2 ^ 32 := pLt32 (p := p)
   unfold negMod
   by_cases h : a == 0
-  · rw [if_pos h]
+  · rw [ite_eq_left h]
     have ha0 : a.toNat = 0 := by
       have : a = 0 := by simpa using h
       simp [this]
     simp [ha0]
-  · rw [if_neg h]
+  · rw [ite_eq_right h]
     have ha0 : a.toNat ≠ 0 := by
       intro hz
       exact h (by simpa using UInt32.toNat_inj.mp (by simpa using hz))
@@ -189,6 +208,7 @@ theorem toNat_negMod {q a : UInt32} (hq : q.toNat = p) (ha : a.toNat < p) :
       Nat.add_mod_right, Nat.mod_eq_of_lt (by omega : p - a.toNat < 2 ^ 32)]
     exact (Nat.mod_eq_of_lt (by omega)).symm
 
+/-- `negMod` returns a reduced residue when its operand is reduced. -/
 theorem negMod_lt {q a : UInt32} (hq : q.toNat = p) (ha : a.toNat < p) :
     (negMod q a).toNat < p := by
   rw [toNat_negMod hq ha]
@@ -226,11 +246,13 @@ not need a word-level extended-Euclid specialization. -/
 @[inline] def invMod (p : Nat) [ZMod64.Bounds p] (a : UInt32) : UInt32 :=
   ofZMod (ZMod64.inv (toZMod p a))
 
+/-- The packed inverse of a packed word is the packed inverse residue. -/
 @[simp] theorem toZMod_invMod (a : UInt32) :
     toZMod p (invMod p a) = (toZMod p a)⁻¹ := by
   rw [invMod, toZMod_ofZMod]
   rfl
 
+/-- `invMod` returns a reduced residue for any input word. -/
 theorem invMod_lt (a : UInt32) : (invMod p a).toNat < p := by
   rw [invMod, toNat_ofZMod]
   exact (ZMod64.inv (toZMod p a)).isLt
@@ -267,11 +289,16 @@ variable {n m : Nat}
 def Rep (A : Matrix UInt32 n m) (E : Matrix (ZMod64 p) n m) : Prop :=
   ∀ (i : Fin n) (j : Fin m), A[i][j].toNat = E[i][j].toNat
 
+/-- Every entry of a representing packed matrix is a reduced residue word,
+because the residues it represents are canonical. -/
 theorem Rep.lt {A : Matrix UInt32 n m} {E : Matrix (ZMod64 p) n m}
     (h : Rep A E) (i : Fin n) (j : Fin m) : A[i][j].toNat < p := by
   rw [h i j]
   exact E[i][j].isLt
 
+/-- Reading an entry of a representing packed matrix recovers the residue
+entry. This is the form `Rep` is consumed in once the goal is stated over
+residues rather than over `toNat`. -/
 theorem Rep.toZMod_eq {A : Matrix UInt32 n m} {E : Matrix (ZMod64 p) n m}
     (h : Rep A E) (i : Fin n) (j : Fin m) : toZMod p A[i][j] = E[i][j] :=
   ZMod64.ext_toNat (by rw [toNat_toZMod_of_lt (h.lt i j), h i j])
@@ -305,23 +332,29 @@ def rowAdd (q : UInt32) (A : Matrix UInt32 n m) (src dst : Fin n) (c : UInt32) :
     Matrix UInt32 n m :=
   rowAddFrom q A (Matrix.getRow A src) dst c
 
+/-- Entrywise characterisation of `rowScale`: row `i` is scaled, every other
+row is untouched. -/
 theorem getElem_rowScale (q : UInt32) (A : Matrix UInt32 n m) (i r : Fin n)
     (c : UInt32) (k : Fin m) :
     (rowScale q A i c)[r][k] = if r = i then mulMod q c A[i][k] else A[r][k] := by
   rw [rowScale, Matrix.getElem_modifyEntries]
   by_cases h : r = i
-  · rw [if_pos (congrArg Fin.val h), if_pos h, h]
-  · rw [if_neg (fun hv => h (Fin.ext hv)), if_neg h]
+  · rw [ite_eq_left (congrArg Fin.val h), ite_eq_left h, h]
+  · rw [ite_eq_right (fun hv => h (Fin.ext hv)), ite_eq_right h]
 
+/-- Entrywise characterisation of `rowAddFrom`: row `dst` gains `c * rsrc`,
+every other row is untouched. -/
 theorem getElem_rowAddFrom (q : UInt32) (A : Matrix UInt32 n m)
     (rsrc : Vector UInt32 m) (dst r : Fin n) (c : UInt32) (k : Fin m) :
     (rowAddFrom q A rsrc dst c)[r][k] =
       if r = dst then addMod q A[dst][k] (mulMod q c rsrc[k]) else A[r][k] := by
   rw [rowAddFrom, Matrix.getElem_modifyEntries]
   by_cases h : r = dst
-  · rw [if_pos (congrArg Fin.val h), if_pos h, h]
-  · rw [if_neg (fun hv => h (Fin.ext hv)), if_neg h]
+  · rw [ite_eq_left (congrArg Fin.val h), ite_eq_left h, h]
+  · rw [ite_eq_right (fun hv => h (Fin.ext hv)), ite_eq_right h]
 
+/-- Entrywise characterisation of `rowAdd`, the `rowAddFrom` special case that
+reads the source row out of the matrix. -/
 theorem getElem_rowAdd (q : UInt32) (A : Matrix UInt32 n m) (src dst r : Fin n)
     (c : UInt32) (k : Fin m) :
     (rowAdd q A src dst c)[r][k] =
@@ -331,17 +364,20 @@ theorem getElem_rowAdd (q : UInt32) (A : Matrix UInt32 n m) (src dst r : Fin n)
 
 /-! ## The packed elementary operations interpret to the generic ones -/
 
+/-- A packed row swap interprets the reference row swap. -/
 theorem Rep.rowSwap {A : Matrix UInt32 n m} {E : Matrix (ZMod64 p) n m}
     (h : Rep A E) (i j : Fin n) :
     Rep (Matrix.rowSwap A i j) (Matrix.rowSwap E i j) := by
   intro r k
   rw [Matrix.getElem_rowSwap, Matrix.getElem_rowSwap]
   by_cases hrj : r = j
-  · simp only [if_pos hrj]; exact h i k
+  · simp only [ite_eq_left hrj]; exact h i k
   · by_cases hri : r = i
-    · simp only [if_neg hrj, if_pos hri]; exact h j k
-    · simp only [if_neg hrj, if_neg hri]; exact h r k
+    · simp only [ite_eq_right hrj, ite_eq_left hri]; exact h j k
+    · simp only [ite_eq_right hrj, ite_eq_right hri]; exact h r k
 
+/-- A packed row scaling by a word representing `γ` interprets the reference
+row scaling by `γ`. -/
 theorem Rep.rowScale {q : UInt32} (hq : q.toNat = p)
     {A : Matrix UInt32 n m} {E : Matrix (ZMod64 p) n m} (h : Rep A E)
     (i : Fin n) {c : UInt32} {γ : ZMod64 p} (hc : c.toNat = γ.toNat) :
@@ -349,10 +385,10 @@ theorem Rep.rowScale {q : UInt32} (hq : q.toNat = p)
   intro r k
   rw [getElem_rowScale, Matrix.getElem_rowScale]
   by_cases hri : r = i
-  · rw [if_pos hri, if_pos hri, toNat_mulMod hq]
+  · rw [ite_eq_left hri, ite_eq_left hri, toNat_mulMod hq]
     show _ = (ZMod64.mul γ E[i][k]).toNat
     rw [ZMod64.toNat_mul, hc, h i k]
-  · rw [if_neg hri, if_neg hri]; exact h r k
+  · rw [ite_eq_right hri, ite_eq_right hri]; exact h r k
 
 /-- A caller-supplied source row that agrees entrywise with row `src` of the
 packed matrix interprets the reference row addition, just as reading the row out
@@ -366,12 +402,14 @@ theorem Rep.rowAddFrom {q : UInt32} (hq : q.toNat = p)
   intro r k
   rw [getElem_rowAddFrom, Matrix.getElem_rowAdd]
   by_cases hrd : r = dst
-  · rw [if_pos hrd, if_pos hrd, hsrc k]
+  · rw [ite_eq_left hrd, ite_eq_left hrd, hsrc k]
     rw [toNat_addMod hq (h.lt dst k) (mulMod_lt hq), toNat_mulMod hq]
     show _ = (ZMod64.add E[dst][k] (ZMod64.mul γ E[src][k])).toNat
     rw [ZMod64.toNat_add, ZMod64.toNat_mul, h dst k, hc, h src k]
-  · rw [if_neg hrd, if_neg hrd]; exact h r k
+  · rw [ite_eq_right hrd, ite_eq_right hrd]; exact h r k
 
+/-- A packed row addition by a word representing `γ` interprets the reference
+row addition by `γ`. -/
 theorem Rep.rowAdd {q : UInt32} (hq : q.toNat = p)
     {A : Matrix UInt32 n m} {E : Matrix (ZMod64 p) n m} (h : Rep A E)
     (src dst : Fin n) {c : UInt32} {γ : ZMod64 p} (hc : c.toNat = γ.toNat) :
@@ -490,18 +528,18 @@ private theorem findPivotAux_eq {A : Matrix UInt32 n m} {E : Matrix (ZMod64 p) n
   | succ fuel ih =>
       unfold findPivotAux Hex.Matrix.findPivotAux
       by_cases hstart : start < n
-      · rw [dif_pos hstart, dif_pos hstart]
+      · rw [dite_eq_left hstart, dite_eq_left hstart]
         have hiff := rep_eq_zero_iff h ⟨start, hstart⟩ col
         show (if (A[((⟨start, hstart⟩ : Fin n), col)] == 0) = true then
               findPivotAux A col (start + 1) fuel else some ⟨start, hstart⟩)
             = (if E[((⟨start, hstart⟩ : Fin n), col)] = 0 then
               Hex.Matrix.findPivotAux E col (start + 1) fuel else some ⟨start, hstart⟩)
         by_cases hA : A[((⟨start, hstart⟩ : Fin n), col)] = 0
-        · rw [if_pos (beq_iff_eq.mpr hA), if_pos (hiff.mp hA)]
+        · rw [ite_eq_left (beq_iff_eq.mpr hA), ite_eq_left (hiff.mp hA)]
           exact ih (start + 1)
-        · rw [if_neg (fun hb => hA (beq_iff_eq.mp hb)),
-            if_neg (fun hE => hA (hiff.mpr hE))]
-      · rw [dif_neg hstart, dif_neg hstart]
+        · rw [ite_eq_right (fun hb => hA (beq_iff_eq.mp hb)),
+            ite_eq_right (fun hE => hA (hiff.mpr hE))]
+      · rw [dite_eq_right hstart, dite_eq_right hstart]
 
 /-- Packed pivot search agrees with the reference pivot search. -/
 private theorem findPivot?_eq {A : Matrix UInt32 n m} {E : Matrix (ZMod64 p) n m}
@@ -527,8 +565,8 @@ private theorem rep_elim_step {q : UInt32} (hq : q.toNat = p)
           if coeff = 0 then st
           else (Matrix.rowAdd st.1 pivotRow j coeff, Matrix.rowAdd st.2 pivotRow j coeff)).1 := by
   by_cases hj : j = pivotRow
-  · rw [if_pos hj, dif_pos hj]; exact h
-  · rw [if_neg hj, dif_neg hj]
+  · rw [ite_eq_left hj, dite_eq_left hj]; exact h
+  · rw [ite_eq_right hj, dite_eq_right hj]
     have hcoeff : (negMod q A[(j, col)]).toNat = (-st.1[(j, col)]).toNat := by
       rw [Matrix.getElem_pair_eq_nested, Matrix.getElem_pair_eq_nested,
         toNat_negMod hq (h.lt j col), h j col]
@@ -545,10 +583,10 @@ private theorem rep_elim_step {q : UInt32} (hq : q.toNat = p)
         rw [hcoeff, hz]
         exact ZMod64.toNat_zero (p := p)
     by_cases hA : negMod q A[(j, col)] = 0
-    · rw [if_pos (beq_iff_eq.mpr hA), if_pos (hiff.mp hA)]
+    · rw [ite_eq_left (beq_iff_eq.mpr hA), ite_eq_left (hiff.mp hA)]
       exact h
-    · rw [if_neg (fun hb => hA (beq_iff_eq.mp hb)),
-        if_neg (fun hE => hA (hiff.mpr hE))]
+    · rw [ite_eq_right (fun hb => hA (beq_iff_eq.mp hb)),
+        ite_eq_right (fun hE => hA (hiff.mpr hE))]
       exact h.rowAddFrom hq pivotRow j hsrc hcoeff
 
 /-- One elimination step leaves the pivot row alone: the step either does
@@ -563,12 +601,12 @@ private theorem elim_step_pivotRow {q : UInt32} (A : Matrix UInt32 n m)
         if c == 0 then A else rowAddFrom q A rsrc j c)[pivotRow][k]
       = A[pivotRow][k] := by
   by_cases hj : j = pivotRow
-  · rw [if_pos hj]
-  · rw [if_neg hj]
+  · rw [ite_eq_left hj]
+  · rw [ite_eq_right hj]
     by_cases hA : negMod q A[(j, col)] = 0
-    · rw [if_pos (beq_iff_eq.mpr hA)]
-    · rw [if_neg (fun hb => hA (beq_iff_eq.mp hb)), getElem_rowAddFrom,
-        if_neg (fun hp => hj hp.symm)]
+    · rw [ite_eq_left (beq_iff_eq.mpr hA)]
+    · rw [ite_eq_right (fun hb => hA (beq_iff_eq.mp hb)), getElem_rowAddFrom,
+        ite_eq_right (fun hp => hj hp.symm)]
 
 omit [ZMod64.PrimeModulus p] in
 /-- The packed column elimination represents the reference column elimination.
@@ -648,11 +686,11 @@ theorem reduceLoop_sim {q : UInt32} (hq : q.toNat = p) :
         · have hfp := findPivot?_eq h ⟨col, hCol⟩ row
           cases hpv : Hex.Matrix.findPivot? E ⟨col, hCol⟩ row with
           | none =>
-              simp only [reduceLoop, Matrix.rowReduceLoop, dif_pos hRow, dif_pos hCol,
+              simp only [reduceLoop, Matrix.rowReduceLoop, dite_eq_left hRow, dite_eq_left hCol,
                 hfp, hpv]
               exact ih (col + 1) row pivots A E T h
           | some pivot =>
-              simp only [reduceLoop, Matrix.rowReduceLoop, dif_pos hRow, dif_pos hCol,
+              simp only [reduceLoop, Matrix.rowReduceLoop, dite_eq_left hRow, dite_eq_left hCol,
                 hfp, hpv]
               have hswap := h.rowSwap (⟨row, hRow⟩ : Fin n) pivot
               have hinv :
@@ -673,9 +711,9 @@ theorem reduceLoop_sim {q : UInt32} (hq : q.toNat = p) :
                       (⟨col, hCol⟩ : Fin m))]⁻¹))
                   (⟨row, hRow⟩ : Fin n) (⟨col, hCol⟩ : Fin m)
               exact ih (col + 1) (row + 1) (pivots.concat (⟨col, hCol⟩ : Fin m)) _ _ _ helim
-        · simp only [reduceLoop, Matrix.rowReduceLoop, dif_pos hRow, dif_neg hCol]
+        · simp only [reduceLoop, Matrix.rowReduceLoop, dite_eq_left hRow, dite_eq_right hCol]
           exact ⟨trivial, trivial, h⟩
-      · simp only [reduceLoop, Matrix.rowReduceLoop, dif_neg hRow]
+      · simp only [reduceLoop, Matrix.rowReduceLoop, dite_eq_right hRow]
         exact ⟨trivial, trivial, h⟩
 
 end Simulation
@@ -777,15 +815,15 @@ private theorem pivotRowOf_drop (D : Matrix.RowEchelonData (ZMod64 p) n m) (j : 
         (List.drop_eq_getElem_cons hlen)
       have hget : D.pivotCols.toList[start] = D.pivotCols.get ⟨start, hlt⟩ := by
         simp [Vector.get]
-      rw [hdrop, hget, pivotRowOf, Matrix.IsRowReduced.pivotIndexAux, dif_pos hlt]
+      rw [hdrop, hget, pivotRowOf, Matrix.IsRowReduced.pivotIndexAux, dite_eq_left hlt]
       show (if D.pivotCols.get ⟨start, hlt⟩ = j then some start
             else pivotRowOf (D.pivotCols.toList.drop (start + 1)) j (start + 1))
           = Option.map Fin.val
               (if D.pivotCols.get ⟨start, hlt⟩ = j then some ⟨start, hlt⟩
                else Matrix.IsRowReduced.pivotIndexAux D j (start + 1) fuel)
       by_cases hc : D.pivotCols.get ⟨start, hlt⟩ = j
-      · rw [if_pos hc, if_pos hc]; rfl
-      · rw [if_neg hc, if_neg hc]
+      · rw [ite_eq_left hc, ite_eq_left hc]; rfl
+      · rw [ite_eq_right hc, ite_eq_right hc]
         exact ih (start + 1) (by omega)
 
 omit [ZMod64.PrimeModulus p] in
@@ -835,14 +873,14 @@ theorem nullspaceArray_eq {q : UInt32} (hq : q.toNat = p)
       Matrix.getElem_pair_eq_nested, Matrix.getElem_ofFn]
     rw [hgetfree]
     by_cases hjf : (⟨j, hj⟩ : Fin m) = hE.toIsEchelonForm.freeCols.get ⟨k, hklt⟩
-    · rw [if_pos hjf, dif_pos hjf]
-    · rw [if_neg hjf, dif_neg hjf, pivotRowOf_eq (Matrix.rowReduce E) ⟨j, hj⟩]
+    · rw [ite_eq_left hjf, dite_eq_left hjf]
+    · rw [ite_eq_right hjf, dite_eq_right hjf, pivotRowOf_eq (Matrix.rowReduce E) ⟨j, hj⟩]
       cases hpi : Matrix.IsRowReduced.pivotIndex? (Matrix.rowReduce E) (⟨j, hj⟩ : Fin m) with
       | none => rfl
       | some i =>
           have hin : i.val < n := Nat.lt_of_lt_of_le i.isLt hrank
           show (if hi : i.val < n then toZMod p (negMod q _) else 0) = _
-          rw [dif_pos hin, toZMod_negMod hq (h.lt _ _), h.toZMod_eq _ _]
+          rw [dite_eq_left hin, toZMod_negMod hq (h.lt _ _), h.toZMod_eq _ _]
           rfl
 
 end Basis

--- a/HexBerlekamp/README.md
+++ b/HexBerlekamp/README.md
@@ -4,12 +4,19 @@ Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
 library for Lean 4. The aim is fast executable code, fully verified, built
 with spec-driven development.
 
-Certified finite-field polynomial factorization and irreducibility testing in
-Lean 4, implemented without Mathlib.
-
-The library provides Rabin irreducibility, distinct-degree factorization, the
-Berlekamp Frobenius matrix and fixed-space kernel, split-step factorization,
-and compact certificates suitable for elaborator-generated proof terms.
+Certified polynomial factorization and irreducibility testing over the prime
+field `F_p`, without Mathlib. The package supplies Rabin's irreducibility
+test, distinct-degree factorization, the Berlekamp Frobenius matrix with its
+fixed-space kernel, split-step factorization, and the `factor_poly` and
+`irreducibility` elaborators that turn a compiled search into a kernel-checked
+proof term. It builds on
+[`hex-poly-fp`](https://github.com/leanprover/hex-poly-fp) for the dense
+`F_p[x]` arithmetic, [`hex-matrix`](https://github.com/leanprover/hex-matrix)
+and [`hex-row-reduce`](https://github.com/leanprover/hex-row-reduce) for the
+kernel computation, and
+[`hex-gfq-ring`](https://github.com/leanprover/hex-gfq-ring) for the quotient
+ring. Statements over Mathlib's `Polynomial (ZMod p)` live in
+[`hex-berlekamp-mathlib`](https://github.com/leanprover/hex-berlekamp-mathlib).
 
 # Quickstart
 
@@ -22,25 +29,102 @@ rev = "main"
 
 ```lean
 import HexBerlekamp
-open Hex
+open Hex Hex.Berlekamp
+
+local instance : ZMod64.Bounds 5 := ⟨by decide, by decide⟩
+local instance : ZMod64.PrimeModulus 5 := ⟨by decide⟩
+
+-- `3 * (x + 1)^2 * (x^2 + 2)` over `F_5`, expanded.
+def f : FpPoly 5 := #p[1, 2, 4, 1, 3]
+
+-- A kernel-checked irreducible factorization, found by compiled search.
+example : True := by
+  obtain ⟨scalar, factors, factors_mul, factors_irred⟩ := factor_poly f
+  trivial
+
+-- Rabin's test; the elaborator emits a certificate the kernel replays.
+theorem irred : FpPoly.Irreducible (#p[2, 0, 1] : FpPoly 5) :=
+  irreducibility (#p[2, 0, 1] : FpPoly 5)
+
+def g : FpPoly 5 := #p[1, 0, 0, 1]
+#eval (berlekampFactor g (by rfl)).factors.length  -- 2
 ```
 
 # Functionality
 
-`factor_poly` and `irreducibility` run search in compiled elaborator code and
-emit checked certificates. The public umbrella contains production APIs only;
-the tactic regression modules are built by the package's dedicated test
-target.
+- `Berlekamp.rabinTest f hmonic` is Rabin's irreducibility test: `f` must be
+  nonconstant, divide `X^(p^n) - X`, and be coprime to `X^(p^d) - X` for every
+  maximal proper divisor `d` of `n = deg f`.
+- `Berlekamp.berlekampMatrix` builds the Frobenius matrix `Q_f` column by
+  column from `powModMonic`, and `Berlekamp.fixedSpaceKernel` returns a basis
+  of the kernel of `Q_f - I`. `Berlekamp.Packed` reimplements the whole
+  reduction over `UInt32` words and connects to the generic development by a
+  `@[csimp]` bridge, so compiled code runs the packed loop while proofs stay
+  on ordinary matrices.
+- `Berlekamp.berlekampFactor f hmonic` returns the complete factorization of a
+  monic input as a `Berlekamp.Factorization`. It takes a root-extraction
+  shortcut when `f` splits completely, and otherwise splits recursively on
+  kernel representatives.
+- `Berlekamp.distinctDegreeFactor f hmonic` separates a monic square-free
+  input into one product per irreducible-factor degree, without building any
+  matrix. `Berlekamp.scoutDegreePattern` answers the cheaper question "how
+  many irreducible factors are there, and of which degrees" and abandons the
+  loop as soon as a caller-supplied factor budget is exceeded.
+- `factor_poly f` elaborates to a `Hex.FpPoly.Factored f`, destructured as
+  `obtain ⟨scalar, factors, factors_mul, factors_irred⟩ := factor_poly f`, and
+  also exists as a tactic. `irreducibility f` elaborates to
+  `Hex.FpPoly.Irreducible f`. Both run the search in compiled elaborator code
+  and emit a certificate that the kernel replays; neither uses
+  `native_decide`.
+- `Berlekamp.IrreducibilityCertificate` is the self-describing certificate
+  data those elaborators emit, checked by
+  `Berlekamp.checkIrreducibilityCertificate`.
+
+The public umbrella contains production APIs only; the tactic regression
+modules are built by the package's dedicated test target.
 
 # Verification
 
+Everything is proved in Lean without Mathlib, and the trust surface contains
+no `axiom`, no `sorry`, and no `native_decide`. Factorization is total and
+product-correct for any monic input:
+
+```lean
+theorem prod_berlekampFactor
+    (f : FpPoly p) (hmonic : DensePoly.Monic f)
+    [ZMod64.PrimeModulus p] :
+    (berlekampFactor f hmonic).product = f
+```
+
+Distinct-degree factorization has the matching product law
+`prod_distinctDegreeFactor`, together with `distinctDegreeFactor_bucket_degree_pos`
+and `distinctDegreeFactor_bucket_matchesFrobeniusDegree`, which say that each
+recorded bucket carries a positive degree and divides the corresponding
+Frobenius difference. Rabin's test is sound against the project-side
+irreducibility predicate,
+
+```lean
+theorem rabinTest_imp_irreducible
+    (f : FpPoly p) (hmonic : DensePoly.Monic f)
+    (hrabin : rabinTest f hmonic = true) :
+    FpPoly.Irreducible f
+```
+
+with `rabinTest_eq_true_iff` restating the Boolean test in theorem-facing
+terms, and `checkIrreducibilityCertificate_rabinTest` tying the certificate
+checker back to it. That chain is what makes an emitted certificate mean
+irreducibility rather than merely "the checker returned `true`".
+
+Irreducibility of the returned factors is stated over Mathlib's `Irreducible`
+predicate in
+[`hex-berlekamp-mathlib`](https://github.com/leanprover/hex-berlekamp-mathlib),
+whose `rabin_irreducible` proves both directions of Rabin's criterion for a
+monic input and whose `fpIsIrreducible_iff` extends it to arbitrary input.
+
 Exact conformance against python-flint is a required release check. FLINT
 timings are informational optimization evidence. The required performance
-checks are the absolute Rabin
-and distinct-degree budgets stated in the [SPEC](SPEC/hex-berlekamp.md).
-
-For statements over Mathlib's `Polynomial (ZMod p)`, use
-[`hex-berlekamp-mathlib`](https://github.com/leanprover/hex-berlekamp-mathlib).
+checks are the absolute Rabin and distinct-degree budgets stated in the
+[SPEC](SPEC/hex-berlekamp.md).
 
 # Contributing
 

--- a/HexBerlekamp/RabinSoundness.lean
+++ b/HexBerlekamp/RabinSoundness.lean
@@ -125,7 +125,7 @@ theorem irreducible_of_no_kernelWitnessSplit_squareFree
     have hlead_zero : (0 : FpPoly p).leadingCoeff = 0 := by
       exact DensePoly.leadingCoeff_zero
     rw [hlead_zero] at hlead
-    exact zmod64_one_ne_zero_local hlead.symm
+    exact ZMod64.one_ne_zero_of_prime (ZMod64.PrimeModulus.prime (p := p)) hlead.symm
   refine ⟨hf_ne_zero, ?_⟩
   intro a₀ b₀ hab
   by_cases ha₀_unit : a₀.degree? = some 0
@@ -459,8 +459,8 @@ private theorem C_add_C (a b : ZMod64 p) :
   rw [DensePoly.coeff_add (DensePoly.C a) (DensePoly.C b) i h0,
       DensePoly.coeff_C, DensePoly.coeff_C, DensePoly.coeff_C]
   by_cases hi : i = 0
-  · rw [if_pos hi, if_pos hi, if_pos hi]
-  · rw [if_neg hi, if_neg hi, if_neg hi]; exact h0
+  · rw [ite_eq_left hi, ite_eq_left hi, ite_eq_left hi]
+  · rw [ite_eq_right hi, ite_eq_right hi, ite_eq_right hi]; exact h0
 
 omit [ZMod64.PrimeModulus p] in
 /-- The `i`-th coefficient of `q * C c` is `q.coeff i * c`. -/
@@ -843,7 +843,7 @@ theorem irreducible_of_no_kernelWitnessSplit_squareFree_of_dvd
     have hlead_zero : (0 : FpPoly p).leadingCoeff = 0 := by
       exact DensePoly.leadingCoeff_zero
     rw [hlead_zero] at hlead
-    exact zmod64_one_ne_zero_local hlead.symm
+    exact ZMod64.one_ne_zero_of_prime (ZMod64.PrimeModulus.prime (p := p)) hlead.symm
   have hg_ne_zero : g ≠ 0 := by
     intro hzero
     have hlead : g.leadingCoeff = 1 := hg_monic
@@ -851,7 +851,7 @@ theorem irreducible_of_no_kernelWitnessSplit_squareFree_of_dvd
     have hlead_zero : (0 : FpPoly p).leadingCoeff = 0 := by
       exact DensePoly.leadingCoeff_zero
     rw [hlead_zero] at hlead
-    exact zmod64_one_ne_zero_local hlead.symm
+    exact ZMod64.one_ne_zero_of_prime (ZMod64.PrimeModulus.prime (p := p)) hlead.symm
   refine ⟨hg_ne_zero, ?_⟩
   intro a₀ b₀ hab
   by_cases ha₀_unit : a₀.degree? = some 0

--- a/HexBerlekamp/RabinSoundness/RabinCore.lean
+++ b/HexBerlekamp/RabinSoundness/RabinCore.lean
@@ -89,8 +89,9 @@ theorem primeFieldLinearFactor_dvd_primeFieldLinearProduct (c : ZMod64 p) :
   exact primeFieldLinearFactor_dvd_foldl_of_mem c (ZMod64.values p) 1
     (ZMod64.mem_values c)
 
-/-- The canonical product has one listed linear factor for each residue. -/
-@[simp, grind =] theorem primeFieldLinearProduct_factor_count :
+/-- The canonical product has one listed linear factor for each residue.
+Not `@[simp]`: `simp` already closes it from `ZMod64.values_length`. -/
+theorem primeFieldLinearProduct_factor_count :
     (ZMod64.values p).length = p :=
   ZMod64.values_length (p := p)
 
@@ -246,23 +247,11 @@ private theorem congr_of_congr_mul_right
         _ = (b * a) * r := by rw [FpPoly.mul_comm a b]
         _ = b * (a * r) := FpPoly.mul_assoc b a r
 
-private theorem zmod64_one_ne_zero_of_prime [ZMod64.PrimeModulus p] :
-    (1 : ZMod64 p) ≠ (0 : ZMod64 p) := by
-  intro h
-  have h2 : 2 ≤ p := Hex.Nat.Prime.two_le (ZMod64.PrimeModulus.prime (p := p))
-  have htoNat : (1 : ZMod64 p).toNat = (0 : ZMod64 p).toNat :=
-    congrArg ZMod64.toNat h
-  rw [show ((1 : ZMod64 p).toNat) = 1 % p from ZMod64.toNat_one,
-      show ((0 : ZMod64 p).toNat) = 0 from ZMod64.toNat_zero,
-      Nat.mod_eq_of_lt (by omega : 1 < p)] at htoNat
-  exact absurd htoNat (by omega)
-
 private theorem constant_eq_zero_of_mod_eq_zero
-    [ZMod64.PrimeModulus p] {a : FpPoly p} {c : ZMod64 p}
+    {a : FpPoly p} {c : ZMod64 p}
     (ha_pos : 0 < a.degree?.getD 0)
     (hmod : (DensePoly.C c : FpPoly p) % a = (0 : FpPoly p) % a) :
     c = 0 := by
-  haveI : DensePoly.DivModLaws (ZMod64 p) := ZMod64.instDivModLawsZMod64Fp p
   have hC : (DensePoly.C c : FpPoly p) % a = DensePoly.C c := by
     apply DensePoly.mod_eq_self_of_degree_lt
     rw [DensePoly.degree?_C_getD]
@@ -272,15 +261,14 @@ private theorem constant_eq_zero_of_mod_eq_zero
   have hpoly : (DensePoly.C c : FpPoly p) = 0 := by
     simpa [hC, hzero] using hmod
   have hcoeff := congrArg (fun q : FpPoly p => q.coeff 0) hpoly
-  simp only [DensePoly.coeff_C, DensePoly.coeff_zero, if_pos] at hcoeff
+  simp only [DensePoly.coeff_C, DensePoly.coeff_zero, ite_eq_left] at hcoeff
   exact hcoeff
 
 private theorem constant_eq_one_of_mod_eq_one
-    [ZMod64.PrimeModulus p] {b : FpPoly p} {c : ZMod64 p}
+    {b : FpPoly p} {c : ZMod64 p}
     (hb_pos : 0 < b.degree?.getD 0)
     (hmod : (DensePoly.C c : FpPoly p) % b = (1 : FpPoly p) % b) :
     c = 1 := by
-  haveI : DensePoly.DivModLaws (ZMod64 p) := ZMod64.instDivModLawsZMod64Fp p
   have hC : (DensePoly.C c : FpPoly p) % b = DensePoly.C c := by
     apply DensePoly.mod_eq_self_of_degree_lt
     rw [DensePoly.degree?_C_getD]
@@ -331,7 +319,7 @@ theorem crtZeroOneCandidate_not_congr_constant_mod_product
     apply constant_eq_one_of_mod_eq_one (b := b) hb_pos
     exact hconst_right.symm.trans
       (crtZeroOneCandidate_mod_one_right a b s t hb hbez)
-  exact zmod64_one_ne_zero_of_prime (hc_one.symm.trans hc_zero)
+  exact ZMod64.one_ne_zero_of_prime (ZMod64.PrimeModulus.prime (p := p)) (hc_one.symm.trans hc_zero)
 
 /-- XGCD-backed specialization of `crtZeroOneCandidate_not_congr_constant_mod_product`. -/
 theorem crtZeroOneXGCDCandidate_not_congr_constant_mod_product
@@ -868,18 +856,6 @@ theorem ne_zero_of_pos_degree
   simp at hpos
 
 omit [ZMod64.PrimeModulus p] in
-private theorem zmod64_one_ne_zero_local [ZMod64.PrimeModulus p] :
-    (1 : ZMod64 p) ≠ (0 : ZMod64 p) := by
-  intro h
-  have h2 : 2 ≤ p := Hex.Nat.Prime.two_le (ZMod64.PrimeModulus.prime (p := p))
-  have htoNat : (1 : ZMod64 p).toNat = (0 : ZMod64 p).toNat :=
-    congrArg ZMod64.toNat h
-  rw [show ((1 : ZMod64 p).toNat) = 1 % p from ZMod64.toNat_one,
-      show ((0 : ZMod64 p).toNat) = 0 from ZMod64.toNat_zero,
-      Nat.mod_eq_of_lt (by omega : 1 < p)] at htoNat
-  exact absurd htoNat (by omega)
-
-omit [ZMod64.PrimeModulus p] in
 private theorem inv_leadingCoeff_ne_zero_of_pos_degree [ZMod64.PrimeModulus p]
     (a : FpPoly p) (ha_pos : 0 < a.degree?.getD 0) :
     (DensePoly.leadingCoeff a)⁻¹ ≠ (0 : ZMod64 p) := by
@@ -891,7 +867,7 @@ private theorem inv_leadingCoeff_ne_zero_of_pos_degree [ZMod64.PrimeModulus p]
   rw [hinv] at hone
   have hzero : (0 : ZMod64 p) * DensePoly.leadingCoeff a = 0 := by grind
   rw [hzero] at hone
-  exact zmod64_one_ne_zero_local hone.symm
+  exact ZMod64.one_ne_zero_of_prime (ZMod64.PrimeModulus.prime (p := p)) hone.symm
 
 omit [ZMod64.PrimeModulus p] in
 private theorem factor_ne_zero_of_ne_zero_local
@@ -1243,14 +1219,6 @@ private theorem lt_of_mem_properDivisors {n d : Nat}
   simp only [List.mem_filter, List.mem_map, List.mem_range,
     decide_eq_true_eq] at hmem
   rcases hmem with ⟨⟨k, hk, rfl⟩, _⟩
-  omega
-
-private theorem pos_of_mem_properDivisors {n d : Nat}
-    (hmem : d ∈ properDivisors n) : 0 < d := by
-  unfold properDivisors at hmem
-  simp only [List.mem_filter, List.mem_map, List.mem_range,
-    decide_eq_true_eq] at hmem
-  rcases hmem with ⟨⟨k, _, rfl⟩, _⟩
   omega
 
 private theorem dvd_of_mem_properDivisors {n d : Nat}

--- a/HexBerlekamp/RabinSoundness/RabinShape.lean
+++ b/HexBerlekamp/RabinSoundness/RabinShape.lean
@@ -116,7 +116,7 @@ private theorem xPowSubX_one_coeff_high {n : Nat} (hn : p < n) :
 theorem xPowSubX_one_size : (xPowSubX (p := p) 1).size = p + 1 := by
   have h_coeff_p_ne : (xPowSubX (p := p) 1).coeff p ≠ 0 := by
     rw [xPowSubX_one_coeff_p]
-    exact zmod64_one_ne_zero_of_prime
+    exact ZMod64.one_ne_zero_of_prime (ZMod64.PrimeModulus.prime (p := p))
   have h_lower : p + 1 ≤ (xPowSubX (p := p) 1).size := by
     apply Classical.byContradiction
     intro h
@@ -206,7 +206,7 @@ theorem primeFieldProduct_X_eq_xPowSubX :
       intro h
       have h_coeff_p_ne : (xPowSubX (p := p) 1).coeff p ≠ 0 := by
         rw [xPowSubX_one_coeff_p]
-        exact zmod64_one_ne_zero_of_prime
+        exact ZMod64.one_ne_zero_of_prime (ZMod64.PrimeModulus.prime (p := p))
       apply h_coeff_p_ne
       rw [h]
       exact DensePoly.coeff_zero p)
@@ -305,7 +305,7 @@ divisor, and contradicting the gcd leg) lives here. The heavy
 mathematical content (Rabin's degree theorem in both directions,
 finite-field factor existence, the absolute–modular Frobenius identity,
 and the `xPowSubX` divisibility chain) is delegated to the foundational
-sorries above.
+lemmas above and in `RabinCore`.
 -/
 theorem rabinTest_imp_irreducible
     (f : FpPoly p) (hmonic : DensePoly.Monic f)

--- a/HexBerlekampZassenhausMathlib/Modular/FactorCoprimality.lean
+++ b/HexBerlekampZassenhausMathlib/Modular/FactorCoprimality.lean
@@ -27,21 +27,15 @@ noncomputable section
 
 open Polynomial
 
-/-- The Berlekamp factor product is multiplicative over list concatenation.
-Local restatement of the (private) `Hex.Berlekamp.factorProduct_append`, needed
-to relate the balanced-split halves `L`, `R` back to the whole list. -/
+/-- The Berlekamp factor product is multiplicative over list concatenation,
+relating the balanced-split halves `L`, `R` back to the whole list. Alias for
+the public `Hex.Berlekamp.factorProduct_append`. -/
 private theorem factorProduct_append
     {p : Nat} [Hex.ZMod64.Bounds p] [Hex.ZMod64.PrimeModulus p]
     (xs ys : List (Hex.FpPoly p)) :
     Hex.Berlekamp.factorProduct (xs ++ ys) =
-      Hex.Berlekamp.factorProduct xs * Hex.Berlekamp.factorProduct ys := by
-  induction xs with
-  | nil =>
-      rw [List.nil_append, Hex.Berlekamp.factorProduct_nil, Hex.FpPoly.one_mul]
-  | cons x rest ih =>
-      rw [List.cons_append, Hex.Berlekamp.factorProduct_cons,
-        Hex.Berlekamp.factorProduct_cons, ih]
-      exact (Hex.DensePoly.mul_assoc_poly x _ _).symm
+      Hex.Berlekamp.factorProduct xs * Hex.Berlekamp.factorProduct ys :=
+  Hex.Berlekamp.factorProduct_append xs ys
 
 /-- Generalized inductive helper for the `factorsModP_coprime` discharger.
 

--- a/libraries.yml
+++ b/libraries.yml
@@ -530,7 +530,7 @@ libraries:
   HexBerlekamp:
     deps: [HexPolyFp, HexMatrix, HexRowReduce, HexGFqRing, HexBasic]
     mathlib: false
-    done_through: 5
+    done_through: 6
     status: active
     phase4:
       comparators:

--- a/libraries.yml
+++ b/libraries.yml
@@ -530,7 +530,7 @@ libraries:
   HexBerlekamp:
     deps: [HexPolyFp, HexMatrix, HexRowReduce, HexGFqRing, HexBasic]
     mathlib: false
-    done_through: 4
+    done_through: 5
     status: active
     phase4:
       comparators:

--- a/libraries.yml
+++ b/libraries.yml
@@ -530,7 +530,7 @@ libraries:
   HexBerlekamp:
     deps: [HexPolyFp, HexMatrix, HexRowReduce, HexGFqRing, HexBasic]
     mathlib: false
-    done_through: 6
+    done_through: 7
     status: active
     phase4:
       comparators:

--- a/progress/20260825T000000Z_berlekamp-phases-5-7.md
+++ b/progress/20260825T000000Z_berlekamp-phases-5-7.md
@@ -1,0 +1,83 @@
+# HexBerlekamp: Phases 5, 6, 7
+
+## Accomplished
+
+`libraries.yml[HexBerlekamp].done_through` advanced 4 -> 7 in three
+commits on `berlekamp-phases-5-7`, one per phase.
+
+**Phase 5** (`chore(berlekamp): record Phase 5 completion`). Verification
+only, no source change. Zero `sorry`/`axiom`/`native_decide` across the
+19 modules; `lake build HexBerlekamp` green on
+`leanprover/lean4:v4.34.0-rc2`; `HexBerlekamp.Conformance` and
+`HexBerlekamp.FactorTacticTests` elaborate their `#guard`s; no open
+bench-found or conformance-found issue targets the library (the only open
+issue matching `HexBerlekamp` is #9425, a `check_dag.py` tooling issue).
+
+**Phase 6** (`polish(berlekamp): complete Phase 6`). The Mathlib linter
+audit ran from a throwaway file *outside* the library (the library is
+Mathlib-free, so it cannot carry a `LintTests` module the way `HexRCF`
+does) importing `HexBerlekamp` plus Batteries' linter framework and
+running `#lint- docBlame docBlameThm' in HexBerlekamp`. 22 hits at the
+start, 0 at the end:
+
+- 5 `docBlame` + 1 `docBlameThm'` -> docstrings.
+- 3 `simpNF` -> `@[simp]` dropped from `degreeBucketProduct_singleton`,
+  `primeFieldLinearProduct_factor_count`, and `Packed.toNat_toZMod`, with
+  the reason recorded in each docstring. Names kept.
+- 13 `unusedArguments` -> 14 dead `[ZMod64.PrimeModulus p]` binders and
+  the unused `[ZMod64.Bounds p]` of `Packed.modWord` removed. `Bounds` is
+  a `Prop` class, so `modWord` compiles identically. Removing the binders
+  cascaded: each round exposed the next lemma whose binder had only been
+  kept alive by a now-deleted user, so the sweep iterated to a fixpoint.
+
+Also: docstrings for every public declaration in the umbrella (the gap
+was `PackedKernel`, one `Factor` lemma, and the `@[csimp]` bridge in
+`DelayedKernel`); two genuinely dead private helpers removed; five
+verbatim copies of `1 != 0 in ZMod64 p` and two copies of the
+`factorProduct` cons/append laws collapsed onto the public upstream names;
+and all 97 Lean-4.34 `if_pos`/`dif_neg`/... deprecation warnings renamed
+to the `ite_eq_*`/`dite_eq_*` aliases, leaving a warning-free build.
+
+A stale `RabinShape` docstring describing the soundness proof as
+delegating to "foundational sorries" was corrected; the library has none.
+
+**Phase 7** (`doc(berlekamp): complete Phase 7`). The chapter and the
+anchored `AESModulus` tutorial already satisfied `check_phase7.py` and
+`check_manual_split.py` with the counter at 7. The real gap was
+`HexBerlekamp/README.md`, which had the five required headings but a
+two-line quickstart. Rewritten to the `SPEC/readme.md` shape, with a
+20-line quickstart build-checked as a temporary module in
+`HexReleaseTests` and two headline theorem signatures quoted verbatim.
+
+## Current frontier
+
+All checkers pass: `check_dag`, `check_phase4`, `check_phase7`,
+`check_file_line_counts`, `check_copyright_headers`,
+`check_manual_split`, `check_released_manifest`, `check_trust_surface`,
+`check_factor_sweep_freshness`. Green builds: `HexBerlekamp`,
+`HexBerlekamp.Conformance`, `HexReleaseTests`, `HexConway`,
+`HexGFqField`, `HexBerlekampMathlib`, `HexBerlekampZassenhaus`,
+`HexManual`. `hexberlekamp_bench verify` reproduces all 26 Lean
+registrations.
+
+13 blob-transition entries were appended to
+`scripts/bench/proof_only_runtime_exemptions.json` (12 `.lean` files, one
+of them refreshed after a later docstring fix) against the recorded
+`hex-factor` measurement commit `7425e083`. No executable factorization
+code changed.
+
+## Next step
+
+The branch is unpushed and has no PR. `origin/main` advanced by four
+commits while this ran, so a rebase is needed before opening one.
+
+The same Lean-4.34 `if_pos`/`dif_neg` deprecation wave is still live in
+other libraries (`HexMatrix/ElementaryAlgebra.lean`, `HexPolyFp/Compose.lean`,
+`HexConway/Api.lean`, `HexGF2Mathlib/Basic.lean`,
+`HexNumberFieldMathlib/Lazy.lean`, ...). The rename is mechanical and
+warning-only; it belongs with each library's own Phase 6 rather than in
+this one.
+
+## Blockers
+
+None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -1324,5 +1324,77 @@
     "baseline_blob": "8088a21c35f5bb60ea8cc0d9f5b5eb2d32a77265",
     "current_blob": "67864822cc40d953e1324bc2f4224ab6d6f24e89",
     "reason": "Extends the shared PARI bench driver helper with the number-field polmod/nffactor codec surface; it remains bench-oracle infrastructure never imported by the factorization service or any Hex library module."
+  },
+  {
+    "path": "HexBerlekamp/BerlekampMatrix.lean",
+    "baseline_blob": "2ce2ddd1a12dc0af8f368c77bb257e4a24738ec0",
+    "current_blob": "04bc056e0cf45ae4cae0fccc9d05b643914594cc",
+    "reason": "Phase 6 polish only: renames the deprecated core `dif_pos`/`dif_neg` rewrites to `dite_eq_left`/`dite_eq_right` (drop-in aliases of the same statements) and drops three unused `[ZMod64.PrimeModulus p]` instance binders from proof-only lemmas. `berlekampMatrix`, `berlekampColumn`, `frobeniusDiffMod`, and every other executable definition in the file are unchanged."
+  },
+  {
+    "path": "HexBerlekamp/DelayedKernel.lean",
+    "baseline_blob": "772cd3048ddb0550ed59d3c9f6ed3b17fe0b50fe",
+    "current_blob": "c17e430d7bd078519cfaea928e3a3f6f4e84e7c0",
+    "reason": "Phase 6 polish only: renames the deprecated `if_pos`/`if_neg`/`dif_pos`/`dif_neg` rewrites to their `ite_eq_*`/`dite_eq_*` aliases inside proofs and adds a docstring to the `@[csimp]` lemma `delayedDot_eq_impl`. `delayedDot`, `delayedDotImpl`, `barrettBaseMul`, `strassenBarrett`, and the Barrett accumulator loop are unchanged, so the compiled dot-product path is identical."
+  },
+  {
+    "path": "HexBerlekamp/DistinctDegree.lean",
+    "baseline_blob": "5dcbf473b634ffff65e4f007025362b8e876a347",
+    "current_blob": "445d82bd0b7b0785e5db88650f372b44ad1e804d",
+    "reason": "Phase 6 polish only: removes duplicate private proofs (`factorProduct_cons_eq`, `factorProduct_append`, `zmod_one_ne_zero_local`) in favour of the public `Hex.Berlekamp.factorProduct_cons`/`factorProduct_append` and the upstream `Hex.ZMod64.one_ne_zero_of_prime`, deletes the unreferenced private lemma `distinctDegreeCandidate_mul_div_eq`, drops unused `[ZMod64.PrimeModulus p]` binders, and demotes the simp-redundant `degreeBucketProduct_singleton` to a plain theorem. `distinctDegreeFactor`, `distinctDegreeLoop`, `finishDegreePower`, `distinctDegreeCandidate`, and `scoutDegreePattern` are unchanged."
+  },
+  {
+    "path": "HexBerlekamp/Factor.lean",
+    "baseline_blob": "e44d43f86ae80274f35478a3246196fe092bd06c",
+    "current_blob": "672da4ddcb29bb8387a087b4cb1d92eeb1434875",
+    "reason": "Phase 6 polish only: renames the deprecated `if_pos`/`if_neg`/`if_false` rewrites to their `ite_*` aliases, promotes the private `factorProduct_append` to public so the duplicate copy in DistinctDegree could be deleted, drops unused `[ZMod64.PrimeModulus p]` binders from proof-only lemmas, and documents `kernelWitnessSplit_factor_pos_degree`. `berlekampFactor`, `fpFactorSearch`, `splitFactorAt`, `kernelWitnessSplit?`, and the split loops are unchanged."
+  },
+  {
+    "path": "HexBerlekamp/FactorPolyElab.lean",
+    "baseline_blob": "c9d914971f41cd52e9c4a5f6d4635fc5ce688d87",
+    "current_blob": "dd813f31f9277710e2bb3de58de2d1171717901a",
+    "reason": "Phase 6 documentation only: adds docstrings to the `factor_poly` term and tactic elaborators. No elaborator logic, reified certificate shape, or kernel check changes, and the file contains no factorization runtime code."
+  },
+  {
+    "path": "HexBerlekamp/Irreducibility.lean",
+    "baseline_blob": "de4103699a6ad204c72ad32395c3496deb960a7a",
+    "current_blob": "ec58158b56e1bac08a219f7f054c74cce98501db",
+    "reason": "Phase 6 polish only: renames a deprecated `if_true` rewrite to `ite_true`, replaces the private `zmod64_one_ne_zero_of_prime` with the upstream public `Hex.ZMod64.one_ne_zero_of_prime`, and documents the `bounds` instance field of `IrreducibilityCertificate`. `rabinTest`, `rabinDividesTest`, `berlekampRankTest`, the certificate checkers, and the certificate structure layout are unchanged."
+  },
+  {
+    "path": "HexBerlekamp/IrreducibilityElab.lean",
+    "baseline_blob": "48bcd76b1f8387493490a99e2997697688c7b5d2",
+    "current_blob": "16e3e61a3fbe2da597b3d27e180078b9ba6dfc91",
+    "reason": "Phase 6 documentation only: adds docstrings to the `irreducibility` term and tactic elaborators. No elaborator logic or emitted proof term changes, and the file contains no factorization runtime code."
+  },
+  {
+    "path": "HexBerlekamp/LinearFactors.lean",
+    "baseline_blob": "b5e563464f7279455eb19eefb395e5b7a13449c2",
+    "current_blob": "571b9760528a9304fedb73242baaaefe3226c80a",
+    "reason": "Phase 6 polish only: replaces the private `zmod64_one_ne_zero_of_prime` with the upstream public `Hex.ZMod64.one_ne_zero_of_prime` and drops an unused `[ZMod64.PrimeModulus p]` binder from a proof-only lemma. `primeFieldLinearFactor`, `rootsIn`, and the reconstruction folds are unchanged."
+  },
+  {
+    "path": "HexBerlekamp/PackedKernel.lean",
+    "baseline_blob": "20a0ca089f1946b5c0d31266e501325d77747ab8",
+    "current_blob": "806ed31de287bd0d5f9fe2fb0684c98cd4b38564",
+    "reason": "Phase 6 polish only: renames the deprecated `if_pos`/`if_neg`/`dif_pos`/`dif_neg` rewrites to their `ite_eq_*`/`dite_eq_*` aliases inside proofs, adds docstrings to the packed-word arithmetic and `Rep` lemmas, and demotes the non-simp-normal `toNat_toZMod` to a plain theorem. The only signature change is dropping the unused `[ZMod64.Bounds p]` argument of `modWord`; `ZMod64.Bounds` is a `Prop` class, so it is compiler-erased and `modWord` generates identical code. `mulMod`, `addMod`, `negMod`, `invMod`, the packed row operations, `reduce`, `kernelArray`, and the `@[csimp]` `fixedSpaceKernelVectors_eq_packed` bridge are unchanged."
+  },
+  {
+    "path": "HexBerlekamp/RabinSoundness.lean",
+    "baseline_blob": "f4d64573fbfb65030ed70c5c72fe8a6812ffc60b",
+    "current_blob": "ff9f168135b562eebc899e966737cbf23dbd14cc",
+    "reason": "Phase 6 polish only: renames the deprecated `if_pos`/`if_neg` rewrites to `ite_eq_left`/`ite_eq_right` and repoints three uses of a deleted private `1 != 0` helper at the upstream public `Hex.ZMod64.one_ne_zero_of_prime`. The file is proofs only; it declares no executable factorization code."
+  },
+  {
+    "path": "HexBerlekamp/RabinSoundness/RabinCore.lean",
+    "baseline_blob": "023f2fe8a19519addb945ad8e3fe88064c333375",
+    "current_blob": "21a9b51389ee87077860e7ffb1b763360c6e813a",
+    "reason": "Phase 6 polish only: renames a deprecated `if_pos` rewrite to `ite_eq_left`, deletes the two duplicate private `1 != 0` helpers in favour of the upstream public `Hex.ZMod64.one_ne_zero_of_prime`, removes the unreferenced private lemma `pos_of_mem_properDivisors`, drops two dead `haveI` lines and the `[ZMod64.PrimeModulus p]` binders they were the only consumers of, and demotes the simp-redundant `primeFieldLinearProduct_factor_count` to a plain theorem. `xPowSubX`, `primeFieldLinearProduct`, the `crtZeroOne*` candidates, and every executable definition are unchanged."
+  },
+  {
+    "path": "HexBerlekamp/RabinSoundness/RabinShape.lean",
+    "baseline_blob": "345ed80958ca9720416f70cdc9e22263f9e9f098",
+    "current_blob": "cc2e8fca3a3a35c1b3b31f1dde1bd53f20bfa44f",
+    "reason": "Phase 6 polish only: repoints two uses of a deleted private `1 != 0` helper at the upstream public `Hex.ZMod64.one_ne_zero_of_prime`, and corrects a stale docstring that still described the soundness proof as delegating to sorries. The file is proofs only; it declares no executable factorization code."
   }
 ]


### PR DESCRIPTION
This PR advance `libraries.yml[HexBerlekamp].done_through` from 4 to 7 in one commit per phase. Phase 5 records the exit criteria with no source change: the library has zero `sorry`, `axiom`, and `native_decide` occurrences, builds green on the pinned toolchain, and its conformance and tactic-regression modules still elaborate. Phase 6 brings the Mathlib linter to clean, audited from a throwaway file outside the library since a Mathlib-free library cannot carry a `LintTests` module, fixing all 22 hits structurally rather than with `@[nolint]`, which Mathlib-free modules cannot use: docstrings for the four `factor_poly`/`irreducibility` elaborators and the `IrreducibilityCertificate.bounds` field, `@[simp]` dropped from three lemmas `simp` already closes or whose left-hand side is not simp-normal, and fifteen dead instance binders removed along with the two dead `haveI` lines that were their only consumers. It also completes docstring coverage over the public umbrella, removes two unreferenced private helpers while keeping the simp-family and public-API members that a reachability sweep flags, collapses seven duplicate private proofs onto their public upstream names (`HexBerlekampZassenhausMathlib`'s local `factorProduct_append` restatement becomes an alias of the now-public upstream theorem), corrects a stale docstring that described the Rabin soundness proof as delegating to sorries, and renames the 97 retired `if_pos`/`dif_neg`-family aliases so the library builds warning-free. Phase 7 rewrites `HexBerlekamp/README.md` to the shape `SPEC/readme.md` specifies, with a twenty-line quickstart build-checked against the monorepo and the `prod_berlekampFactor` and `rabinTest_imp_irreducible` signatures quoted from source; the reference chapter and the anchored AES-modulus tutorial already satisfied the Phase 7 checkers. Every edited `.lean` file carries an exact blob-transition entry in the proof-only runtime exemptions, since no executable factorization code changed.

🤖 Prepared with Claude Code
