### PR TITLE
fix: compute totient from certified factors

### DIFF
--- a/HexIntFactor/DivisorEnumeration.lean
+++ b/HexIntFactor/DivisorEnumeration.lean
@@ -135,7 +135,9 @@ private theorem prime_dvd_product {q : Nat} (hq : Prime q) :
           (fun x hx => hprime x (by simp [hx])) hr
         exact ⟨x, by simp [hx], heq⟩
 
-private theorem head_coprime {entry : PrimePower} {rest : List PrimePower}
+/-- The first prime power in a strictly ordered prime-power list is coprime to
+the product represented by the tail. -/
+theorem head_coprime {entry : PrimePower} {rest : List PrimePower}
     (hprime : ∀ e ∈ entry :: rest, Prime e.prime)
     (hsorted : (entry :: rest).Pairwise fun a b => a.prime < b.prime) :
     Nat.Coprime (entry.prime ^ entry.exponent)

--- a/HexIntFactor/Divisors.lean
+++ b/HexIntFactor/Divisors.lean
@@ -239,8 +239,9 @@ def sigma {n : Nat} (F : CheckedFactorization n) (k : Nat) : Nat :=
 
 /-- Euler's totient from a checked prime-power decomposition. -/
 @[expose]
-def totient {n : Nat} (_F : CheckedFactorization n) : Nat :=
-  ((List.range n).filter fun a => decide (Nat.Coprime a n)).length
+def totient {n : Nat} (F : CheckedFactorization n) : Nat :=
+  (F.raw.factors.map fun entry =>
+    entry.prime ^ (entry.exponent - 1) * (entry.prime - 1)).prod
 
 /-- Product of the distinct prime divisors. -/
 @[expose]
@@ -261,6 +262,13 @@ def squarefreePart {n : Nat} (F : CheckedFactorization n) : Nat :=
 @[expose]
 def isSquarefree {n : Nat} (F : CheckedFactorization n) : Bool :=
   F.raw.factors.all fun e => e.exponent == 1
+
+/-- The totient uses one canonical contribution per certified prime power. -/
+theorem totient_eq_prod {n : Nat} (F : CheckedFactorization n) :
+    totient F =
+      (F.raw.factors.map fun entry =>
+        entry.prime ^ (entry.exponent - 1) * (entry.prime - 1)).prod :=
+  rfl
 
 /-- The largest square-divisor root uses half of each certified exponent. -/
 theorem squareDivisor_eq_prod {n : Nat} (F : CheckedFactorization n) :
@@ -409,11 +417,6 @@ theorem sigma_eq_sum {n k : Nat} (F : CheckedFactorization n) :
     have hsum := (hperm.map (fun d => d ^ k)).sum_nat
     simpa only [divisors, List.toList_toArray] using hsum.symm
 
-/-- The factor-product formula counts residues coprime to `n`. -/
-theorem totient_eq_count {n : Nat} (F : CheckedFactorization n) :
-    totient F = ((List.range n).filter (fun a => Nat.Coprime a n)).length := by
-  simp [totient]
-
 /-- Coprime-residue counts multiply across coprime moduli. -/
 theorem coprimeCount_mul {m n : Nat} (hcop : Nat.Coprime m n) :
     ((List.range (m * n)).filter fun a => Nat.Coprime a (m * n)).length =
@@ -500,6 +503,41 @@ theorem coprimeCount_primePow {p e : Nat} (hp : Prime p) (he : 0 < e) :
       decide_eq_decide.mpr (coprime_primePow_iff he)
   rw [hcongr, hpow]
   exact coprimeCount_blocks hp (p ^ (e - 1))
