### PR TITLE
HexNumberField pair: Phase-6 cleanups from the Phase-2 review

### DIFF
--- a/HexNumberField/AlgebraicPoly.lean
+++ b/HexNumberField/AlgebraicPoly.lean
@@ -127,8 +127,9 @@ private def sqrtTwo? : Option AlgebraicNumber :=
     | some sqrtTwo =>
         let z := AlgebraicNumber.zero
         let f := ofArray #[z, sqrtTwo, z]
+        let g := ofArray #[z, sqrtTwo, z, z]
         !f.isZero && f.size = 2 && f.degree? = some 1 &&
-          (f.coeff 1 == sqrtTwo)
+          (f.coeff 1 == sqrtTwo) && f == g
     | none => false
 
 end AlgebraicPoly

--- a/HexNumberField/AlgebraicPoly.lean
+++ b/HexNumberField/AlgebraicPoly.lean
@@ -93,6 +93,24 @@ instance : BEq AlgebraicPoly := ⟨beq⟩
 
 /-! Compiled semantic-normalization checks. -/
 
+private def sqrtTwoPoly : ZPoly := DensePoly.ofList [-2, 0, 1]
+
+private def sqrtTwoSquare : DyadicSquare :=
+  ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
+
+private def sqrtTwoRep : RefinedIsolation sqrtTwoPoly :=
+  ⟨⟨sqrtTwoSquare, .ofWitness (by decide)⟩, by decide⟩
+
+private def sqrtTwo? : Option AlgebraicNumber :=
+  if hirred : ZPoly.isIrreducible sqrtTwoPoly = true then
+    if hsimple : HasOnlySimpleRoots sqrtTwoPoly then
+      AlgebraicNumber.ofNormalized? sqrtTwoPoly (by rfl) (by decide)
+        (by decide) ⟨hirred, by decide⟩ hsimple sqrtTwoRep
+    else
+      none
+  else
+    none
+
 #guard
     let z := AlgebraicNumber.zero
     let f := ofArray #[z, z, z]
@@ -103,6 +121,15 @@ instance : BEq AlgebraicPoly := ⟨beq⟩
     let f := ofArray #[]
     let g := ofArray #[z]
     f == g && (f.coeff 17).isZero
+
+#guard
+    match sqrtTwo? with
+    | some sqrtTwo =>
+        let z := AlgebraicNumber.zero
+        let f := ofArray #[z, sqrtTwo, z]
+        !f.isZero && f.size = 2 && f.degree? = some 1 &&
+          (f.coeff 1 == sqrtTwo)
+    | none => false
 
 end AlgebraicPoly
 end Hex

--- a/HexNumberField/Convert.lean
+++ b/HexNumberField/Convert.lean
@@ -192,17 +192,6 @@ variable {p : ZPoly} {x : SimpleRoot p}
 
 /-! # Fixed-presentation minimal polynomials -/
 
-/-- Matrix of multiplication by `a` in the power basis
-`1, X, ..., X^(degree p - 1)`. -/
-@[expose]
-def mulMatrix (a : QAdjoin p x) :
-    Matrix Rat (p.degree?.getD 0) (p.degree?.getD 0) :=
-  let n := p.degree?.getD 0
-  let products : Vector (QAdjoin p x) n := Vector.ofFn fun j =>
-    a * reduce p x (DensePoly.monomial j.val 1)
-  Matrix.ofFn fun i j =>
-    products[j].coeffs.coeff i.val
-
 /-- The first `n + 1` Krylov powers, built with one multiplication per step. -/
 @[expose]
 def krylovPowers (a : QAdjoin p x) :

--- a/HexNumberField/QAdjoin.lean
+++ b/HexNumberField/QAdjoin.lean
@@ -224,7 +224,9 @@ example : LawfulBEq (QAdjoin sqrtTwoPoly sqrtTwoRoot) := inferInstance
       let x : QAdjoin sqrtTwoPoly sqrtTwoRoot :=
         reduce sqrtTwoPoly sqrtTwoRoot xPoly
       x * x⁻¹ = 1 && x / x = 1 &&
-        (0 : QAdjoin sqrtTwoPoly sqrtTwoRoot)⁻¹ = 0
+        (0 : QAdjoin sqrtTwoPoly sqrtTwoRoot)⁻¹ = 0 &&
+        x ^ (5 : Nat) = (4 : Rat) • x &&
+        x ^ (6 : Nat) = (8 : Rat) • 1
     else
       false
 

--- a/HexNumberField/QAdjoin.lean
+++ b/HexNumberField/QAdjoin.lean
@@ -133,12 +133,17 @@ def div [ZPoly.CheckedIrreducible p] (a b : QAdjoin p x) : QAdjoin p x :=
 
 instance [ZPoly.CheckedIrreducible p] : Div (QAdjoin p x) := ⟨div⟩
 
-/-- Natural powers assembled from executable fixed-presentation
+/-- Natural powers by repeated squaring using executable fixed-presentation
 multiplication. -/
 @[expose]
 def natPow (a : QAdjoin p x) : Nat → QAdjoin p x
   | 0 => 1
-  | n + 1 => natPow a n * a
+  | n + 1 =>
+      let q := natPow a ((n + 1) / 2)
+      let q2 := q * q
+      if (n + 1) % 2 = 0 then q2 else q2 * a
+termination_by n => n
+decreasing_by omega
 
 instance : Pow (QAdjoin p x) Nat := ⟨natPow⟩
 

--- a/HexNumberField/Roots.lean
+++ b/HexNumberField/Roots.lean
@@ -397,19 +397,8 @@ def extendShift? (theta alpha : AlgebraicNumber) : Option ShiftCandidate := do
 primitive-element search. The maximum-degree candidate generates the
 compositum even when the two fields overlap. -/
 @[expose]
