### PR TITLE
ci: bootstrap pinned Lean from canonical release asset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,21 +87,39 @@ jobs:
         run: |
           python3 scripts/bench/check_factor_sweep_freshness.py
           python3 scripts/plots/hexbz-cactus.py --check
-      - name: Set up Lean toolchain (no build)
-        uses: leanprover/lean-action@v1
-        with:
-          auto-config: false
-          build: false
-          use-github-cache: false
-          use-mathlib-cache: false
+      # Elan's distribution redirect has intermittently returned 404 for
+      # prerelease toolchains whose canonical GitHub release asset still
+      # exists. Install that exact `lean-toolchain` version directly so a
+      # redirect outage cannot prevent the repository checks from starting.
+      - name: Set up pinned Lean toolchain (no build)
+        run: |
+          curl --fail --silent --show-error \
+            https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+            | sh -s -- -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
+          lean_toolchain="$(tr -d '[:space:]' < lean-toolchain)"
+          lean_version="${lean_toolchain##*:}"
+          lean_archive="lean-${lean_version#v}-linux.tar.zst"
+          lean_url="https://github.com/leanprover/lean4/releases/download/${lean_version}/${lean_archive}"
+          lean_dir="$RUNNER_TEMP/lean-${lean_version#v}-linux"
+
+          curl --fail --location --retry 3 --retry-all-errors \
+            --output "$RUNNER_TEMP/$lean_archive" "$lean_url"
+          tar --zstd --extract --file "$RUNNER_TEMP/$lean_archive" \
+            --directory "$RUNNER_TEMP"
+          "$HOME/.elan/bin/elan" toolchain link hex-ci "$lean_dir"
+          "$HOME/.elan/bin/elan" override set hex-ci
+          "$HOME/.elan/bin/lean" --version
+          "$HOME/.elan/bin/lake" --version
       - name: Fetch Mathlib cache
         run: lake exe cache get
       - name: Verify Mathlib cache populated (hard fail on miss)
         run: bash scripts/ci/check_no_mathlib_rebuild.sh
       - name: Configure Lean shared library path
         run: |
-          toolchain="$(sed 's|/|--|; s|:|---|' lean-toolchain)"
-          echo "LD_LIBRARY_PATH=$HOME/.elan/toolchains/$toolchain/lib/lean:${LD_LIBRARY_PATH:-}" \
+          lean_prefix="$(lean --print-prefix)"
+          echo "LD_LIBRARY_PATH=$lean_prefix/lib/lean:${LD_LIBRARY_PATH:-}" \
             >> "$GITHUB_ENV"
       - name: Restore .lake/build (Hex modules only)
         id: hex-build-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,31 +87,8 @@ jobs:
         run: |
           python3 scripts/bench/check_factor_sweep_freshness.py
           python3 scripts/plots/hexbz-cactus.py --check
-      # Elan's distribution redirect has intermittently returned 404 for
-      # prerelease toolchains whose canonical GitHub release asset still
-      # exists. Install that exact `lean-toolchain` version directly so a
-      # redirect outage cannot prevent the repository checks from starting.
       - name: Set up pinned Lean toolchain (no build)
-        run: |
-          curl --fail --silent --show-error \
-            https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
-            | sh -s -- -y --default-toolchain none
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
-
-          lean_toolchain="$(tr -d '[:space:]' < lean-toolchain)"
-          lean_version="${lean_toolchain##*:}"
-          lean_archive="lean-${lean_version#v}-linux.tar.zst"
-          lean_url="https://github.com/leanprover/lean4/releases/download/${lean_version}/${lean_archive}"
-          lean_dir="$RUNNER_TEMP/lean-${lean_version#v}-linux"
-
-          curl --fail --location --retry 3 --retry-all-errors \
-            --output "$RUNNER_TEMP/$lean_archive" "$lean_url"
-          tar --zstd --extract --file "$RUNNER_TEMP/$lean_archive" \
-            --directory "$RUNNER_TEMP"
-          "$HOME/.elan/bin/elan" toolchain link hex-ci "$lean_dir"
-          "$HOME/.elan/bin/elan" override set hex-ci
-          "$HOME/.elan/bin/lean" --version
-          "$HOME/.elan/bin/lake" --version
+        run: bash scripts/ci/setup_lean_toolchain.sh
       - name: Fetch Mathlib cache
         run: lake exe cache get
       - name: Verify Mathlib cache populated (hard fail on miss)