+
+private theorem totientEntries_eq_count : ∀ entries : List PrimePower,
+    (∀ entry ∈ entries, Prime entry.prime) →
+    (∀ entry ∈ entries, 0 < entry.exponent) →
+    entries.Pairwise (fun a b => a.prime < b.prime) →
+    (entries.map fun entry =>
+      entry.prime ^ (entry.exponent - 1) * (entry.prime - 1)).prod =
+      ((List.range ((entries.map fun entry =>
+        entry.prime ^ entry.exponent).prod)).filter fun a =>
+          Nat.Coprime a ((entries.map fun entry =>
+            entry.prime ^ entry.exponent).prod)).length
+  | [], _, _, _ => by simp
+  | entry :: rest, hprime, hexponent, hsorted => by
+      have hp := hprime entry (by simp)
+      have he := hexponent entry (by simp)
+      have hprimeRest : ∀ e ∈ rest, Prime e.prime := by
+        intro e heMem
+        exact hprime e (by simp [heMem])
+      have hexponentRest : ∀ e ∈ rest, 0 < e.exponent := by
+        intro e heMem
+        exact hexponent e (by simp [heMem])
+      have hsortedRest := (List.pairwise_cons.mp hsorted).2
+      rw [List.map_cons, List.prod_cons, List.map_cons, List.prod_cons,
+        coprimeCount_mul (DivisorEnumeration.head_coprime hprime hsorted),
+        coprimeCount_primePow hp he,
+        totientEntries_eq_count rest hprimeRest hexponentRest hsortedRest]
+
+/-- The certified prime-power product formula counts residues coprime to `n`. -/
+theorem totient_eq_count {n : Nat} (F : CheckedFactorization n) :
+    totient F = ((List.range n).filter (fun a => Nat.Coprime a n)).length := by
+  have h := totientEntries_eq_count F.raw.factors
+    (checkFactorization_prime F.valid)
+    (checkFactorization_exponent F.valid)
+    (checkFactorization_sorted F.valid)
+  simpa [totient, checkFactorization_prod F.valid, F.subject_eq] using h
 
 private theorem prime_dvd_product {q : Nat} (hq : Prime q) :
     ∀ (entries : List PrimePower),

--- a/HexIntFactor/SPEC/hex-int-factor.md
+++ b/HexIntFactor/SPEC/hex-int-factor.md
@@ -738,6 +738,10 @@ theorem sigmaEntry_eq_powerSum (entry : PrimePower) (k : Nat) :
         (fun q => q ^ k)).sum
 theorem totient_eq_count {n} (F : CheckedFactorization n) :
     totient F = ((List.range n).filter (fun a => Nat.Coprime a n)).length
+theorem totient_eq_prod {n} (F : CheckedFactorization n) :
+    totient F =
+      (F.raw.factors.map fun e =>
+        e.prime ^ (e.exponent - 1) * (e.prime - 1)).prod
 theorem coprimeCount_mul {m n} (hcop : Nat.Coprime m n) :
     ((List.range (m * n)).filter (fun a => Nat.Coprime a (m * n))).length =
       ((List.range m).filter (fun a => Nat.Coprime a m)).length *
@@ -771,8 +775,8 @@ mean each call re-factors, and would mean each has to answer at `0` and at
 inputs the search cannot handle. Taking certified data makes them total
 functions whose semantic theorems need no side hypothesis, and makes the
 cost model visible: factoring is expensive, while most certificate consumers
-are linear in the number of prime-power entries. Divisor enumeration and the
-current placeholder implementation of `totient` are the stated exceptions.
+are linear in the number of prime-power entries. Divisor enumeration is the
+stated exception.
 The `coprimeCount_mul` and two `coprime*primePow` theorems are raw-`Nat`
 ingredients for the totient proof, rather than additional divisor functions.
 
@@ -808,12 +812,10 @@ the Mathlib-free layer by counting periodic blocks modulo the base prime.
 `coprimeCount_mul` supplies the second: the forward map sends a residue to
 its representatives modulo the two coprime factors, and a constructive
 extended-GCD inverse proves the resulting finite lists are permutations.
