### PR TITLE
feat: export factor checker projections

### DIFF
--- a/HexIntFactor/Cert.lean
+++ b/HexIntFactor/Cert.lean
@@ -181,6 +181,17 @@ private theorem checked_parts {F : Factorization}
       factorProduct F.subject F.factors 1 = some F.subject := by
   simpa [checkFactorization, Bool.and_eq_true, and_assoc] using h
 
+/-- A complete factorization accepted by the checker has positive subject. -/
+theorem checkFactorization_pos {F : Factorization}
+    (h : checkFactorization F = true) : 0 < F.subject :=
+  (checked_parts h).1
+
+/-- The subject indexed by checked complete factorization data is positive. -/
+theorem CheckedFactorization.pos {n : Nat} (F : CheckedFactorization n) :
+    0 < n := by
+  rw [← F.subject_eq]
+  exact checkFactorization_pos F.valid
+
 /-- The checked prime powers multiply to the claimed subject. -/
 theorem checkFactorization_prod {F : Factorization}
     (h : checkFactorization F = true) :

--- a/HexIntFactor/Order.lean
+++ b/HexIntFactor/Order.lean
@@ -51,6 +51,39 @@ private theorem checkOrder_parts {c : OrderCert} (h : checkOrder c = true) :
   simpa only [checkOrder, Bool.and_eq_true, decide_eq_true_eq,
     List.all_eq_true, and_assoc] using h
 
+/-- An accepted order certificate has a nontrivial modulus. -/
+theorem checkOrder_modulus {c : OrderCert} (h : checkOrder c = true) :
+    1 < c.modulus :=
+  (checkOrder_parts h).1
+
+/-- An accepted order certificate has positive claimed order. -/
+theorem checkOrder_order_pos {c : OrderCert} (h : checkOrder c = true) :
+    0 < c.order :=
+  (checkOrder_parts h).2.1
+
+/-- The factorization in an accepted order certificate targets its order. -/
+theorem checkOrder_factorization_subject {c : OrderCert}
+    (h : checkOrder c = true) : c.orderFac.subject = c.order :=
+  (checkOrder_parts h).2.2.1
+
+/-- The factorization in an accepted order certificate is valid. -/
+theorem checkOrder_factorization {c : OrderCert} (h : checkOrder c = true) :
+    checkFactorization c.orderFac = true :=
+  (checkOrder_parts h).2.2.2.1
+
+/-- The claimed order in an accepted certificate sends the base to one. -/
+theorem checkOrder_pow {c : OrderCert} (h : checkOrder c = true) :
+    HexArith.powModNat c.base c.order c.modulus = 1 % c.modulus :=
+  (checkOrder_parts h).2.2.2.2.1
+
+/-- Removing any listed prime divisor from an accepted claimed order does not
+send the base to one. -/
+theorem checkOrder_prime_divisor {c : OrderCert} (h : checkOrder c = true) :
+    ∀ e ∈ c.orderFac.factors,
+      HexArith.powModNat c.base (c.order / e.prime) c.modulus ≠
+        1 % c.modulus :=
+  (checkOrder_parts h).2.2.2.2.2
+
 private theorem prime_dvd_pow' {q a : Nat} (hq : Prime q) :
     ∀ {k : Nat}, q ∣ a ^ k → q ∣ a := by
   intro k
@@ -450,23 +483,7 @@ theorem pow_carmichael {n : Nat} (F : CheckedFactorization n)
     a ^ carmichael F % n = 1 % n := by
   by_cases hn : n = 1
   · simpa only [hn, Nat.mod_one]
