### PR TITLE
chore: advance the number-field bridges to done_through 3

### DIFF
--- a/libraries.yml
+++ b/libraries.yml
@@ -957,7 +957,7 @@ libraries:
   HexNumberFieldMathlib:
     deps: [HexNumberField, HexResultantMathlib, HexBerlekampZassenhausMathlib, HexRootsMathlib, HexPolyZMathlib]
     mathlib: true
-    done_through: 2
+    done_through: 3
     status: active
   HexNumberFieldTower:
     deps: [HexNumberField, HexResultant, HexBerlekampZassenhaus]
@@ -981,7 +981,7 @@ libraries:
   HexNumberFieldTowerMathlib:
     deps: [HexNumberFieldTower, HexNumberFieldMathlib, HexResultantMathlib, HexBerlekampZassenhausMathlib, HexRowReduceMathlib]
     mathlib: true
-    done_through: 2
+    done_through: 3
     status: active
   HexRealRoots:
     deps: [HexPolyZ]

--- a/status/hex-number-field-mathlib.conformance-reviewed
+++ b/status/hex-number-field-mathlib.conformance-reviewed
@@ -1,0 +1,14 @@
+HexNumberFieldMathlib Phase 3 was reviewed on 2026-08-26. The library is a
+proof-only correspondence layer with no executable reifier, certificate
+checker, tactic, or other runtime surface, so the absence of a dedicated
+Conformance module and HexConformance glob is intentional per
+SPEC/testing.md's ceremonial-bridge ban.
+
+The executable surface it verifies (QAdjoin arithmetic, root isolation and
+disambiguation, approximation, Yun square-free decomposition) is exercised
+by conformance/HexNumberField/Conformance.lean and the python-flint oracle
+wired through scripts/ci/run_oracles.sh. The correspondence and
+completeness declarations here are proofs rather than executable
+destinations for conformance cases. Precedent:
+status/hex-roots-mathlib.conformance-reviewed and
+status/hex-truncated-series-mathlib.conformance-reviewed.

--- a/status/hex-number-field-tower-mathlib.conformance-reviewed
+++ b/status/hex-number-field-tower-mathlib.conformance-reviewed
@@ -1,0 +1,15 @@
+HexNumberFieldTowerMathlib Phase 3 was reviewed on 2026-08-26. The library
+is a proof-only correspondence layer with no executable reifier,
+certificate checker, tactic, or other runtime surface, so the absence of a
+dedicated Conformance module and HexConformance glob is intentional per
+SPEC/testing.md's ceremonial-bridge ban.
+
+The executable surface it verifies (tower extension arithmetic, flattening,
+norms, splitting, and the Trager-style factorization pipeline) is exercised
+by conformance/HexNumberFieldTower/Conformance.lean and its oracle wired
+through scripts/ci/run_oracles.sh. The field/algebra transport
+(Lean.Grind.Field law package, coordEquiv, embedAlgHom) and the
+factorization correspondence are proofs rather than executable destinations
+for conformance cases. Precedent:
+status/hex-roots-mathlib.conformance-reviewed and
+status/hex-truncated-series-mathlib.conformance-reviewed.


### PR DESCRIPTION
This PR advance HexNumberFieldMathlib and HexNumberFieldTowerMathlib to done_through 3 and add their Phase-3 conformance-reviewed exemption records. Both libraries are proof-only correspondence layers with no executable reifier, checker, or tactic surface, so a dedicated conformance module would violate SPEC/testing.md's ceremonial-bridge ban; the executable surface each verifies is exercised by the computational sibling's conformance module and oracle in CI. Every dependency, including HexBerlekampZassenhausMathlib as of #9674, is at phase 3 or beyond, and check_dag, check_phase4, and check_phase7 pass.

🤖 Prepared with Claude Code