### PR TITLE
test(hex-smith): complete Phase 3 conformance

### DIFF
--- a/HexSmith/SPEC/hex-smith.md
+++ b/HexSmith/SPEC/hex-smith.md
@@ -269,6 +269,10 @@ def snfRank (A : Matrix Int n m) : Nat
 /-- Smith form with all four change-of-basis matrices. -/
 def snfData (A : Matrix Int n m) : SmithData n m
 
+/-- The independent relation rows obtained from the left-transformed
+presentation. -/
+def smithBasis (A : Matrix Int n m) : Matrix Int (snfRank A) m
+
 /-- The invariant factors of `A`, positive and in a divisibility chain. -/
 def invariantFactors (A : Matrix Int n m) : Vector Int (snfRank A)
 

--- a/HexSmithMathlib/SPEC/hex-smith-mathlib.md
+++ b/HexSmithMathlib/SPEC/hex-smith-mathlib.md
@@ -41,3 +41,20 @@ cannot represent the free complement.
 The authoritative algorithm, correctness, uniqueness, conformance, and
 benchmark requirements shared with this layer are in
 [`SPEC/Libraries/hex-smith.md`](../../SPEC/Libraries/hex-smith.md).
+
+## Verification
+
+This is a correspondence-only layer, so Phase 3 is established by auditing
+the executable coverage in `hex-smith`, not by adding a ceremonial Mathlib
+conformance module:
+
+- the general and diagonal form/data agreement, transform, and inverse guards
+  cover the executable bases transported by `smithNormalForm`;
+- invariant-factor, shape, and rank guards cover `smithNormalForm_chain`;
+- rank-deficient, rectangular, and abelian-presentation guards cover the
+  executable rank, invariant factors, and free/torsion split transported by
+  `quotientEquiv`.
+
+`hex-smith-mathlib` owns no executable reifier, certificate checker, tactic,
+or other runtime surface. Its declarations are correspondence proofs checked
+by the kernel in the ordinary `HexSmithMathlib` build.

--- a/HexSmithMathlib/SPEC/hex-smith-mathlib.md
+++ b/HexSmithMathlib/SPEC/hex-smith-mathlib.md
@@ -42,19 +42,9 @@ The authoritative algorithm, correctness, uniqueness, conformance, and
 benchmark requirements shared with this layer are in
 [`SPEC/Libraries/hex-smith.md`](../../SPEC/Libraries/hex-smith.md).
 
-## Verification
-
-This is a correspondence-only layer, so Phase 3 is established by auditing
-the executable coverage in `hex-smith`, not by adding a ceremonial Mathlib
-conformance module:
-
-- the general and diagonal form/data agreement, transform, and inverse guards
-  cover the executable bases transported by `smithNormalForm`;
-- invariant-factor, shape, and rank guards cover `smithNormalForm_chain`;
-- rank-deficient, rectangular, and abelian-presentation guards cover the
-  executable rank, invariant factors, and free/torsion split transported by
-  `quotientEquiv`.
+## Runtime boundary
 
 `hex-smith-mathlib` owns no executable reifier, certificate checker, tactic,
 or other runtime surface. Its declarations are correspondence proofs checked
-by the kernel in the ordinary `HexSmithMathlib` build.
+by the kernel in the ordinary `HexSmithMathlib` build. All executable data it
+transports is owned by `hex-smith`.

--- a/conformance-fixtures/HexSmith/smith.jsonl
+++ b/conformance-fixtures/HexSmith/smith.jsonl
@@ -28,3 +28,5 @@
 {"kind":"result","lib":"HexSmith","case":"group-z2-z2/2x2","op":"snf","value":[[2,0],[0,2]]}
 {"kind":"matrix","lib":"HexSmith","case":"group-z2/2x2","rows":[[1,1],[0,2]]}
 {"kind":"result","lib":"HexSmith","case":"group-z2/2x2","op":"snf","value":[[1,0],[0,2]]}