-  have hnPos : 0 < n := by
-    have product_pos : ∀ (entries : List PrimePower),
-        (∀ e ∈ entries, Prime e.prime) →
-        0 < (entries.map fun e => e.prime ^ e.exponent).prod := by
-      intro entries
-      induction entries with
-      | nil => simp
-      | cons e rest ih =>
-          intro hprime
-          simp only [List.map_cons, List.prod_cons]
-          exact Nat.mul_pos (Nat.pow_pos (hprime e List.mem_cons_self).pos)
-            (ih (fun x hx => hprime x (List.mem_cons_of_mem e hx)))
-    have hprodPos : 0 <
-        (F.raw.factors.map fun e => e.prime ^ e.exponent).prod := by
-      exact product_pos F.raw.factors (checkFactorization_prime F.valid)
-    rw [checkFactorization_prod F.valid, F.subject_eq] at hprodPos
-    exact hprodPos
+  have hnPos : 0 < n := F.pos
   have hnOne : 1 < n := by omega
   have hlocal : ∀ e ∈ F.raw.factors,
       e.prime ^ e.exponent ∣ a ^ carmichael F - 1 := by

--- a/HexIntFactor/Order.lean
+++ b/HexIntFactor/Order.lean
@@ -41,48 +41,49 @@ structure CheckedOrderCert where
   raw : OrderCert
   valid : checkOrder raw = true
 
-private theorem checkOrder_parts {c : OrderCert} (h : checkOrder c = true) :
+/-- Characterisation of every condition replayed by the order checker. -/
+theorem checkOrder_iff {c : OrderCert} : checkOrder c = true ↔
     1 < c.modulus ∧ 0 < c.order ∧ c.orderFac.subject = c.order ∧
       checkFactorization c.orderFac = true ∧
       HexArith.powModNat c.base c.order c.modulus = 1 % c.modulus ∧
       ∀ e ∈ c.orderFac.factors,
         HexArith.powModNat c.base (c.order / e.prime) c.modulus ≠
           1 % c.modulus := by
-  simpa only [checkOrder, Bool.and_eq_true, decide_eq_true_eq,
-    List.all_eq_true, and_assoc] using h
+  simp only [checkOrder, Bool.and_eq_true, decide_eq_true_eq,
+    List.all_eq_true, and_assoc]
 
 /-- An accepted order certificate has a nontrivial modulus. -/
-theorem checkOrder_modulus {c : OrderCert} (h : checkOrder c = true) :
+theorem checkOrder_one_lt_modulus {c : OrderCert} (h : checkOrder c = true) :
     1 < c.modulus :=
-  (checkOrder_parts h).1
+  (checkOrder_iff.mp h).1
 
 /-- An accepted order certificate has positive claimed order. -/
 theorem checkOrder_order_pos {c : OrderCert} (h : checkOrder c = true) :
     0 < c.order :=
-  (checkOrder_parts h).2.1
+  (checkOrder_iff.mp h).2.1
 
 /-- The factorization in an accepted order certificate targets its order. -/
-theorem checkOrder_factorization_subject {c : OrderCert}
+theorem checkOrder_orderFac_subject {c : OrderCert}
     (h : checkOrder c = true) : c.orderFac.subject = c.order :=
-  (checkOrder_parts h).2.2.1
+  (checkOrder_iff.mp h).2.2.1
 
 /-- The factorization in an accepted order certificate is valid. -/
-theorem checkOrder_factorization {c : OrderCert} (h : checkOrder c = true) :
+theorem checkOrder_orderFac {c : OrderCert} (h : checkOrder c = true) :
     checkFactorization c.orderFac = true :=
-  (checkOrder_parts h).2.2.2.1
+  (checkOrder_iff.mp h).2.2.2.1
 
 /-- The claimed order in an accepted certificate sends the base to one. -/
 theorem checkOrder_pow {c : OrderCert} (h : checkOrder c = true) :
     HexArith.powModNat c.base c.order c.modulus = 1 % c.modulus :=
-  (checkOrder_parts h).2.2.2.2.1
+  (checkOrder_iff.mp h).2.2.2.2.1
 
 /-- Removing any listed prime divisor from an accepted claimed order does not
 send the base to one. -/
