### PR TITLE
fix: compute divisors from certified factors

### DIFF
--- a/HexIntFactor/DivisorEnumeration.lean
+++ b/HexIntFactor/DivisorEnumeration.lean
@@ -1,0 +1,302 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexIntFactor.Cert
+
+public section
+
+/-! Canonical divisor enumeration from a checked prime-power list. -/
+
+namespace Hex
+
+namespace Nat
+
+namespace DivisorEnumeration
+
+/-- The powers `acc, acc * p, ..., acc * p ^ e`. -/
+@[expose]
+def powers (p : Nat) : Nat → Nat → List Nat
+  | 0, acc => [acc]
+  | e + 1, acc => acc :: powers p e (acc * p)
+
+/-- Extend divisor products with every allowed power of one prime. -/
+@[expose]
+def extend (values : List Nat) (entry : PrimePower) : List Nat :=
+  values.flatMap fun d =>
+    (powers entry.prime entry.exponent 1).map fun q => d * q
+
+/-- Unsorted positive divisors generated from a canonical prime-power list. -/
+@[expose]
+def values : List PrimePower → List Nat
+  | [] => [1]
+  | entry :: rest => extend (values rest) entry
+
+private theorem mem_powers {p e acc x : Nat} :
+    x ∈ powers p e acc ↔ ∃ j, j ≤ e ∧ x = acc * p ^ j := by
+  induction e generalizing acc with
+  | zero => simp [powers]
+  | succ e ih =>
+      simp only [powers, List.mem_cons, ih]
+      constructor
+      · intro h
+        rcases h with rfl | ⟨j, hj, rfl⟩
+        · exact ⟨0, by omega, by simp⟩
+        · refine ⟨j + 1, by omega, ?_⟩
+          rw [Nat.pow_succ]
+          ac_rfl
+      · rintro ⟨j, hj, rfl⟩
+        cases j with
+        | zero => simp
+        | succ j =>
+            right
+            refine ⟨j, by omega, ?_⟩
+            rw [Nat.pow_succ]
+            ac_rfl
+
+@[simp] private theorem length_powers (p e acc : Nat) :
+    (powers p e acc).length = e + 1 := by
+  induction e generalizing acc with
+  | zero => simp [powers]
+  | succ e ih => simp [powers, ih, Nat.add_assoc]
+
+private theorem prime_dvd_pow {p a : Nat} (hp : Prime p) :
+    ∀ {k : Nat}, p ∣ a ^ k → p ∣ a := by
+  intro k
+  induction k with
+  | zero =>
+      intro h
+      exact absurd (Nat.dvd_one.mp h) hp.ne_one
+  | succ k ih =>
+      intro h
+      rw [Nat.pow_succ] at h
+      exact (hp.dvd_mul.mp h).elim ih id
+
+private theorem divisor_prime_power {p e d : Nat} (hp : Prime p)
+    (hd : d ∣ p ^ e) : ∃ j, j ≤ e ∧ d = p ^ j := by
+  induction e generalizing d with
+  | zero =>
+      refine ⟨0, by omega, ?_⟩
+      rw [Nat.pow_zero]
+      exact Nat.dvd_one.mp hd
+  | succ e ih =>
+      by_cases hd1 : d = 1
+      · refine ⟨0, by omega, ?_⟩
+        rw [hd1, Nat.pow_zero]
+      · have hd2 : 2 ≤ d := by
+          have hdpos := Nat.pos_of_dvd_of_pos hd (Nat.pow_pos hp.pos)
+          omega
+        obtain ⟨q, hq, hqd⟩ := exists_prime_dvd hd2
+        have hqp : q ∣ p := prime_dvd_pow hq (Nat.dvd_trans hqd hd)
+        have hqpEq : q = p := by
+          rcases hp.2 q hqp with hq1 | hqpEq
+          · exact absurd hq1 hq.ne_one
+          · exact hqpEq
+        have hpd : p ∣ d := hqpEq ▸ hqd
+        obtain ⟨d', rfl⟩ := hpd
+        have hd' : d' ∣ p ^ e := by
+          apply (Nat.mul_dvd_mul_iff_left hp.pos).mp
+          simpa [Nat.pow_succ, Nat.mul_comm] using hd
+        obtain ⟨j, hj, rfl⟩ := ih hd'
+        refine ⟨j + 1, by omega, ?_⟩
+        simp [Nat.pow_succ, Nat.mul_comm]
+
+private theorem mem_powers_one_iff {p e d : Nat} (hp : Prime p) :
+    d ∈ powers p e 1 ↔ d ∣ p ^ e := by
+  rw [mem_powers]
+  constructor
+  · rintro ⟨j, hj, rfl⟩
+    simpa using Nat.pow_dvd_pow p hj
+  · intro hd
+    obtain ⟨j, hj, rfl⟩ := divisor_prime_power hp hd
+    exact ⟨j, hj, by simp⟩
+
+private theorem prime_dvd_product {q : Nat} (hq : Prime q) :
+    ∀ (entries : List PrimePower),
+      (∀ e ∈ entries, Prime e.prime) →
+      q ∣ (entries.map fun e => e.prime ^ e.exponent).prod →
+      ∃ e ∈ entries, e.prime = q := by
+  intro entries hprime hdvd
+  induction entries with
+  | nil =>
+      exact absurd (Nat.dvd_one.mp hdvd) hq.ne_one
+  | cons e rest ih =>
+      simp only [List.map_cons, List.prod_cons] at hdvd
+      rcases hq.dvd_mul.mp hdvd with he | hr
+      · have he' := prime_dvd_pow hq he
+        rcases (hprime e (by simp)).2 q he' with heq | heq
+        · exact absurd heq hq.ne_one
+        · exact ⟨e, by simp, heq.symm⟩
+      · obtain ⟨x, hx, heq⟩ := ih
+          (fun x hx => hprime x (by simp [hx])) hr
+        exact ⟨x, by simp [hx], heq⟩
+
+private theorem head_coprime {entry : PrimePower} {rest : List PrimePower}
+    (hprime : ∀ e ∈ entry :: rest, Prime e.prime)
+    (hsorted : (entry :: rest).Pairwise fun a b => a.prime < b.prime) :
+    Nat.Coprime (entry.prime ^ entry.exponent)
+      (rest.map fun e => e.prime ^ e.exponent).prod := by
+  have hp := hprime entry (by simp)
+  have htail : ∀ e ∈ rest, Prime e.prime := by
+    intro e he
+    exact hprime e (by simp [he])
+  have hnot : ¬entry.prime ∣
+      (rest.map fun e => e.prime ^ e.exponent).prod := by
+    intro hd
+    obtain ⟨e, he, heq⟩ := prime_dvd_product hp rest htail hd
+    have hlt := (List.pairwise_cons.mp hsorted).1 e he
+    rw [heq] at hlt
+    exact Nat.lt_irrefl _ hlt
+  exact (hp.coprime_of_not_dvd hnot).pow_left _
+
+/-- Generated values are exactly the divisors of the represented product. -/
+theorem mem_values_iff {entries : List PrimePower} {d : Nat}
+    (hprime : ∀ e ∈ entries, Prime e.prime)
+    (hsorted : entries.Pairwise fun a b => a.prime < b.prime) :
+    d ∈ values entries ↔
+      d ∣ (entries.map fun e => e.prime ^ e.exponent).prod := by
+  induction entries generalizing d with
+  | nil => simp [values]
+  | cons entry rest ih =>
+      have hp := hprime entry (by simp)
+      have htail : ∀ e ∈ rest, Prime e.prime := by
+        intro e he
+        exact hprime e (by simp [he])
+      have hsortedTail := (List.pairwise_cons.mp hsorted).2
+      have hcop := head_coprime hprime hsorted
+      simp only [values, extend, List.mem_flatMap, List.mem_map,
+        List.map_cons, List.prod_cons]
+      constructor
+      · rintro ⟨b, hb, a, ha, rfl⟩
+        have hb' := (ih htail hsortedTail).mp hb
+        have ha' := (mem_powers_one_iff hp).mp ha
+        simpa [Nat.mul_comm] using Nat.mul_dvd_mul ha' hb'
+      · intro hd
+        let A := entry.prime ^ entry.exponent
+        let B := (rest.map fun e => e.prime ^ e.exponent).prod
+        let a := Nat.gcd d A
+        let b := Nat.gcd d B
+        have ha : a ∣ A := Nat.gcd_dvd_right d A
+        have hb : b ∣ B := Nat.gcd_dvd_right d B
+        have hab : a * b = d := by
+          calc
+            a * b = Nat.gcd d (A * B) := by
+              symm
+              exact hcop.gcd_mul d
+            _ = d := Nat.gcd_eq_left_iff_dvd.mpr hd
+        refine ⟨b, (ih htail hsortedTail).mpr hb, a,
+          (mem_powers_one_iff hp).mpr ha, ?_⟩
+        simpa [Nat.mul_comm] using hab
+
+private theorem product_pos (entries : List PrimePower)
+    (hprime : ∀ e ∈ entries, Prime e.prime) :
+    0 < (entries.map fun e => e.prime ^ e.exponent).prod := by
+  induction entries with
+  | nil => simp
+  | cons e rest ih =>
+      simp only [List.map_cons, List.prod_cons]
+      exact Nat.mul_pos (Nat.pow_pos (hprime e (by simp)).pos)
+        (ih fun x hx => hprime x (by simp [hx]))
+
+private theorem nodup_powers (p e acc : Nat) (hp : Prime p) (hacc : 0 < acc) :
+    (powers p e acc).Nodup := by
+  induction e generalizing acc with
+  | zero => simp [powers]
+  | succ e ih =>
+      simp only [powers, List.nodup_cons]
+      refine ⟨?_, ih (acc * p) (Nat.mul_pos hacc hp.pos)⟩
+      intro hmem
+      obtain ⟨j, _, heq⟩ := mem_powers.mp hmem
+      have hlt : acc < (acc * p) * p ^ j := by
+        exact Nat.lt_of_lt_of_le
+          (by simpa using (Nat.mul_lt_mul_left hacc).mpr hp.one_lt)
+          (Nat.le_mul_of_pos_right (acc * p) (Nat.pow_pos hp.pos))
+      exact Nat.ne_of_lt hlt heq
+
+private theorem unique_split {A B a₁ a₂ b₁ b₂ : Nat}
+    (hcop : Nat.Coprime A B) (hA : 0 < A)
+    (ha₁ : a₁ ∣ A) (ha₂ : a₂ ∣ A) (hb₁ : b₁ ∣ B) (hb₂ : b₂ ∣ B)
+    (h : b₁ * a₁ = b₂ * a₂) : a₁ = a₂ ∧ b₁ = b₂ := by
+  have ha₁b₂ : Nat.Coprime a₁ b₂ :=
+    (hcop.coprime_dvd_left ha₁).coprime_dvd_right hb₂
+  have ha₂b₁ : Nat.Coprime a₂ b₁ :=
+    (hcop.coprime_dvd_left ha₂).coprime_dvd_right hb₁
+  have ha₁a₂ : a₁ ∣ a₂ := by
+    apply ha₁b₂.dvd_of_dvd_mul_right
+    exact ⟨b₁, by simpa [Nat.mul_comm] using h.symm⟩
+  have ha₂a₁ : a₂ ∣ a₁ := by
+    apply ha₂b₁.dvd_of_dvd_mul_right
+    exact ⟨b₂, by simpa [Nat.mul_comm] using h⟩
+  have ha : a₁ = a₂ := Nat.dvd_antisymm ha₁a₂ ha₂a₁
+  subst a₂
+  have haPos := Nat.pos_of_dvd_of_pos ha₁ hA
+  exact ⟨rfl, Nat.eq_of_mul_eq_mul_left haPos (by simpa [Nat.mul_comm] using h)⟩
+
+/-- Canonical prime powers generate every divisor exactly once. -/
+theorem nodup_values {entries : List PrimePower}
+    (hprime : ∀ e ∈ entries, Prime e.prime)
+    (hsorted : entries.Pairwise fun a b => a.prime < b.prime) :
+    (values entries).Nodup := by
+  induction entries with
+  | nil => simp [values]
+  | cons entry rest ih =>
+      have hp := hprime entry (by simp)
+      have htail : ∀ e ∈ rest, Prime e.prime := by
+        intro e he
+        exact hprime e (by simp [he])
+      have hsortedTail := (List.pairwise_cons.mp hsorted).2
+      have hcop := head_coprime hprime hsorted
+      have htailNodup := ih htail hsortedTail
+      have htailPos := product_pos rest htail
+      rw [values, extend, List.nodup_iff_pairwise_ne,
+        List.pairwise_flatMap]
+      refine ⟨?_, ?_⟩
+      · intro b hb
+        rw [List.pairwise_map]
+        exact (nodup_powers entry.prime entry.exponent 1 hp (by decide)).imp
+          (fun hne heq => hne (Nat.eq_of_mul_eq_mul_left
+            (Nat.pos_of_dvd_of_pos
+              ((mem_values_iff htail hsortedTail).mp hb) htailPos) heq))
+      · rw [List.nodup_iff_pairwise_ne] at htailNodup
+        apply htailNodup.imp_of_mem
+        intro b₁ b₂ hb₁ hb₂ hbne
+        intro x hx y hy heq
+        obtain ⟨a₁, ha₁, rfl⟩ := List.mem_map.mp hx
+        obtain ⟨a₂, ha₂, rfl⟩ := List.mem_map.mp hy
+        apply hbne
+        exact (unique_split hcop (Nat.pow_pos hp.pos)
+          ((mem_powers_one_iff hp).mp ha₁)
+          ((mem_powers_one_iff hp).mp ha₂)
+          ((mem_values_iff htail hsortedTail).mp hb₁)
+          ((mem_values_iff htail hsortedTail).mp hb₂)
+          heq).2
+
+private theorem length_extend (values : List Nat) (entry : PrimePower) :
+    (extend values entry).length = values.length * (entry.exponent + 1) := by
+  unfold extend
+  simp only [List.length_flatMap, List.length_map, length_powers]
+  induction values with
+  | nil => simp
+  | cons d rest ih =>
+      simp only [List.map_cons, List.sum_cons, List.length_cons]
+      rw [ih, Nat.succ_mul]
+      exact Nat.add_comm _ _
+
+/-- The generated list has the textbook product-of-successors size. -/
+theorem length_values (entries : List PrimePower) :
+    (values entries).length =
+      (entries.map fun e => e.exponent + 1).prod := by
+  induction entries with
+  | nil => simp [values]
+  | cons entry rest ih =>
+      simp [values, length_extend, ih, Nat.mul_comm]
+
+end DivisorEnumeration
+
+end Nat
+
+end Hex