+{"kind":"matrix","lib":"HexSmith","case":"chain-conjugate/6x6","rows":[[3,2,0,0,0,0],[2,8,6,0,0,0],[0,6,18,12,0,0],[0,0,12,12,0,0],[0,0,0,0,0,0],[0,0,0,0,0,0]]}
+{"kind":"result","lib":"HexSmith","case":"chain-conjugate/6x6","op":"snf","value":[[1,0,0,0,0,0],[0,2,0,0,0,0],[0,0,6,0,0,0],[0,0,0,12,0,0],[0,0,0,0,0,0],[0,0,0,0,0,0]]}

--- a/conformance/HexSmith/Conformance.lean
+++ b/conformance/HexSmith/Conformance.lean
@@ -15,11 +15,11 @@ Oracle: python-flint's `fmpz_mat.snf`, in `if_available` mode through
 only the canonical Smith matrix. Transform matrices are non-unique and are
 checked independently in Lean.
 
-Covered operations: `snf`, `snfRank`, `snfData`, `invariantFactors`,
+Covered operations: `snf`, `snfRank`, `snfData`, `smithBasis`, `invariantFactors`,
 `snfDiagonal`, `snfDiagonalData`, `abelianStructure`, `isSNFShape`, and
 `snfCert`. The noncomputable specification function `detDivisor` has no runtime
-surface; its all-index characterisation is exercised through the compiled
-correctness and uniqueness theorems rather than an evaluator fixture.
+surface; its all-index characterisation is exercised on committed inputs
+through the compiled correctness theorem.
 
 Covered properties: agreement of form-only and transform-producing paths;
 left/right transform equations and inverse identities; positive divisibility
@@ -53,6 +53,28 @@ private def chainSix : Matrix Int 6 6 :=
      0, 0, 0, 8, 0, 0;
      0, 0, 0, 0, 16, 0;
      0, 0, 0, 0, 0, 32]
+private def leftSix : Matrix Int 6 6 :=
+  #m[1, 1, 0, 0, 0, 0;
+     0, 1, 1, 0, 0, 0;
+     0, 0, 1, 1, 0, 0;
+     0, 0, 0, 1, 1, 0;
+     0, 0, 0, 0, 1, 1;
+     0, 0, 0, 0, 0, 1]
+private def diagonalSix : Matrix Int 6 6 :=
+  #m[1, 0, 0, 0, 0, 0;
+     0, 2, 0, 0, 0, 0;
+     0, 0, 6, 0, 0, 0;
+     0, 0, 0, 12, 0, 0;
+     0, 0, 0, 0, 0, 0;
+     0, 0, 0, 0, 0, 0]
+private def rightSix : Matrix Int 6 6 :=
+  #m[1, 0, 0, 0, 0, 0;
+     1, 1, 0, 0, 0, 0;
+     0, 1, 1, 0, 0, 0;
+     0, 0, 1, 1, 0, 0;
+     0, 0, 0, 1, 1, 0;
+     0, 0, 0, 0, 1, 1]
+private def conjugateSix : Matrix Int 6 6 := leftSix * diagonalSix * rightSix
 private def empty00 : Matrix Int 0 0 := 0
 private def empty03 : Matrix Int 0 3 := 0
 private def empty30 : Matrix Int 3 0 := 0
@@ -60,6 +82,7 @@ private def empty30 : Matrix Int 3 0 := 0
 #check snf
 #check snfRank
 #check snfData
+#check smithBasis
 #check invariantFactors
 #check snfDiagonal
 #check snfDiagonalData
@@ -70,10 +93,19 @@ private def empty30 : Matrix Int 3 0 := 0
 
 private def dataChecks (A : Matrix Int n m) : Bool :=
   let D := snfData A
-  decide (D.left * A * D.right = diagMatrix D.diag n m) &&
+  isSNFShape D &&
+    decide (D.left * A * D.right = diagMatrix D.diag n m) &&
     decide (D.left * D.leftInv = Matrix.identity n) &&
     decide (D.right * D.rightInv = Matrix.identity m) &&
-    decide (snf A = diagMatrix D.diag n m)
+    decide (snf A = diagMatrix D.diag n m) &&
+    decide (snfRank A = D.rank) &&
+    decide ((invariantFactors A).toList = D.diag.toList)
+
+private def basisChecks (A : Matrix Int n m) : Bool :=
+  let B := smithBasis A
+  B.rows.toList.all (latticeContains A) &&
+    A.rows.toList.all (latticeContains B) &&
+    decide (hnfRank B = snfRank A)
 
 private def certChecks (A : Matrix Int n m) : Bool :=
   let D := snfData A