-theorem checkOrder_prime_divisor {c : OrderCert} (h : checkOrder c = true) :
+theorem checkOrder_pow_div_prime {c : OrderCert} (h : checkOrder c = true) :
     ∀ e ∈ c.orderFac.factors,
       HexArith.powModNat c.base (c.order / e.prime) c.modulus ≠
         1 % c.modulus :=
-  (checkOrder_parts h).2.2.2.2.2
+  (checkOrder_iff.mp h).2.2.2.2.2
 
 private theorem prime_dvd_pow' {q a : Nat} (hq : Prime q) :
     ∀ {k : Nat}, q ∣ a ^ k → q ∣ a := by
@@ -148,38 +149,43 @@ private theorem factorProduct_dvd {d : Nat} :
 /-- Accepted order data identifies the local `orderOf`. -/
 theorem order_eq_of_checkOrder {c : OrderCert} (h : checkOrder c = true) :
     orderOf c.base c.modulus = c.order := by
-  have hp := checkOrder_parts h
-  have hpow := hp.2.2.2.2.1
-  rw [HexArith.powModNat_eq _ _ _ (by omega)] at hpow
+  have hn : 0 < c.modulus := Nat.zero_lt_of_lt (checkOrder_one_lt_modulus h)
+  have hpow := checkOrder_pow h
+  rw [HexArith.powModNat_eq _ _ _ hn] at hpow
   have hord_dvd : orderOf c.base c.modulus ∣ c.order :=
-    orderOf_dvd_of_pow_eq_one hp.1 hp.2.1 hpow
+    orderOf_dvd_of_pow_eq_one (checkOrder_one_lt_modulus h)
+      (checkOrder_order_pos h) hpow
   have hentry : ∀ e ∈ c.orderFac.factors,
       e.prime ^ e.exponent ∣ orderOf c.base c.modulus := by
     intro e he
     have heOrder : e.prime ^ e.exponent ∣ c.order := by
-      rw [← hp.2.2.1]
-      exact (checkFactorization_multiplicity hp.2.2.2.1 he).2 (Nat.le_refl _)
-    have hne := hp.2.2.2.2.2 e he
-    rw [HexArith.powModNat_eq _ _ _ (by omega)] at hne
+      rw [← checkOrder_orderFac_subject h]
+      exact (checkFactorization_multiplicity (checkOrder_orderFac h) he).2
+        (Nat.le_refl _)
+    have hne := checkOrder_pow_div_prime h e he
+    rw [HexArith.powModNat_eq _ _ _ hn] at hne
     exact prime_pow_dvd_orderOf
-      (checkFactorization_prime hp.2.2.2.1 e he) heOrder hp.1 hpow hne
+      (checkFactorization_prime (checkOrder_orderFac h) e he) heOrder
+      (checkOrder_one_lt_modulus h) hpow hne
   have horder_product :
       (c.orderFac.factors.map fun e => e.prime ^ e.exponent).prod ∣
         orderOf c.base c.modulus :=
-    factorProduct_dvd (checkFactorization_prime hp.2.2.2.1)
-      (checkFactorization_sorted hp.2.2.2.1) hentry
+    factorProduct_dvd (checkFactorization_prime (checkOrder_orderFac h))
+      (checkFactorization_sorted (checkOrder_orderFac h)) hentry
   have hc_dvd : c.order ∣ orderOf c.base c.modulus := by
-    rw [← hp.2.2.1, ← checkFactorization_prod hp.2.2.2.1]
+    rw [← checkOrder_orderFac_subject h,
+      ← checkFactorization_prod (checkOrder_orderFac h)]
     exact horder_product
   exact Nat.dvd_antisymm hord_dvd hc_dvd
 
 /-- A positive power equal to one makes the base a unit. -/
 theorem coprime_of_checkOrder {c : OrderCert} (h : checkOrder c = true) :
     Nat.Coprime c.base c.modulus := by