--- a/HexIntFactor/Divisors.lean
+++ b/HexIntFactor/Divisors.lean
@@ -6,7 +6,7 @@ Authors: Kim Morrison
 
 module
 
-public import HexIntFactor.Cert
+public import HexIntFactor.DivisorEnumeration
 
 public section
 
@@ -16,23 +16,16 @@ namespace Hex
 
 namespace Nat
 
-def divisorPowers (p : Nat) : Nat → Nat → List Nat
-  | 0, acc => [acc]
-  | e + 1, acc => acc :: divisorPowers p e (acc * p)
-
-def expandDivisors (values : List Nat) (entry : PrimePower) : List Nat :=
-  values.flatMap fun d =>
-    (divisorPowers entry.prime entry.exponent 1).map fun q => d * q
-
 /-- Positive divisors, in ascending order. -/
 @[expose]
-def divisors {n : Nat} (_F : CheckedFactorization n) : Array Nat :=
-  (List.range (n + 1)).filter (fun d => decide (d ∣ n)) |>.toArray
+def divisors {n : Nat} (F : CheckedFactorization n) : Array Nat :=
+  (DivisorEnumeration.values F.raw.factors).mergeSort
+    (fun a b => decide (a ≤ b)) |>.toArray
 
 /-- Number of positive divisors, `τ(n) = ∏ (eᵢ + 1)`. -/
 @[expose]
 def numDivisors {n : Nat} (F : CheckedFactorization n) : Nat :=