-The zero/unit boundary is included in the theorem. Listing
-`totient_eq_count` here is not a claim that the arithmetic root already uses
-these ingredients: `totient` currently ignores its certificate and enumerates
-`List.range n`, so it costs `O(n)` gcd computations rather than `O(k)`.
-Replacing it by `∏ pᵢ^(eᵢ-1)(pᵢ-1)`, proved from the two counting theorems,
-is the next divisor-API milestone.
+The zero/unit boundary is included in the theorem. The implementation of
+`totient` uses these ingredients to justify the certified product
+`∏ pᵢ^(eᵢ-1)(pᵢ-1)`. It traverses only the checked prime-power list and
+does not enumerate residues below the subject.
 
 ## Complexity
 
@@ -832,8 +834,8 @@ the number of distinct primes, `B` a smoothness bound.
 | `checkOrder` | `O(k)` modular exponentiations plus `checkFactorization` | includes the order's primality replays |
 | `divisors` | `O(τ log τ)` | `τ = ∏(eᵢ + 1)` |
 | `sigma` | `O(k)` geometric sums | each entry uses `O(log r + log e)` multiplications for power argument `r`; for fixed `p` and `r`, its output has `Θ(e)` bits |
-| `totient` (current placeholder) | `O(n)` gcds | becomes `O(k)` when the certified product formula lands |
-| everything else in the divisor API | `O(k)` | excludes `divisors` and the current `totient` placeholder |
+| `totient` | `O(Σ log eᵢ)` multiplications | `k` certified prime-power contributions; no residue scan |
+| everything else in the divisor API | `O(k)` | excludes `divisors` |
 
 These are **arithmetic-operation counts on `Nat`**, not bit
 complexity: the operands are big integers throughout, `p^e` costs

--- a/HexIntFactorMathlib/Factorization.lean
+++ b/HexIntFactorMathlib/Factorization.lean
@@ -127,7 +127,7 @@ theorem divisors_eq {n : Nat} (F : CheckedFactorization n) :
 /-- The checked totient agrees with Mathlib's Euler totient. -/
 theorem totient_eq {n : Nat} (F : CheckedFactorization n) :
     totient F = _root_.Nat.totient n := by
-  rw [Hex.Nat.totient, _root_.Nat.totient]
+  rw [Hex.Nat.totient_eq_count F, _root_.Nat.totient]
   rw [← List.toFinset_card_of_nodup
     (List.nodup_range.filter (fun a => decide (Nat.Coprime a n)))]
   rw [List.toFinset_filter, List.toFinset_range]

--- a/bench/HexIntFactor/Bench.lean
+++ b/bench/HexIntFactor/Bench.lean
@@ -135,6 +135,9 @@ def runSigmaFactorCount (input : SigmaInput) : Nat :=
 def runSquareFactorCount (input : SigmaInput) : Nat :=
   squareDivisor input.checked + squarefreePart input.checked
 
+def runTotientFactorCount (input : SigmaInput) : Nat :=
+  totient input.checked
+
 /- Generic factorization is rho-dominated on balanced semiprimes: the smaller
 factor has size `sqrt n`, and rho takes its square root, giving `O(n^(1/4))`
 arithmetic iterations. The returned factor-count hash is constant-size. -/
@@ -213,7 +216,7 @@ setup_benchmark runOrder n => n
     targetInnerNanos := 100000000
   }
 
-/- These two targets are much faster per call than the route-search targets
+/- These targets are much faster per call than the route-search targets
 above, while using the same warm, autotuned 100 ms child-side batches. On the
 scheduled high-startup host, the default ten-spawn floor would discard their
 in-process measurements; the 1.0 multiplier changes only that filter, and
@@ -273,6 +276,27 @@ setup_benchmark runSquareFactorCount n => n * n
     signalFloorMultiplier := 1.0
     -- At 32..512 the early accumulator-width regimes gave an inconclusive
     -- slope. Extending to 1024 exposes convergence toward the n² model.