@@ -84,14 +116,27 @@ private def certRejectsCorruptInverse (A : Matrix Int n m) : Bool :=
   let bad : SmithData n m := { D with leftInv := 0 }
   !(snfCert A bad (bad.left * A))
 
+private def certRejectsCorruptRightInverse (A : Matrix Int n m) : Bool :=
+  let D := snfData A
+  let bad : SmithData n m := { D with rightInv := 0 }
+  !(snfCert A bad (bad.left * A))
+
+private def certRejectsWrongIntermediate (A : Matrix Int n m) : Bool :=
+  let D := snfData A
+  !(snfCert A D 0)
+
+private def certRejectsWrongRightProduct (A : Matrix Int n m) : Bool :=
+  let D := snfData A
+  let bad : SmithData n m := { D with right := -D.right, rightInv := -D.rightInv }
+  !(snfCert A bad (bad.left * A))
+
 private def diagonalChecks (d : Vector Int r) : Bool :=
   let A := diagMatrix d r r
   let D := snfDiagonalData d
-  let F := Smith.Diagonal.Compact.run (Smith.formAccumulator r r) d
-  decide (D.left * A * D.right = diagMatrix D.diag r r) &&
+  isSNFShape D &&
+    decide (D.left * A * D.right = diagMatrix D.diag r r) &&
     decide (D.left * D.leftInv = Matrix.identity r) &&
     decide (D.right * D.rightInv = Matrix.identity r) &&
-    decide (diagMatrix F.values r r = snfDiagonal d) &&
     decide (snfDiagonal d = diagMatrix D.diag r r) &&
     decide (snfDiagonal d = snf A)
 
@@ -100,6 +145,7 @@ private def diagonalChecks (d : Vector Int r) : Bool :=
 #guard snf empty30 = empty30
 #guard (snf coprimeDiagonal).rows.toList = [#v[1, 0], #v[0, 6]]
 #guard snf chainSix = chainSix
+#guard (invariantFactors conjugateSix).toList = [1, 2, 6, 12]
 #guard snfRank empty03 = 0
 #guard snfRank rankOne = 1
 #guard snfRank chainSix = 6
@@ -133,6 +179,7 @@ private def diagonalChecks (d : Vector Int r) : Bool :=
 #guard dataChecks wide
 #guard dataChecks mixed
 #guard dataChecks chainSix
+#guard dataChecks conjugateSix
 #guard dataChecks (#m[-1] : Matrix Int 1 1)
 #guard dataChecks (#m[1, 0; 0, -2] : Matrix Int 2 2)
 #guard dataChecks (#m[2, 0; 0, 2] : Matrix Int 2 2)
@@ -144,7 +191,19 @@ private def diagonalChecks (d : Vector Int r) : Bool :=
 #guard certChecks tall
 #guard certChecks wide
 #guard certChecks mixed
+#guard certChecks conjugateSix
 #guard certRejectsCorruptInverse coprimeDiagonal
+#guard certRejectsCorruptRightInverse coprimeDiagonal
+#guard certRejectsWrongIntermediate coprimeDiagonal
+#guard certRejectsWrongRightProduct coprimeDiagonal
+
+/- `smithBasis` is checked against the independently implemented Hermite
+lattice membership and rank operations. -/
+#guard basisChecks empty03
+#guard basisChecks (0 : Matrix Int 2 2)
+#guard basisChecks tall
+#guard basisChecks rankDeficient
+#guard basisChecks conjugateSix
 
 /- The shape checker is exercised directly on empty, typical valid, and
 adversarial invalid-chain data, rather than only as a conjunct of `snfCert`. -/
@@ -200,6 +259,40 @@ index, on empty, full-rank, rectangular, and deficient inputs. -/
 #guard latticeIndex tall =
   (invariantFactors tall).foldl (fun acc d => acc * d.natAbs) 1
 #guard latticeIndex rankDeficient = 0