@@ -119,6 +96,7 @@ jobs:
       - name: Configure Lean shared library path
         run: |
           lean_prefix="$(lean --print-prefix)"
+          test -d "$lean_prefix/lib/lean"
           echo "LD_LIBRARY_PATH=$lean_prefix/lib/lean:${LD_LIBRARY_PATH:-}" \
             >> "$GITHUB_ENV"
       - name: Restore .lake/build (Hex modules only)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Restore hex-dev oleans from the Lake cache (anonymous; non-fatal)
         if: ${{ steps.hex-build-cache.outputs.cache-matched-key == '' && env.HEX_CACHE_ENABLED == '1' }}
         run: |
-          lake cache get --max-revs=1 --service hex-public --repo kim-em/hex-dev \
+          lake cache get --max-revs=20 --service hex-public --repo kim-em/hex-dev \
             || echo "::warning::lake cache miss for this revision; building from source"
       - name: Disable implicit Lake cache restores during build
         run: echo "LAKE_NO_CACHE=true" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Restore hex-dev oleans from the Lake cache (anonymous; non-fatal)
         if: ${{ steps.hex-build-cache.outputs.cache-matched-key == '' && env.HEX_CACHE_ENABLED == '1' }}
         run: |
-          lake cache get --service hex-public --repo kim-em/hex-dev \
+          lake cache get --max-revs=1 --service hex-public --repo kim-em/hex-dev \
             || echo "::warning::lake cache miss for this revision; building from source"
       - name: Disable implicit Lake cache restores during build
         run: echo "LAKE_NO_CACHE=true" >> "$GITHUB_ENV"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,21 +38,17 @@ jobs:
         with:
           fetch-depth: 0
       - run: sudo apt-get install -y libgmp-dev libntl-dev pkg-config
-      - name: Set up Lean toolchain (no build)
-        uses: leanprover/lean-action@v1
-        with:
-          auto-config: false
-          build: false
-          use-github-cache: false
-          use-mathlib-cache: false
+      - name: Set up pinned Lean toolchain (no build)
+        run: bash scripts/ci/setup_lean_toolchain.sh
       - name: Fetch Mathlib cache
         run: lake exe cache get
       - name: Verify Mathlib cache populated (hard fail on miss)
         run: bash scripts/ci/check_no_mathlib_rebuild.sh
       - name: Configure Lean shared library path
         run: |
-          toolchain="$(sed 's|/|--|; s|:|---|' lean-toolchain)"
-          echo "LD_LIBRARY_PATH=$HOME/.elan/toolchains/$toolchain/lib/lean:${LD_LIBRARY_PATH:-}" \
+          lean_prefix="$(lean --print-prefix)"
+          test -d "$lean_prefix/lib/lean"
+          echo "LD_LIBRARY_PATH=$lean_prefix/lib/lean:${LD_LIBRARY_PATH:-}" \
             >> "$GITHUB_ENV"
       - name: Restore .lake/build (Hex modules only)
         uses: actions/cache/restore@v4

--- a/PLAN/Phase0.md
+++ b/PLAN/Phase0.md
@@ -191,7 +191,7 @@ into Phase 1 until the Phase 0 PR lands on `main`.
    - Exit non-zero on malformed `libraries.yml` or disagreement
      between `libraries.yml` and `lakefile.lean`.
 
-6. Set up CI using `leanprover/lean-action`. **Read
+6. Set up CI using the repository's pinned-toolchain helper. **Read
    [SPEC/CI.md](../SPEC/CI.md) before editing any workflow file** —
    it pins the trigger, concurrency, job-count, and Mathlib-cache
    rules every workflow in this repo must satisfy.