-  (divisors F).size
+  (F.raw.factors.map fun e => e.exponent + 1).prod
 
 def sigmaEntry (entry : PrimePower) (k : Nat) : Nat :=
   (List.range (entry.exponent + 1)).foldl
@@ -74,19 +67,39 @@ def isSquarefree {n : Nat} (F : CheckedFactorization n) : Bool :=
 /-- Enumeration has exactly the positive divisors of `n`. -/
 theorem mem_divisors {n d : Nat} (F : CheckedFactorization n) :
     d ∈ (divisors F).toList ↔ d ∣ n := by
-  have hnraw : 0 < F.raw.subject := by
-    have hv := F.valid
-    simp only [checkFactorization, Bool.and_eq_true, decide_eq_true_eq] at hv
-    exact hv.1.1
-  have hn : 0 < n := F.subject_eq ▸ hnraw
-  simp only [divisors, List.mem_filter, List.mem_range, decide_eq_true_eq]
-  exact ⟨fun h => h.2, fun hd =>
-    ⟨by exact Nat.lt_succ_of_le (Nat.le_of_dvd hn hd), hd⟩⟩
+  rw [divisors, List.toList_toArray, List.mem_mergeSort,
+    DivisorEnumeration.mem_values_iff
+      (checkFactorization_prime F.valid)
+      (checkFactorization_sorted F.valid),
+    checkFactorization_prod F.valid, F.subject_eq]
+
+/-- The ascending divisor enumeration contains no duplicates. -/
+theorem divisors_nodup {n : Nat} (F : CheckedFactorization n) :
+    (divisors F).toList.Nodup := by
+  apply (List.mergeSort_perm _ _).symm.nodup
+  exact DivisorEnumeration.nodup_values
+    (checkFactorization_prime F.valid)
+    (checkFactorization_sorted F.valid)
+
+/-- The divisor enumeration is in ascending order. -/
+theorem divisors_sorted {n : Nat} (F : CheckedFactorization n) :
+    (divisors F).toList.Pairwise (fun a b => a ≤ b) := by
+  rw [divisors, List.toList_toArray]
+  simpa only [decide_eq_true_eq] using
+    (List.pairwise_mergeSort
+      (le := fun a b : Nat => decide (a ≤ b))
+      (fun a b c hab hbc => by
+        simp only [decide_eq_true_eq] at hab hbc ⊢
+        exact Nat.le_trans hab hbc)
+      (fun a b => by
+        simp only [Bool.or_eq_true, decide_eq_true_eq]
+        exact Nat.le_total a b)
+      (DivisorEnumeration.values F.raw.factors))
 
 /-- The product formula agrees with divisor enumeration. -/
 theorem numDivisors_eq_size {n : Nat} (F : CheckedFactorization n) :
     numDivisors F = (divisors F).size := by
