### PR TITLE
fix: expose integer-factor candidate rejection

### DIFF
--- a/HexIntFactor/Cyclotomic.lean
+++ b/HexIntFactor/Cyclotomic.lean
@@ -142,14 +142,18 @@ private def factorPowerTarget? (target : Nat) (parts? : Option (List CyclotomicP
           let raw : Factorization := ⟨target, entries⟩
           if h : checkFactorization raw = true then
             .ok (⟨raw, rfl, h⟩, r', .cyclotomic)
-          else
-            match factor? target r' fuel with
-            | .ok (F, r'') => .ok (F, r'', .generic)
-            | .error failure => .error failure
+          else .error
+            { stop := .rejected
+              attempts := 0
+              rand := r'
+              culprit := some ⟨target, entries, 1⟩ }
       | .error failure =>
-          match factor? target failure.rand fuel with
-          | .ok (F, r') => .ok (F, r', .generic)
-          | .error fallback => .error fallback
+          match failure.stop with
+          | .rejected => .error failure
+          | .zero | .incomplete =>
+              match factor? target failure.rand fuel with
+              | .ok (F, r') => .ok (F, r', .generic)
+              | .error fallback => .error fallback
   | none =>
       match factor? target r fuel with
       | .ok (F, r') => .ok (F, r', .generic)

--- a/HexIntFactor/Cyclotomic.lean
+++ b/HexIntFactor/Cyclotomic.lean
@@ -110,6 +110,21 @@ inductive PowerRoute where
   | generic
 deriving Repr, DecidableEq
 
+namespace Internal
+
+/-- Retry a power target only after ordinary subproblem exhaustion. An
+invariant rejection is propagated with its original diagnostic scope. -/
+def retryPower? (target : Nat) (failure : FactorFailure) (fuel : Nat) :
+    Except FactorFailure (CheckedFactorization target × Rand × PowerRoute) :=
+  match failure.stop with
+  | .rejected => .error failure
+  | .zero | .incomplete =>
+      match factor? target failure.rand fuel with
+      | .ok (F, r') => .ok (F, r', .generic)
+      | .error fallback => .error fallback
+
+end Internal
+
 private def insertPartPower (entry : PrimePower) : List PrimePower → List PrimePower
   | [] => [entry]
   | current :: rest =>
@@ -146,14 +161,10 @@ private def factorPowerTarget? (target : Nat) (parts? : Option (List CyclotomicP
             { stop := .rejected
               attempts := 0
               rand := r'
-              culprit := some ⟨target, entries, 1⟩ }
+              culprit := some ⟨target, entries, 1⟩
+              metered := false }
       | .error failure =>
-          match failure.stop with
-          | .rejected => .error failure
-          | .zero | .incomplete =>
-              match factor? target failure.rand fuel with
-              | .ok (F, r') => .ok (F, r', .generic)
-              | .error fallback => .error fallback
+          Internal.retryPower? target failure fuel
   | none =>
       match factor? target r fuel with
       | .ok (F, r') => .ok (F, r', .generic)

--- a/HexIntFactor/Factor.lean
+++ b/HexIntFactor/Factor.lean
@@ -24,13 +24,21 @@ namespace Nat
 inductive FactorStop where
   | zero
   | incomplete
+  | rejected
 deriving Repr, DecidableEq
+
+/-- Checked partial data retained when complete search stops. -/
+structure PartialSnapshot where
+  raw : PartialFactorization
+  valid : checkPartial raw = true
+deriving Repr
 
 /-- Resumable factorization failure. -/
 structure FactorFailure where
   stop : FactorStop
   attempts : Nat
   rand : Rand
+  snapshot : Option PartialSnapshot := none
 deriving Repr
 
 /-- Default search budget, scaled by input bit length. -/
@@ -118,59 +126,112 @@ private def smallAttempt (n : Nat) (r : Rand) (fuel : Nat) :
   ⟨⟨n, result.factors, result.residual⟩, rfl,
     result.rand, result.attempts⟩
 
-/-- Return checked partial data for every positive input. -/
+namespace Internal
+
+/-- Check an untrusted partial candidate and tie it to the requested subject.
+Checker rejection is an internal search failure, not fuel exhaustion. -/
+def acceptPartial? (n : Nat) (hn : 0 < n) (raw : PartialFactorization)
+    (r : Rand) (attempts : Nat) :
+    Except FactorFailure (CheckedPartialFactorization n × Rand) :=
+  let fallback : PartialFactorization := ⟨n, [], n⟩
+  have hf : checkPartial fallback = true := by
+    dsimp [fallback]
+    simp [checkPartial, checkEntries, factorProduct, boundedPowMul, hn]
+  let rejected : FactorFailure :=
+    { stop := .rejected
+      attempts
+      rand := r
+      snapshot := some ⟨fallback, hf⟩ }
+  if hs : raw.subject = n then
+    if hv : checkPartial raw = true then
+      .ok (⟨raw, hs, hv⟩, r)
+    else .error rejected
+  else .error rejected
+
+/-- Candidate acceptance never confuses checker rejection with exhaustion. -/
+theorem acceptPartial?_error {n hn raw r attempts f}
+    (h : acceptPartial? n hn raw r attempts = .error f) :
+    f.stop = .rejected ∧
+      ∃ saved, f.snapshot = some saved ∧ saved.raw.subject = n := by
+  unfold acceptPartial? at h
+  dsimp only at h
+  split at h
+  · split at h
+    · cases h
+    · injection h with h
+      subst h
+      simp
+  · injection h with h
+    subst h
+    simp
+
+end Internal
+
+/-- Return checked partial data for positive input, or expose a rejected
+internal candidate. -/
 def factorPartial? (n : Nat) (r : Rand) (fuel : Nat := defaultFuel n) :
     Except FactorFailure (CheckedPartialFactorization n × Rand) :=
-  if hn : n = 0 then .error ⟨.zero, 0, r⟩
+  if hn : n = 0 then .error { stop := .zero, attempts := 0, rand := r }
   else
     let out := smallAttempt n r fuel
-    if hv : checkPartial out.raw = true then
-      .ok (⟨out.raw, out.subject_eq, hv⟩, out.rand)
-    else
-      let fallback : PartialFactorization := ⟨n, [], n⟩
-      have hf : checkPartial fallback = true := by
-        dsimp [fallback]
-        simp [checkPartial, checkEntries, factorProduct, boundedPowMul,
-          Nat.pos_of_ne_zero hn]
-      .ok (⟨fallback, rfl, hf⟩, out.rand)
+    Internal.acceptPartial? n (Nat.pos_of_ne_zero hn) out.raw out.rand out.attempts
 
 /-- Complete factorization when the checked partial residual is `1`. -/
 def factor? (n : Nat) (r : Rand) (fuel : Nat := defaultFuel n) :
     Except FactorFailure (CheckedFactorization n × Rand) :=
-  if _hn : n = 0 then .error ⟨.zero, 0, r⟩
+  if hn : n = 0 then .error { stop := .zero, attempts := 0, rand := r }
   else
     let out := smallAttempt n r fuel
-    if _hp : checkPartial out.raw = true then
-      if _hr : out.raw.residual = 1 then
-        let raw : Factorization := ⟨n, out.raw.factors⟩
-        if hv : checkFactorization raw = true then
-          .ok (⟨raw, rfl, hv⟩, out.rand)
-        else .error ⟨.incomplete, out.attempts, out.rand⟩
-      else .error ⟨.incomplete, out.attempts, out.rand⟩
-    else .error ⟨.incomplete, out.attempts, out.rand⟩
+    match Internal.acceptPartial? n (Nat.pos_of_ne_zero hn) out.raw out.rand
+        out.attempts with
+    | .error failure => .error failure
+    | .ok (F, r') =>
+        if _hr : F.raw.residual = 1 then
+          let raw : Factorization := ⟨n, F.raw.factors⟩
+          if hv : checkFactorization raw = true then
+            .ok (⟨raw, rfl, hv⟩, r')
+          else .error
+            { stop := .rejected
+              attempts := out.attempts
+              rand := r'
+              snapshot := some ⟨F.raw, F.valid⟩ }
+        else .error
+          { stop := .incomplete
+            attempts := out.attempts
+            rand := r'
+            snapshot := some ⟨F.raw, F.valid⟩ }
 
-/-- Partial search errors exactly on the input `0`. -/
+/-- Partial search errors are either the distinguished zero input or an
+internal candidate rejection. -/
 theorem factorPartial?_error {n r fuel f}
     (h : factorPartial? n r fuel = .error f) :
-    f.stop = .zero ∧ n = 0 := by
+    (f.stop = .zero ∧ n = 0) ∨
+      (f.stop = .rejected ∧
+        ∃ saved, f.snapshot = some saved ∧ saved.raw.subject = n) := by
   unfold factorPartial? at h
   split at h
   · rename_i hn
     injection h with h
     subst h
-    exact ⟨rfl, hn⟩
+    exact Or.inl ⟨rfl, hn⟩
   · dsimp only at h
-    split at h <;> cases h
+    exact Or.inr (Internal.acceptPartial?_error h)
 
-/-- Every positive input has checked partial data, independently of fuel. -/
+/-- Every positive input either has checked partial data or exposes an internal
+candidate rejection; rejection is never reported as ordinary exhaustion. -/
 theorem factorPartial?_success {n r fuel} (hn : 0 < n) :
-    ∃ F r', factorPartial? n r fuel = .ok (F, r') := by
+    (∃ F r', factorPartial? n r fuel = .ok (F, r')) ∨
+      ∃ f saved, factorPartial? n r fuel = .error f ∧
+        f.stop = .rejected ∧ f.snapshot = some saved ∧
+          saved.raw.subject = n := by
   cases hresult : factorPartial? n r fuel with
-  | ok result => exact ⟨result.1, result.2, by simpa using hresult⟩
+  | ok result => exact Or.inl ⟨result.1, result.2, rfl⟩
   | error f =>
-      obtain ⟨_, hz⟩ := factorPartial?_error hresult
-      subst n
-      cases hn
+      rcases factorPartial?_error hresult with ⟨_, hz⟩ | ⟨hrejected, hsnapshot⟩
+      · subst n
+        cases hn
+      · obtain ⟨saved, hsaved, hsubject⟩ := hsnapshot
+        exact Or.inr ⟨f, saved, rfl, hrejected, hsaved, hsubject⟩
 
 end Nat
 

--- a/HexIntFactor/Factor.lean
+++ b/HexIntFactor/Factor.lean
@@ -38,8 +38,12 @@ structure FactorFailure where
   stop : FactorStop
   attempts : Nat
   rand : Rand
+  /-- Last checked partial aggregate, when the stopped route has one. -/
   snapshot : Option PartialSnapshot := none
+  /-- Raw aggregate rejected by a checker, when rejection caused the stop. -/
   culprit : Option PartialFactorization := none
+  /-- Whether `attempts` is an exact count for the stopped route. -/
+  metered : Bool := true
 deriving Repr
 
 /-- Default search budget, scaled by input bit length. -/
@@ -225,7 +229,7 @@ theorem factorPartial?_error {n r fuel f}
 
 /-- Every positive input either has checked partial data or exposes an internal
 candidate rejection; rejection is never reported as ordinary exhaustion. -/
-theorem factorPartial?_success {n r fuel} (hn : 0 < n) :
+theorem factorPartial?_result {n r fuel} (hn : 0 < n) :
     (∃ F r', factorPartial? n r fuel = .ok (F, r')) ∨
       ∃ f rejected saved, factorPartial? n r fuel = .error f ∧
         f.stop = .rejected ∧ f.culprit = some rejected ∧

--- a/HexIntFactor/Factor.lean
+++ b/HexIntFactor/Factor.lean
@@ -39,6 +39,7 @@ structure FactorFailure where
   attempts : Nat
   rand : Rand
   snapshot : Option PartialSnapshot := none
+  culprit : Option PartialFactorization := none
 deriving Repr
 
 /-- Default search budget, scaled by input bit length. -/
@@ -131,7 +132,7 @@ namespace Internal
 /-- Check an untrusted partial candidate and tie it to the requested subject.
 Checker rejection is an internal search failure, not fuel exhaustion. -/
 def acceptPartial? (n : Nat) (hn : 0 < n) (raw : PartialFactorization)
-    (r : Rand) (attempts : Nat) :
+    (hs : raw.subject = n) (r : Rand) (attempts : Nat) :
     Except FactorFailure (CheckedPartialFactorization n × Rand) :=
   let fallback : PartialFactorization := ⟨n, [], n⟩
   have hf : checkPartial fallback = true := by
@@ -141,28 +142,30 @@ def acceptPartial? (n : Nat) (hn : 0 < n) (raw : PartialFactorization)
     { stop := .rejected
       attempts
       rand := r
-      snapshot := some ⟨fallback, hf⟩ }
-  if hs : raw.subject = n then
-    if hv : checkPartial raw = true then
-      .ok (⟨raw, hs, hv⟩, r)
-    else .error rejected
+      snapshot := some ⟨fallback, hf⟩
+      culprit := some raw }
+  if hv : checkPartial raw = true then
+    .ok (⟨raw, hs, hv⟩, r)
   else .error rejected
 
 /-- Candidate acceptance never confuses checker rejection with exhaustion. -/
-theorem acceptPartial?_error {n hn raw r attempts f}
-    (h : acceptPartial? n hn raw r attempts = .error f) :
-    f.stop = .rejected ∧
+theorem acceptPartial?_error {n hn raw hs r attempts f}
+    (h : acceptPartial? n hn raw hs r attempts = .error f) :
+    f.stop = .rejected ∧ f.culprit = some raw ∧
+      checkPartial raw = false ∧
       ∃ saved, f.snapshot = some saved ∧ saved.raw.subject = n := by
   unfold acceptPartial? at h
   dsimp only at h
   split at h
-  · split at h
-    · cases h
-    · injection h with h
-      subst h
-      simp
-  · injection h with h
+  · cases h
+  · rename_i hv
+    injection h with h
     subst h
+    have hbad : checkPartial raw = false := by
+      cases hcheck : checkPartial raw with
+      | false => rfl
+      | true => exact False.elim (hv hcheck)
+    refine ⟨rfl, rfl, hbad, ?_⟩
     simp
 
 end Internal
@@ -174,7 +177,8 @@ def factorPartial? (n : Nat) (r : Rand) (fuel : Nat := defaultFuel n) :
   if hn : n = 0 then .error { stop := .zero, attempts := 0, rand := r }
   else
     let out := smallAttempt n r fuel
-    Internal.acceptPartial? n (Nat.pos_of_ne_zero hn) out.raw out.rand out.attempts
+    Internal.acceptPartial? n (Nat.pos_of_ne_zero hn) out.raw out.subject_eq
+      out.rand out.attempts
 
 /-- Complete factorization when the checked partial residual is `1`. -/
 def factor? (n : Nat) (r : Rand) (fuel : Nat := defaultFuel n) :
@@ -182,19 +186,16 @@ def factor? (n : Nat) (r : Rand) (fuel : Nat := defaultFuel n) :
   if hn : n = 0 then .error { stop := .zero, attempts := 0, rand := r }
   else
     let out := smallAttempt n r fuel
-    match Internal.acceptPartial? n (Nat.pos_of_ne_zero hn) out.raw out.rand
-        out.attempts with
+    match Internal.acceptPartial? n (Nat.pos_of_ne_zero hn) out.raw
+        out.subject_eq out.rand out.attempts with
     | .error failure => .error failure
     | .ok (F, r') =>
         if _hr : F.raw.residual = 1 then
           let raw : Factorization := ⟨n, F.raw.factors⟩
-          if hv : checkFactorization raw = true then
-            .ok (⟨raw, rfl, hv⟩, r')
-          else .error
-            { stop := .rejected
-              attempts := out.attempts
-              rand := r'
-              snapshot := some ⟨F.raw, F.valid⟩ }
+          have hv : checkFactorization raw = true := by
+            simpa [raw, F.subject_eq] using
+              checkFactorization_of_checkPartial F.valid _hr
+          .ok (⟨raw, rfl, hv⟩, r')
         else .error
           { stop := .incomplete
             attempts := out.attempts
@@ -207,7 +208,9 @@ theorem factorPartial?_error {n r fuel f}
     (h : factorPartial? n r fuel = .error f) :
     (f.stop = .zero ∧ n = 0) ∨
       (f.stop = .rejected ∧
-        ∃ saved, f.snapshot = some saved ∧ saved.raw.subject = n) := by
+        ∃ rejected saved, f.culprit = some rejected ∧
+          checkPartial rejected = false ∧ f.snapshot = some saved ∧
+            saved.raw.subject = n) := by
   unfold factorPartial? at h
   split at h
   · rename_i hn
@@ -215,23 +218,29 @@ theorem factorPartial?_error {n r fuel f}
     subst h
     exact Or.inl ⟨rfl, hn⟩
   · dsimp only at h
-    exact Or.inr (Internal.acceptPartial?_error h)
+    obtain ⟨hrejected, hculprit, hbad, saved, hsaved, hsubject⟩ :=
+      Internal.acceptPartial?_error h
+    exact Or.inr
+      ⟨hrejected, _, saved, hculprit, hbad, hsaved, hsubject⟩
 
 /-- Every positive input either has checked partial data or exposes an internal
 candidate rejection; rejection is never reported as ordinary exhaustion. -/
 theorem factorPartial?_success {n r fuel} (hn : 0 < n) :
     (∃ F r', factorPartial? n r fuel = .ok (F, r')) ∨
-      ∃ f saved, factorPartial? n r fuel = .error f ∧
-        f.stop = .rejected ∧ f.snapshot = some saved ∧
-          saved.raw.subject = n := by
+      ∃ f rejected saved, factorPartial? n r fuel = .error f ∧
+        f.stop = .rejected ∧ f.culprit = some rejected ∧
+          checkPartial rejected = false ∧ f.snapshot = some saved ∧
+            saved.raw.subject = n := by
   cases hresult : factorPartial? n r fuel with
   | ok result => exact Or.inl ⟨result.1, result.2, rfl⟩
   | error f =>
-      rcases factorPartial?_error hresult with ⟨_, hz⟩ | ⟨hrejected, hsnapshot⟩
+      rcases factorPartial?_error hresult with ⟨_, hz⟩ | ⟨hrejected, evidence⟩
       · subst n
         cases hn
-      · obtain ⟨saved, hsaved, hsubject⟩ := hsnapshot
-        exact Or.inr ⟨f, saved, rfl, hrejected, hsaved, hsubject⟩
+      · obtain ⟨rejected, saved, hculprit, hbad, hsaved, hsubject⟩ := evidence
+        exact Or.inr
+          ⟨f, rejected, saved, rfl, hrejected, hculprit, hbad, hsaved,
+            hsubject⟩
 
 end Nat
 

--- a/HexIntFactor/PMinusOne.lean
+++ b/HexIntFactor/PMinusOne.lean
@@ -21,6 +21,13 @@ namespace Nat
 def pMinusOneFactor (n base bound : Nat) : PMinusOneResult :=
   pMinusOneStage1 n base bound
 
+/-- Every factor reported by the integer-factorization adapter is a proper
+divisor of its subject. -/
+theorem pMinusOneFactor_spec {n base bound d : Nat}
+    (h : pMinusOneFactor n base bound = .factor d) :
+    1 < d ∧ d < n ∧ d ∣ n :=
+  pMinusOneStage1_spec h
+
 end Nat
 
 end Hex

--- a/HexIntFactor/Partial.lean
+++ b/HexIntFactor/Partial.lean
@@ -127,6 +127,22 @@ theorem checkPartial_sorted {F : PartialFactorization}
     F.factors.Pairwise (fun a b => a.prime < b.prime) :=
   checkEntries_pairwise (checkedPartial_parts h).2.1
 
+/-- A checked partial factorization with residual one is already a complete
+factorization certificate; no second checker replay is needed. -/
+theorem checkFactorization_of_checkPartial {F : PartialFactorization}
+    (h : checkPartial F = true) (hr : F.residual = 1) :
+    checkFactorization ⟨F.subject, F.factors⟩ = true := by
+  obtain ⟨hsubject, hentries, acc, hproduct, hresidual⟩ :=
+    checkedPartial_parts h
+  rw [hr] at hresidual
+  unfold boundedPowMul at hresidual
+  split at hresidual
+  · cases hresidual
+  · unfold boundedPowMul at hresidual
+    have hacc : acc = F.subject := by simpa using hresidual
+    simp only [checkFactorization, Bool.and_eq_true, decide_eq_true_eq]
+    exact ⟨⟨hsubject, hentries⟩, hacc ▸ hproduct⟩
+
 end Nat
 
 end Hex

--- a/HexIntFactor/Partial.lean
+++ b/HexIntFactor/Partial.lean
@@ -134,14 +134,11 @@ theorem checkFactorization_of_checkPartial {F : PartialFactorization}
     checkFactorization ⟨F.subject, F.factors⟩ = true := by
   obtain ⟨hsubject, hentries, acc, hproduct, hresidual⟩ :=
     checkedPartial_parts h
-  rw [hr] at hresidual
-  unfold boundedPowMul at hresidual
-  split at hresidual
-  · cases hresidual
-  · unfold boundedPowMul at hresidual
-    have hacc : acc = F.subject := by simpa using hresidual
-    simp only [checkFactorization, Bool.and_eq_true, decide_eq_true_eq]
-    exact ⟨⟨hsubject, hentries⟩, hacc ▸ hproduct⟩
+  have hacc : acc = F.subject := by
+    have heq := boundedPowMul_eq 1 acc F.subject hresidual
+    simpa [hr] using heq.symm
+  simp only [checkFactorization, Bool.and_eq_true, decide_eq_true_eq]
+  exact ⟨⟨hsubject, hentries⟩, hacc ▸ hproduct⟩
 
 end Nat
 

--- a/HexIntFactor/SPEC/hex-int-factor.md
+++ b/HexIntFactor/SPEC/hex-int-factor.md
@@ -238,18 +238,26 @@ consumer.
 ## The algorithms
 
 Every route produces a candidate `Factorization` and `factor?` accepts
-it only through `checkFactorization`. A rejected candidate is a bug in
-a route, never a wrong answer, and the dispatch simply continues.
+it only through `checkFactorization`. A rejected final aggregate is a bug in
+a route, never ordinary fuel exhaustion, and is exposed as
+`FactorStop.rejected`. Route-local attempts that report no factor may still
+continue to the next search route.
 
 ```lean
 inductive FactorStop where
   | zero
   | incomplete
+  | rejected
+
+structure PartialSnapshot where
+  raw   : PartialFactorization
+  valid : checkPartial raw = true
 
 structure FactorFailure where
   stop     : FactorStop
   attempts : Nat
   rand     : Rand
+  snapshot : Option PartialSnapshot := none
 
 def defaultFuel (n : Nat) : Nat
 
@@ -321,6 +329,15 @@ Like rho, stage 1 is sited upstream: hex-primality owns it beside
 `rhoFactor?`, under the same dynamically validated proper-factor
 contract, and this library reuses it. What follows specifies the
 algorithm both consumers get.
+
+The integer-factor adapter re-exports that contract under its own route name,
+parallel to the rho and ECM adapters:
+
+```lean
+theorem pMinusOneFactor_spec
+    (h : pMinusOneFactor n base bound = .factor d) :
+    1 < d ∧ d < n ∧ d ∣ n
+```
 
 Stage 1 chooses `1 < a < n` and first checks `gcd(a,n)`: a gcd greater
 than `1` is necessarily a proper factor. Otherwise it computes
@@ -398,6 +415,15 @@ remedy, propagating the failure upward, and it is the right one here:
 there is no fallback that is correct-but-slow, because trial division
 past `10^{18}` is not slow, it is unavailable.
 
+`FactorStop.rejected` is deliberately separate: it means the final aggregate
+failed its subject or certificate checker. It preserves the advanced random
+state, attempt count, and a checked empty-factor snapshot for the positive
+subject, and must be treated as an implementation defect rather than a request
+for more fuel. The internal candidate-acceptance boundary is exercised directly
+by negative conformance tests. Genuine incomplete failures likewise retain
+the checked aggregate in `FactorFailure.snapshot`; the zero case has no such
+snapshot.
+
 A partial answer is more useful than no answer, so the search also
 exposes
 
@@ -433,23 +459,30 @@ ordering without requiring consumers to unfold the checker, and
 ```lean
 theorem factorPartial?_error {n r fuel f}
     (h : factorPartial? n r fuel = .error f) :
-    f.stop = .zero ∧ n = 0
+    (f.stop = .zero ∧ n = 0) ∨
+      (f.stop = .rejected ∧
+        ∃ saved, f.snapshot = some saved ∧ saved.raw.subject = n)
 
 theorem factorPartial?_success {n r fuel} (hn : 0 < n) :
-    ∃ F r', factorPartial? n r fuel = .ok (F, r')
+    (∃ F r', factorPartial? n r fuel = .ok (F, r')) ∨
+      ∃ f saved, factorPartial? n r fuel = .error f ∧
+        f.stop = .rejected ∧ f.snapshot = some saved ∧
+          saved.raw.subject = n
 ```
 
-For positive `n`, the empty factor list with residual `n` is always a
-valid fallback, so fuel exhaustion still returns checked partial data.
-At `n = 0` no object satisfying `0 < subject` and `subject = n` exists,
-and `FactorStop.zero` reports that fact instead of returning checked
-data about another number. A failure retains its advanced state and
-attempt count, while success returns the state alongside the checked
+For positive `n`, ordinary fuel exhaustion returns the checked aggregate with
+its unfactored residual. It does not use an empty fallback to conceal an
+aggregate that failed `checkPartial`. Such a failure is returned as
+`FactorStop.rejected`, and the success-or-rejection theorem makes that internal
+failure case explicit. At `n = 0` no object satisfying `0 < subject` and
+`subject = n` exists, and `FactorStop.zero` reports that fact instead of
+returning checked data about another number. A failure retains its advanced
+state and attempt count, while success returns the state alongside the checked
 data, so a caller never repeats a failed random stream accidentally.
 
-`factor?` is the convenience projection of `factorPartial?`: it
-propagates `FactorStop.zero`, returns the complete checked form exactly
-when the checked residual is `1`, and returns `FactorStop.incomplete`
+`factor?` uses the same partial-candidate acceptance boundary: it propagates
+`FactorStop.zero` or `FactorStop.rejected`, returns the complete checked form
+exactly when the checked residual is `1`, and returns `FactorStop.incomplete`
 otherwise, retaining
 the same advanced state and attempt count. Keeping both APIs avoids
 forcing callers that require completeness to unpack an object they

--- a/HexIntFactor/SPEC/hex-int-factor.md
+++ b/HexIntFactor/SPEC/hex-int-factor.md
@@ -258,6 +258,7 @@ structure FactorFailure where
   attempts : Nat
   rand     : Rand
   snapshot : Option PartialSnapshot := none
+  culprit  : Option PartialFactorization := none
 
 def defaultFuel (n : Nat) : Nat
 
@@ -415,14 +416,16 @@ remedy, propagating the failure upward, and it is the right one here:
 there is no fallback that is correct-but-slow, because trial division
 past `10^{18}` is not slow, it is unavailable.
 
-`FactorStop.rejected` is deliberately separate: it means the final aggregate
+`FactorStop.rejected` is deliberately separate: it means a final aggregate
 failed its subject or certificate checker. It preserves the advanced random
-state, attempt count, and a checked empty-factor snapshot for the positive
-subject, and must be treated as an implementation defect rather than a request
-for more fuel. The internal candidate-acceptance boundary is exercised directly
-by negative conformance tests. Genuine incomplete failures likewise retain
-the checked aggregate in `FactorFailure.snapshot`; the zero case has no such
-snapshot.
+state and attempt count. A rejected partial aggregate also retains both the
+unchecked candidate in `FactorFailure.culprit` and a checked empty-factor
+recovery snapshot for the positive subject; the two are not conflated. It must
+be treated as an implementation defect rather than a request for more fuel.
+The internal candidate-acceptance boundary is exercised directly by negative
+conformance tests. Genuine incomplete failures retain the checked aggregate in
+`FactorFailure.snapshot`; the zero case has no snapshot. Cyclotomic dispatch
+propagates rejection rather than retrying it as though it were exhaustion.
 
 A partial answer is more useful than no answer, so the search also
 exposes
@@ -454,20 +457,26 @@ partial factorization of one subject from answering a request about
 another. The characterising lemmas `checkPartial_prod`,
 `checkPartial_prime`, `checkPartial_exponent`, and `checkPartial_sorted`
 expose reconstruction, primality, exponent positivity, and factor-base
-ordering without requiring consumers to unfold the checker, and
+ordering without requiring consumers to unfold the checker.
+`checkFactorization_of_checkPartial` proves that residual one is already a
+complete certificate, avoiding a second certificate replay. The search result
+theorems are
 
 ```lean
 theorem factorPartial?_error {n r fuel f}
     (h : factorPartial? n r fuel = .error f) :
     (f.stop = .zero ∧ n = 0) ∨
       (f.stop = .rejected ∧
-        ∃ saved, f.snapshot = some saved ∧ saved.raw.subject = n)
+        ∃ rejected saved, f.culprit = some rejected ∧
+          checkPartial rejected = false ∧ f.snapshot = some saved ∧
+            saved.raw.subject = n)
 
 theorem factorPartial?_success {n r fuel} (hn : 0 < n) :
     (∃ F r', factorPartial? n r fuel = .ok (F, r')) ∨
