### PR TITLE
feat: count coprime residues modulo a prime power

### DIFF
--- a/HexIntFactor/Divisors.lean
+++ b/HexIntFactor/Divisors.lean
@@ -224,6 +224,72 @@ theorem totient_eq_count {n : Nat} (F : CheckedFactorization n) :
     totient F = ((List.range n).filter (fun a => Nat.Coprime a n)).length := by
   simp [totient]
 
+private theorem coprimeCount_prime {p : Nat} (hp : Prime p) :
+    ((List.range p).filter fun a => Nat.Coprime a p).length = p - 1 := by
+  have hp2 := hp.two_le
+  obtain ⟨q, rfl⟩ : ∃ q, p = q + 1 := ⟨p - 1, by omega⟩
+  rw [List.range_succ_eq_map]
+  rw [List.filter_cons_of_neg (by simp; omega), List.filter_map,
+    List.length_map]
+  calc
+    (List.filter ((fun a => decide (Nat.Coprime a (q + 1))) ∘ Nat.succ)
+        (List.range q)).length = (List.range q).length := by
+      apply List.length_filter_eq_length_iff.mpr
+      intro a ha
+      simp only [Function.comp_apply, decide_eq_true_eq]
+      apply (hp.coprime_of_not_dvd ?_).symm
+      intro hdvd
+      have ha_lt : a + 1 < q + 1 := by
+        have := List.mem_range.mp ha
+        omega
+      have hp_le : q + 1 ≤ a + 1 := Nat.le_of_dvd (by omega) hdvd
+      omega
+    _ = q + 1 - 1 := by simp
+
+private theorem coprimeCount_blocks {p : Nat} (hp : Prime p) : ∀ k : Nat,
+    ((List.range (k * p)).filter fun a => Nat.Coprime a p).length =
+      k * (p - 1)
+  | 0 => by simp
+  | k + 1 => by
+      rw [Nat.succ_mul, List.range_add, List.filter_append,
+        List.length_append, coprimeCount_blocks hp k]
+      have hblock :
+          (((List.range p).map (k * p + ·)).filter
+            fun a => Nat.Coprime a p).length = p - 1 := by
+        rw [List.filter_map, List.length_map]
+        -- `gcd (k * p + a) p = gcd a p`: coprimality is `p`-periodic.
+        simpa only [Function.comp_def, Nat.Coprime,
+          Nat.gcd_mul_right_add_left] using coprimeCount_prime hp
+      rw [hblock]
+      simp [Nat.succ_mul]
+
+/-- Coprimality to a positive power is equivalent to coprimality to its base. -/
+theorem coprime_primePow_iff {a p e : Nat} (he : 0 < e) :
+    Nat.Coprime a (p ^ e) ↔ Nat.Coprime a p := by
+  constructor
+  · intro h
+    have hpdiv : p ∣ p ^ e := by
+      simpa using Nat.pow_dvd_pow p (show 1 ≤ e by omega)
+    exact Nat.Coprime.coprime_dvd_right hpdiv h
+  · exact fun h => h.pow_right e
+
+/-- A prime power has `p^(e-1) * (p-1)` coprime residue representatives. -/
+theorem coprimeCount_primePow {p e : Nat} (hp : Prime p) (he : 0 < e) :
+    ((List.range (p ^ e)).filter fun a => Nat.Coprime a (p ^ e)).length =
+      p ^ (e - 1) * (p - 1) := by
+  have hpow : p ^ e = p ^ (e - 1) * p := by
+    rw [← Nat.pow_succ]
+    congr 1
+    omega
+  have hcongr :
+      (List.range (p ^ e)).filter
+          (fun a => decide (Nat.Coprime a (p ^ e))) =
+        (List.range (p ^ e)).filter (fun a => decide (Nat.Coprime a p)) :=
+    List.filter_congr fun _ _ =>
+      decide_eq_decide.mpr (coprime_primePow_iff he)
+  rw [hcongr, hpow]
+  exact coprimeCount_blocks hp (p ^ (e - 1))
+
 private theorem prime_dvd_product {q : Nat} (hq : Prime q) :
     ∀ (entries : List PrimePower),
       (∀ e ∈ entries, Prime e.prime) →

--- a/HexIntFactor/SPEC/hex-int-factor.md
+++ b/HexIntFactor/SPEC/hex-int-factor.md
@@ -738,6 +738,11 @@ theorem sigmaEntry_eq_powerSum (entry : PrimePower) (k : Nat) :
         (fun q => q ^ k)).sum
 theorem totient_eq_count {n} (F : CheckedFactorization n) :
     totient F = ((List.range n).filter (fun a => Nat.Coprime a n)).length
+theorem coprime_primePow_iff {a p e} (he : 0 < e) :
+    Nat.Coprime a (p ^ e) ↔ Nat.Coprime a p
+theorem coprimeCount_primePow {p e} (hp : Hex.Nat.Prime p) (he : 0 < e) :
+    ((List.range (p ^ e)).filter (fun a => Nat.Coprime a (p ^ e))).length =
+      p ^ (e - 1) * (p - 1)
 theorem prime_dvd_radical_iff {n q} (F : CheckedFactorization n)
     (hq : Hex.Nat.Prime q) : q ∣ radical F ↔ q ∣ n
 theorem squareDivisor_eq_prod {n} (F : CheckedFactorization n) :
