### PR TITLE
polish: NumberField trio Phase-6 pass

### DIFF
--- a/HexNumberField/AlgebraicPoly.lean
+++ b/HexNumberField/AlgebraicPoly.lean
@@ -35,7 +35,9 @@ coefficients. Construction is sealed so every stored array has had its
 trailing semantic zeros removed. -/
 structure AlgebraicPoly where
   private mk ::
+  /-- The stored coefficients, in increasing degree order. -/
   data : Array AlgebraicNumber
+  /-- The stored coefficients have no trailing semantic zero. -/
   normalized : AlgebraicPolyNormalized data
 
 namespace AlgebraicPoly

--- a/HexNumberField/Basic.lean
+++ b/HexNumberField/Basic.lean
@@ -121,6 +121,7 @@ namespace AlgebraicNumber
 def x (a : AlgebraicNumber) : SimpleRoot a.p :=
   SimpleRoot.mk a.rep
 
+/-- The stored canonical representative selects exactly the root `a.x`. -/
 @[simp] theorem rep_mk (a : AlgebraicNumber) :
     SimpleRoot.mk a.rep = a.x := rfl
 

--- a/HexNumberField/Basic.lean
+++ b/HexNumberField/Basic.lean
@@ -29,24 +29,37 @@ namespace Hex
 /-- Runtime evidence that the factorization-backed irreducibility checker
 accepted an integer polynomial. -/
 class ZPoly.CheckedIrreducible (p : ZPoly) : Prop where
+  /-- The factorization-backed Boolean irreducibility checker accepted `p`. -/
   is_true : ZPoly.isIrreducible p = true
+  /-- `p` has positive degree, excluding the prime constants the integer
+  checker also accepts. -/
   pos_degree : 0 < p.degree?.getD 0
 
 /-- Canonical reduced rational coordinates in the fixed field `ℚ(x)`. -/
 structure QAdjoin (p : ZPoly) (x : SimpleRoot p) where
+  /-- Reduced rational coordinates in the power basis of the selected root. -/
   coeffs : DensePoly Rat
+  /-- The coordinates are already reduced modulo the defining polynomial. -/
   degree_lt : coeffs.degree?.getD 0 < p.degree?.getD 0
 
 /-- A factorization-lazy algebraic root with an eagerly certified isolating
 representative. -/
 structure AlgebraicRoot where
+  /-- The enclosing integer polynomial; it need not be irreducible. -/
   p : ZPoly
+  /-- `p` has unit content. -/
   prim : ZPoly.Primitive p
+  /-- `p` has positive leading coefficient. -/
   pos_lc : 0 < p.leadingCoeff
+  /-- `p` has positive degree. -/
   pos_degree : 0 < p.degree?.getD 0
+  /-- `p` has only simple roots. -/
   squarefree : HasOnlySimpleRoots p
+  /-- The selected root of `p`. -/
   x : SimpleRoot p
+  /-- The certified refined isolation of the selected root. -/
   rep : RefinedIsolation p
+  /-- The stored representative selects exactly the root `x`. -/
   rep_mk : SimpleRoot.mk rep = x
 
 namespace AlgebraicNumber
@@ -105,13 +118,22 @@ end AlgebraicNumber
 polynomial/root pair receives one fixed representative. -/
 structure AlgebraicNumber where
   private mk ::
+  /-- The normalized minimal integer polynomial of the represented value. -/
   p : ZPoly
+  /-- `p` has unit content. -/
   prim : ZPoly.Primitive p
+  /-- `p` has positive leading coefficient. -/
   pos_lc : 0 < p.leadingCoeff
+  /-- `p` has positive degree. -/
   pos_degree : 0 < p.degree?.getD 0
+  /-- The Boolean irreducibility checker accepted `p`. -/
   checked : ZPoly.CheckedIrreducible p
+  /-- `p` has only simple roots. -/
   squarefree : HasOnlySimpleRoots p
+  /-- The certified refined isolation of the represented root. -/
   rep : RefinedIsolation p
+  /-- The stored representative comes from the deterministic canonical
+  isolation pipeline (or is the fixed representative of zero). -/
   canonical : AlgebraicNumber.IsCanonical p squarefree rep
 
 namespace AlgebraicNumber
@@ -316,8 +338,11 @@ def panicWith (fallback : α) (message : String) : α :=
 
 /-- A root paired with its positive multiplicity. -/
 structure RootCount where