-      ∃ f saved, factorPartial? n r fuel = .error f ∧
-        f.stop = .rejected ∧ f.snapshot = some saved ∧
-          saved.raw.subject = n
+      ∃ f rejected saved, factorPartial? n r fuel = .error f ∧
+        f.stop = .rejected ∧ f.culprit = some rejected ∧
+          checkPartial rejected = false ∧ f.snapshot = some saved ∧
+            saved.raw.subject = n
 ```
 
 For positive `n`, ordinary fuel exhaustion returns the checked aggregate with
@@ -481,9 +490,9 @@ state and attempt count, while success returns the state alongside the checked
 data, so a caller never repeats a failed random stream accidentally.
 
 `factor?` uses the same partial-candidate acceptance boundary: it propagates
-`FactorStop.zero` or `FactorStop.rejected`, returns the complete checked form
-exactly when the checked residual is `1`, and returns `FactorStop.incomplete`
-otherwise, retaining
+`FactorStop.zero` or `FactorStop.rejected`, converts residual one to the complete
+checked form by `checkFactorization_of_checkPartial` without replaying the
+certificates, and returns `FactorStop.incomplete` otherwise, retaining
 the same advanced state and attempt count. Keeping both APIs avoids
 forcing callers that require completeness to unpack an object they
 cannot use.
@@ -1087,9 +1096,11 @@ nothing extra.
    structural reductions, and trial division against hex-primality's
    table. The whole library starts after
    hex-primality milestone 3, because `PrimePower` carries
-   `PrimeCert`. This milestone returns checked partial data for every
-   positive input and a complete result when every residual prime can
-   be certified; it makes no blanket size claim. The committed Conway
+   `PrimeCert`. This milestone returns checked partial data on every ordinary
+   positive-input outcome; an internal aggregate rejection is explicit and
+   retains both its rejected candidate and checked recovery snapshot. It returns
+   a complete result when every residual prime can be certified and makes no
+   blanket size claim. The committed Conway
    table is a required regression family, not a currently blocked
    consumer.
 

--- a/HexIntFactor/SPEC/hex-int-factor.md
+++ b/HexIntFactor/SPEC/hex-int-factor.md
@@ -237,11 +237,13 @@ consumer.
 
 ## The algorithms
 
-Every route produces a candidate `Factorization` and `factor?` accepts
-it only through `checkFactorization`. A rejected final aggregate is a bug in
-a route, never ordinary fuel exhaustion, and is exposed as
-`FactorStop.rejected`. Route-local attempts that report no factor may still
-continue to the next search route.
+The generic routes produce a partial aggregate, which `factor?` accepts through
+`checkPartial`; residual one becomes a complete certificate by
+`checkFactorization_of_checkPartial`, without another checker replay. The
+cyclotomic route separately replays `checkFactorization` on its merged complete
+aggregate. Rejection at either boundary is a route bug, never ordinary fuel
+exhaustion, and is exposed as `FactorStop.rejected`. Route-local attempts that
+report no factor may still continue to the next search route.
 
 ```lean
 inductive FactorStop where