+    slopeTolerance := 0.20
+    outerTrials := 3
+  }
+
+/- Each prepared certificate has `n` fixed-exponent prime-power entries.
+`totient` builds one bounded-size contribution per entry, then sequentially
+multiplies an accumulator whose limb count grows linearly, giving the declared
+`Theta(n²)` native-cost model. Hashing the linearly sized result is lower-order.
+Preparation hoists the enormous subject out of the timed loop; scanning
+residues below it would not terminate on these subjects. -/
+setup_benchmark runTotientFactorCount n => n * n
+  with prep := sigmaInputForCount
+  where {
+    paramFloor := 32
+    paramCeiling := 1024
+    paramSchedule := .custom #[32, 64, 128, 256, 512, 1024]
+    maxSecondsPerCall := 5.0
+    targetInnerNanos := 100000000
+    signalFloorMultiplier := 1.0
+    -- The ladder crosses accumulator-width regimes; 0.20 admits that
+    -- finite-range transition without changing the model.
     slopeTolerance := 0.20
     outerTrials := 3
   }

--- a/conformance/HexIntFactor/Conformance.lean
+++ b/conformance/HexIntFactor/Conformance.lean
@@ -100,6 +100,13 @@ example : numDivisors checkedHugeTau = 101 ^ 6 := by decide +kernel
 example : sigma checkedHugeTau 0 = 101 ^ 6 := by decide +kernel
 example : sigma checkedPow64 1 = 2 ^ 65 - 1 := by decide +kernel
 #guard totient checked12 == 4
+#guard totient checked1 == 1
+#guard totient checked64 == 32
+#guard totient checked10800 == 2880
+#guard totient checked30 == 8
+-- A range scan to this subject is infeasible; this exercises the factor route.
+#guard totient checkedPow64 == 2 ^ 63
+example : totient checkedPow64 = 2 ^ 63 := by decide +kernel
 example :
     ((List.range (7 ^ 1)).filter fun a => Nat.Coprime a (7 ^ 1)).length = 6 := by
   simpa using coprimeCount_primePow (p := 7) (e := 1) (by decide) (by decide)

--- a/progress/20260826T070500Z_issue9641.md
+++ b/progress/20260826T070500Z_issue9641.md
@@ -1,0 +1,14 @@
+# Issue #9641 progress
+
+- Replaced the residue-range implementation of `totient` with the canonical
+  product over the checked prime-power entries.
+- Proved the product counts coprime residues by induction, composing the
+  prime-power count and finite CRT multiplicativity theorems.
+- Updated the Mathlib correspondence proof to pass through the public
+  Mathlib-free semantic theorem instead of relying on definitional equality.
+- Added prime-power, mixed-composite, unit, and infeasibly-large-subject
+  conformance checks.
+- Registered a controlled factor-count benchmark whose prepared subjects make
+  a hidden range scan nonterminating, and updated the SPEC's complexity claim.
+  Its 32-to-1024-entry scientific ladder was consistent with the declared
+  native `n²` cost model.


### PR DESCRIPTION
Closes #9641

## Summary
- compute `totient` from the checked prime-power product instead of scanning `List.range n`
- prove the product counts coprime residues by composing prime-power counting with finite CRT multiplicativity
- route the Mathlib correspondence through the Mathlib-free semantic theorem
- add product characterization, large-subject conformance, and a controlled factor-count benchmark

## Verification
- `lake build HexIntFactor HexIntFactorMathlib HexConformance`
- `lake exe hexintfactor_bench list`
- `lake exe hexintfactor_bench verify`
- `lake exe hexintfactor_bench run Hex.IntFactorBench.runTotientFactorCount` (consistent with declared complexity)
- existing `EmitFixtures`/PARI oracle path checks `phi` independently on eight subjects
- DAG, line-count, Phase 4/7, trust-surface, banned-token, and diff checks

## Independent review
Fresh Claude Opus review found no blocker. All seven polish findings were addressed: benchmark tolerance/hash/wording, exact scan-failure description, exponent-aware SPEC cost, `totient_eq_prod`, and squarefree conformance.