+  /-- The recorded root. -/
   root : AlgebraicRoot
+  /-- The multiplicity of the root in the polynomial being solved. -/
   multiplicity : Nat
+  /-- Roots are recorded only with positive multiplicity. -/
   multiplicity_pos : 0 < multiplicity
 
 /-- A polynomial root set; `.all` is reserved for the zero polynomial. -/

--- a/HexNumberField/Lazy.lean
+++ b/HexNumberField/Lazy.lean
@@ -315,21 +315,28 @@ end AlgebraicRoot
 
 namespace AlgebraicNumber
 
+/-- Canonical sum: perform the lazy operation, then exactify. -/
 @[expose] def add (a b : AlgebraicNumber) : AlgebraicNumber :=
   (a.toRoot.add b.toRoot).exact
 
+/-- Canonical difference: perform the lazy operation, then exactify. -/
 @[expose] def sub (a b : AlgebraicNumber) : AlgebraicNumber :=
   (a.toRoot.sub b.toRoot).exact
 
+/-- Canonical product: perform the lazy operation, then exactify. -/
 @[expose] def mul (a b : AlgebraicNumber) : AlgebraicNumber :=
   (a.toRoot.mul b.toRoot).exact
 
+/-- Canonical negation: reflect the lazy root, then exactify. -/
 @[expose] def neg (a : AlgebraicNumber) : AlgebraicNumber :=
   a.toRoot.neg.exact
 
+/-- Canonical inverse, with `inv 0 = 0`: perform the lazy operation, then
+exactify. -/
 @[expose] def inv (a : AlgebraicNumber) : AlgebraicNumber :=
   a.toRoot.inv.exact
 
+/-- Canonical quotient: perform the lazy operation, then exactify. -/
 @[expose] def div (a b : AlgebraicNumber) : AlgebraicNumber :=
   (a.toRoot.div b.toRoot).exact
 

--- a/HexNumberField/QAdjoin.lean
+++ b/HexNumberField/QAdjoin.lean
@@ -45,6 +45,10 @@ theorem ext {a b : QAdjoin p x} (h : a.coeffs = b.coeffs) : a = b := by
           subst bc
           rfl
 
+/-- Equality is exactly equality of canonical coordinate polynomials; the
+generated iff form of {name}`Hex.QAdjoin.ext`. -/
+add_decl_doc Hex.QAdjoin.ext_iff
+
 /-- Equality is exactly equality of canonical coordinate polynomials. -/
 theorem eq_iff_coeffs {a b : QAdjoin p x} : a = b ↔ a.coeffs = b.coeffs :=
   ⟨fun h => congrArg QAdjoin.coeffs h, ext⟩

--- a/HexNumberField/Roots.lean
+++ b/HexNumberField/Roots.lean
@@ -309,7 +309,9 @@ namespace Hex.AlgebraicPoly.Common
 
 /-- A primitive fixed-field presentation of an algebraic coefficient array. -/
 structure Presentation where
+  /-- The canonical primitive element of the common field. -/
   generator : AlgebraicNumber
+  /-- The input coefficients rewritten in the generator's fixed field. -/
   coefficients : Array (QAdjoin generator.p generator.x)
 
 /-- Deterministic signed shift order `0, 1, -1, 2, -2, ...`. -/
@@ -366,7 +368,9 @@ def degree (a : AlgebraicNumber) : Nat :=
 /-- A primitive-search candidate together with the signed shift that produced
 it. -/
 structure ShiftCandidate where
+  /-- The signed integer shift that produced this candidate. -/
   shift : Int
+  /-- The candidate primitive element `theta + shift * alpha`. -/
   value : AlgebraicNumber
 
 /-- One maximum-degree update that retains the producing signed shift. -/

--- a/HexNumberFieldMathlib/AdjoinRoot.lean
+++ b/HexNumberFieldMathlib/AdjoinRoot.lean
@@ -659,6 +659,7 @@ noncomputable def adjoinRootEquiv [ZPoly.CheckedIrreducible p] :
     QAdjoin p x ≃+* AdjoinRoot (definingPolynomial p) :=
   RingEquiv.ofBijective toAdjoinRootHom toAdjoinRoot_bijective
 
