### PR TITLE
feat: expose partial-factorization entry invariants

### DIFF
--- a/HexIntFactor/Partial.lean
+++ b/HexIntFactor/Partial.lean
@@ -115,6 +115,18 @@ theorem checkPartial_prime {F : PartialFactorization}
     ∀ e ∈ F.factors, Prime e.prime :=
   checkEntries_prime (checkedPartial_parts h).2.1
 
+/-- Every listed exponent in accepted partial data is positive. -/
+theorem checkPartial_exponent {F : PartialFactorization}
+    (h : checkPartial F = true) :
+    ∀ e ∈ F.factors, 0 < e.exponent :=
+  checkEntries_positive (checkedPartial_parts h).2.1
+
+/-- Listed bases in accepted partial data are strictly ascending. -/
+theorem checkPartial_sorted {F : PartialFactorization}
+    (h : checkPartial F = true) :
+    F.factors.Pairwise (fun a b => a.prime < b.prime) :=
+  checkEntries_pairwise (checkedPartial_parts h).2.1
+
 end Nat
 
 end Hex

--- a/HexIntFactor/SPEC/hex-int-factor.md
+++ b/HexIntFactor/SPEC/hex-int-factor.md
@@ -427,8 +427,8 @@ It makes **no** completeness claim. The indexed checked form prevents a
 partial factorization of one subject from answering a request about
 another. The characterising lemmas `checkPartial_prod`,
 `checkPartial_prime`, `checkPartial_exponent`, and `checkPartial_sorted`
-expose those checked invariants without requiring consumers to unfold the
-checker, and
+expose reconstruction, primality, exponent positivity, and factor-base
+ordering without requiring consumers to unfold the checker, and
 
 ```lean
 theorem factorPartial?_error {n r fuel f}

--- a/HexIntFactor/SPEC/hex-int-factor.md
+++ b/HexIntFactor/SPEC/hex-int-factor.md
@@ -425,7 +425,10 @@ as `checkFactorization` minus the requirement that the residual be `1`.
 Its product calculation uses the same subject-bounded loop.
 It makes **no** completeness claim. The indexed checked form prevents a
 partial factorization of one subject from answering a request about
-another, and
+another. The characterising lemmas `checkPartial_prod`,
+`checkPartial_prime`, `checkPartial_exponent`, and `checkPartial_sorted`
+expose those checked invariants without requiring consumers to unfold the
+checker, and
 
 ```lean
 theorem factorPartial?_error {n r fuel f}

--- a/conformance/HexIntFactor/Conformance.lean
+++ b/conformance/HexIntFactor/Conformance.lean
@@ -37,6 +37,17 @@ private def checkedHugeTau :
       ⟨100, .small 7⟩, ⟨100, .small 11⟩, ⟨100, .small 13⟩]⟩,
     rfl, by decide⟩
 
+private def checkedPartial12 : CheckedPartialFactorization 12 :=
+  ⟨⟨12, [⟨2, .small 2⟩], 3⟩, rfl, by decide⟩
+
+-- Partial-certificate consumers obtain entry invariants directly from `valid`.
+example : ∀ e ∈ checkedPartial12.raw.factors, 0 < e.exponent :=
+  checkPartial_exponent checkedPartial12.valid
+
+example : checkedPartial12.raw.factors.Pairwise
+    (fun a b => a.prime < b.prime) :=
+  checkPartial_sorted checkedPartial12.valid
+
 #guard checkFactorization raw12
 #guard !checkFactorization ⟨12, [⟨1, .small 4⟩, ⟨1, .small 3⟩]⟩
 #guard !checkFactorization ⟨12, [⟨1, .small 2⟩, ⟨1, .small 3⟩]⟩

--- a/conformance/HexIntFactor/Conformance.lean
+++ b/conformance/HexIntFactor/Conformance.lean
@@ -37,16 +37,25 @@ private def checkedHugeTau :
       ⟨100, .small 7⟩, ⟨100, .small 11⟩, ⟨100, .small 13⟩]⟩,
     rfl, by decide⟩
 
-private def checkedPartial12 : CheckedPartialFactorization 12 :=
-  ⟨⟨12, [⟨2, .small 2⟩], 3⟩, rfl, by decide⟩
+private def checkedPartial60 : CheckedPartialFactorization 60 :=
+  ⟨⟨60, [⟨2, .small 2⟩, ⟨1, .small 3⟩], 5⟩, rfl, by decide⟩
 
 -- Partial-certificate consumers obtain entry invariants directly from `valid`.
-example : ∀ e ∈ checkedPartial12.raw.factors, 0 < e.exponent :=
-  checkPartial_exponent checkedPartial12.valid
+example : ∀ e ∈ checkedPartial60.raw.factors, 0 < e.exponent :=
+  checkPartial_exponent checkedPartial60.valid
 
-example : checkedPartial12.raw.factors.Pairwise
+example : checkedPartial60.raw.factors.Pairwise
     (fun a b => a.prime < b.prime) :=
-  checkPartial_sorted checkedPartial12.valid
+  checkPartial_sorted checkedPartial60.valid
+
+example {n : Nat} (F : CheckedPartialFactorization n) :
+    ∀ e ∈ F.raw.factors, 0 < e.exponent :=
+  checkPartial_exponent F.valid
+
+example {n : Nat} (F : CheckedPartialFactorization n) :
+    F.raw.factors.Pairwise
+    (fun a b => a.prime < b.prime) :=
+  checkPartial_sorted F.valid
 
 #guard checkFactorization raw12
 #guard !checkFactorization ⟨12, [⟨1, .small 4⟩, ⟨1, .small 3⟩]⟩

--- a/progress/20260826T034337Z_issue9650.md
+++ b/progress/20260826T034337Z_issue9650.md
@@ -1,0 +1,9 @@
+# Issue #9650 progress
+
+- Confirmed `checkPartial` delegates structural validation to the shared
+  `checkEntries` checker.
+- Added public positivity and strict-order characterising lemmas by reusing
+  `checkEntries_positive` and `checkEntries_pairwise`.
+- Added conformance compile checks consuming both lemmas directly from
+  `CheckedPartialFactorization.valid`.
+- Documented the partial-certificate characterising surface in the SPEC.

--- a/progress/20260826T034337Z_issue9650.md
+++ b/progress/20260826T034337Z_issue9650.md
@@ -5,5 +5,6 @@
 - Added public positivity and strict-order characterising lemmas by reusing
   `checkEntries_positive` and `checkEntries_pairwise`.
 - Added conformance compile checks consuming both lemmas directly from
-  `CheckedPartialFactorization.valid`.
+  `CheckedPartialFactorization.valid`, for both abstract consumers and a
+  nontrivial two-entry partial certificate.
 - Documented the partial-certificate characterising surface in the SPEC.


### PR DESCRIPTION
Closes #9650

## Summary

- expose positive-exponent and strict-order invariants for accepted partial factorizations
- reuse the shared checkEntries proof surface rather than unfolding or duplicating checker proofs
- compile-check both lemmas directly from CheckedPartialFactorization.valid and document the surface in the SPEC

## Verification

- lake build HexIntFactor
- lake build HexConformance
- python3 scripts/release/check_trust_surface.py
- git diff --check

depends-on: none