@@ -259,6 +261,7 @@ structure FactorFailure where
   rand     : Rand
   snapshot : Option PartialSnapshot := none
   culprit  : Option PartialFactorization := none
+  metered   : Bool := true
 
 def defaultFuel (n : Nat) : Nat
 
@@ -417,15 +420,21 @@ there is no fallback that is correct-but-slow, because trial division
 past `10^{18}` is not slow, it is unavailable.
 
 `FactorStop.rejected` is deliberately separate: it means a final aggregate
-failed its subject or certificate checker. It preserves the advanced random
-state and attempt count. A rejected partial aggregate also retains both the
-unchecked candidate in `FactorFailure.culprit` and a checked empty-factor
+failed its certificate checker. At the generic partial-acceptance boundary it
+preserves the advanced random state and attempt count. A rejected partial
+aggregate also retains both the unchecked candidate in
+`FactorFailure.culprit` and a checked empty-factor
 recovery snapshot for the positive subject; the two are not conflated. It must
 be treated as an implementation defect rather than a request for more fuel.
 The internal candidate-acceptance boundary is exercised directly by negative
 conformance tests. Genuine incomplete failures retain the checked aggregate in
 `FactorFailure.snapshot`; the zero case has no snapshot. Cyclotomic dispatch
-propagates rejection rather than retrying it as though it were exhaustion.
+propagates rejection rather than retrying it as though it were exhaustion. A
+rejection propagated from a cyclotomic part remains scoped to that subproblem;
+a rejected merged cyclotomic aggregate records the target candidate and random
+state. Its successful subsearch attempts are not exposed by `factor?`, so its
+placeholder count is marked unavailable by `metered = false` rather than being
+presented as an exact total.
 
 A partial answer is more useful than no answer, so the search also
 exposes