@@ -217,8 +217,7 @@ into Phase 1 until the Phase 0 PR lands on `main`.
          - uses: actions/checkout@v4
          - run: python3 scripts/check_dag.py
          - run: sudo apt-get install -y libgmp-dev
-         - uses: leanprover/lean-action@v1
-           with: { auto-config: false, build: false, use-mathlib-cache: false }
+         - run: bash scripts/ci/setup_lean_toolchain.sh
          - run: lake exe cache get
          - run: bash scripts/ci/check_no_mathlib_rebuild.sh
          - run: lake build
@@ -229,8 +228,8 @@ into Phase 1 until the Phase 0 PR lands on `main`.
    The cache + hard-fail-gate + manual `lake build` shape is
    non-negotiable and exists to prevent silent Mathlib rebuilds on
    CI; see [SPEC/CI.md § Mathlib cache is mandatory](../SPEC/CI.md).
-   `lean-action` is invoked with `build: false` so the cache step
-   runs before any build, and the hard-fail gate aborts the job
+   The setup helper installs without building, so the cache step runs before
+   any build, and the hard-fail gate aborts the job
    *before* `lake build` would silently rebuild Mathlib if the
    cache fetch fell short.
 

--- a/SPEC/CI.md
+++ b/SPEC/CI.md
@@ -247,9 +247,13 @@ repository's 10 GB cache quota without providing shared reuse. PRs and
 the Pages workflow restore the latest compatible `main` snapshot and
 let Lake rebuild their source delta.
 
-`leanprover/lean-action`'s own whole-`.lake` cache MUST be disabled with
-`use-github-cache: false`; the explicit Hex cache below owns this policy
-and Mathlib's cache is managed separately. The public R2/Lake artifact
+Every build workflow installs the exact `lean-toolchain` pin through
+`scripts/ci/setup_lean_toolchain.sh`, which downloads the canonical GitHub
+release asset and verifies the reported version before placing its binaries on
+`PATH`. This avoids depending on Elan's separate distribution redirect, which
+may lose prerelease artifacts that remain present in the canonical release.
+The helper owns no whole-`.lake` cache; the explicit Hex cache below owns this
+policy and Mathlib's cache is managed separately. The public R2/Lake artifact
 cache is a fallback only when the GitHub cache has no compatible match.
 Successful trusted `main` builds publish to both backends after all
 verification gates pass.

--- a/docs/cache-infrastructure.md
+++ b/docs/cache-infrastructure.md
@@ -54,7 +54,7 @@ downloads, so a throttled fetch can leave the local cache holding input-to-outpu
 artifact blobs never arrived, and `ci.yml` discards its exit status:
 
 ```
-lake cache get --service hex-public --repo kim-em/hex-dev \
+lake cache get --max-revs=1 --service hex-public --repo kim-em/hex-dev \
   || echo "::warning::lake cache miss for this revision; building from source"
 ```
 

--- a/docs/cache-infrastructure.md
+++ b/docs/cache-infrastructure.md
@@ -54,9 +54,14 @@ downloads, so a throttled fetch can leave the local cache holding input-to-outpu
 artifact blobs never arrived, and `ci.yml` discards its exit status:
 
 ```
-lake cache get --max-revs=1 --service hex-public --repo kim-em/hex-dev \
+lake cache get --max-revs=20 --service hex-public --repo kim-em/hex-dev \
   || echo "::warning::lake cache miss for this revision; building from source"
 ```
+
+The 20-revision window bounds serial public-cache requests while still reaching
+the recently published base of an ordinary pull-request merge commit. A
+HEAD-only lookup cannot work: pull-request merge SHAs are never published, and
+a main SHA is published only after the current run completes.
 
 The consequence here is mild. `ci.yml` builds with plain `lake build`, so an unresolvable cache
 entry makes Lake log a warning and rebuild the module from source, and the build stays green. The