@@ -756,13 +761,14 @@ theorem isSquarefree_iff {n} (F : CheckedFactorization n) :
       ∀ q, Hex.Nat.Prime q → ¬ (q ^ 2 ∣ n)
 ```
 
-All of these take a `CheckedFactorization` rather than a `Nat`, which
-is the API decision worth defending. Taking a `Nat` would mean each
-call re-factors, and would mean each has to answer at `0` and at inputs
-the search cannot handle. Taking certified data makes them total
-functions whose theorems need no side hypothesis, and makes the cost
-model visible: factoring is expensive, everything downstream of it is
-not.
+All public divisor functions take a `CheckedFactorization` rather than
+a `Nat`, which is the API decision worth defending. Taking a `Nat` would
+mean each call re-factors, and would mean each has to answer at `0` and at
+inputs the search cannot handle. Taking certified data makes them total
+functions whose semantic theorems need no side hypothesis, and makes the
+cost model visible: factoring is expensive, everything downstream of it
+is not. The two `coprime*primePow` theorems are raw-`Nat` ingredients for
+the totient proof, rather than additional divisor functions.
 
 `squareDivisor` and `squarefreePart` traverse only the certified factor
 list: the former multiplies `pᵢ^(eᵢ / 2)`, and the latter multiplies
@@ -789,11 +795,13 @@ finite power sum over `powers p e 1`.
 The semantic theorems also name real proof work rather than assumed
 infrastructure. `mem_divisors` needs the bounded-exponent
 characterization of a divisor of a product of distinct prime powers.
-`totient_eq_count` additionally needs the prime-power coprime count and
-the multiplicative counting bijection for coprime moduli (a finite CRT
-argument). None of those results is presently exported by hex-arith.
-They are part of the divisor-API milestone; listing the theorems here is
-not a claim that the existing arithmetic root already proves them.
+`totient_eq_count` needs two ingredients: the prime-power coprime count
+and the multiplicative counting bijection for coprime moduli (a finite
+CRT argument). `coprimeCount_primePow` now supplies the first directly in
+the Mathlib-free layer by counting periodic blocks modulo the base prime.
+The CRT counting bijection is still outstanding and is part of the
+divisor-API milestone; listing `totient_eq_count` here is not a claim
+that the arithmetic root already proves that step.
 
 ## Complexity
 

--- a/conformance/HexIntFactor/Conformance.lean
+++ b/conformance/HexIntFactor/Conformance.lean
@@ -100,6 +100,14 @@ example : numDivisors checkedHugeTau = 101 ^ 6 := by decide +kernel
 example : sigma checkedHugeTau 0 = 101 ^ 6 := by decide +kernel
 example : sigma checkedPow64 1 = 2 ^ 65 - 1 := by decide +kernel
 #guard totient checked12 == 4
+example :
+    ((List.range (7 ^ 1)).filter fun a => Nat.Coprime a (7 ^ 1)).length = 6 := by
+  simpa using coprimeCount_primePow (p := 7) (e := 1) (by decide) (by decide)
+#guard ((List.range (7 ^ 1)).filter fun a => Nat.Coprime a (7 ^ 1)).length == 6
+example :
+    ((List.range (3 ^ 4)).filter fun a => Nat.Coprime a (3 ^ 4)).length = 54 := by
+  simpa using coprimeCount_primePow (p := 3) (e := 4) (by decide) (by decide)
+#guard ((List.range (3 ^ 4)).filter fun a => Nat.Coprime a (3 ^ 4)).length == 54
 #guard radical checked12 == 6
 #guard squarefreePart checked1 == 1
 #guard squareDivisor checked1 == 1

--- a/progress/20260826T051320Z_issue9647.md
+++ b/progress/20260826T051320Z_issue9647.md
@@ -1,0 +1,11 @@
+# Issue #9647 progress
+
+- Audited the Mathlib-free coprimality and list-range infrastructure; the
+  requested statement is sound without adding a CRT dependency.
+- Reduced prime-power coprimality to coprimality modulo the base prime and
+  counted periodic blocks of length `p`.
+- Added the downstream-facing theorem to the SPEC and conformance proof checks
+  at exponent one and at a higher prime power.
+- Incorporated independent review feedback: independently evaluated guards now
+  accompany theorem-use examples, the power-coprimality reduction is public,
+  and the periodic gcd and filter rewrites are explicit.


### PR DESCRIPTION
Closes #9647

## Summary
- prove that coprimality modulo a positive prime power reduces to the base prime
- count residues in periodic blocks of length `p` to obtain `p^(e-1) * (p-1)`
- expose the theorem in the SPEC and add exponent-one and higher-power proof checks

## Verification
- `lake build HexIntFactor`
- `lake build HexIntFactor HexIntFactorMathlib HexConformance`
- `python3 scripts/release/check_trust_surface.py`