+/-- The packaged ring equivalence acts by the underlying comparison map. -/
 @[simp]
 theorem adjoinRootEquiv_apply [ZPoly.CheckedIrreducible p]
     (a : QAdjoin p x) : adjoinRootEquiv a = toAdjoinRoot a := rfl
@@ -674,6 +675,7 @@ noncomputable def embedding [ZPoly.CheckedIrreducible p]
   map_add' := fun a b => map_add a b rep h
   map_mul' := fun a b => map_mul a b rep h
 
+/-- The packaged ring homomorphism acts by evaluation at the selected root. -/
 @[simp]
 theorem embedding_apply [ZPoly.CheckedIrreducible p]
     (a : QAdjoin p x) (rep : RefinedIsolation p)

--- a/HexNumberFieldMathlib/Exact.lean
+++ b/HexNumberFieldMathlib/Exact.lean
@@ -485,15 +485,6 @@ private theorem relationPoly_natDegree {k : Nat} (coeffs : Vector Rat k) :
   rw [HexPolyMathlib.natDegree_toPolynomial]
   simp [DensePoly.degree?, relationPoly_size coeffs]
 
-private theorem relationPoly_monic {k : Nat} (coeffs : Vector Rat k) :
-    (HexPolyMathlib.toPolynomial (relationPoly coeffs)).Monic := by
-  rw [Polynomial.Monic.def]
-  rw [HexPolyMathlib.leadingCoeff_toPolynomial]
-  have hsize := relationPoly_size coeffs
-  have hpos : 0 < (relationPoly coeffs).size := by omega
-  rw [DensePoly.leadingCoeff_eq_coeff_last _ hpos, hsize]
-  simpa using relationPoly_coeff_top coeffs
-
 private theorem adjoinRoot_repr [ZPoly.CheckedIrreducible p]
     (a : QAdjoin p x) (i : Fin (definingPolynomial p).natDegree) :
     (AdjoinRoot.powerBasisAux' (definingPolynomial_monic p)).repr

--- a/HexNumberFieldMathlib/Field.lean
+++ b/HexNumberFieldMathlib/Field.lean
@@ -106,7 +106,8 @@ noncomputable def field : Field AlgebraicNumber := by
     rfl
   · intro q a
     change (smul q a).toComplex = q • a.toComplex
-    rw [smul, mul_toComplex, ofRat_toComplex, Rat.smul_def]
+    rw [Rat.smul_def]
+    exact smul_toComplex q a
   · exact natPow_toComplex
   · exact intPow_toComplex
   · intro n

--- a/HexNumberFieldMathlib/Lazy.lean
+++ b/HexNumberFieldMathlib/Lazy.lean
@@ -25,6 +25,8 @@ noncomputable section
 
 section
 
+/-- Proof-local Mathlib `CommRing` view of `ZPoly`, assembled from the
+executable library's verified `Lean.Grind.CommRing` instance. -/
 @[implicit_reducible] local instance : CommRing ZPoly :=
   let s := (inferInstance : Lean.Grind.CommRing ZPoly)
   { s with
@@ -45,6 +47,8 @@ section
         Lean.Grind.Ring.intCast_natCast_add_one,
         Lean.Grind.Semiring.natCast_succ] }
 
+/-- Proof-local domain structure on `ZPoly`, transported from
+`Polynomial Int`. -/
 local instance : IsDomain ZPoly :=
   MulEquiv.isDomain (Polynomial Int)
     (HexPolyMathlib.equiv (R := Int)).toMulEquiv

--- a/HexNumberFieldMathlib/Roots.lean
+++ b/HexNumberFieldMathlib/Roots.lean
@@ -23,6 +23,8 @@ normal-form contracts for both fixed-field and algebraic-coefficient drivers.
 
 namespace Hex
 
+/-- Proof-local Mathlib `CommRing` view of `ZPoly`, assembled from the
+executable library's verified `Lean.Grind.CommRing` instance. -/
 @[implicit_reducible] local instance : CommRing ZPoly :=
   let s := (inferInstance : Lean.Grind.CommRing ZPoly)
   { s with
@@ -43,6 +45,8 @@ namespace Hex
         Lean.Grind.Ring.intCast_natCast_add_one,
         Lean.Grind.Semiring.natCast_succ] }
 
+/-- Proof-local domain structure on `ZPoly`, transported from
+`Polynomial Int`. -/
 local instance : IsDomain ZPoly :=
   MulEquiv.isDomain (Polynomial Int)
     (HexPolyMathlib.equiv (R := Int)).toMulEquiv