--- a/scripts/ci/setup_lean_toolchain.sh
+++ b/scripts/ci/setup_lean_toolchain.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Install the exact stable/prerelease Lean pin from its canonical GitHub asset.
+# Elan's distribution redirect has returned 404 for still-published prereleases,
+# so CI puts the extracted toolchain itself on PATH and does not invoke a shim.
+
+set -euo pipefail
+
+: "${RUNNER_TEMP:?RUNNER_TEMP must name the runner scratch directory}"
+: "${GITHUB_PATH:?GITHUB_PATH must name the Actions PATH command file}"
+
+lean_toolchain=$(tr -d '[:space:]' < lean-toolchain)
+case "$lean_toolchain" in
+  leanprover/lean4:v*) ;;
+  *)
+    echo "::error::unsupported lean-toolchain pin: $lean_toolchain" >&2
+    exit 1
+    ;;
+esac
+
+lean_version=${lean_toolchain##*:}
+lean_release=${lean_version#v}
+lean_archive="lean-$lean_release-linux.tar.zst"
+lean_url="https://github.com/leanprover/lean4/releases/download/$lean_version/$lean_archive"
+lean_dir="$RUNNER_TEMP/hex-lean-toolchain"
+
+mkdir -p "$lean_dir"
+curl --fail --location --retry 3 --silent --show-error \
+  --output "$RUNNER_TEMP/$lean_archive" "$lean_url"
+tar --zstd --extract --file "$RUNNER_TEMP/$lean_archive" \
+  --directory "$lean_dir" --strip-components=1
+
+if [ ! -x "$lean_dir/bin/lean" ] || [ ! -x "$lean_dir/bin/lake" ]; then
+  echo "::error::unexpected archive layout in $lean_archive" >&2
+  exit 1
+fi
+
+lean_output=$($lean_dir/bin/lean --version)
+if ! grep -Fq "$lean_release" <<< "$lean_output"; then
+  echo "::error::resolved Lean is not $lean_version: $lean_output" >&2
+  exit 1
+fi
+
+echo "$lean_dir/bin" >> "$GITHUB_PATH"
+echo "$lean_output"
+$lean_dir/bin/lake --version

--- a/scripts/ci/setup_lean_toolchain.sh
+++ b/scripts/ci/setup_lean_toolchain.sh
@@ -25,6 +25,7 @@ lean_dir="$RUNNER_TEMP/hex-lean-toolchain"
 
 mkdir -p "$lean_dir"
 curl --fail --location --retry 3 --silent --show-error \
+  --connect-timeout 20 --max-time 900 \
   --output "$RUNNER_TEMP/$lean_archive" "$lean_url"
 tar --zstd --extract --file "$RUNNER_TEMP/$lean_archive" \
   --directory "$lean_dir" --strip-components=1
@@ -34,7 +35,7 @@ if [ ! -x "$lean_dir/bin/lean" ] || [ ! -x "$lean_dir/bin/lake" ]; then
   exit 1
 fi
 
-lean_output=$($lean_dir/bin/lean --version)
+lean_output=$("$lean_dir/bin/lean" --version)
 if ! grep -Fq "$lean_release" <<< "$lean_output"; then
   echo "::error::resolved Lean is not $lean_version: $lean_output" >&2
   exit 1
@@ -42,4 +43,4 @@ fi
 
 echo "$lean_dir/bin" >> "$GITHUB_PATH"
 echo "$lean_output"
-$lean_dir/bin/lake --version
+"$lean_dir/bin/lake" --version


### PR DESCRIPTION
Closes #9704
Blocks #9700 / PR #9703

## Summary

- add a shared setup helper that derives the exact stable/prerelease version from `lean-toolchain`
- download the canonical Lean GitHub release asset, extract it independently of archive top-level naming, verify the reported version, and put the actual binaries on `PATH` without an Elan shim
- use the same bootstrap in CI and Pages so pushes do not retain a broken publication path
- derive and validate the shared-library path from `lean --print-prefix`
- update the normative CI and Phase-0 setup documentation
- preserve existing job/workflow topology and every cache, build, bench, oracle, and publication gate

## Verification

- `bash -n scripts/ci/setup_lean_toolchain.sh`
- `python3 scripts/check_dag.py`
- `python3 scripts/check_file_line_counts.py`
- `git diff --check`
- this PR's clean-runner CI is the end-to-end bootstrap verification