-  rfl
+  simp [numDivisors, divisors, DivisorEnumeration.length_values]
 
 /-- `sigma` is the sum of `k`th powers over all divisors. -/
 theorem sigma_eq_sum {n k : Nat} (F : CheckedFactorization n) :

--- a/HexIntFactor/SPEC/hex-int-factor.md
+++ b/HexIntFactor/SPEC/hex-int-factor.md
@@ -720,6 +720,10 @@ def isSquarefree {n} (F : CheckedFactorization n) : Bool   -- ∀ i, eᵢ = 1
 
 theorem mem_divisors {n d} (F : CheckedFactorization n) :
     d ∈ (divisors F).toList ↔ d ∣ n
+theorem divisors_nodup {n} (F : CheckedFactorization n) :
+    (divisors F).toList.Nodup
+theorem divisors_sorted {n} (F : CheckedFactorization n) :
+    (divisors F).toList.Pairwise (fun a b => a ≤ b)
 theorem numDivisors_eq_size {n} (F : CheckedFactorization n) :
     numDivisors F = (divisors F).size
 theorem sigma_eq_sum {n k} (F : CheckedFactorization n) :
@@ -811,7 +815,12 @@ appear in a proof term and should not pay for exposure.
 
 The divisor-function API sits between the two: it is cheap, it is
 sometimes wanted in a proof (`totient` in a Fermat-Euler argument, say),