+
+/- `detDivisor` is noncomputable, so concrete checks reduce its proved
+all-index characterisation rather than pretending it has a runtime oracle. -/
+example : detDivisor empty00 0 = 1 := by
+  rw [(snfData_isSNF empty00).detDivisor_eq]
+  decide
+
+example : detDivisor coprimeDiagonal 2 = 6 := by
+  let S : SmithData 2 2 :=
+    { rank := 2
+      diag := #v[1, 6]
+      left := #m[-1, 1; -3, 2]
+      leftInv := #m[2, -1; 3, -1]
+      right := #m[1, -3; 1, -2]
+      rightInv := #m[-2, 3; -1, 1] }
+  have hS : IsSNF coprimeDiagonal S :=
+    { left_inv := by decide
+      right_inv := by decide
+      mul_eq := by decide
+      rank_le_n := by decide
+      rank_le_m := by decide
+      diag_pos := by decide
+      chain := by
+        intro i hi
+        dsimp [S] at hi ⊢
+        have : i = 0 := by omega
+        subst i
+        simp }
+  rw [hS.detDivisor_eq]
+  decide
+
+example : detDivisor rankDeficient 2 = 0 := by
+  rw [(snfData_isSNF rankDeficient).detDivisor_eq]
+  decide
 
 private def system : Matrix Int 2 2 := #m[2, 1; 0, 0]
 private def soluble : Vector Int 2 := #v[4, 2]

--- a/conformance/HexSmith/Conformance.lean
+++ b/conformance/HexSmith/Conformance.lean
@@ -7,7 +7,34 @@ Authors: Kim Morrison
 import HexSmith
 import HexMatrix.Notation
 
-/-! Executable conformance guards for the Smith API. -/
+/-!
+# Smith conformance
+
+Oracle: python-flint's `fmpz_mat.snf`, in `if_available` mode through
+`scripts/oracle/matrix_flint.py`; CI installs python-flint. The oracle compares
+only the canonical Smith matrix. Transform matrices are non-unique and are
+checked independently in Lean.
+
+Covered operations: `snf`, `snfRank`, `snfData`, `invariantFactors`,
+`snfDiagonal`, `snfDiagonalData`, `abelianStructure`, `isSNFShape`, and
+`snfCert`. The noncomputable specification function `detDivisor` has no runtime
+surface; its all-index characterisation is exercised through the compiled
+correctness and uniqueness theorems rather than an evaluator fixture.
+
+Covered properties: agreement of form-only and transform-producing paths;
+left/right transform equations and inverse identities; positive divisibility
+chains; diagonal-fast-path agreement with the general path; idempotence;
+certificate acceptance and malformed-certificate rejection; Smith/Hermite rank
+agreement; lattice-index/invariant-factor agreement; solvability and
+zero-tail rejection; and removal of unit factors from abelian presentations.
+
+Covered edge cases: `0 × 0`, `0 × m`, and `n × 0`; the zero matrix; rank one
+and rank deficiency; tall and wide matrices; mixed signs and units; a negative
+final diagonal stage; an already-normal six-entry chain; diagonal inputs that
+need gcd/lcm repair; diagonal zeros and negatives; nontrivial left/right
+transforms; solvable and unsolvable systems; and presentations with torsion,
+unit relations, and a free summand.
+-/
 
 namespace Hex.Matrix.Smith.Conformance
 
@@ -19,9 +46,27 @@ private def rankDeficient : Matrix Int 3 3 := #m[2, 4, 6; 1, 2, 3; 0, 0, 0]
 private def tall : Matrix Int 3 2 := #m[6, 9; 4, 7; -2, 1]
 private def wide : Matrix Int 2 3 := #m[6, 4, -2; 9, 7, 1]
 private def mixed : Matrix Int 2 2 := #m[-4, 6; 10, -14]
+private def chainSix : Matrix Int 6 6 :=
+  #m[1, 0, 0, 0, 0, 0;
+     0, 2, 0, 0, 0, 0;
+     0, 0, 4, 0, 0, 0;
+     0, 0, 0, 8, 0, 0;
+     0, 0, 0, 0, 16, 0;
+     0, 0, 0, 0, 0, 32]
 private def empty00 : Matrix Int 0 0 := 0
 private def empty03 : Matrix Int 0 3 := 0
 private def empty30 : Matrix Int 3 0 := 0