-  have hp := checkOrder_parts h
-  have hpow := hp.2.2.2.2.1
-  rw [HexArith.powModNat_eq _ _ _ (by omega)] at hpow
-  exact coprime_of_pow_mod_eq_one hp.1 hp.2.1 hpow
+  have hn : 0 < c.modulus := Nat.zero_lt_of_lt (checkOrder_one_lt_modulus h)
+  have hpow := checkOrder_pow h
+  rw [HexArith.powModNat_eq _ _ _ hn] at hpow
+  exact coprime_of_pow_mod_eq_one (checkOrder_one_lt_modulus h)
+    (checkOrder_order_pos h) hpow
 
 /-- Test primitivity modulo a certified prime using the complete
 factorization of `p - 1`. -/
@@ -221,14 +227,8 @@ theorem isPrimitiveRoot_iff {p : Nat} {pc : CheckedPrimeCert p}
       · simpa [horder] using hquotLt
       · rw [← HexArith.powModNat_eq _ _ _ hp.pos]
         exact heq
-    simpa only [isPrimitiveRoot, checkOrder, Bool.and_eq_true,
-      decide_eq_true_eq, List.all_eq_true, and_assoc] using
-      (show 1 < p ∧ 0 < p - 1 ∧ F.raw.subject = p - 1 ∧
-          checkFactorization F.raw = true ∧
-          HexArith.powModNat g (p - 1) p = 1 % p ∧
-          ∀ e ∈ F.raw.factors,
-            HexArith.powModNat g ((p - 1) / e.prime) p ≠ 1 % p from
-        ⟨hp.one_lt, hpred, F.subject_eq, F.valid, hpow, hne⟩)
+    exact checkOrder_iff.mpr
+      ⟨hp.one_lt, hpred, F.subject_eq, F.valid, hpow, hne⟩
 
 private def primitiveRootGo {p : Nat} (F : CheckedFactorization (p - 1)) :
     Nat → Nat → Option (Nat × CheckedOrderCert)

--- a/HexIntFactor/Partial.lean
+++ b/HexIntFactor/Partial.lean
@@ -57,6 +57,17 @@ private theorem checkedPartial_parts {F : PartialFactorization}
     simp only [Bool.and_eq_true, decide_eq_true_eq] at h
     exact ⟨h.1.1, h.1.2, acc, hprod, h.2⟩
 
+/-- A partial factorization accepted by the checker has positive subject. -/
+theorem checkPartial_pos {F : PartialFactorization}
+    (h : checkPartial F = true) : 0 < F.subject :=
+  (checkedPartial_parts h).1
+
+/-- The subject indexed by checked partial factorization data is positive. -/
+theorem CheckedPartialFactorization.pos {n : Nat}
+    (F : CheckedPartialFactorization n) : 0 < n := by
+  rw [← F.subject_eq]
+  exact checkPartial_pos F.valid
+
 private theorem boundedPowMul_eq {bound q : Nat} :
     ∀ (e acc r : Nat), boundedPowMul bound q acc e = some r →
       r = acc * q ^ e := by

--- a/HexIntFactor/SPEC/hex-int-factor.md
+++ b/HexIntFactor/SPEC/hex-int-factor.md
@@ -474,8 +474,8 @@ partial factorization of one subject from answering a request about
 another. The characterising lemmas `checkPartial_pos`,
 `CheckedPartialFactorization.pos`, `checkPartial_prod`,
 `checkPartial_prime`, `checkPartial_exponent`, and `checkPartial_sorted`
-expose reconstruction, primality, exponent positivity, and factor-base
-ordering without requiring consumers to unfold the checker.
+expose subject positivity, reconstruction, primality, exponent positivity, and
+factor-base ordering without requiring consumers to unfold the checker.
 `checkFactorization_of_checkPartial` proves that residual one is already a
 complete certificate, avoiding a second certificate replay. The search result
 theorems are