-and it takes already-checked data. It is `@[expose]`.
+and it takes already-checked data. It is `@[expose]`. This exposure makes
+the factor-list bodies available for definitional reasoning; it does not
+promise kernel evaluation of `divisors`, whose asymptotically appropriate
+`List.mergeSort` uses well-founded recursion. Proofs about that enumeration
+use `mem_divisors`, `divisors_nodup`, and `divisors_sorted`; `numDivisors`
+is the kernel-facing operation when only the count is required.
 
 ## Conformance
 
@@ -1017,6 +1026,7 @@ nothing extra.
 HexIntFactor/
   Cert.lean         -- PrimePower, Factorization, checkFactorization, soundness
   Partial.lean      -- PartialFactorization and checkPartial
+  DivisorEnumeration.lean -- certified enumeration from prime powers
   Divisors.lean     -- the divisor-function API
   Small.lean        -- trailing zeros, perfect powers, trial division
   Rho.lean          -- adapter from the shared rho primitive to the dispatch

--- a/HexIntFactorMathlib/Factorization.lean
+++ b/HexIntFactorMathlib/Factorization.lean
@@ -137,10 +137,7 @@ theorem totient_eq {n : Nat} (F : CheckedFactorization n) :
 Mathlib's divisor finset. -/
 theorem sigma_eq {n k : Nat} (F : CheckedFactorization n) :
     sigma F k = ∑ d ∈ n.divisors, d ^ k := by