@@ -471,7 +480,7 @@ theorem factorPartial?_error {n r fuel f}
           checkPartial rejected = false ∧ f.snapshot = some saved ∧
             saved.raw.subject = n)
 
-theorem factorPartial?_success {n r fuel} (hn : 0 < n) :
+theorem factorPartial?_result {n r fuel} (hn : 0 < n) :
     (∃ F r', factorPartial? n r fuel = .ok (F, r')) ∨
       ∃ f rejected saved, factorPartial? n r fuel = .error f ∧
         f.stop = .rejected ∧ f.culprit = some rejected ∧
@@ -485,9 +494,10 @@ aggregate that failed `checkPartial`. Such a failure is returned as
 `FactorStop.rejected`, and the success-or-rejection theorem makes that internal
 failure case explicit. At `n = 0` no object satisfying `0 < subject` and
 `subject = n` exists, and `FactorStop.zero` reports that fact instead of
-returning checked data about another number. A failure retains its advanced
-state and attempt count, while success returns the state alongside the checked
-data, so a caller never repeats a failed random stream accidentally.
+returning checked data about another number. A generic-search failure retains
+its advanced state and exact attempt count, while success returns the state
+alongside the checked data, so a caller never repeats a failed random stream
+accidentally.
 
 `factor?` uses the same partial-candidate acceptance boundary: it propagates
 `FactorStop.zero` or `FactorStop.rejected`, converts residual one to the complete

