### PR TITLE
fix: reduce recursive factor cofactors

### DIFF
--- a/HexIntFactor/Factor.lean
+++ b/HexIntFactor/Factor.lean
@@ -54,6 +54,7 @@ private structure FactorAttempt (n : Nat) where
   subject_eq : raw.subject = n
   rand : Rand
   attempts : Nat
+  powerRoutes : Nat
 
 private def insertPower (entry : PrimePower) : List PrimePower → List PrimePower
   | [] => [entry]
@@ -72,43 +73,52 @@ private structure SearchState where
   residual : Nat
   rand : Rand
   attempts : Nat
+  powerRoutes : Nat
 
 private def searchGo : Nat → List (Nat × Nat) → List PrimePower → Nat →
-    Rand → Nat → SearchState
-  | 0, stack, factors, residual, r, attempts =>
+    Rand → Nat → Nat → SearchState
+  | 0, stack, factors, residual, r, attempts, powerRoutes =>
       { factors
         residual := stack.foldl (fun acc item => acc * item.1 ^ item.2) residual
         rand := r
-        attempts }
-  | _fuel + 1, [], factors, residual, r, attempts =>
-      ⟨factors, residual, r, attempts⟩
-  | fuel + 1, (m, multiplier) :: stack, factors, residual, r, attempts =>
-      if m = 1 then searchGo fuel stack factors residual r attempts
+        attempts
+        powerRoutes }
+  | _fuel + 1, [], factors, residual, r, attempts, powerRoutes =>
+      ⟨factors, residual, r, attempts, powerRoutes⟩
+  | fuel + 1, (m, multiplier) :: stack, factors, residual, r, attempts,
+      powerRoutes =>
+      if m = 1 then
+        searchGo fuel stack factors residual r attempts powerRoutes
       else