--- a/HexNumberFieldMathlib/Yun.lean
+++ b/HexNumberFieldMathlib/Yun.lean
@@ -291,15 +291,6 @@ theorem rootMultiplicity_monicDiv [ZPoly.CheckedIrreducible p]
   rw [rootMultiplicity_monic (dividend / divisor) hquotient z]
   exact rootMultiplicity_div dividend divisor hdivisor hdividend z
 
-/-- A monic exact quotient of a nonzero executable polynomial is nonzero. -/
-theorem toPolynomial_monicDiv_ne_zero [ZPoly.CheckedIrreducible p]
-    (dividend divisor : DensePoly (QAdjoin p x))
-    (hdivisor : divisor ∣ dividend)
-    (hdividend : HexPolyMathlib.toPolynomial dividend ≠ 0) :
-    HexPolyMathlib.toPolynomial (monic (dividend / divisor)) ≠ 0 :=
-  toPolynomial_monic_ne_zero _
-    (toPolynomial_div_ne_zero dividend divisor hdivisor hdividend)
-
 /-- Monic normalization remains associated after any field embedding. -/
 theorem map_monic_associated [ZPoly.CheckedIrreducible p]
     {K : Type*} [Field K] (embedding : QAdjoin p x →+* K)

--- a/HexNumberFieldMathlib/Yun.lean
+++ b/HexNumberFieldMathlib/Yun.lean
@@ -470,10 +470,14 @@ repeated part contains the remaining `r - k` copies. -/
 structure YunInvariant [ZPoly.CheckedIrreducible p]
     {K : Type*} [Field K] (embedding : QAdjoin p x →+* K) (z : K)
     (r k : Nat) (w repeated : DensePoly (QAdjoin p x)) : Prop where
+  /-- The current squarefree-product accumulator is nonzero. -/
   w_ne : toPolynomialMap embedding w ≠ 0
+  /-- The current repeated part is nonzero. -/
   repeated_ne : toPolynomialMap embedding repeated ≠ 0
+  /-- The accumulator contains `z` exactly once while copies remain. -/
   w_multiplicity : (toPolynomialMap embedding w).rootMultiplicity z =
     if k ≤ r then 1 else 0
+  /-- The repeated part contains the remaining `r - k` copies of `z`. -/
   repeated_multiplicity :
     (toPolynomialMap embedding repeated).rootMultiplicity z = r - k
 

--- a/HexNumberFieldTower/Basic.lean
+++ b/HexNumberFieldTower/Basic.lean
@@ -72,7 +72,10 @@ end NumberTower
 only API for extending towers. -/
 structure NumberTower where
   private mk ::
+  /-- The extension levels, stored top-first. -/
   levels : Array NumberTower.Level
+  /-- Every level passed its structural, irreducibility, and fixed-embedding
+  checks at construction time. -/
   valid : NumberTower.LevelsValid levels.toList
 
 namespace NumberTower
@@ -158,7 +161,9 @@ def height (T : NumberTower) : Nat :=
 /-- Canonical mixed-radix rational coordinates in a fixed tower. -/
 structure Elem (T : NumberTower) where
   private mk ::
+  /-- The flattened mixed-radix rational coordinates. -/
   data : Array Rat
+  /-- The coordinate array has exactly the tower's dimension. -/
   size_eq : data.size = T.dim
 
 /-- Normalize an arbitrary coordinate array to the tower dimension by
@@ -208,6 +213,10 @@ theorem Elem.ext {T : NumberTower} {a b : Elem T}
   cases h
   rfl
 
+/-- Equality is exact coordinate equality inside a fixed tower; the generated
+iff form of {name}`Hex.NumberTower.Elem.ext`. -/
+add_decl_doc Hex.NumberTower.Elem.ext_iff
+
 instance {T : NumberTower} : DecidableEq (Elem T) := fun a b =>
   match decEq (coeffs a).toList (coeffs b).toList with
   | isTrue h =>
@@ -227,9 +236,13 @@ theorem ofRat_eq_ofCoeffs (T : NumberTower) (q : Rat) :
 /-- A dependent extension result carries the canonical lower-field embedding,
 the new generator, and its selected absolute algebraic root. -/
 structure Extension (T : NumberTower) where