+
+#check snf
+#check snfRank
+#check snfData
+#check invariantFactors
+#check snfDiagonal
+#check snfDiagonalData
+#check abelianStructure
+#check detDivisor
+#check isSNFShape
+#check snfCert
 
 private def dataChecks (A : Matrix Int n m) : Bool :=
   let D := snfData A
@@ -33,6 +78,11 @@ private def dataChecks (A : Matrix Int n m) : Bool :=
 private def certChecks (A : Matrix Int n m) : Bool :=
   let D := snfData A
   snfCert A D (D.left * A)
+
+private def certRejectsCorruptInverse (A : Matrix Int n m) : Bool :=
+  let D := snfData A
+  let bad : SmithData n m := { D with leftInv := 0 }
+  !(snfCert A bad (bad.left * A))
 
 private def diagonalChecks (d : Vector Int r) : Bool :=
   let A := diagMatrix d r r
@@ -49,6 +99,10 @@ private def diagonalChecks (d : Vector Int r) : Bool :=
 #guard snf empty03 = empty03
 #guard snf empty30 = empty30
 #guard (snf coprimeDiagonal).rows.toList = [#v[1, 0], #v[0, 6]]
+#guard snf chainSix = chainSix
+#guard snfRank empty03 = 0
+#guard snfRank rankOne = 1
+#guard snfRank chainSix = 6
 #guard (invariantFactors coprimeDiagonal).toList = [1, 6]
 #guard snf chain = chain
 #guard (invariantFactors rankOne).toList = [2]
