### PR TITLE
chore: advance HexBerlekampZassenhausMathlib to done_through 3

### DIFF
--- a/libraries.yml
+++ b/libraries.yml
@@ -808,7 +808,7 @@ libraries:
   HexBerlekampZassenhausMathlib:
     deps: [HexBerlekampZassenhaus, HexBerlekampMathlib, HexHenselMathlib, HexPolyZMathlib, HexMatrixMathlib, HexLLLMathlib]
     mathlib: true
-    done_through: 2
+    done_through: 3
     status: active
     proof_probes: [bench/HexBerlekampZassenhausMathlib/ProofProbe]
   HexTruncatedSeriesMathlib:


### PR DESCRIPTION
This PR advance HexBerlekampZassenhausMathlib to done_through 3. The Phase-3 evidence is the dedicated conformance target merged in #9504, which exercises the factor_poly tactic's runtime contract in CI against the SPEC; all dependencies are at phase 3 or beyond, and check_dag, check_phase4, and check_phase7 pass.

🤖 Prepared with Claude Code