+  /-- The extended tower. -/
   tower : NumberTower
+  /-- The canonical embedding of the lower field. -/
   embed : Elem T → Elem tower
+  /-- The adjoined generator as an element of the extended tower. -/
   gen : Elem tower
+  /-- The absolute algebraic root selected for the generator. -/
   root : AlgebraicRoot
 
 /-- Primitive associate with positive leading coefficient. This leaves every

--- a/HexNumberFieldTower/Data.lean
+++ b/HexNumberFieldTower/Data.lean
@@ -24,8 +24,12 @@ namespace Hex.NumberTower
 flattened lower-tower coefficient of `X^j`; the omitted coefficient of
 `X^degree` is one. -/
 structure Level where
+  /-- Relative degree of this extension over the tower below it. -/
   degree : Nat
+  /-- Lower coefficients of the monic defining polynomial, each flattened to
+  the lower tower's mixed-radix coordinates. -/
   defining : Array (Array Rat)
+  /-- The absolute algebraic root chosen as this level's generator. -/
   root : AlgebraicRoot
 
 /-- Dimension represented by a top-first list of extension levels. -/

--- a/HexNumberFieldTower/Factor.lean
+++ b/HexNumberFieldTower/Factor.lean
@@ -33,8 +33,12 @@ def checkFactorization {T : NumberTower} (f : Poly T) (scalar : Elem T)
 
 /-- A checked complete factorization in a fixed tower. -/
 structure Factorization (T : NumberTower) (f : Poly T) where
+  /-- The leading scalar; the listed factors are monic. -/
   scalar : Elem T
+  /-- Monic irreducible factors, canonically sorted, each with its positive
+  multiplicity. -/
   factors : Array (Poly T × Nat)
+  /-- The reconstruction and recursive irreducibility replay succeeded. -/
   checked : checkFactorization f scalar factors = true
 
 /-- Complete irreducible factorization with multiplicity. -/

--- a/HexNumberFieldTower/FactorRaw.lean
+++ b/HexNumberFieldTower/FactorRaw.lean
@@ -252,7 +252,9 @@ def factorSquarefree? : (levels : List Level) → Array (Array Rat) →
 /-- Runtime factorization payload before re-indexing coefficients by a public
 `NumberTower`. -/
 structure RawFactorization where
+  /-- The leading scalar's raw coordinates. -/
   scalar : Array Rat
+  /-- Raw monic factors, canonically sorted, each with its multiplicity. -/
   factors : Array (Array (Array Rat) × Nat)
 
 /-- Lexicographic order on rational lists. -/

--- a/HexNumberFieldTower/Flatten.lean
+++ b/HexNumberFieldTower/Flatten.lean
@@ -27,8 +27,11 @@ namespace Hex.NumberTower
 /-- A one-generator presentation of a tower together with checked executable
 coordinate conversions in both directions. -/
 structure Flattening (T : NumberTower) where
+  /-- The canonical primitive element generating the whole tower. -/
   root : AlgebraicNumber
+  /-- Rewrite tower coordinates in the primitive presentation. -/
   toPrimitive : Elem T → QAdjoin root.p root.x
+  /-- Evaluate primitive coordinates back to a tower element. -/
   fromPrimitive : QAdjoin root.p root.x → Elem T
 
 /-- The finite combined bound for primitive-element and coordinate-recovery
@@ -42,15 +45,23 @@ namespace Flatten
 /-- One exact absolute generator and its mixed-radix coordinate in the final
 tower. -/
 structure Generator (T : NumberTower) where
+  /-- The generator's relative degree at its level. -/
   degree : Nat
+  /-- The exactified canonical value of the generator. -/
   root : AlgebraicNumber
+  /-- The generator's mixed-radix coordinate in the final tower. -/
   value : Elem T
 
 /-- A primitive generator accumulated through the lower part of the tower. -/
 structure Candidate (T : NumberTower) where
+  /-- The mixed-radix dimension generated so far. -/
   dimension : Nat
+  /-- The canonical primitive element accumulated so far. -/
   root : AlgebraicNumber
+  /-- The accumulated primitive element as a tower coordinate. -/
   value : Elem T
+  /-- Each combined generator's coordinate in the accumulated
+  presentation. -/
   coordinates : Array (QAdjoin root.p root.x)
 
 /-- Standard coordinate vector of length `dimension`. -/