-  have hd : (divisors F).toList.Nodup := by
-    simpa [divisors] using
-      (List.nodup_range.filter (fun d => decide (d ∣ n)))
-  rw [sigma_eq_sum, ← List.sum_toFinset _ hd, divisors_eq F]
+  rw [sigma_eq_sum, ← List.sum_toFinset _ (divisors_nodup F), divisors_eq F]
 
 /-- The checked radical is Mathlib's product of the distinct prime factors. -/
 theorem radical_eq {n : Nat} (F : CheckedFactorization n) :

--- a/conformance/HexIntFactor/Conformance.lean
+++ b/conformance/HexIntFactor/Conformance.lean
@@ -18,6 +18,25 @@ private def raw12 : Factorization :=
 private def checked12 : CheckedFactorization 12 :=
   ⟨raw12, rfl, by decide⟩
 
+private def checked1 : CheckedFactorization 1 :=
+  ⟨⟨1, []⟩, rfl, by decide⟩
+
+private def checked64 : CheckedFactorization 64 :=
+  ⟨⟨64, [⟨6, .small 2⟩]⟩, rfl, by decide⟩
+
+private def checked10800 : CheckedFactorization 10800 :=
+  ⟨⟨10800, [⟨4, .small 2⟩, ⟨3, .small 3⟩, ⟨2, .small 5⟩]⟩, rfl, by decide⟩
+
+private def checkedPow64 : CheckedFactorization (2 ^ 64) :=
+  ⟨⟨2 ^ 64, [⟨64, .small 2⟩]⟩, rfl, by decide⟩
+
+private def checkedHugeTau :
+    CheckedFactorization ((2 * 3 * 5 * 7 * 11 * 13) ^ 100) :=
+  ⟨⟨(2 * 3 * 5 * 7 * 11 * 13) ^ 100,
+    [⟨100, .small 2⟩, ⟨100, .small 3⟩, ⟨100, .small 5⟩,
+      ⟨100, .small 7⟩, ⟨100, .small 11⟩, ⟨100, .small 13⟩]⟩,
+    rfl, by decide⟩
+
 #guard checkFactorization raw12
 #guard !checkFactorization ⟨12, [⟨1, .small 4⟩, ⟨1, .small 3⟩]⟩
 #guard !checkFactorization ⟨12, [⟨1, .small 2⟩, ⟨1, .small 3⟩]⟩