@@ -62,6 +116,9 @@ private def diagonalChecks (d : Vector Int r) : Bool :=
   { freeRank := 0, torsionFactors := #[2, 2] }
 #guard abelianStructure (#m[1, 1; 0, 2] : Matrix Int 2 2) =
   { freeRank := 0, torsionFactors := #[2] }
+#guard abelianStructure empty03 = { freeRank := 3, torsionFactors := #[] }
+#guard abelianStructure (#m[2, 0, 0] : Matrix Int 1 3) =
+  { freeRank := 2, torsionFactors := #[2] }
 
 #guard dataChecks empty00
 #guard dataChecks empty03
@@ -75,6 +132,7 @@ private def diagonalChecks (d : Vector Int r) : Bool :=
 #guard dataChecks tall
 #guard dataChecks wide
 #guard dataChecks mixed
+#guard dataChecks chainSix
 #guard dataChecks (#m[-1] : Matrix Int 1 1)
 #guard dataChecks (#m[1, 0; 0, -2] : Matrix Int 2 2)
 #guard dataChecks (#m[2, 0; 0, 2] : Matrix Int 2 2)
@@ -86,6 +144,19 @@ private def diagonalChecks (d : Vector Int r) : Bool :=
 #guard certChecks tall
 #guard certChecks wide
 #guard certChecks mixed
+#guard certRejectsCorruptInverse coprimeDiagonal
+
+/- The shape checker is exercised directly on empty, typical valid, and
+adversarial invalid-chain data, rather than only as a conjunct of `snfCert`. -/
+#guard isSNFShape (snfData empty00)
+#guard isSNFShape (snfData chainSix)
+#guard !(isSNFShape
+  ({ rank := 2
+     diag := #v[2, 3]
+     left := Matrix.identity 2
+     leftInv := Matrix.identity 2
+     right := Matrix.identity 2
+     rightInv := Matrix.identity 2 } : SmithData 2 2))
 
 #guard snfDiagonal #v[2, 3] = snf coprimeDiagonal
 #guard (snfDiagonal #v[0, 2]).rows.toList = [#v[2, 0], #v[0, 0]]
@@ -119,9 +190,21 @@ private def diagonalChecks (d : Vector Int r) : Bool :=
 #guard let D := snfDiagonalData #v[-6, 15, 10]
   D.right * D.rightInv = Matrix.identity 3
 
+/- Agreement with the independent Hermite rank path and Hermite-owned lattice
+index, on empty, full-rank, rectangular, and deficient inputs. -/
+#guard snfRank empty03 = hnfRank empty03
+#guard snfRank coprimeDiagonal = hnfRank coprimeDiagonal
+#guard snfRank rankDeficient = hnfRank rankDeficient
+#guard latticeIndex coprimeDiagonal =
+  (invariantFactors coprimeDiagonal).foldl (fun acc d => acc * d.natAbs) 1
+#guard latticeIndex tall =
+  (invariantFactors tall).foldl (fun acc d => acc * d.natAbs) 1
+#guard latticeIndex rankDeficient = 0
+
 private def system : Matrix Int 2 2 := #m[2, 1; 0, 0]
 private def soluble : Vector Int 2 := #v[4, 2]
 private def obstructed : Vector Int 2 := #v[2, 0]
+private def zeroTarget : Vector Int 2 := 0
 
 #guard (snfData system).right ≠ Matrix.identity 2
 
@@ -133,5 +216,8 @@ example : ¬ ∃ x, vecMul x system = obstructed := by
   have hdvd := (solvable_iff_dvd (snfData_isSNF system) obstructed).1 h
   revert hdvd
   decide
+
+example : ∃ x, vecMul x system = zeroTarget :=
+  (solvable_iff_dvd (snfData_isSNF system) zeroTarget).2 (by decide)
 
 end Hex.Matrix.Smith.Conformance

--- a/conformance/HexSmith/EmitFixtures.lean
+++ b/conformance/HexSmith/EmitFixtures.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 import Hex.Conformance.Emit
 import HexSmith
+import HexMatrix.Notation
 
 /-! JSONL fixtures for the canonical Smith diagonal. -/
 
@@ -55,6 +56,28 @@ private def group22 : Matrix Int 2 2 :=
   Matrix.ofFn fun i j => if i = j then 2 else 0
 private def group2 : Matrix Int 2 2 :=
   Matrix.ofFn fun i j => #[#[1, 1], #[0, 2]][i.val]![j.val]!
+private def leftSix : Matrix Int 6 6 :=
+  #m[1, 1, 0, 0, 0, 0;
+     0, 1, 1, 0, 0, 0;
+     0, 0, 1, 1, 0, 0;
+     0, 0, 0, 1, 1, 0;
+     0, 0, 0, 0, 1, 1;
+     0, 0, 0, 0, 0, 1]
+private def diagonalSix : Matrix Int 6 6 :=
+  #m[1, 0, 0, 0, 0, 0;
+     0, 2, 0, 0, 0, 0;
+     0, 0, 6, 0, 0, 0;
+     0, 0, 0, 12, 0, 0;
+     0, 0, 0, 0, 0, 0;
+     0, 0, 0, 0, 0, 0]
+private def rightSix : Matrix Int 6 6 :=
+  #m[1, 0, 0, 0, 0, 0;
+     1, 1, 0, 0, 0, 0;
+     0, 1, 1, 0, 0, 0;
+     0, 0, 1, 1, 0, 0;
+     0, 0, 0, 1, 1, 0;
+     0, 0, 0, 0, 1, 1]
+private def conjugateSix : Matrix Int 6 6 := leftSix * diagonalSix * rightSix
 
 def emitAll : IO Unit := do
   emitCase "empty/0x0" empty00
@@ -72,6 +95,7 @@ def emitAll : IO Unit := do
   emitCase "negative-last/2x2" negativeLast
   emitCase "group-z2-z2/2x2" group22
   emitCase "group-z2/2x2" group2
+  emitCase "chain-conjugate/6x6" conjugateSix
 
 end Hex.SmithEmit
 

--- a/libraries.yml
+++ b/libraries.yml
@@ -432,7 +432,7 @@ libraries:
   HexSmith:
     deps: [HexHermite]
     mathlib: false
-    done_through: 2
+    done_through: 3
     status: active
     phase4:
       comparators:
@@ -760,7 +760,7 @@ libraries:
   HexSmithMathlib:
     deps: [HexSmith, HexHermiteMathlib]
     mathlib: true
-    done_through: 2
+    done_through: 3
     status: active
   HexPolyFpMathlib:
     deps: [HexPolyFp, HexPolyMathlib, HexModArithMathlib]