@@ -178,9 +189,13 @@ def recoverPair? (theta alpha gamma : AlgebraicNumber) (shift : Int) :
 /-- A full-degree primitive candidate together with its recovered old and new
 generator coordinates. -/
 structure Recovered where
+  /-- The signed shift producing the accepted candidate. -/
   shift : Int
+  /-- The accepted full-degree primitive candidate. -/
   root : AlgebraicNumber
+  /-- The prior generator's coordinate in the candidate presentation. -/
   thetaCoordinate : QAdjoin root.p root.x
+  /-- The new generator's coordinate in the candidate presentation. -/
   alphaCoordinate : QAdjoin root.p root.x
 
 /-- Search a prescribed shift suffix, rejecting degree collisions and any

--- a/HexNumberFieldTower/RawArithmetic.lean
+++ b/HexNumberFieldTower/RawArithmetic.lean
@@ -335,6 +335,7 @@ theorem mulCoords_size (levels : List Level) (a b : Array Rat) :
 recurses through runtime level data rather than a dependent `NumberTower`.
 The `raw` helper normalizes to the represented mixed-radix dimension. -/
 structure RawElem (levels : List Level) where
+  /-- The flattened mixed-radix rational coordinates. -/
   data : Array Rat
 
 /-- Wrap coordinate data as a `RawElem`, zero-padding or truncating to the
@@ -374,7 +375,9 @@ instance (levels : List Level) : Mul (RawElem levels) :=
 general-purpose `RawElem`, this type carries the fixed-width invariant needed
 by the semantic field bridge for polynomial xgcd. -/
 structure Coeff (levels : List Level) where
+  /-- The flattened mixed-radix rational coordinates. -/
   data : Array Rat
+  /-- The coordinate array has exactly the represented dimension. -/
   size_eq : data.size = levelsDim levels
 
 /-- Normalize arbitrary data into a canonical lower-tower coefficient. -/

--- a/HexNumberFieldTower/Split.lean
+++ b/HexNumberFieldTower/Split.lean
@@ -129,15 +129,6 @@ theorem Extension.trans_embed {T : NumberTower} (outer : Extension T)
     (inner : Extension outer.tower) (a : Elem T) :
     (outer.trans inner).embed a = inner.embed (outer.embed a) := rfl
 
-/-- Record-level normal form for a composed extension. -/
-theorem Extension.trans_eq {T : NumberTower} (outer : Extension T)
-    (inner : Extension outer.tower) :
-    outer.trans inner =
-      { tower := inner.tower
-        embed := fun a => inner.embed (outer.embed a)
-        gen := inner.gen
-        root := inner.root } := rfl
-
 /-- Whole-record normal form for pulling an inner splitting back through an
 extension.  Stating the equality at this level keeps the dependent root
 carrier aligned while clients reason about the explicit composite. -/

--- a/HexNumberFieldTower/Split.lean
+++ b/HexNumberFieldTower/Split.lean
@@ -91,7 +91,9 @@ inductive Roots (T : NumberTower) where
 /-- A checked extension together with all roots of the original polynomial in
 that extension. -/
 structure Splitting (T : NumberTower) (f : Poly T) where
+  /-- The extension over which the polynomial splits into linear factors. -/
   extension : Extension T
+  /-- All roots of the input polynomial in the extended tower. -/
   roots : Roots extension.tower
 
 /-- Map polynomial coefficients through an explicitly supplied tower


### PR DESCRIPTION
This PR complete the Phase-6 polishing pass for HexNumberField, HexNumberFieldMathlib, and HexNumberFieldTower, complementing the TowerMathlib pass from #9621. It adds 83 docstrings, mostly structure and class field documentation across the QAdjoin, AlgebraicRoot, NumberTower, Extension, and Splitting families, deletes three dead declarations (a private monicity lemma, an unused Yun nonvanishing lemma, and Extension.trans_eq, whose role is served by Splitting.trans_eq with the componentwise characterization lemmas kept), and derives the field instance's qsmul law from smul_toComplex instead of an inline reproof. No renames were needed; the trio had no slop names. The Batteries docBlame and docBlameThm' lints are clean across all three libraries, the #9432 refactor left no orphans in Roots.lean, and the full build with axiom guards, check_dag, check_phase4, and the freshness check are all green. The done_through bumps follow separately with the Phase-4 measurement evidence.

🤖 Prepared with Claude Code