@@ -25,8 +44,19 @@ private def checked12 : CheckedFactorization 12 :=
 #guard !checkFactorization ⟨12, [⟨0, .small 2⟩, ⟨1, .small 3⟩]⟩
 #guard !checkFactorization ⟨12, [⟨1, .small 3⟩, ⟨2, .small 2⟩]⟩
 
+#guard divisors checked1 == #[1]
+#guard numDivisors checked1 == 1
 #guard divisors checked12 == #[1, 2, 3, 4, 6, 12]
 #guard numDivisors checked12 == 6
+#guard divisors checked64 == #[1, 2, 4, 8, 16, 32, 64]
+#guard numDivisors checked64 == 7
+#guard (divisors checked10800).size == 60
+#guard numDivisors checked10800 == 60
+-- This subject is far beyond any feasible scan through `List.range n`.
+#guard numDivisors checkedPow64 == 65
+-- `101 ^ 6` divisors rules out computing the count by enumeration.
+#guard numDivisors checkedHugeTau == 101 ^ 6
+example : numDivisors checkedHugeTau = 101 ^ 6 := by decide +kernel
 #guard sigma checked12 1 == 28
 #guard totient checked12 == 4
 #guard radical checked12 == 6

--- a/progress/20260826T013121Z_issue9639.md
+++ b/progress/20260826T013121Z_issue9639.md
@@ -1,0 +1,27 @@
+# HexIntFactor certified divisor enumeration
+
+- Date/time: 2026-08-26 01:31:21 UTC
+- Session type: feature
+- Replaced the linear scan through `0 .. n` with canonical prime-power
+  expansion followed by merge sort. Proved exact membership, uniqueness,
+  ascending order, and the product-of-successors length formula.
+- Replaced `numDivisors`' enumeration alias with the direct `∏ (eᵢ + 1)`
+  computation and retained `numDivisors_eq_size` as a proved theorem.
+- Repaired the Mathlib sigma correspondence through the public nodup theorem,
+  without unfolding the former scan implementation.
+- Added conformance cases for `n = 1`, repeated prime powers, mixed factors,
+  a `2^64` subject that makes a subject-sized scan infeasible, and a certified
+  subject with `101^6` divisors whose kernel-checked count rules out divisor
+  enumeration.
+- Updated the SPEC file layout for the certified enumeration unit.
+- Clarified that exposed divisor bodies support definitional reasoning while
+  concrete sorted enumeration uses well-founded merge sort; downstream proofs
+  use the public membership, nodup, and sortedness characterisations.
+- Verification completed: `lake build HexIntFactor`,
+  `lake build HexIntFactorMathlib`, and `lake build HexConformance`.
+- Quality delta: divisor enumeration drops from `O(n)` candidate scanning to
+  `O(τ log τ)` output sorting; divisor count drops to `O(k)` in the number
+  of certified prime powers. Both factor libraries remain free of `sorry`,
+  `axiom`, and `native_decide`.
+- Remaining work: the dependent multiplicative sigma repair in #9640 and the
+  rest of the #9619 publication DAG.


### PR DESCRIPTION
Closes #9639
Depends on #9619.

## Summary

- enumerate divisors from the checked canonical prime-power list and prove exact membership, nodup, and ascending order
- compute `numDivisors` directly as `∏ (eᵢ + 1)` and prove it agrees with enumeration size
- repair the Mathlib `sigma_eq` bridge without unfolding the former subject-sized scan
- cover `n = 1`, repeated powers, mixed factors, and a `2^64` no-scan case in conformance

## Verification

- `lake build HexIntFactor`
- `lake build HexIntFactorMathlib`
- `lake build HexConformance`
- banned-token scan across `HexIntFactor/**` and `HexIntFactorMathlib/**`