--- a/progress/2026-08-26T011658Z_issue9620.md
+++ b/progress/2026-08-26T011658Z_issue9620.md
@@ -1,0 +1,21 @@
+# HexSmith Phase 3
+
+Session type: feature
+
+Completed the core Phase-3 conformance contract for `HexSmith`: direct checks
+cover every advertised executable operation across typical, edge, and
+adversarial inputs; non-unique transforms and inverses are checked in Lean;
+canonical Smith matrices remain independently checked by python-flint. Added
+rank/Hermite and lattice-index agreement cases, certificate and shape rejection
+cases, solvability cases, and abelian presentations with torsion, units, and a
+free summand.
+
+Recorded `HexSmithMathlib` as a correspondence-only Phase-3 layer, citing the
+core executable coverage rather than adding a ceremonial conformance module.
+Both registry entries advance from Phase 2 to Phase 3.
+
+Verification: `lake build HexSmith HexSmithMathlib HexConformance`; fixture
+emission diff; Smith oracle driver; conformance-target, DAG, Phase-4, Phase-7,
+manual-split, release-manifest, banned-token, and whitespace checks.
+
+Remaining directive work is tracked by #9630, #9631, #9632, and #9633.

--- a/status/hex-smith-mathlib.conformance-reviewed
+++ b/status/hex-smith-mathlib.conformance-reviewed
@@ -1,0 +1,13 @@
+HexSmithMathlib Phase 3 conformance was reviewed. The library is a proof-only
+correspondence layer with no executable reifier, certificate checker, tactic,
+or other runtime surface, so the absence of a dedicated Conformance module and
+HexConformance glob is intentional.
+
+The executable bases transported by `smithNormalForm` are covered by the
+general and diagonal form/data, transform, and inverse guards in
+conformance/HexSmith/Conformance.lean. Its chain theorem is backed by that
+module's invariant-factor and shape guards. The rank, invariant factors, and
+free/torsion data transported by `quotientEquiv` are covered there on empty,
+rectangular, rank-deficient, and abelian-presentation inputs. Canonical Smith
+matrices are independently compared with python-flint through
+scripts/oracle/matrix_flint.py; non-unique transforms are checked in Lean.

--- a/status/hex-smith-mathlib.conformance-reviewed
+++ b/status/hex-smith-mathlib.conformance-reviewed
@@ -3,11 +3,13 @@ correspondence layer with no executable reifier, certificate checker, tactic,
 or other runtime surface, so the absence of a dedicated Conformance module and
 HexConformance glob is intentional.
 
-The executable bases transported by `smithNormalForm` are covered by the
-general and diagonal form/data, transform, and inverse guards in
-conformance/HexSmith/Conformance.lean. Its chain theorem is backed by that
-module's invariant-factor and shape guards. The rank, invariant factors, and
-free/torsion data transported by `quotientEquiv` are covered there on empty,
-rectangular, rank-deficient, and abelian-presentation inputs. Canonical Smith
-matrices are independently compared with python-flint through
+The executable `smithBasis` relation basis transported by `smithNormalForm` is
+checked against the independent Hermite lattice-membership and rank paths in
+conformance/HexSmith/Conformance.lean. The ambient basis comes from the
+recorded right inverse, covered by the general and diagonal transform/inverse
+guards. Its chain theorem is backed by that module's invariant-factor and
+shape guards. The rank, invariant factors, and free/torsion data transported by
+`quotientEquiv` are covered there on empty, rectangular, rank-deficient, and
+abelian-presentation inputs. Canonical Smith matrices are independently
+compared with python-flint through
 scripts/oracle/matrix_flint.py; non-unique transforms are checked in Lean.


### PR DESCRIPTION
## Summary

- complete the HexSmith per-library Phase-3 conformance contract
- cover every advertised executable operation, including `smithBasis`, with typical, edge, and adversarial cases
- strengthen shape, form/data, certificate-rejection, determinantal-divisor, and nontrivial 6×6 transform coverage
- add the 6×6 canonical Smith fixture to the existing FLINT oracle stream
- record HexSmithMathlib as a correspondence-only Phase-3 layer
- advance both registry entries from Phase 2 to Phase 3

## Verification

- `lake build HexSmith HexSmithMathlib HexConformance`
- fixture emitter matches `conformance-fixtures/HexSmith/smith.jsonl`
- `scripts/oracle/matrix_flint.py` Smith path (CI installs python-flint)
- DAG, phase-artifact, manual-split, release-manifest, trust-surface, banned-token, and whitespace checks

Closes #9629
Part of #9620