@@ -664,9 +664,10 @@ The identity is normalised as `1 % modulus` rather than `1` so that the
 same modular expression is used throughout, although `1 < c.modulus`
 excludes the degenerate modulus.
 
-The named projections `checkOrder_modulus`, `checkOrder_order_pos`,
-`checkOrder_factorization_subject`, `checkOrder_factorization`,
-`checkOrder_pow`, and `checkOrder_prime_divisor` expose these accepted facts so
+The characterisation `checkOrder_iff` and named projections
+`checkOrder_one_lt_modulus`, `checkOrder_order_pos`,
+`checkOrder_orderFac_subject`, `checkOrder_orderFac`, `checkOrder_pow`, and
+`checkOrder_pow_div_prime` expose these accepted facts so
 downstream proofs do not unfold the Boolean checker or index a nested
 conjunction.
 

--- a/HexIntFactor/SPEC/hex-int-factor.md
+++ b/HexIntFactor/SPEC/hex-int-factor.md
@@ -188,6 +188,11 @@ theorem checkFactorization_prod {F} (h : checkFactorization F = true) :
 theorem checkFactorization_prime {F} (h : checkFactorization F = true) :
     ∀ e ∈ F.factors, Hex.Nat.Prime e.prime
 
+theorem checkFactorization_pos {F} (h : checkFactorization F = true) :
+    0 < F.subject
+
+theorem CheckedFactorization.pos {n} (F : CheckedFactorization n) : 0 < n
+
 /-- The prime support is exactly the listed primes. Not "nothing else
 divides" -- composite divisors certainly exist -- but no other *prime*
 does, which is the statement the order and primitivity certificates
@@ -466,7 +471,8 @@ as `checkFactorization` minus the requirement that the residual be `1`.
 Its product calculation uses the same subject-bounded loop.
 It makes **no** completeness claim. The indexed checked form prevents a
 partial factorization of one subject from answering a request about
-another. The characterising lemmas `checkPartial_prod`,
+another. The characterising lemmas `checkPartial_pos`,
+`CheckedPartialFactorization.pos`, `checkPartial_prod`,
 `checkPartial_prime`, `checkPartial_exponent`, and `checkPartial_sorted`
 expose reconstruction, primality, exponent positivity, and factor-base
 ordering without requiring consumers to unfold the checker.
@@ -657,6 +663,12 @@ structure CheckedOrderCert where
 The identity is normalised as `1 % modulus` rather than `1` so that the
 same modular expression is used throughout, although `1 < c.modulus`
 excludes the degenerate modulus.