--- a/bench/HexIntFactor/Bench.lean
+++ b/bench/HexIntFactor/Bench.lean
@@ -26,7 +26,7 @@ def runRho (n : Nat) : Nat :=
   | .error f => f.attempts
 
 def runPMinusOne (n : Nat) : Nat :=
-  match pMinusOneStage1 n 2 10000 with
+  match pMinusOneFactor n 2 10000 with
   | .factor d => d
   | .noFactor => 1
   | .whole => n

--- a/conformance/HexIntFactor/Conformance.lean
+++ b/conformance/HexIntFactor/Conformance.lean
@@ -164,8 +164,10 @@ example :
 #guard pMinusOneFactor 25 2 2 == .noFactor
 #guard pMinusOneFactor 15 4 2 == .whole
 
-example : 1 < 3 ∧ 3 < 15 ∧ 3 ∣ 15 :=
-  pMinusOneFactor_spec (n := 15) (base := 2) (bound := 2) (d := 3) (by decide)
+example {n base bound d : Nat}
+    (h : pMinusOneFactor n base bound = .factor d) :
+    1 < d ∧ d < n ∧ d ∣ n :=
+  pMinusOneFactor_spec h
 
 -- ECM's three stage-boundary gcd outcomes are observably distinct.
 #guard ecmStage1 191 6 2 == .noFactor