-        let trial := trialFactors m
-        let found := trial.1.map fun e =>
-          { e with exponent := e.exponent * multiplier }
-        let factors := mergePowers found factors
-        let m := trial.2
-        if m = 1 then searchGo fuel stack factors residual r attempts
+        let candidate := (smallCandidate m).scale multiplier
+        let powerRoutes := match candidate.route with
+          | .trial => powerRoutes
+          | .perfectPower => powerRoutes + 1
+        let factors := mergePowers candidate.factors factors
+        let m := candidate.residualBase
+        let multiplier := candidate.residualExponent
+        if m = 1 then
+          searchGo fuel stack factors residual r attempts powerRoutes
         else
           match primeCert? m r (fuel + 1) with
           | .ok (cert, r') =>
               searchGo fuel stack
                 (insertPower ⟨multiplier, cert.raw⟩ factors)
-                residual r' attempts
+                residual r' attempts powerRoutes
           | .error primeFailure =>
               match rhoSplit? m primeFailure.rand
                   (min 1000000 ((fuel + 1) * (fuel + 1))) with
               | .ok (d, r') =>
                   searchGo fuel ((d, multiplier) :: (m / d, multiplier) :: stack)
                     factors residual r' (attempts + primeFailure.attempts + 1)
+                    powerRoutes
               | .error rhoFailure =>
                   match pMinusOneFactor m 2 (min primeTableBound (64 * (fuel + 1))) with
                   | .factor d =>
                       searchGo fuel ((d, multiplier) :: (m / d, multiplier) :: stack)
                         factors residual rhoFailure.rand
                         (attempts + primeFailure.attempts + rhoFailure.attempts + 1)
+                        powerRoutes
                   | .noFactor | .whole =>
                       match ecmStage1 m (6 + attempts % 64)
                           (min primeTableBound (64 * (fuel + 1))) with
@@ -117,21 +127,31 @@ private def searchGo : Nat → List (Nat × Nat) → List PrimePower → Nat →
                             ((d, multiplier) :: (m / d, multiplier) :: stack)
                             factors residual rhoFailure.rand
                             (attempts + primeFailure.attempts + rhoFailure.attempts + 1)
+                            powerRoutes
                       | .noFactor | .whole =>
                           searchGo fuel stack factors (residual * m ^ multiplier)
                             rhoFailure.rand
                             (attempts + primeFailure.attempts + rhoFailure.attempts + 1)
+                            powerRoutes
 
 private def smallAttempt (n : Nat) (r : Rand) (fuel : Nat) :
     FactorAttempt n :=
   let candidate := smallCandidate n
+  let powerRoutes := match candidate.route with
+    | .trial => 0
+    | .perfectPower => 1
   let result := searchGo fuel
     [(candidate.residualBase, candidate.residualExponent)]
-    candidate.factors 1 r 0
+    candidate.factors 1 r 0 powerRoutes
   ⟨⟨n, result.factors, result.residual⟩, rfl,
-    result.rand, result.attempts⟩
+    result.rand, result.attempts, result.powerRoutes⟩
 
 namespace Internal
+
+/-- Count perfect-power reductions taken by the exact factor dispatcher. This
+diagnostic exists for route-level conformance tests. -/
+def countPowerRoutes (n : Nat) (r : Rand) (fuel : Nat := defaultFuel n) : Nat :=
+  (smallAttempt n r fuel).powerRoutes
 
 /-- Check an untrusted partial candidate and tie it to the requested subject.
 Checker rejection is an internal search failure, not fuel exhaustion. -/

--- a/HexIntFactor/Factor.lean
+++ b/HexIntFactor/Factor.lean
@@ -90,6 +90,8 @@ private def searchGo : Nat → List (Nat × Nat) → List PrimePower → Nat →
       if m = 1 then
         searchGo fuel stack factors residual r attempts powerRoutes
       else
+        -- Keep the full structural pipeline here: table-coprimality of stack
+        -- entries is an invariant of the current producers, not of their type.
         let candidate := (smallCandidate m).scale multiplier
         let powerRoutes := match candidate.route with
           | .trial => powerRoutes
@@ -148,10 +150,10 @@ private def smallAttempt (n : Nat) (r : Rand) (fuel : Nat) :
 
 namespace Internal
 
-/-- Count perfect-power reductions taken by the exact factor dispatcher. This
-diagnostic exists for route-level conformance tests. -/
+/-- Run a full factor search and count its perfect-power reductions. This
+diagnostic exists for route-level conformance tests and rejects zero cheaply. -/
 def countPowerRoutes (n : Nat) (r : Rand) (fuel : Nat := defaultFuel n) : Nat :=
-  (smallAttempt n r fuel).powerRoutes
+  if n = 0 then 0 else (smallAttempt n r fuel).powerRoutes
 
 /-- Check an untrusted partial candidate and tie it to the requested subject.
 Checker rejection is an internal search failure, not fuel exhaustion. -/

--- a/HexIntFactor/SPEC/hex-int-factor.md
+++ b/HexIntFactor/SPEC/hex-int-factor.md
@@ -291,9 +291,9 @@ prerequisite, specified there and sited in hex-basic.
 - **Perfect powers.** If `n = m^k` for some `k ≥ 2`, factor `m` and
   multiply the exponents. Detected by trying each prime `k ≤ log₂ n`
   and taking an exact integer `k`th root by bounded binary search. The
-  reduction is reapplied to every recursive cofactor popped after a split;
-  its exponent is multiplied by the cofactor's accumulated multiplicity
-  before the result is merged. Strongly
+  full structural pipeline is reapplied to every popped search-stack entry,
+  including recursive cofactors produced by a split; its exponent is multiplied
+  by the entry's accumulated multiplicity before the result is merged. Strongly
   recommended rather than mathematically required: an earlier draft
   claimed Pollard `p − 1` and ECM "fail on prime powers, because the
   group they work in has no distinct primes to separate", and that is

--- a/HexIntFactor/SPEC/hex-int-factor.md
+++ b/HexIntFactor/SPEC/hex-int-factor.md
@@ -290,7 +290,10 @@ prerequisite, specified there and sited in hex-basic.
   slowest per bit.
 - **Perfect powers.** If `n = m^k` for some `k ≥ 2`, factor `m` and
   multiply the exponents. Detected by trying each prime `k ≤ log₂ n`
-  and taking an integer `k`th root by Newton iteration. Strongly
+  and taking an exact integer `k`th root by bounded binary search. The
+  reduction is reapplied to every recursive cofactor popped after a split;
+  its exponent is multiplied by the cofactor's accumulated multiplicity
+  before the result is merged. Strongly
   recommended rather than mathematically required: an earlier draft
   claimed Pollard `p − 1` and ECM "fail on prime powers, because the
   group they work in has no distinct primes to separate", and that is

--- a/HexIntFactor/Small.lean
+++ b/HexIntFactor/Small.lean
@@ -99,6 +99,15 @@ structure SmallCandidate where
   route : SmallRoute
 deriving Repr
 
+/-- Scale every multiplicity represented by a structural candidate. -/
+def SmallCandidate.scale (candidate : SmallCandidate) (multiplier : Nat) :
+    SmallCandidate :=
+  { factors := candidate.factors.map fun entry =>
+      { entry with exponent := entry.exponent * multiplier }
+    residualBase := candidate.residualBase
+    residualExponent := candidate.residualExponent * multiplier
+    route := candidate.route }
+
 /-- Apply perfect-power reduction before table trial division. -/
 def smallCandidate (n : Nat) : SmallCandidate :=
   match perfectPower? n with

--- a/conformance/HexIntFactor/Conformance.lean
+++ b/conformance/HexIntFactor/Conformance.lean
@@ -173,7 +173,8 @@ private def recursivePowerCandidate : SmallCandidate :=
 #guard recursivePowerCandidate.factors.isEmpty
 #guard recursivePowerCandidate.residualBase == 10037
 #guard recursivePowerCandidate.residualExponent == 6
-#guard 0 < Hex.Nat.Internal.countPowerRoutes recursivePowerInput (Rand.ofSeed 17)
+#guard Hex.Nat.Internal.countPowerRoutes recursivePowerInput (Rand.ofSeed 17) == 1
+#guard Hex.Nat.Internal.countPowerRoutes 0 (Rand.ofSeed 17) == 0
 #guard (match factor? recursivePowerInput (Rand.ofSeed 17) with
   | .ok (F, _) =>
       F.raw.factors.map (fun entry => (entry.prime, entry.exponent)) ==
@@ -187,6 +188,17 @@ private def nestedPowerCandidate : SmallCandidate :=
 #guard nestedPowerCandidate.factors.map (fun entry => (entry.prime, entry.exponent)) ==
   [(2, 30), (3, 30)]
 #guard nestedPowerCandidate.residualBase == 1
+
+-- Composite exponents reduce at both the initial and recursive boundaries:
+-- `p^8` becomes `(p^4)^2`, then the popped `p^4` becomes `(p^2)^2` with
+-- accumulated multiplicity four. The eventual split still restores exponent 8.
+private def iteratedPower : Nat := 10009 ^ 8
+
+#guard Hex.Nat.Internal.countPowerRoutes iteratedPower (Rand.ofSeed 19) == 2
+#guard (match factor? iteratedPower (Rand.ofSeed 19) with
+  | .ok (F, _) =>
+      F.raw.factors.map (fun entry => (entry.prime, entry.exponent)) == [(10009, 8)]
+  | .error _ => false)
 
 #guard pMinusOneFactor 15 2 2 == .factor 3
 #guard pMinusOneFactor 25 2 2 == .noFactor

--- a/conformance/HexIntFactor/Conformance.lean
+++ b/conformance/HexIntFactor/Conformance.lean
@@ -160,6 +160,34 @@ example :
 #guard (smallCandidate (1000003 ^ 2)).route == .perfectPower
 #guard (smallCandidate ((6 ^ 5) ^ 3)).route == .perfectPower
 
+-- The subject is not a perfect power, but this exact split leaves a square
+-- cofactor. The same structural producer used for every popped search entry
+-- detects it, and stack multiplicity scales both its known and residual powers.
+private def recursivePowerInput : Nat := 10009 * 10037 ^ 2
+private def recursivePowerCandidate : SmallCandidate :=
+  (smallCandidate (recursivePowerInput / 10009)).scale 3
+
+#guard (perfectPower? recursivePowerInput).isNone
+#guard recursivePowerInput / 10009 == 10037 ^ 2
+#guard recursivePowerCandidate.route == .perfectPower
+#guard recursivePowerCandidate.factors.isEmpty
+#guard recursivePowerCandidate.residualBase == 10037
+#guard recursivePowerCandidate.residualExponent == 6
+#guard 0 < Hex.Nat.Internal.countPowerRoutes recursivePowerInput (Rand.ofSeed 17)
+#guard (match factor? recursivePowerInput (Rand.ofSeed 17) with
+  | .ok (F, _) =>
+      F.raw.factors.map (fun entry => (entry.prime, entry.exponent)) ==
+        [(10009, 1), (10037, 2)]
+  | .error _ => false)
+
+private def nestedPowerCandidate : SmallCandidate :=
+  (smallCandidate ((6 ^ 5) ^ 3)).scale 2
+
+#guard nestedPowerCandidate.route == .perfectPower
+#guard nestedPowerCandidate.factors.map (fun entry => (entry.prime, entry.exponent)) ==
+  [(2, 30), (3, 30)]
+#guard nestedPowerCandidate.residualBase == 1
+
 #guard pMinusOneFactor 15 2 2 == .factor 3
 #guard pMinusOneFactor 25 2 2 == .noFactor
 #guard pMinusOneFactor 15 4 2 == .whole


### PR DESCRIPTION
Closes #9651

## Summary

- reapply the canonical structural candidate pipeline to every cofactor popped after rho, p−1, or ECM splitting
- scale both discovered prime exponents and residual multiplicity before sorted merging
- add an exact dispatcher route counter under `Hex.Nat.Internal` for non-fallback route evidence, with a cheap zero guard
- cover a non-power subject with a square split cofactor, exact recursive route count, nested composite-power scaling, and a multi-level `p^8` case
- correct the SPEC implementation description to bounded binary-search roots and every popped stack entry

## Verification

- `lake build HexIntFactor.Conformance`
- `lake build HexIntFactor HexIntFactorMathlib HexConformance` (10,255 targets)
- `lake exe hexintfactor_bench verify` (11 benchmarks passed)
- `scripts/run-oracles-local.sh intfactor_pari --check` (414 cases, 0 failures)
- DAG, line-count, Mathlib-free bench, banned-token, and diff checks