-def extend? (theta alpha : AlgebraicNumber) : Option AlgebraicNumber := do
-  let upper := degree theta * degree alpha
-  let count := Nat.choose upper 2 + 1
-  let best ← (List.range count).foldlM
-    (fun best k => do
-      let candidate ← shift? theta alpha (signedShift k)
-      some <| match best with
-      | none => some candidate
-      | some current =>
-          if degree current < degree candidate then some candidate
-          else some current)
-    (none : Option AlgebraicNumber)
-  best
+def extend? (theta alpha : AlgebraicNumber) : Option AlgebraicNumber :=
+  (extendShift? theta alpha).map ShiftCandidate.value
 
 /-- Bounded primitive element for all nonzero coefficients. -/
 @[expose]

--- a/HexNumberField/SPEC/hex-number-field.md
+++ b/HexNumberField/SPEC/hex-number-field.md
@@ -103,6 +103,10 @@ inductive RootSet where
 /-- A polynomial with canonical algebraic coefficients. The constructor trims
     trailing coefficients using semantic `AlgebraicNumber.isZero`. -/
 opaque AlgebraicPoly
+def AlgebraicPolyNormalized (coeffs : Array AlgebraicNumber) : Prop
+def AlgebraicPoly.data (f : AlgebraicPoly) : Array AlgebraicNumber
+def AlgebraicPoly.normalized (f : AlgebraicPoly) :
+    AlgebraicPolyNormalized f.data
 def AlgebraicPoly.ofArray (coeffs : Array AlgebraicNumber) : AlgebraicPoly
 def AlgebraicPoly.coeffs (f : AlgebraicPoly) : Array AlgebraicNumber
 def AlgebraicPoly.coeff (f : AlgebraicPoly) (n : Nat) : AlgebraicNumber
@@ -145,9 +149,8 @@ of represented complex values. `AlgebraicPoly` owns the required semantic
 trimming without exporting an unjustified `DecidableEq`. That Boolean
 operation is `AlgebraicPoly.beq` (with its `BEq` instance): coefficientwise
 canonical equality over the trimmed data. Its faithfulness on canonical