@@ -227,6 +229,23 @@ private def starvedInput : Nat := 1000003 * 1000033
 #guard (match factorPowerWithRoute? 2 6 .minus (Rand.ofSeed 1) with
   | .ok (_, _, route) => route == .cyclotomic
   | .error _ => false)
+
+-- A rejected cyclotomic subproblem is propagated, never retried as generic
+-- exhaustion for the outer target.
+private def rejectedPart : FactorFailure :=
+  { stop := .rejected
+    attempts := 4
+    rand := Rand.ofSeed 11
+    culprit := some ⟨7, [⟨1, .small 2⟩], 3⟩ }
+
+#guard (match Hex.Nat.Internal.retryPower? 63 rejectedPart 0 with
+  | .error failure =>
+      failure.stop == .rejected && failure.attempts == 4 && failure.metered &&
+        failure.rand == Rand.ofSeed 11 &&
+          match failure.culprit with
+          | some rejected => rejected.subject == 7
+          | none => false
+  | .ok _ => false)
 
 #guard (match factor? 4826808 (Rand.ofSeed 7) with
   | .ok (F, _) =>

--- a/conformance/HexIntFactor/Conformance.lean
+++ b/conformance/HexIntFactor/Conformance.lean
@@ -180,11 +180,38 @@ example : 1 < 3 ∧ 3 < 15 ∧ 3 ∣ 15 :=
 -- being replaced by an empty partial answer or ordinary exhaustion.
 #guard (match Hex.Nat.Internal.acceptPartial? 12 (by decide)
     ⟨12, [⟨1, .small 2⟩], 5⟩