+
+The named projections `checkOrder_modulus`, `checkOrder_order_pos`,
+`checkOrder_factorization_subject`, `checkOrder_factorization`,
+`checkOrder_pow`, and `checkOrder_prime_divisor` expose these accepted facts so
+downstream proofs do not unfold the Boolean checker or index a nested
+conjunction.
 
 ```lean
 theorem order_eq_of_checkOrder {c} (h : checkOrder c = true) :

--- a/HexIntFactorMathlib/Factorization.lean
+++ b/HexIntFactorMathlib/Factorization.lean
@@ -89,7 +89,7 @@ theorem factors_eq (F : Factorization) (h : checkFactorization F = true) :
     (expandedFactors_prod F |>.trans (checkFactorization_prod h))
     (prime_of_mem_expandedFactors F h)).symm
 
-/-- An absent prime has zero Mathlib multiplicity. -/
+/-- A base absent from the checked list has zero Mathlib multiplicity. -/
 theorem factorization_absent (F : Factorization)
     (h : checkFactorization F = true) {p : Nat}
     (hmem : ∀ e ∈ F.factors, e.prime ≠ p) :

--- a/HexIntFactorMathlib/Factorization.lean
+++ b/HexIntFactorMathlib/Factorization.lean
@@ -41,18 +41,13 @@ private theorem prime_of_mem_expandedFactors (F : Factorization)
   obtain ⟨e, he, _, rfl⟩ := hp
   exact prime_iff.mp (checkFactorization_prime h e he)
 
-private theorem subject_ne_zero {F : Factorization}
-    (h : checkFactorization F = true) : F.subject ≠ 0 := by
-  have hp := h
-  simp only [checkFactorization, Bool.and_eq_true, decide_eq_true_eq] at hp
-  omega
-
-private theorem factorization_entry_eq (F : Factorization)
+/-- A listed exponent is exactly Mathlib's multiplicity. -/
+theorem factorization_entry (F : Factorization)
     (h : checkFactorization F = true) (e : PrimePower) (he : e ∈ F.factors) :
     F.subject.factorization e.prime = e.exponent := by
   have hp : _root_.Nat.Prime e.prime :=
     prime_iff.mp (checkFactorization_prime h e he)
-  have hn := subject_ne_zero h
+  have hn := (checkFactorization_pos h).ne'
   apply Nat.le_antisymm
   · have hdvd : e.prime ^ (F.subject.factorization e.prime) ∣ F.subject :=
       (hp.pow_dvd_iff_le_factorization hn).2 (Nat.le_refl _)
@@ -68,14 +63,14 @@ theorem factorization_eq (F : Factorization)
   unfold factorExponent
   cases hfind : F.factors.find? (fun e => e.prime == p) with
   | some e =>
-    simp only [hfind, Option.elim_some]
+    simp only [Option.elim_some]
     have he := List.mem_of_find?_eq_some hfind
     have hep : e.prime = p := by
       simpa using List.find?_some hfind
     subst p
-    exact factorization_entry_eq F h e he
+    exact factorization_entry F h e he
   | none =>
-    simp only [hfind, Option.elim_none]
+    simp only [Option.elim_none]
     by_cases hp : _root_.Nat.Prime p
     · apply Nat.factorization_eq_zero_of_not_dvd
       intro hdiv
@@ -94,15 +89,9 @@ theorem factors_eq (F : Factorization) (h : checkFactorization F = true) :
     (expandedFactors_prod F |>.trans (checkFactorization_prod h))
     (prime_of_mem_expandedFactors F h)).symm
 
-/-- A listed exponent is exactly Mathlib's multiplicity. -/
-theorem factorization_entry (F : Factorization)
-    (h : checkFactorization F = true) (e : PrimePower) (he : e ∈ F.factors) :
-    F.subject.factorization e.prime = e.exponent :=
-  factorization_entry_eq F h e he
-
 /-- An absent prime has zero Mathlib multiplicity. -/
 theorem factorization_absent (F : Factorization)
-    (h : checkFactorization F = true) {p : Nat} (_hp : _root_.Nat.Prime p)
+    (h : checkFactorization F = true) {p : Nat}
     (hmem : ∀ e ∈ F.factors, e.prime ≠ p) :
     F.subject.factorization p = 0 := by
   rw [factorization_eq F h]
@@ -115,10 +104,7 @@ theorem factorization_absent (F : Factorization)
 /-- The checked divisor enumeration is Mathlib's divisor finset. -/
 theorem divisors_eq {n : Nat} (F : CheckedFactorization n) :
     (divisors F).toList.toFinset = n.divisors := by
-  have hn : n ≠ 0 := by
-    have hv := F.valid
-    simp only [checkFactorization, Bool.and_eq_true, decide_eq_true_eq] at hv
-    exact (F.subject_eq ▸ hv.1.1).ne'
+  have hn : n ≠ 0 := F.pos.ne'
   ext d
   simp only [List.mem_toFinset, Hex.Nat.mem_divisors F,
     _root_.Nat.mem_divisors]
@@ -142,10 +128,7 @@ theorem sigma_eq {n k : Nat} (F : CheckedFactorization n) :
 /-- The checked radical is Mathlib's product of the distinct prime factors. -/
 theorem radical_eq {n : Nat} (F : CheckedFactorization n) :
     radical F = ∏ p ∈ n.primeFactors, p := by
-  have hn : n ≠ 0 := by
-    have hv := F.valid
-    simp only [checkFactorization, Bool.and_eq_true, decide_eq_true_eq] at hv
-    exact (F.subject_eq ▸ hv.1.1).ne'
+  have hn : n ≠ 0 := F.pos.ne'
   have hset : (F.raw.factors.map fun e => e.prime).toFinset = n.primeFactors := by
     ext p
     simp only [List.mem_toFinset, List.mem_map, Nat.mem_primeFactors_of_ne_zero hn]
@@ -179,10 +162,7 @@ theorem squarefreePart_mathlib {n : Nat} (F : CheckedFactorization n) :
     Squarefree (squarefreePart F) := by
   rw [Nat.squarefree_iff_prime_squarefree]
   intro q hq hq2
-  have hn : 0 < n := by
-    have hv := F.valid
-    simp only [checkFactorization, Bool.and_eq_true, decide_eq_true_eq] at hv
-    exact F.subject_eq ▸ hv.1.1
+  have hn : 0 < n := F.pos
   have hd : 0 < squareDivisor F := by
     apply Nat.pos_of_ne_zero
     intro hd0
@@ -207,10 +187,7 @@ theorem squarefreePart_mathlib {n : Nat} (F : CheckedFactorization n) :
 order-theoretic vocabulary. -/
 theorem squareDivisor_mathlib {n : Nat} (F : CheckedFactorization n) :
     IsGreatest {d : Nat | d ^ 2 ∣ n} (squareDivisor F) := by
-  have hn : 0 < n := by
-    have hv := F.valid
-    simp only [checkFactorization, Bool.and_eq_true, decide_eq_true_eq] at hv
-    exact F.subject_eq ▸ hv.1.1
+  have hn : 0 < n := F.pos
   have hd : 0 < squareDivisor F := by
     apply Nat.pos_of_ne_zero
     intro hd0

--- a/HexIntFactorMathlib/Order.lean
+++ b/HexIntFactorMathlib/Order.lean
@@ -36,30 +36,23 @@ private theorem unit_pow_iff {a n k : Nat} (ha : Nat.Coprime a n) :
 theorem orderOf_eq {c : OrderCert} (h : checkOrder c = true) :
     _root_.orderOf
         (ZMod.unitOfCoprime c.base (coprime_of_checkOrder h)) = c.order := by
-  have hp :
-      1 < c.modulus ∧ 0 < c.order ∧ c.orderFac.subject = c.order ∧
-        checkFactorization c.orderFac = true ∧
-        HexArith.powModNat c.base c.order c.modulus = 1 % c.modulus ∧
-        ∀ e ∈ c.orderFac.factors,
-          HexArith.powModNat c.base (c.order / e.prime) c.modulus ≠
-            1 % c.modulus := by
-    simpa only [checkOrder, Bool.and_eq_true, decide_eq_true_eq,
-      List.all_eq_true, and_assoc] using h
   let ha := coprime_of_checkOrder h
-  apply orderOf_eq_of_pow_and_pow_div_prime hp.2.1
+  have hn : 0 < c.modulus := Nat.zero_lt_of_lt (checkOrder_modulus h)
+  apply orderOf_eq_of_pow_and_pow_div_prime (checkOrder_order_pos h)
   · apply (unit_pow_iff ha).2
-    have hpow := hp.2.2.2.2.1
-    rw [HexArith.powModNat_eq _ _ _ (by omega)] at hpow
+    have hpow := checkOrder_pow h
+    rw [HexArith.powModNat_eq _ _ _ hn] at hpow
     exact hpow
   · intro q hq hqDvd hunit
     have hqLocal : Prime q := prime_iff.mpr hq
-    have hqRaw : q ∣ c.orderFac.subject := by simpa [hp.2.2.1] using hqDvd
+    have hqRaw : q ∣ c.orderFac.subject := by
+      simpa [checkOrder_factorization_subject h] using hqDvd
     obtain ⟨e, he, heq⟩ :=
-      (checkFactorization_primeSupport hp.2.2.2.1 hqLocal).mp hqRaw
+      (checkFactorization_primeSupport (checkOrder_factorization h) hqLocal).mp hqRaw
     have hbad := (unit_pow_iff ha).1 hunit
     rw [← heq] at hbad
-    have hne := hp.2.2.2.2.2 e he
-    rw [HexArith.powModNat_eq _ _ _ (by omega)] at hne
+    have hne := checkOrder_prime_divisor h e he
+    rw [HexArith.powModNat_eq _ _ _ hn] at hne
     exact hne hbad
 
 end Nat

--- a/HexIntFactorMathlib/Order.lean
+++ b/HexIntFactorMathlib/Order.lean
@@ -37,7 +37,8 @@ theorem orderOf_eq {c : OrderCert} (h : checkOrder c = true) :
     _root_.orderOf
         (ZMod.unitOfCoprime c.base (coprime_of_checkOrder h)) = c.order := by
   let ha := coprime_of_checkOrder h
-  have hn : 0 < c.modulus := Nat.zero_lt_of_lt (checkOrder_modulus h)
+  have hn : 0 < c.modulus :=
+    _root_.Nat.zero_lt_of_lt (checkOrder_one_lt_modulus h)
   apply orderOf_eq_of_pow_and_pow_div_prime (checkOrder_order_pos h)
   · apply (unit_pow_iff ha).2
     have hpow := checkOrder_pow h
@@ -46,12 +47,12 @@ theorem orderOf_eq {c : OrderCert} (h : checkOrder c = true) :
   · intro q hq hqDvd hunit
     have hqLocal : Prime q := prime_iff.mpr hq
     have hqRaw : q ∣ c.orderFac.subject := by
-      simpa [checkOrder_factorization_subject h] using hqDvd
+      simpa [checkOrder_orderFac_subject h] using hqDvd
     obtain ⟨e, he, heq⟩ :=
-      (checkFactorization_primeSupport (checkOrder_factorization h) hqLocal).mp hqRaw
+      (checkFactorization_primeSupport (checkOrder_orderFac h) hqLocal).mp hqRaw
     have hbad := (unit_pow_iff ha).1 hunit
     rw [← heq] at hbad
-    have hne := checkOrder_prime_divisor h e he
+    have hne := checkOrder_pow_div_prime h e he
     rw [HexArith.powModNat_eq _ _ _ hn] at hne
     exact hne hbad
 


### PR DESCRIPTION
Closes #9700
Depends on #9619

## Summary

- expose positive-subject facts for checked complete and partial factorizations
- expose `checkOrder_iff` plus named semantic projections for accepted order certificates
- migrate both core and Mathlib proofs away from checker unfolding and nested conjunction indexing
- remove the exact factorization-entry alias and strengthen `factorization_absent` by removing its unused primality premise
- replace a 17-line positivity reconstruction in the Carmichael proof with the checked-data fact
- document the stable projection surface in the governing SPEC

The `factorization_absent` signature change is source-breaking for positional callers, but the theorem has no in-tree callers and neither library is released; the new statement is strictly stronger. The two `simp only` cleanups remove linter-reported unused arguments.

## Verification

- `lake build HexIntFactor HexIntFactorMathlib`
- `lake exe runLinter HexIntFactorMathlib.Factorization`
- `lake exe runLinter HexIntFactorMathlib.Order`
- `python3 scripts/check_file_line_counts.py`
- banned-token scan over both libraries
- `git diff --check`
