### PR TITLE
chore: advance HexBerlekampMathlib to done_through 7

### DIFF
--- a/libraries.yml
+++ b/libraries.yml
@@ -780,7 +780,7 @@ libraries:
   HexBerlekampMathlib:
     deps: [HexBerlekamp, HexPolyMathlib, HexModArithMathlib, HexPolyFpMathlib]
     mathlib: true
-    done_through: 4
+    done_through: 7
     status: active
     proof_probes: [bench/HexBerlekampMathlib/ProofProbe]
   HexHenselMathlib:


### PR DESCRIPTION
This PR advance HexBerlekampMathlib to done_through 7. Phase 5 holds with the sorry-free tree and the #9679 headline report, Phase 6 is the polishing pass merged in #9672, and Phase 7 is carried by the HexBerlekamp chapter's Mathlib-correspondence section and the AESModulus tutorial anchor already on main; check_phase7, check_phase4, and check_dag all pass.

🤖 Prepared with Claude Code