-    (Rand.ofSeed 9) 17 with
+    rfl (Rand.ofSeed 9) 17 with
   | .error failure =>
       failure.stop == .rejected && failure.attempts == 17 &&
+        (match failure.snapshot with
+          | some saved => checkPartial saved.raw && saved.raw.subject == 12
+          | none => false) &&
+        (match failure.culprit with
+          | some rejected => !checkPartial rejected
+          | none => false)
+  | .ok _ => false)
+
+-- Real producer output must cross the aggregate checker without rejection.
+#guard ([1, 2, 4, 12, 97, 4826808, 2 ^ 32 - 1,
+    1000003 ^ 2, 1000003 * 1000033].all fun n =>
+  match factorPartial? n (Rand.ofSeed n) with
+  | .ok (F, _) => checkPartial F.raw
+  | .error _ => false)
+
+-- Zero fuel is checked partial exhaustion, while complete search reports the
+-- distinct incomplete stop and retains the same checked aggregate.
+private def starvedInput : Nat := 1000003 * 1000033
+
+#guard (match factorPartial? starvedInput (Rand.ofSeed 3) (fuel := 0) with
+  | .ok (F, _) => checkPartial F.raw && F.raw.residual == starvedInput
+  | .error _ => false)
+
+#guard (match factor? starvedInput (Rand.ofSeed 3) (fuel := 1) with
+  | .error failure =>
+      failure.stop == .incomplete && 0 < failure.attempts &&
+        failure.rand != Rand.ofSeed 3 &&
         match failure.snapshot with
-        | some saved => checkPartial saved.raw && saved.raw.subject == 12
+        | some saved => checkPartial saved.raw && saved.raw.subject == starvedInput
         | none => false
   | .ok _ => false)
 

--- a/conformance/HexIntFactor/Conformance.lean
+++ b/conformance/HexIntFactor/Conformance.lean
@@ -160,9 +160,12 @@ example :
 #guard (smallCandidate (1000003 ^ 2)).route == .perfectPower
 #guard (smallCandidate ((6 ^ 5) ^ 3)).route == .perfectPower
 