-coefficients follows from the companion's `LawfulBEq AlgebraicNumber`
-plus trimming; packaging that as an `AlgebraicPoly.beq_iff` is Phase-6
-work (#9418). `coeff n` is the canonical
+coefficients is the companion theorem `AlgebraicPoly.beq_iff`, derived from
+`LawfulBEq AlgebraicNumber` plus trimming. `coeff n` is the canonical
 coefficient (`0` beyond the degree) and `size` is the trimmed length backing
 `degree?`; all three are exercised by the module's compiled regressions.
 
@@ -235,6 +238,9 @@ def AlgebraicRoot.exact? (a : AlgebraicRoot) : Option AlgebraicNumber
 /-- Primary total API. -/
 def AlgebraicRoot.exact (a : AlgebraicRoot) : AlgebraicNumber :=
   a.exact?.getD (panicWith 0 "AlgebraicRoot.exact: certification failed")
+
+def AlgebraicRoot.ofEliminant? (raw : ZPoly)
+    (ballAt : Int → Option DyadicComplexBall) : Option AlgebraicRoot
 ```
 
 `QAdjoin.toAlgebraicNumber?` materializes `1, a, a², ...` once with one
@@ -387,6 +393,13 @@ remove its maximal `X` power, and take the primitive part. If the evaluation
 is nonzero, `q(0) ≠ 0` and the reciprocal Cauchy bound gives
 `|value| ≥ 1 / (1 + height(q))`. Let `C` be the explicit Horner error majorant
 computed from the input coefficient heights, degrees, and Cauchy root bounds.
+The generic cross-library recurrence is public:
+
+```lean
+def Disambiguation.evalMajorant {A : Type} [Zero A] [DecidableEq A]
+    (f : DensePoly A) (valueBound : A → Nat) (q : ZPoly) : Nat
+```
+
 Define `evalDisambiguationPrec` as the least precision in the finite range
 
 ```text
@@ -449,8 +462,9 @@ primitive-element candidate `theta + c * alpha`, with `c = 0` returning
 `extend? theta alpha` is the bounded primitive-element search: it tests
 `choose(degree theta * degree alpha, 2) + 1` signed shifts and keeps a
 maximum-degree candidate, which generates the compositum even when the two
-fields overlap. `extendShift?` is the same search retaining the producing
-shift (the form the tower's flattening recovery needs), and
+fields overlap. It is the value projection of `extendShift?`, so both APIs run
+one shared search retaining the producing shift (the form the tower's
+flattening recovery needs), and
 `extendShiftStep` is its single fold step, exposed so consumers can interleave
 the search with their own early exits. `primitive?` folds `extend?` over the
 nonzero entries of a coefficient array.

--- a/HexNumberField/SPEC/hex-number-field.md
+++ b/HexNumberField/SPEC/hex-number-field.md
@@ -149,10 +149,11 @@ of represented complex values. `AlgebraicPoly` owns the required semantic
 trimming without exporting an unjustified `DecidableEq`. That Boolean
 operation is `AlgebraicPoly.beq` (with its `BEq` instance): coefficientwise
 canonical equality over the trimmed data. Its faithfulness on canonical
-coefficients is the companion theorem `AlgebraicPoly.beq_iff`, derived from
-`LawfulBEq AlgebraicNumber` plus trimming. `coeff n` is the canonical
-coefficient (`0` beyond the degree) and `size` is the trimmed length backing
-`degree?`; all three are exercised by the module's compiled regressions.
+coefficients is the companion theorem `AlgebraicPoly.beq_iff`, which equates
+Boolean equality with equality of the semantic polynomial interpretations and
+is derived from `LawfulBEq AlgebraicNumber` plus trimming. `coeff n` is the
+canonical coefficient (`0` beyond the degree) and `size` is the trimmed length
+backing `degree?`; all three are exercised by the module's compiled regressions.
 
 ## Equality and zero
 
@@ -242,6 +243,9 @@ def AlgebraicRoot.exact (a : AlgebraicRoot) : AlgebraicNumber :=
 def AlgebraicRoot.ofEliminant? (raw : ZPoly)
     (ballAt : Int → Option DyadicComplexBall) : Option AlgebraicRoot
 ```
+
+`AlgebraicRoot.ofEliminant?` returns `none` unless normalization, root
+isolation, and the supplied operation ball identify one unique root.
 
 `QAdjoin.toAlgebraicNumber?` materializes `1, a, a², ...` once with one
 fixed-field multiplication per new power, finds the first Krylov dependence by
@@ -462,12 +466,12 @@ primitive-element candidate `theta + c * alpha`, with `c = 0` returning
 `extend? theta alpha` is the bounded primitive-element search: it tests
 `choose(degree theta * degree alpha, 2) + 1` signed shifts and keeps a
 maximum-degree candidate, which generates the compositum even when the two
-fields overlap. It is the value projection of `extendShift?`, so both APIs run
-one shared search retaining the producing shift (the form the tower's
-flattening recovery needs), and
-`extendShiftStep` is its single fold step, exposed so consumers can interleave
-the search with their own early exits. `primitive?` folds `extend?` over the
-nonzero entries of a coefficient array.
+fields overlap. It is the value projection of `extendShift?`, so both APIs
+share one search retaining the producing shift (the form the tower's
+flattening recovery needs). `extendShiftStep` is `extendShift?`'s single fold
+step, exposed so consumers can interleave the search with their own early
+exits. `primitive?` folds `extend?` over the nonzero entries of a coefficient
+array.
 
 `powers? gamma last` returns the checked canonical powers
 `1, gamma, ..., gamma^last`. `trace? ambient a` is the field trace of `a`

--- a/HexNumberFieldMathlib/AdjoinRoot.lean
+++ b/HexNumberFieldMathlib/AdjoinRoot.lean
@@ -96,8 +96,7 @@ noncomputable def toAdjoinRoot (a : QAdjoin p x) :
 
 /-- Recover the unique reduced executable coordinates of an {name}`AdjoinRoot`
 class. -/
-@[expose]
-noncomputable def fromAdjoinRoot [ZPoly.CheckedIrreducible p]
+private noncomputable def fromAdjoinRoot [ZPoly.CheckedIrreducible p]
     (a : AdjoinRoot (definingPolynomial p)) : QAdjoin p x where
   coeffs := HexPolyMathlib.ofPolynomial
     (AdjoinRoot.modByMonicHom (definingPolynomial_monic p) a)
@@ -427,9 +426,26 @@ theorem map_div [ZPoly.CheckedIrreducible p] (a b : QAdjoin p x)
 theorem map_natPow (a : QAdjoin p x) (n : Nat)
     (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x) :
     toComplex (natPow a n) rep h = toComplex a rep h ^ n := by
-  induction n with
-  | zero => simp [natPow, map_one]
-  | succ n ih => rw [natPow, map_mul, ih, pow_succ]
+  induction n using Nat.strongRecOn with
+  | ind n ih =>
+      cases n with
+      | zero => simp [natPow, map_one]
+      | succ n =>
+          have hlt : (n + 1) / 2 < n + 1 :=
+            Nat.div_lt_self (Nat.succ_pos n) (by decide : 1 < 2)
+          rw [natPow]
+          by_cases heven : (n + 1) % 2 = 0
+          · rw [if_pos heven, map_mul, ih ((n + 1) / 2) hlt,
+              ← pow_add]
+            have hdecomp := Nat.mod_add_div (n + 1) 2
+            congr 1
+            omega
+          · rw [if_neg heven, map_mul, map_mul,
+              ih ((n + 1) / 2) hlt, ← pow_add, ← pow_succ]
+            have hdecomp := Nat.mod_add_div (n + 1) 2
+            have hmod := Nat.mod_two_eq_zero_or_one (n + 1)
+            congr 1
+            omega
 
 /-- Executable integer powers preserve the selected interpretation. -/
 theorem map_intPow [ZPoly.CheckedIrreducible p]

--- a/HexNumberFieldMathlib/AlgebraicPoly.lean
+++ b/HexNumberFieldMathlib/AlgebraicPoly.lean
@@ -21,6 +21,23 @@ numbers.
 
 namespace Hex.AlgebraicPoly
 
+/-- Canonical coefficientwise Boolean equality agrees with equality of the
+trimmed executable representation. -/
+theorem beq_iff (f g : AlgebraicPoly) :
+    f == g ↔ f = g := by
+  constructor
+  · intro h
+    change f.data == g.data at h
+    have hdata : f.data = g.data := eq_of_beq h
+    cases f
+    cases g
+    cases hdata
+    rfl
+  · intro h
+    subst g
+    change f.data == f.data
+    exact BEq.rfl
+
 /-- Interpret a normalized executable algebraic polynomial in `Polynomial ℂ`. -/
 @[expose]
 noncomputable def toPolynomial (f : AlgebraicPoly) : Polynomial ℂ :=

--- a/HexNumberFieldMathlib/AlgebraicPoly.lean
+++ b/HexNumberFieldMathlib/AlgebraicPoly.lean
@@ -21,23 +21,6 @@ numbers.
 
 namespace Hex.AlgebraicPoly
 
-/-- Canonical coefficientwise Boolean equality agrees with equality of the
-trimmed executable representation. -/
-theorem beq_iff (f g : AlgebraicPoly) :
-    f == g ↔ f = g := by
-  constructor
-  · intro h
-    change f.data == g.data at h
-    have hdata : f.data = g.data := eq_of_beq h
-    cases f
-    cases g
-    cases hdata
-    rfl
-  · intro h
-    subst g
-    change f.data == f.data
-    exact BEq.rfl
-
 /-- Interpret a normalized executable algebraic polynomial in `Polynomial ℂ`. -/
 @[expose]
 noncomputable def toPolynomial (f : AlgebraicPoly) : Polynomial ℂ :=
@@ -148,5 +131,60 @@ theorem natDegree_toPolynomial (f : AlgebraicPoly) (h : !f.isZero) :
   have hfalse : f.isZero = false := by
     cases hz : f.isZero <;> simp_all
   simp [AlgebraicPoly.degree?, hfalse]
+
+/-- Canonical coefficientwise Boolean equality is faithful to the semantic
+polynomial interpretation. -/
+theorem beq_iff (f g : AlgebraicPoly) :
+    f == g ↔ f.toPolynomial = g.toPolynomial := by
+  constructor
+  · intro h
+    change f.data == g.data at h
+    have hdata : f.data = g.data := eq_of_beq h
+    cases f
+    cases g
+    cases hdata
+    rfl
+  · intro hpoly
+    have hzero : f.isZero = g.isZero := by
+      apply Bool.eq_iff_iff.mpr
+      rw [isZero_iff, isZero_iff, hpoly]
+    have hsize : f.size = g.size := by
+      by_cases hf : f.isZero
+      · have hg : g.isZero := by simpa [hzero] using hf
+        have hfsize := Array.isEmpty_iff_size_eq_zero.mp hf
+        have hgsize := Array.isEmpty_iff_size_eq_zero.mp hg
+        change f.data.size = g.data.size
+        omega
+      · have hg : g.isZero ≠ true := by simpa [hzero] using hf
+        have hfn : !f.isZero := by
+          cases hz : f.isZero <;> simp_all
+        have hgn : !g.isZero := by
+          cases hz : g.isZero <;> simp_all
+        have hdegree := congrArg Polynomial.natDegree hpoly
+        rw [natDegree_toPolynomial f hfn,
+          natDegree_toPolynomial g hgn] at hdegree
+        have hfsize : 0 < f.size := by
+          apply Nat.pos_of_ne_zero
+          intro h
+          apply hf
+          exact Array.isEmpty_iff_size_eq_zero.mpr h
+        have hgsize : 0 < g.size := by
+          apply Nat.pos_of_ne_zero
+          intro h
+          apply hg
+          exact Array.isEmpty_iff_size_eq_zero.mpr h
+        have hffalse : f.isZero = false := Bool.eq_false_iff.mpr hf
+        have hgfalse : g.isZero = false := Bool.eq_false_iff.mpr hg
+        simp [AlgebraicPoly.degree?, hffalse, hgfalse] at hdegree
+        omega
+    change f.data == g.data
+    apply beq_iff_eq.mpr
+    apply Array.ext
+    · exact hsize
+    · intro i hif hig
+      apply AlgebraicNumber.toComplex_injective
+      have hcoeff := congrArg (fun p : Polynomial ℂ => p.coeff i) hpoly
+      rw [coeff_toPolynomial, coeff_toPolynomial] at hcoeff
+      simpa [AlgebraicPoly.coeff, Array.getD, hif, hig] using hcoeff
 
 end Hex.AlgebraicPoly

--- a/HexNumberFieldMathlib/Exact.lean
+++ b/HexNumberFieldMathlib/Exact.lean
@@ -519,13 +519,7 @@ private noncomputable def adjoinRootAlgEquiv [ZPoly.CheckedIrreducible p] :
 
 private theorem natPow_succ [ZPoly.CheckedIrreducible p]
     (a : QAdjoin p x) (n : Nat) :
-    a ^ (n + 1) = a ^ n * a := by
-  let rep : RefinedIsolation p := Quot.out x
-  have hrep : SimpleRoot.mk rep = x := Quot.out_eq x
-  apply toComplex_injective rep hrep
-  change toComplex (natPow a (n + 1)) rep hrep =
-    toComplex (natPow a n * a) rep hrep
-  rw [map_natPow, map_mul, map_natPow, pow_succ]
+    a ^ (n + 1) = a ^ n * a := pow_succ a n
 
 private theorem krylovPowers_get [ZPoly.CheckedIrreducible p]
     (a : QAdjoin p x) (n : Nat)

--- a/HexNumberFieldMathlib/Exact.lean
+++ b/HexNumberFieldMathlib/Exact.lean
@@ -517,19 +517,32 @@ private noncomputable def adjoinRootAlgEquiv [ZPoly.CheckedIrreducible p] :
       r • (1 : AdjoinRoot (definingPolynomial p))
     rw [toAdjoinRoot_smul, toAdjoinRoot_one]
 
-private theorem krylovPowers_get (a : QAdjoin p x) (n : Nat)
+private theorem natPow_succ [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) (n : Nat) :
+    a ^ (n + 1) = a ^ n * a := by
+  let rep : RefinedIsolation p := Quot.out x
+  have hrep : SimpleRoot.mk rep = x := Quot.out_eq x
+  apply toComplex_injective rep hrep
+  change toComplex (natPow a (n + 1)) rep hrep =
+    toComplex (natPow a n * a) rep hrep
+  rw [map_natPow, map_mul, map_natPow, pow_succ]
+
+private theorem krylovPowers_get [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) (n : Nat)
     (i : Fin (n + 1)) :
     (krylovPowers a n).get i = a ^ i.val := by
   induction n with
   | zero =>
       have hi : i = 0 := Fin.eq_zero i
       subst i
+      change (krylovPowers a 0).get 0 = natPow a 0
+      unfold krylovPowers Vector.get natPow
       rfl
   | succ n ih =>
       by_cases hi : i = Fin.last (n + 1)
       · subst i
         simp [krylovPowers, ih]
-        rfl
+        exact (natPow_succ a n).symm
       · let j : Fin (n + 1) := ⟨i.val, by
           have hilast : i.val ≠ n + 1 := by
             intro hval

--- a/HexNumberFieldMathlib/Field.lean
+++ b/HexNumberFieldMathlib/Field.lean
@@ -148,6 +148,7 @@ attribute [-instance] AlgebraicNumber.instZero AlgebraicNumber.instOne
   AlgebraicNumber.instMul AlgebraicNumber.instNeg AlgebraicNumber.instInv
   AlgebraicNumber.instDiv AlgebraicNumber.instPowNat
   AlgebraicNumber.instPowInt AlgebraicNumber.instSMulRat
+  AlgebraicNumber.instSMulNat AlgebraicNumber.instSMulInt
 
 example : (0 : AlgebraicNumber) = AlgebraicNumber.zero := rfl
 example : (1 : AlgebraicNumber) = AlgebraicNumber.ofRat 1 := rfl

--- a/HexNumberFieldMathlib/Field.lean
+++ b/HexNumberFieldMathlib/Field.lean
@@ -137,7 +137,7 @@ info: 'Hex.AlgebraicNumber.field' depends on axioms: [propext, Classical.choice,
 
 section OperationRegression
 
-variable (a b : AlgebraicNumber) (q : Rat)
+variable (a b : AlgebraicNumber) (q : Rat) (n : Nat) (z : Int)
 
 -- Force notation through the installed field dictionary, rather than the
 -- standalone executable instances, so these equalities inspect the data
@@ -160,6 +160,8 @@ example : a / b = AlgebraicNumber.div a b := rfl
 example : a ^ (3 : Nat) = AlgebraicNumber.natPow a 3 := rfl
 example : a ^ (-3 : Int) = AlgebraicNumber.intPow a (-3) := rfl
 example : q • a = AlgebraicNumber.smul q a := rfl
+example : n • a = AlgebraicNumber.smul (n : Rat) a := rfl
+example : z • a = AlgebraicNumber.smul (z : Rat) a := rfl
 example : ((2 : Nat) : AlgebraicNumber) = (2 : AlgebraicNumber) := rfl
 
 end OperationRegression

--- a/HexNumberFieldMathlib/Presentation.lean
+++ b/HexNumberFieldMathlib/Presentation.lean
@@ -343,132 +343,69 @@ theorem signedShift_injective : Function.Injective signedShift := by
         exact Int.ofNat.inj hij
       omega
 
-/-- One maximum-degree update in the bounded primitive-element search. -/
-@[expose]
-def extendStep (theta alpha : AlgebraicNumber) :
-    Option AlgebraicNumber → Nat → Option (Option AlgebraicNumber) :=
-  fun best k => do
-    let candidate ← shift? theta alpha (signedShift k)
-    some <| match best with
-    | none => some candidate
-    | some current =>
-        if degree current < degree candidate then some candidate
-        else some current
-
-private theorem extendStep_some (theta alpha : AlgebraicNumber)
-    (best : Option AlgebraicNumber) (k : Nat) :
-    ∃ candidate, extendStep theta alpha best k = some (some candidate) := by
+private theorem extendShiftStep_some (theta alpha : AlgebraicNumber)
+    (best : Option ShiftCandidate) (k : Nat) :
+    ∃ candidate, extendShiftStep theta alpha best k = some (some candidate) := by
   obtain ⟨shifted, hshifted⟩ := Option.isSome_iff_exists.mp
     (shift?_isSome theta alpha (signedShift k))
-  unfold extendStep
-  rw [hshifted]
+  simp only [extendShiftStep, hshifted]
   cases best with
-  | none => exact ⟨shifted, rfl⟩
+  | none => exact ⟨⟨signedShift k, shifted⟩, rfl⟩
   | some current =>
-      by_cases hdegree : degree current < degree shifted
-      · exact ⟨shifted, by simp [hdegree]⟩
+      by_cases hdegree : degree current.value < degree shifted
+      · exact ⟨⟨signedShift k, shifted⟩, by simp [hdegree]⟩
       · exact ⟨current, by simp [hdegree]⟩
 
-private theorem extendFold_fromSome (theta alpha : AlgebraicNumber)
-    (indices : List Nat) (current : AlgebraicNumber) :
-    ∃ candidate, indices.foldlM (extendStep theta alpha) (some current) =
+private theorem extendShiftFold_fromSome (theta alpha : AlgebraicNumber)
+    (indices : List Nat) (current : ShiftCandidate) :
+    ∃ candidate, indices.foldlM (extendShiftStep theta alpha) (some current) =
       some (some candidate) := by
   induction indices generalizing current with
   | nil => exact ⟨current, rfl⟩
   | cons k indices ih =>
-      obtain ⟨next, hnext⟩ := extendStep_some theta alpha (some current) k
+      obtain ⟨next, hnext⟩ :=
+        extendShiftStep_some theta alpha (some current) k
       rw [List.foldlM_cons, hnext]
       exact ih next
 
-private theorem extendFold_nonempty (theta alpha : AlgebraicNumber)
+private theorem extendShiftFold_nonempty (theta alpha : AlgebraicNumber)
     (indices : List Nat) (hnonempty : indices ≠ []) :
-    ∃ candidate, indices.foldlM (extendStep theta alpha) none =
+    ∃ candidate, indices.foldlM (extendShiftStep theta alpha) none =
       some (some candidate) := by
   cases indices with
   | nil => exact (hnonempty rfl).elim
   | cons k indices =>
-      obtain ⟨first, hfirst⟩ := extendStep_some theta alpha none k
+      obtain ⟨first, hfirst⟩ := extendShiftStep_some theta alpha none k
       rw [List.foldlM_cons, hfirst]
-      exact extendFold_fromSome theta alpha indices first
+      exact extendShiftFold_fromSome theta alpha indices first
 
-/-- The bounded maximum-degree primitive-element search is operationally
-total. Its field-generation invariant is established separately. -/
-theorem extend?_isSome (theta alpha : AlgebraicNumber) :
-    (extend? theta alpha).isSome := by
+/-- The shift-retaining primitive search is total. -/
+theorem extendShift?_isSome (theta alpha : AlgebraicNumber) :
+    (extendShift? theta alpha).isSome := by
   let upper := degree theta * degree alpha
   let count := Nat.choose upper 2 + 1
   have hcount : count ≠ 0 := by omega
   have hrange : List.range count ≠ [] := by simp [hcount]
   obtain ⟨candidate, hfold⟩ :=
-    extendFold_nonempty theta alpha (List.range count) hrange
-  unfold extend?
-  change ((List.range count).foldlM (extendStep theta alpha) none >>=
+    extendShiftFold_nonempty theta alpha (List.range count) hrange
+  unfold extendShift?
+  change ((List.range count).foldlM (extendShiftStep theta alpha) none >>=
     fun best => best).isSome
   rw [hfold]
   simp
-
-private theorem extendShiftFold_value (theta alpha : AlgebraicNumber)
-    (indices : List Nat) (best : Option ShiftCandidate) :
-    (indices.foldlM (extendShiftStep theta alpha) best).map
-        (Option.map ShiftCandidate.value) =
-      indices.foldlM (extendStep theta alpha)
-        (best.map ShiftCandidate.value) := by
-  induction indices generalizing best with
-  | nil => simp
-  | cons k indices ih =>
-      rw [List.foldlM_cons, List.foldlM_cons]
-      cases hshift : shift? theta alpha (signedShift k) with
-      | none => simp [extendShiftStep, extendStep, hshift]
-      | some candidate =>
-          cases best with
-          | none =>
-              simpa [extendShiftStep, extendStep, hshift] using
-                ih (some ⟨signedShift k, candidate⟩)
-          | some current =>
-              by_cases hdegree : degree current.value < degree candidate
-              · simpa [extendShiftStep, extendStep, hshift, hdegree] using
-                  ih (some ⟨signedShift k, candidate⟩)
-              · simpa [extendShiftStep, extendStep, hshift, hdegree] using
-                  ih (some current)
 
 /-- Retaining the producing shift does not change the selected primitive
 element. -/
 theorem extendShift?_value (theta alpha : AlgebraicNumber) :
     (extendShift? theta alpha).map ShiftCandidate.value =
-      extend? theta alpha := by
-  let upper := degree theta * degree alpha
-  let count := Nat.choose upper 2 + 1
-  have hfold := extendShiftFold_value theta alpha
-    (List.range count) none
-  unfold extendShift? extend?
-  change (((List.range count).foldlM
-      (extendShiftStep theta alpha) none >>= fun best => best).map
-        ShiftCandidate.value) =
-    ((List.range count).foldlM (extendStep theta alpha) none >>=
-      fun best => best)
-  cases htracked : (List.range count).foldlM
-      (extendShiftStep theta alpha) none with
-  | none =>
-      rw [htracked] at hfold
-      simp only [Option.map_none] at hfold
-      have hplain : (List.range count).foldlM
-          (extendStep theta alpha) none = none := by
-        simpa using hfold.symm
-      simp [htracked, hplain]
-  | some tracked =>
-      rw [htracked] at hfold
-      simp only [Option.map_some] at hfold
-      have hplain : (List.range count).foldlM
-          (extendStep theta alpha) none =
-            some (tracked.map ShiftCandidate.value) := by
-        simpa using hfold.symm
-      simp [htracked, hplain]
+      extend? theta alpha := rfl
 
-/-- The shift-retaining primitive search is total. -/
-theorem extendShift?_isSome (theta alpha : AlgebraicNumber) :
-    (extendShift? theta alpha).isSome := by
-  rw [← Option.isSome_map, extendShift?_value]
-  exact extend?_isSome theta alpha
+/-- The bounded maximum-degree primitive-element search is operationally
+total. Its field-generation invariant is established separately. -/
+theorem extend?_isSome (theta alpha : AlgebraicNumber) :
+    (extend? theta alpha).isSome := by
+  rw [← extendShift?_value, Option.isSome_map]
+  exact extendShift?_isSome theta alpha
 
 private theorem extendShiftFold_source (theta alpha : AlgebraicNumber)
     (indices : List Nat) (best : Option ShiftCandidate)
@@ -489,7 +426,7 @@ private theorem extendShiftFold_source (theta alpha : AlgebraicNumber)
       | some candidate =>
           cases best with
           | none =>
-              simp only [extendShiftStep, hshift, Option.bind_some] at hfold
+              simp only [extendShiftStep, hshift] at hfold
               apply ih (some ⟨signedShift k, candidate⟩)
               · intro current hcurrent
                 have heq := Option.some.inj hcurrent

--- a/HexNumberFieldMathlib/Primitive.lean
+++ b/HexNumberFieldMathlib/Primitive.lean
@@ -207,16 +207,16 @@ private theorem exists_shift_degree_eq (theta alpha : AlgebraicNumber) :
     exact _root_.Nat.choose_le_choose 2 hfinrank
   exact ⟨k, by omega, candidate, hcandidate, hdegree⟩
 
-private theorem extendStep_bounds (theta alpha : AlgebraicNumber)
-    (best : Option AlgebraicNumber) (k : Nat) (next : AlgebraicNumber)
-    (hnext : extendStep theta alpha best k = some (some next)) :
-    (∀ current, best = some current → degree current ≤ degree next) ∧
+private theorem extendShiftStep_bounds (theta alpha : AlgebraicNumber)
+    (best : Option ShiftCandidate) (k : Nat) (next : ShiftCandidate)
+    (hnext : extendShiftStep theta alpha best k = some (some next)) :
+    (∀ current, best = some current →
+      degree current.value ≤ degree next.value) ∧
       ∀ candidate, shift? theta alpha (signedShift k) = some candidate →
-        degree candidate ≤ degree next := by
+        degree candidate ≤ degree next.value := by
   obtain ⟨candidate, hcandidate⟩ := Option.isSome_iff_exists.mp
     (shift?_isSome theta alpha (signedShift k))
-  unfold extendStep at hnext
-  rw [hcandidate] at hnext
+  simp only [extendShiftStep, hcandidate] at hnext
   cases best with
   | none =>
       have hvalue := Option.some.inj hnext
@@ -230,7 +230,7 @@ private theorem extendStep_bounds (theta alpha : AlgebraicNumber)
           Option.some.inj (hshifted.symm.trans hcandidate)
         exact le_of_eq (congrArg degree heq)
   | some current =>
-      by_cases hdegree : degree current < degree candidate
+      by_cases hdegree : degree current.value < degree candidate
       · simp [hdegree] at hnext
         subst next
         constructor
@@ -248,29 +248,32 @@ private theorem extendStep_bounds (theta alpha : AlgebraicNumber)
         constructor
         · intro previous hprevious
           exact le_of_eq
-            (congrArg degree (Option.some.inj hprevious)).symm
+            (congrArg (fun a => degree a.value)
+              (Option.some.inj hprevious)).symm
         · intro shifted hshifted
           have heq : shifted = candidate :=
             Option.some.inj (hshifted.symm.trans hcandidate)
           subst shifted
           exact Nat.le_of_not_gt hdegree
 
-private theorem extendFold_max (theta alpha : AlgebraicNumber)
-    (indices : List Nat) (best : Option AlgebraicNumber)
-    (out : AlgebraicNumber)
-    (hfold : indices.foldlM (extendStep theta alpha) best =
+private theorem extendShiftFold_max (theta alpha : AlgebraicNumber)
+    (indices : List Nat) (best : Option ShiftCandidate)
+    (out : ShiftCandidate)
+    (hfold : indices.foldlM (extendShiftStep theta alpha) best =
       some (some out)) :
-    (∀ current, best = some current → degree current ≤ degree out) ∧
+    (∀ current, best = some current →
+      degree current.value ≤ degree out.value) ∧
       ∀ k ∈ indices, ∀ candidate,
         shift? theta alpha (signedShift k) = some candidate →
-          degree candidate ≤ degree out := by
+          degree candidate ≤ degree out.value := by
   induction indices generalizing best with
   | nil =>
       have hbest := Option.some.inj hfold
       constructor
       · intro current hcurrent
         rw [hbest] at hcurrent
-        exact le_of_eq (congrArg degree (Option.some.inj hcurrent)).symm
+        exact le_of_eq (congrArg (fun a => degree a.value)
+          (Option.some.inj hcurrent)).symm
       · simp
   | cons k indices ih =>
       rw [List.foldlM_cons] at hfold
@@ -279,19 +282,21 @@ private theorem extendFold_max (theta alpha : AlgebraicNumber)
       obtain ⟨shifted, hshifted⟩ := Option.isSome_iff_exists.mp
         (shift?_isSome theta alpha (signedShift k))
       have hnextExists : ∃ next, nextBest = some next := by
-        unfold extendStep at hstep
-        rw [hshifted] at hstep
+        simp only [extendShiftStep, hshifted] at hstep
         cases best with
-        | none => exact ⟨shifted, (Option.some.inj hstep).symm⟩
+        | none =>
+            exact ⟨⟨signedShift k, shifted⟩,
+              (Option.some.inj hstep).symm⟩
         | some current =>
-            by_cases hdegree : degree current < degree shifted
-            · exact ⟨shifted, by simpa [hdegree] using hstep.symm⟩
+            by_cases hdegree : degree current.value < degree shifted
+            · exact ⟨⟨signedShift k, shifted⟩,
+                by simpa [hdegree] using hstep.symm⟩
             · exact ⟨current, by simpa [hdegree] using hstep.symm⟩
       obtain ⟨next, hnext⟩ := hnextExists
       subst nextBest
       obtain ⟨hnextOut, htailMax⟩ := ih (some next) htail
       obtain ⟨hbestNext, hshiftNext⟩ :=
-        extendStep_bounds theta alpha best k next hstep
+        extendShiftStep_bounds theta alpha best k next hstep
       constructor
       · intro current hcurrent
         exact (hbestNext current hcurrent).trans
@@ -303,59 +308,6 @@ private theorem extendFold_max (theta alpha : AlgebraicNumber)
             (hnextOut next rfl)
         · exact htailMax index hindex candidate hcandidate
 
-private theorem extendStep_source (theta alpha : AlgebraicNumber)
-    (best : Option AlgebraicNumber) (k : Nat) (next : AlgebraicNumber)
-    (hnext : extendStep theta alpha best k = some (some next)) :
-    best = some next ∨
-      shift? theta alpha (signedShift k) = some next := by
-  obtain ⟨candidate, hcandidate⟩ := Option.isSome_iff_exists.mp
-    (shift?_isSome theta alpha (signedShift k))
-  unfold extendStep at hnext
-  rw [hcandidate] at hnext
-  cases best with
-  | none =>
-      change some (some candidate) = some (some next) at hnext
-      have heq : candidate = next :=
-        Option.some.inj (Option.some.inj hnext)
-      right
-      exact hcandidate.trans (congrArg some heq)
-  | some current =>
-      change some (if degree current < degree candidate then some candidate
-        else some current) = some (some next) at hnext
-      by_cases hdegree : degree current < degree candidate
-      · right
-        simp [hdegree] at hnext
-        subst next
-        exact hcandidate
-      · left
-        simp [hdegree] at hnext
-        subst next
-        rfl
-
-private theorem extendFold_source (theta alpha : AlgebraicNumber)
-    (indices : List Nat) (best : Option AlgebraicNumber)
-    (out : AlgebraicNumber)
-    (hfold : indices.foldlM (extendStep theta alpha) best =
-      some (some out)) :
-    best = some out ∨
-      ∃ k ∈ indices,
-        shift? theta alpha (signedShift k) = some out := by
-  induction indices generalizing best with
-  | nil =>
-      left
-      exact Option.some.inj hfold
-  | cons k indices ih =>
-      rw [List.foldlM_cons] at hfold
-      obtain ⟨nextBest, hstep, htail⟩ :=
-        Option.bind_eq_some_iff.mp hfold
-      rcases ih nextBest htail with hsame | ⟨index, hindex, hshift⟩
-      · rw [hsame] at hstep
-        rcases extendStep_source theta alpha best k out hstep with
-          hbest | hshift
-        · exact Or.inl hbest
-        · exact Or.inr ⟨k, by simp, hshift⟩
-      · exact Or.inr ⟨index, by simp [hindex], hshift⟩
-
 /-- A successful maximum-degree shift search reaches the full compositum
 degree. -/
 theorem extend?_degree (theta alpha gamma : AlgebraicNumber)
@@ -364,26 +316,34 @@ theorem extend?_degree (theta alpha gamma : AlgebraicNumber)
       finrank Rat Rat⟮theta.toComplex, alpha.toComplex⟯ := by
   let upper := degree theta * degree alpha
   let count := Nat.choose upper 2 + 1
-  unfold extend? at hgamma
-  change ((List.range count).foldlM (extendStep theta alpha) none >>=
-    fun best => best) = some gamma at hgamma
+  obtain ⟨shifted, hshifted⟩ := Option.isSome_iff_exists.mp
+    (extendShift?_isSome theta alpha)
+  have hvalue : shifted.value = gamma := by
+    unfold extend? at hgamma
+    rw [hshifted] at hgamma
+    exact Option.some.inj hgamma
+  subst gamma
+  have hselected := hshifted
+  unfold extendShift? at hshifted
+  change ((List.range count).foldlM
+    (extendShiftStep theta alpha) none >>= fun best => best) =
+      some shifted at hshifted
   obtain ⟨best, hfold, hbest⟩ :=
-    Option.bind_eq_some_iff.mp hgamma
+    Option.bind_eq_some_iff.mp hshifted
   subst best
-  obtain ⟨_, hmaximum⟩ := extendFold_max theta alpha
-    (List.range count) none gamma hfold
+  obtain ⟨_, hmaximum⟩ := extendShiftFold_max theta alpha
+    (List.range count) none shifted hfold
   obtain ⟨k, hk, candidate, hcandidate, hcandidateDegree⟩ :=
     exists_shift_degree_eq theta alpha
   have hlower :
-      finrank Rat Rat⟮theta.toComplex, alpha.toComplex⟯ ≤ degree gamma := by
+      finrank Rat Rat⟮theta.toComplex, alpha.toComplex⟯ ≤
+        degree shifted.value := by
     rw [← hcandidateDegree]
     exact hmaximum k (List.mem_range.mpr hk) candidate hcandidate
-  have hsource := extendFold_source theta alpha
-    (List.range count) none gamma hfold
-  rcases hsource with hnone | ⟨k, _hk, hshift⟩
-  · simp at hnone
-  · exact le_antisymm
-      (shift_degree_le theta alpha gamma (signedShift k) hshift) hlower
+  have hsource := extendShift?_source theta alpha shifted hselected
+  exact le_antisymm
+    (shift_degree_le theta alpha shifted.value shifted.shift hsource)
+    hlower
 
 /-- The maximum-degree shift returned by `extend?` generates exactly the
 compositum of its two inputs. -/
@@ -391,20 +351,18 @@ theorem extend?_field (theta alpha gamma : AlgebraicNumber)
     (hgamma : extend? theta alpha = some gamma) :
     Rat⟮gamma.toComplex⟯ =
       Rat⟮theta.toComplex, alpha.toComplex⟯ := by
-  let upper := degree theta * degree alpha
-  let count := Nat.choose upper 2 + 1
-  unfold extend? at hgamma
-  change ((List.range count).foldlM (extendStep theta alpha) none >>=
-    fun best => best) = some gamma at hgamma
-  obtain ⟨best, hfold, hbest⟩ :=
-    Option.bind_eq_some_iff.mp hgamma
-  subst best
-  obtain ⟨k, _hk, hshift⟩ := (extendFold_source theta alpha
-    (List.range count) none gamma hfold).resolve_left (by simp)
+  obtain ⟨shifted, hshifted⟩ := Option.isSome_iff_exists.mp
+    (extendShift?_isSome theta alpha)
+  have hvalue : shifted.value = gamma := by
+    unfold extend? at hgamma
+    rw [hshifted] at hgamma
+    exact Option.some.inj hgamma
+  have hshift := extendShift?_source theta alpha shifted hshifted
+  rw [hvalue] at hshift
   let K : IntermediateField Rat ℂ :=
     Rat⟮theta.toComplex, alpha.toComplex⟯
   have hmember : gamma.toComplex ∈ K := by
-    rw [shift?_sound theta alpha (signedShift k) hshift]
+    rw [shift?_sound theta alpha shifted.shift hshift]
     apply K.add_mem
     · exact IntermediateField.mem_adjoin_pair_left
         Rat theta.toComplex alpha.toComplex

--- a/HexNumberFieldMathlib/SPEC/hex-number-field-mathlib.md
+++ b/HexNumberFieldMathlib/SPEC/hex-number-field-mathlib.md
@@ -67,6 +67,9 @@ identical and avoids a second, diamond-forming rational action.
 theorem AlgebraicNumber.beq_iff (a b : AlgebraicNumber) :
     a == b ↔ a.toComplex = b.toComplex
 
+theorem AlgebraicPoly.beq_iff (f g : AlgebraicPoly) :
+    f == g ↔ f = g
+
 theorem AlgebraicRoot.isZero_iff (a : AlgebraicRoot) :
     a.isZero ↔ a.toComplex = 0
 

--- a/HexNumberFieldMathlib/SPEC/hex-number-field-mathlib.md
+++ b/HexNumberFieldMathlib/SPEC/hex-number-field-mathlib.md
@@ -68,7 +68,7 @@ theorem AlgebraicNumber.beq_iff (a b : AlgebraicNumber) :
     a == b ↔ a.toComplex = b.toComplex
 
 theorem AlgebraicPoly.beq_iff (f g : AlgebraicPoly) :
-    f == g ↔ f = g
+    f == g ↔ f.toPolynomial = g.toPolynomial
 
 theorem AlgebraicRoot.isZero_iff (a : AlgebraicRoot) :
     a.isZero ↔ a.toComplex = 0


### PR DESCRIPTION
Closes #9418

## Summary

- switch `QAdjoin.natPow` to square-and-multiply and preserve its semantic/rfl regression coverage
- collapse primitive-element extension onto the shared shift-retaining search and remove dead executable helpers
- add `AlgebraicPoly.beq_iff`, strengthen compiled normalization coverage, and finish the requested visibility/rfl cleanups
- document the reviewed cross-library and projection surfaces in the pair SPECs

## Verification

- `lake build HexNumberField HexNumberFieldMathlib HexNumberFieldTowerMathlib`
- `python3 scripts/check_dag.py`