-#guard pMinusOneStage1 15 2 2 == .factor 3
-#guard pMinusOneStage1 25 2 2 == .noFactor
-#guard pMinusOneStage1 15 4 2 == .whole
+#guard pMinusOneFactor 15 2 2 == .factor 3
+#guard pMinusOneFactor 25 2 2 == .noFactor
+#guard pMinusOneFactor 15 4 2 == .whole
+
+example : 1 < 3 ∧ 3 < 15 ∧ 3 ∣ 15 :=
+  pMinusOneFactor_spec (n := 15) (base := 2) (bound := 2) (d := 3) (by decide)
 
 -- ECM's three stage-boundary gcd outcomes are observably distinct.
 #guard ecmStage1 191 6 2 == .noFactor
@@ -172,6 +175,18 @@ example :
 #guard (match rhoSplit? 91 (Rand.ofSeed 1) 16 with
   | .ok (d, _) => decide (1 < d) && decide (d < 91) && 91 % d == 0
   | .error _ => false)
+
+-- A malformed aggregate is exposed as an invariant failure, rather than
+-- being replaced by an empty partial answer or ordinary exhaustion.
+#guard (match Hex.Nat.Internal.acceptPartial? 12 (by decide)
+    ⟨12, [⟨1, .small 2⟩], 5⟩
+    (Rand.ofSeed 9) 17 with
+  | .error failure =>
+      failure.stop == .rejected && failure.attempts == 17 &&
+        match failure.snapshot with
+        | some saved => checkPartial saved.raw && saved.raw.subject == 12
+        | none => false
+  | .ok _ => false)
 
 #guard checkOrder ⟨2, 7, 3, ⟨3, [⟨1, .small 3⟩]⟩⟩
 

--- a/conformance/HexIntFactor/EmitFixtures.lean
+++ b/conformance/HexIntFactor/EmitFixtures.lean
@@ -29,13 +29,16 @@ private def powersJson (entries : List PrimePower) : String :=
   "[" ++ String.intercalate "," (entries.map fun e =>
     "[" ++ toString e.prime ++ "," ++ toString e.exponent ++ "]") ++ "]"
 
-private def factorJson (n : Nat) : String :=
+private def rejected (context : String) : IO α :=
+  throw <| IO.userError (context ++ ": factorization candidate rejected")
+
+private def factorJson (n : Nat) : IO String :=
   match factor? n (Hex.Rand.ofSeed n) with
-  | .ok (F, _) => powersJson F.raw.factors
+  | .ok (F, _) => pure (powersJson F.raw.factors)
   | .error f => match f.stop with
-    | .zero => quote "refused"
-    | .incomplete => "null"
-    | .rejected => quote "rejected"
+    | .zero => pure (quote "refused")
+    | .incomplete => pure "null"
+    | .rejected => rejected ("factor/" ++ toString n)
 
 private def partsJson (parts : List CyclotomicPart) : String :=
   "[" ++ String.intercalate "," (parts.map fun p =>
@@ -44,15 +47,17 @@ private def partsJson (parts : List CyclotomicPart) : String :=
 private def emitFactor (tag : String) (n : Nat) : IO Unit := do
   let case := "factor/" ++ tag
   emitFixture "factor" case (",\"n\":" ++ toString n)
-  emitResult lib case "factor" (factorJson n)
+  emitResult lib case "factor" (← factorJson n)
 
 private def emitDivisorFns (tag : String) (n : Nat) : IO Unit := do
   let case := "divisorfn/" ++ tag
   emitFixture "divisorfn" case (",\"n\":" ++ toString n)
-  let value := match factor? n (Hex.Rand.ofSeed n) with
-    | .error _ => "null"
+  let value ← match factor? n (Hex.Rand.ofSeed n) with
+    | .error failure => match failure.stop with
+      | .rejected => rejected case
+      | .zero | .incomplete => pure "null"
     | .ok (F, _) =>
-        "{\"tau\":" ++ toString (numDivisors F) ++
+        pure <| "{\"tau\":" ++ toString (numDivisors F) ++
         ",\"sigma0\":" ++ toString (sigma F 0) ++
         ",\"sigma1\":" ++ toString (sigma F 1) ++
         ",\"sigma2\":" ++ toString (sigma F 2) ++

--- a/conformance/HexIntFactor/EmitFixtures.lean
+++ b/conformance/HexIntFactor/EmitFixtures.lean
@@ -32,7 +32,10 @@ private def powersJson (entries : List PrimePower) : String :=
 private def factorJson (n : Nat) : String :=
   match factor? n (Hex.Rand.ofSeed n) with
   | .ok (F, _) => powersJson F.raw.factors
-  | .error f => match f.stop with | .zero => quote "refused" | .incomplete => "null"
+  | .error f => match f.stop with
+    | .zero => quote "refused"
+    | .incomplete => "null"
+    | .rejected => quote "rejected"
 
 private def partsJson (parts : List CyclotomicPart) : String :=
   "[" ++ String.intercalate "," (parts.map fun p =>


### PR DESCRIPTION
Closes #9643

## Summary

- distinguish final checker rejection from genuine fuel exhaustion with `FactorStop.rejected`
- retain the rejected raw candidate, a checked recovery snapshot, and advanced search evidence
- mark diagnostic attempt counts explicitly when a route cannot meter an aggregate
- route both partial and complete aggregation through one explicit acceptance boundary
- derive complete validity from checked partial validity at residual one, avoiding duplicate certificate replay
- propagate cyclotomic rejection unchanged instead of silently retrying it as exhaustion
- re-export the Pollard p−1 proper-divisor contract and add real-producer, malformed-candidate, cyclotomic-propagation, and fuel-starvation regression coverage
- make fixture emission fail loudly on invariant rejection and update the SPEC

## Verification

- `lake build HexIntFactor HexIntFactorMathlib HexIntFactorKernelProbe HexConformance`
- `lake exe hexintfactor_bench list`
- `lake exe hexintfactor_bench verify` (11 benchmarks passed)
- `scripts/run-oracles-local.sh intfactor_pari --check` (414 cases, 0 failures)
- `python3 scripts/check_dag.py`
- `python3 scripts/check_file_line_counts.py`
- `python3 scripts/ci/check_benches_mathlib_free.py`
- scoped banned-token scan and `git diff --check`