### PR TITLE
doc: re-attest the HexResultant core through Phase 7

### DIFF
--- a/HexManual/Chapters/HexResultant.lean
+++ b/HexManual/Chapters/HexResultant.lean
@@ -286,13 +286,16 @@ exact rather than truncating.
 
 {docstring Hex.DensePoly.subresultantChainExt_law}
 
+The two halves are also available separately:
+
 {docstring Hex.DensePoly.subresultantChainExt_bezout}
 
 {docstring Hex.DensePoly.subresultantChainExt_exact}
 
-`HexPolyZGcd` and `HexMvGcd` consume this to produce the `splitBezout`
-certificate constructor for their deterministic fallback route, which needs a
-Bezout pair with no modulus and so cannot go through the modular gcd.
+Both gcd libraries read the terminal entry for a deterministic fallback that
+needs a Bezout pair with no modulus, and so cannot go through the modular
+route. `HexPolyZGcd` turns it into a `CoprimeWitness.constant`; `HexMvGcd`
+turns it into a `splitBezout` certificate.
 
 # A small exact computation
 %%%

--- a/HexManual/Chapters/HexResultant.lean
+++ b/HexManual/Chapters/HexResultant.lean
@@ -256,6 +256,44 @@ the zero and constant conventions handled explicitly:
 
 {docstring Hex.DensePoly.disc}
 
+# The extended chain
+%%%
+tag := "hex-resultant-extended-chain"
+%%%
+
+Gcd consumers need more than the chain entries: to build a Bezout certificate
+they need the transformation that produced each entry. The extended chain runs
+the same Brown recurrence and additionally carries a cofactor pair through
+every pseudo-scaling and every exact scalar division, so each stored triple is
+a Bezout identity for the caller's two inputs.
+
+{docstring Hex.DensePoly.SubresultantExt.Entry}
+
+{docstring Hex.DensePoly.subresultantChainExt}
+
+The third components are the plain chain, unchanged. The extension adds
+information; it does not alter the resultant or discriminant contracts.
+
+{docstring Hex.DensePoly.subresultantChainExt_values}
+
+Correctness is packaged as one law with two halves. The Bezout half applies to
+every stored entry. The exactness half is what makes the executable divisions
+legitimate: at each divided step, both transformation numerators are the Brown
+scalar times the stored quotients, so the division the executable performs is
+exact rather than truncating.
+
+{docstring Hex.DensePoly.SubresultantExt.Law}
+
+{docstring Hex.DensePoly.subresultantChainExt_law}
+
+{docstring Hex.DensePoly.subresultantChainExt_bezout}
+
+{docstring Hex.DensePoly.subresultantChainExt_exact}
+
+`HexPolyZGcd` and `HexMvGcd` consume this to produce the `splitBezout`
+certificate constructor for their deterministic fallback route, which needs a
+Bezout pair with no modulus and so cannot go through the modular gcd.
+
 # A small exact computation
 %%%
 tag := "hex-resultant-example"
@@ -315,6 +353,11 @@ with the executable correspondence, this identity underlies one-level field
 norms and the Trager collision bound:
 
 {docstring Hex.DensePoly.resultant_eq_leadingCoeff_mul_prod_roots}
+
+Its immediate consequence is the classical vanishing criterion, stated over
+the complex numbers for integer inputs:
+
+{docstring Hex.DensePoly.resultant_eq_zero_iff_common_root}
 
 # Cross-references
 %%%

--- a/HexMvGcd/SPEC/hex-mv-gcd.md
+++ b/HexMvGcd/SPEC/hex-mv-gcd.md
@@ -432,36 +432,29 @@ lines belonging with the content operations here. The arity-preserving
 recursive view is not wanted at all, for the reason under "The recursive
 view".
 
-## Required amendment to hex-resultant
+## The extended chain from hex-resultant
 
 The `splitBezout` certificate constructor needs the Bézout cofactors of
-the subresultant chain. hex-resultant does not compute them, and it is
-worth saying so explicitly because the chain looks as though it must:
-`subresultantAux` calls `pseudoDivMod` and keeps only `.2`
-(`HexResultant/Subresultant.lean:609` and `:616`); the quotient is
-discarded and no transformation is accumulated.
+the subresultant chain. The plain chain does not carry them:
+`subresultantAux` calls `pseudoDivMod` and keeps only `.2`, discarding the
+quotient and accumulating no transformation.
 
-An extended chain is therefore a new recurrence that tracks the
-transformation pair through the pseudo-scaling and the exact scalar
-division at every step, with proofs that each cofactor numerator is
-divisible by the Brown scalar it is divided by.
-
-The owning contract is now recorded under "Extended subresultant chain for
-gcd consumers" in [SPEC/future-work.md](../../SPEC/future-work.md), with a pointer
-from the Downstream contracts section of
+The extended chain is a separate recurrence that tracks the transformation
+pair through the pseudo-scaling and the exact scalar division at every step,
+with proofs that each cofactor numerator is divisible by the Brown scalar it
+is divided by. It is owned by hex-resultant, whose SPEC records the contract
+under Downstream contracts in
 [hex-resultant's SPEC](../../HexResultant/SPEC/hex-resultant.md); its
 signature is repeated here only to show the consumer boundary:
 
 ```lean
-/-- The subresultant chain with the cofactors producing each entry:
-`(uₖ, vₖ, Sₖ)` with `uₖ · f + vₖ · g = Sₖ`. -/
-def subresultantChainExt [Zero R] [DecidableEq R] [One R] [Add R] [Sub R]
-    [Mul R] [Div R] (f g : DensePoly R) :
-    Array (DensePoly R × DensePoly R × DensePoly R)
+/-- Brown's nonzero subresultant chain together with a caller-order-sensitive
+Bezout representation for every stored entry. -/
+def subresultantChainExt [One R] [Add R] [Sub R] [Mul R] [Div R]
+    (f g : DensePoly R) : Array (DensePoly R × DensePoly R × DensePoly R)
 ```
 
-That is a substantive development, not a one-line export, and it is a
-hard prerequisite for this library's complete fallback. The modular
+This library's complete fallback depends on it. The modular
 constructor is intentionally primary but cannot be complete while
 `ZMod64.Bounds` caps its primes. With
 `L = lcm(1, …, 2^31 - 1)`, the coprime univariate pair `x` and `x + L`

--- a/HexMvGcd/SPEC/hex-mv-gcd.md
+++ b/HexMvGcd/SPEC/hex-mv-gcd.md
@@ -450,8 +450,9 @@ signature is repeated here only to show the consumer boundary:
 ```lean
 /-- Brown's nonzero subresultant chain together with a caller-order-sensitive
 Bezout representation for every stored entry. -/
-def subresultantChainExt [One R] [Add R] [Sub R] [Mul R] [Div R]
-    (f g : DensePoly R) : Array (DensePoly R × DensePoly R × DensePoly R)
+def subresultantChainExt [Zero R] [DecidableEq R] [One R] [Add R] [Sub R]
+    [Mul R] [Div R] (f g : DensePoly R) :
+    Array (DensePoly R × DensePoly R × DensePoly R)
 ```
 
 This library's complete fallback depends on it. The modular
@@ -1671,7 +1672,7 @@ public semantic operation: `gcd`, `cofactors`, `contentIn`, `primPartIn`,
 ## Milestones
 
 1. **Prerequisite and coefficient kernel.** Land
-   `Hex.Resultant.subresultantChainExt` with its transformation and exact
+   `Hex.DensePoly.subresultantChainExt` with its transformation and exact
    division proofs. Then implement `GcdOps`, `BezoutOps`,
    `LawfulGcdOps`, `LawfulBezoutOps`, `CoeffHom`, `divMod`,
    `divExact?`, the `Dvd` / `Div` / `ExactDivLaws` instances, `constIn`,

--- a/HexPolyZGcd/SPEC/hex-poly-z-gcd.md
+++ b/HexPolyZGcd/SPEC/hex-poly-z-gcd.md
@@ -504,10 +504,9 @@ recombination loop rather than about division.
 
 **`subresultantChainExt` belongs in hex-resultant.** Route 4 needs the
 Bézout cofactors of the chain to produce the `constant` witness, and
-`subresultantAux` discards the quotient of each `pseudoDivMod`
-(`HexResultant/Subresultant.lean:609` and `:616`).
-[hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) asks for the same addition under the same
-name for its `splitBezout` constructor, so it should be written once.
+`subresultantAux` discards the quotient of each `pseudoDivMod`.
+[hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) needs the same operation for
+its `splitBezout` constructor, so it is written once, in hex-resultant.
 
 **`Modulus` and the bundled `Prime` belong in hex-mod-arith**, as
 [hex-modular](../../HexModular/SPEC/hex-modular.md) sets out. The `modular` witness names one.
@@ -730,8 +729,8 @@ companion beyond these and one correspondence lemma per public operation.
    code.
 
 5. **The heuristic and the subresultant fallback.** Route 2, and route 4
-   becoming the primary deterministic fallback once hex-resultant is far
-   enough along, with the rational implementation retained for an absent
+   as the primary deterministic fallback on hex-resultant's extended
+   chain, with the rational implementation retained for an absent
    extended-chain terminal.
 
 6. **The companion**, and the fast squarefree decomposition. The

--- a/HexResultant/Fraction.lean
+++ b/HexResultant/Fraction.lean
@@ -51,8 +51,11 @@ end Fraction
 
 /-- A numerator and a certified nonzero denominator. -/
 structure Fraction.Rep (R : Type u) [Zero R] where
+  /-- The numerator. -/
   num : R
+  /-- The denominator. -/
   den : R
+  /-- The denominator is nonzero, so the quotient is well defined. -/
   den_ne : den ≠ 0
 
 namespace Fraction.Rep

--- a/HexResultant/README.md
+++ b/HexResultant/README.md
@@ -5,12 +5,13 @@ library for Lean 4. The aim is fast executable code, fully verified, built
 with spec-driven development.
 
 Polynomial resultants and discriminants for `Hex.DensePoly R` over a
-commutative exact-division domain, implemented in Lean 4 without Mathlib.
-The algorithm is the subresultant pseudo-remainder sequence of Collins and
-Brown, the standard fraction-free method. The package depends on
-[`hex-poly`](https://github.com/leanprover/hex-poly) and
-[`hex-basic`](https://github.com/leanprover/hex-basic); its Mathlib
-counterpart is
+commutative exact-division domain. It is implemented in Lean 4 without
+Mathlib. The algorithm is the subresultant pseudo-remainder sequence of
+Collins and Brown, the standard fraction-free method. The package depends on
+[`hex-poly`](https://github.com/leanprover/hex-poly),
+[`hex-basic`](https://github.com/leanprover/hex-basic) and
+[`hex-determinant`](https://github.com/leanprover/hex-determinant); its
+Mathlib counterpart is
 [`hex-resultant-mathlib`](https://github.com/leanprover/hex-resultant-mathlib).
 
 # Quickstart

--- a/HexResultant/README.md
+++ b/HexResultant/README.md
@@ -41,6 +41,8 @@ def g : DensePoly Int := DensePoly.ofList [-3, 0, 1]  -- X^2 - 3
 - `Hex.DensePoly.subresultantRun` and `Hex.DensePoly.subresultantChain`:
   Brown's nonzero subresultant pseudo-remainder sequence with its corrected
   terminal scale.
+- `Hex.DensePoly.subresultantChainExt`: the same chain carrying the Bezout
+  cofactors `(uₖ, vₖ)` that produce each entry from the two inputs.
 - `Hex.DensePoly.resultant`: the resultant under Mathlib's
   default-formal-degree conventions, total on zero and reversed inputs.
 - `Hex.DensePoly.disc`: the standard discriminant, with the
@@ -64,9 +66,13 @@ algorithm's own typeclass context. This package itself proves the
 Mathlib-free algebra of the chain: pseudo-division identities, the
 Brown--Traub minor correspondence, and exact-division totality.
 
-The extended cofactor chain `subresultantChainExt` is currently provided
-for executable use only; its Bezout contract is stated but its proof is in
-progress, and no released consumer depends on it.
+The extended cofactor chain is proved to the same standard.
+`Hex.DensePoly.subresultantChainExt_bezout` gives `u * f + v * g = S` for
+every stored entry, `subresultantChainExt_exact` gives the divisibility
+that makes each transformation row's exact division legitimate, and
+`subresultantChainExt_values` identifies the stored values with
+`subresultantChain`. The gcd libraries build their Bezout certificates on
+these.
 
 # Contributing
 

--- a/HexResultant/SPEC/hex-resultant.md
+++ b/HexResultant/SPEC/hex-resultant.md
@@ -1,4 +1,4 @@
-# hex-resultant (polynomial resultant via subresultant chain, depends on hex-poly and hex-basic)
+# hex-resultant (polynomial resultant via subresultant chain, depends on hex-poly, hex-basic and hex-determinant)
 
 Polynomial resultant and discriminant for `Hex.DensePoly R` over a
 commutative exact-division domain. Computed via the **subresultant
@@ -241,9 +241,15 @@ exact scalar multiple after its factorization has been proved.
 
 The generalized Sylvester constructions in this proof are local,
 coefficient-indexed proof objects with their finite-sum identities developed
-inside `hex-resultant`; they are not matrices from `hex-matrix` or
-`hex-determinant`. Consequently the released dependency graph remains the one
-stated at the top of this SPEC.
+inside `hex-resultant`; they are not matrices from `hex-matrix`. The
+executable resultant and discriminant path never leaves this library.
+
+The cofactor development behind the extended chain does reach for
+`hex-determinant`: `SubresultantMinor.toMatrix` regards a local square
+coefficient family as a `Hex.Matrix` so the kernel row-transport argument
+can use `Matrix.det` and `Matrix.adjugate` rather than redevelop them.
+`hex-determinant` is therefore a proof-side dependency of this library and
+is recorded as such in `libraries.yml`.
 
 Concretely, `DensePoly.Subresultant.coeffMatrixAt` is a finite scalar
 coefficient family at explicit formal degrees, and
@@ -452,10 +458,12 @@ quotient is exact over every stated exact-division domain.
 
 The extended chain `subresultantChainExt` (Bezout cofactors for every stored
 Brown entry) is delivered in `SubresultantExt.lean`:
-`subresultantChainExt_law` packages the Bezout, exactness, and value laws,
-with the determinantal cofactor development in `SubresultantCofactor.lean`.
-`hex-poly-z-gcd` and `hex-mv-gcd` consume it for their `splitBezout`
-fallback. It does not alter the resultant or discriminant contracts.
+`subresultantChainExt_law` packages the Bezout and exactness laws,
+`subresultantChainExt_values` projects the stored values onto
+`subresultantChain`, and the determinantal cofactor development lives in
+`SubresultantCofactor.lean`. `hex-poly-z-gcd` reads the terminal entry for
+its `CoprimeWitness.constant` route and `hex-mv-gcd` for its `splitBezout`
+constructor. It does not alter the resultant or discriminant contracts.
 
 ## File organisation
 
@@ -479,8 +487,9 @@ fallback. It does not alter the resultant or discriminant contracts.
   fraction-embedding image certificates.
 - `HexResultant/DeterminantAlgebra.lean`: local column multilinearity,
   adjacent swaps and swap-sequence parity, arbitrary alternation and update
-  laws, consecutive-block scaling, and the resulting left/right homogeneity
-  laws for generalized subresultants.
+  laws, consecutive-block scaling, the resulting left/right homogeneity
+  laws for generalized subresultants, and the `toMatrix`/`lastCofactor`
+  bridge to `hex-determinant`'s Laplace and adjugate algebra.
 - `HexResultant/BlockDeterminant.lean`: dimension recasting, numeric adjacent
   swaps, consecutive-block rotation with its parity law, and the resulting
   generalized-subresultant input-swap law.

--- a/HexResultant/SPEC/hex-resultant.md
+++ b/HexResultant/SPEC/hex-resultant.md
@@ -451,11 +451,11 @@ quotient is exact over every stated exact-division domain.
 ## Downstream contracts
 
 The extended chain `subresultantChainExt` (Bezout cofactors for every stored
-Brown entry) is the `hex-poly-z-gcd`/`hex-mv-gcd` prerequisite. It is
-delivered in `SubresultantExt.lean`: `subresultantChainExt_law` packages the
-Bezout, exactness, and value laws, with the determinantal cofactor
-development in `SubresultantCofactor.lean`. It does not alter the current
-resultant or discriminant contracts.
+Brown entry) is delivered in `SubresultantExt.lean`:
+`subresultantChainExt_law` packages the Bezout, exactness, and value laws,
+with the determinantal cofactor development in `SubresultantCofactor.lean`.
+`hex-poly-z-gcd` and `hex-mv-gcd` consume it for their `splitBezout`
+fallback. It does not alter the resultant or discriminant contracts.
 
 ## File organisation
 

--- a/HexResultant/SPEC/hex-resultant.md
+++ b/HexResultant/SPEC/hex-resultant.md
@@ -1,4 +1,4 @@
-# hex-resultant (polynomial resultant via subresultant chain, depends on hex-poly, hex-basic and hex-determinant)
+# hex-resultant (subresultant chain, depends on hex-poly, hex-basic, hex-determinant)
 
 Polynomial resultant and discriminant for `Hex.DensePoly R` over a
 commutative exact-division domain. Computed via the **subresultant
@@ -488,8 +488,9 @@ constructor. It does not alter the resultant or discriminant contracts.
 - `HexResultant/DeterminantAlgebra.lean`: local column multilinearity,
   adjacent swaps and swap-sequence parity, arbitrary alternation and update
   laws, consecutive-block scaling, the resulting left/right homogeneity
-  laws for generalized subresultants, and the `toMatrix`/`lastCofactor`
-  bridge to `hex-determinant`'s Laplace and adjugate algebra.
+  laws for generalized subresultants, and `toMatrix`/`lastCofactor`, which
+  read a local coefficient family as a `Hex.Matrix` so that
+  `hex-determinant`'s Laplace and adjugate algebra applies to it.
 - `HexResultant/BlockDeterminant.lean`: dimension recasting, numeric adjacent
   swaps, consecutive-block rotation with its parity law, and the resulting
   generalized-subresultant input-swap law.

--- a/HexResultant/SubresultantCofactor.lean
+++ b/HexResultant/SubresultantCofactor.lean
@@ -256,6 +256,8 @@ private theorem foldl_add_eq_foldr {A : Type v} (xs : List A) (h : A → R)
       rw [ih]
       grind
 
+/-- Each column inside the block contributes one reversed coefficient of `p`
+at its own index, and columns outside the block contribute nothing. -/
 private theorem coeff_blockCols (start count total : Nat) (p : DensePoly R)
     (cols : List (Fin total)) (k : Nat) :
     (blockCols start count total p cols).coeff k =
@@ -614,6 +616,8 @@ theorem bounded_bezout_unique [Div R] [ExactDivLaws R]
       simpa only [j, hindex] using hj
     · exact coeff_eq_zero_of_size_le v (by omega)
 
+/-- Vanishing above index `n` bounds the normalized size by `n`. This is the
+size-bound entry point for the cofactor columns below. -/
 private theorem size_le_of_coeff_zero_above (p : DensePoly R) (n : Nat)
     (hzero : ∀ k, n ≤ k → p.coeff k = 0) : p.size ≤ n := by
   by_cases hle : p.size ≤ n
@@ -637,6 +641,8 @@ theorem size_sub_le_max (p q : DensePoly R) :
     coeff_eq_zero_of_size_le q hq]
   grind
 
+/-- The `f`-side cofactor accumulates only monomials below `dg - J`, so it
+stays inside the `g` block's column budget. -/
 private theorem cofactorUCols_size_le (df dg J : Nat) (f g : DensePoly R)
     (cols : List (Fin ((df - J) + (dg - J)))) :
     (cofactorUCols df dg J f g cols).size ≤ dg - J := by
@@ -655,6 +661,8 @@ private theorem cofactorUCols_size_le (df dg J : Nat) (f g : DensePoly R)
       · rw [if_neg hj]
         exact ih
 
+/-- The `g`-side cofactor accumulates only monomials below `df - J`, so it
+stays inside the `f` block's column budget. -/
 private theorem cofactorVCols_size_le (df dg J : Nat) (f g : DensePoly R)
     (cols : List (Fin ((df - J) + (dg - J)))) :
     (cofactorVCols df dg J f g cols).size ≤ df - J := by
@@ -788,6 +796,8 @@ theorem coeff_cofactorAt_mul (df dg J l : Nat) (f g : DensePoly R)
   rw [cofactorCols_mul, coeff_cofactorRowCols,
     cofactorScalarCols_finRange df dg J l f g hcount]
 
+/-- The integer-indexed lookup vanishes above the normalized size, which is
+what lets the cofactor rows be summed over a fixed integer window. -/
 private theorem coeffInt_eq_zero_of_size_le (p : DensePoly R) (k : Int)
     (h : Int.ofNat p.size ≤ k) : coeffInt p k = 0 := by
   cases k with

--- a/HexResultant/SubresultantExt.lean
+++ b/HexResultant/SubresultantExt.lean
@@ -979,5 +979,9 @@ theorem subresultantChainExt_exact {S : Type u}
     subresultantChainExt linear 0 = #[(1, 0, linear)] &&
     subresultantChainExt (0 : DensePoly Int) 0 = #[]
 
+/-- info: 'Hex.DensePoly.subresultantChainExt' depends on axioms: [propext, Quot.sound] -/
+#guard_msgs in
+#print axioms subresultantChainExt
+
 end DensePoly
 end Hex

--- a/HexResultant/SubresultantExt.lean
+++ b/HexResultant/SubresultantExt.lean
@@ -819,6 +819,8 @@ private theorem subresultantOrderedExt_swap [One R] [Add R] [Sub R] [Mul R]
           simpa [delta, h₂, qr, q, p, hp, sign, g₃, hg₃, a, g₃U, g₃V,
             Array.map_push, swap] using haux
 
+/-- Exchanging the two cofactor coordinates commutes with indexed lookup,
+including past the end where both sides read the zero entry. -/
 private theorem getD_map_swap (chain : Array (Entry R)) (i : Nat) :
     (chain.map swap).getD i (0, 0, 0) =
       swap (chain.getD i (0, 0, 0)) := by
@@ -826,6 +828,8 @@ private theorem getD_map_swap (chain : Array (Entry R)) (i : Nat) :
     Array.getElem?_map]
   cases chain[i]? <;> rfl
 
+/-- The Brown scale reads only the stored values, so exchanging the cofactor
+coordinates leaves it unchanged. -/
 private theorem brownScale_map_swap [One R] [Mul R] [Div R]
     (chain : Array (Entry R)) (i : Nat) :
     brownScale (chain.map swap) i = brownScale chain i := by
@@ -842,6 +846,8 @@ private theorem brownScale_map_swap [One R] [Mul R] [Div R]
           rw [getD_map_swap, getD_map_swap, ih]
           rfl
 
+/-- One divided Brown step keeps its exactness witness when both cofactor
+coordinates are exchanged; the two numerator equations trade places. -/
 private theorem CofactorStep.swap [One R] [Add R] [Sub R] [Mul R] [Div R]
     (chain : Array (Entry R)) (i : Nat) (h : CofactorStep chain i) :
     CofactorStep (chain.map swap) i := by

--- a/HexResultantMathlib/Discriminant.lean
+++ b/HexResultantMathlib/Discriminant.lean
@@ -22,7 +22,7 @@ variable {R : Type u}
 
 /-- The executable and Mathlib discriminants agree under dense-polynomial
 correspondence. -/
-theorem toPolynomial_disc [CommRing R] [IsDomain R] [DecidableEq R]
+theorem toPolynomial_disc [CommRing R] [DecidableEq R]
     [Div R] [Hex.ExactDivLaws R] (f : DensePoly R) :
     disc f = Polynomial.discr (HexPolyMathlib.toPolynomial f) := by
   let F := HexPolyMathlib.toPolynomial f

--- a/HexResultantMathlib/README.md
+++ b/HexResultantMathlib/README.md
@@ -55,7 +55,7 @@ consumer surface:
 
 Everything in this package is proved; it contains no executable code of its
 own. The typeclass context of the headline theorem is the executable
-algorithm's own (`CommRing R`, `IsDomain R`, `DecidableEq R`, `Div R`,
+algorithm's own (`CommRing R`, `DecidableEq R`, `Div R`,
 `Hex.ExactDivLaws R`), so the correspondence applies to every instantiation
 the computational package supports. The computational library stays
 Mathlib-free; algebraic semantics live here. See the

--- a/HexResultantMathlib/SPEC/hex-resultant-mathlib.md
+++ b/HexResultantMathlib/SPEC/hex-resultant-mathlib.md
@@ -19,8 +19,8 @@ the end-to-end post-condition of the public API: exact agreement of
 values, units, powers, and signs included, not merely simultaneous
 vanishing. It needs no monicity, coprimality, or nonzero hypotheses on
 `f` and `g`; its typeclass context is the executable algorithm's own
-(`CommRing R`, `IsDomain R`, `DecidableEq R`, `Div R`,
-`Hex.ExactDivLaws R`). It is built from
+(`CommRing R`, `DecidableEq R`, `Div R`, `Hex.ExactDivLaws R`). It is
+built from
 `coeffMinor_zero_eq_resultant` through the ordered Brown-Traub chain
 correspondence.
 
@@ -167,7 +167,7 @@ end PseudoDivMod
 
 /-- The executable and Mathlib resultants agree under the dense-polynomial
     correspondence. -/
-theorem toPolynomial_resultant [CommRing R] [IsDomain R] [DecidableEq R]
+theorem toPolynomial_resultant [CommRing R] [DecidableEq R]
     [Div R] [Hex.ExactDivLaws R] (f g : DensePoly R) :
     resultant f g =
       Polynomial.resultant (HexPolyMathlib.toPolynomial f)
@@ -184,7 +184,7 @@ theorem resultant_eq_zero_iff_common_root
 
 /-- Specialize the coefficient variable after eliminating the polynomial
     variable. -/
-theorem eval_resultant [CommRing R] [IsDomain R] [DecidableEq R]
+theorem eval_resultant [CommRing R] [DecidableEq R]
     [Div R] [Hex.ExactDivLaws R]
     (f g : DensePoly (DensePoly R)) (a : R) :
     eval (resultant f g) a =
@@ -194,7 +194,7 @@ theorem eval_resultant [CommRing R] [IsDomain R] [DecidableEq R]
 /-- Default-formal-degree specialization when neither leading coefficient
     vanishes at the specialization point. -/
 theorem eval_resultant_default
-    [CommRing R] [IsDomain R] [DecidableEq R]
+    [CommRing R] [DecidableEq R]
     [Div R] [Hex.ExactDivLaws R]
     (f g : DensePoly (DensePoly R)) (a : R)
     (hf : eval f.leadingCoeff a ≠ 0) (hg : eval g.leadingCoeff a ≠ 0) :
@@ -218,7 +218,7 @@ theorem resultant_eq_leadingCoeff_mul_prod_roots
     Polynomial.resultant f g =
       f.leadingCoeff ^ g.natDegree * (f.roots.map g.eval).prod
 
-theorem toPolynomial_disc [CommRing R] [IsDomain R] [DecidableEq R]
+theorem toPolynomial_disc [CommRing R] [DecidableEq R]
     [Div R] [Hex.ExactDivLaws R] (f : DensePoly R) :
     disc f = Polynomial.discr (HexPolyMathlib.toPolynomial f)
 

--- a/HexResultantMathlib/Specialize.lean
+++ b/HexResultantMathlib/Specialize.lean
@@ -61,7 +61,7 @@ private theorem eval_coeffMinorAt_zero [CommRing R] [DecidableEq R]
     eval (Subresultant.coeffMinorAt df dg 0 0 f g) a =
       Polynomial.resultant (specialize f a) (specialize g a)
         (m := df) (n := dg) := by
-  letI : CommRing (DensePoly R) := denseCommRing
+  let _ : CommRing (DensePoly R) := denseCommRing
   let ε : DensePoly R →+* R :=
     (Polynomial.evalRingHom a).comp
       (HexPolyMathlib.equiv (R := R)).toRingHom

--- a/HexResultantMathlib/Specialize.lean
+++ b/HexResultantMathlib/Specialize.lean
@@ -90,7 +90,7 @@ private theorem eval_coeffMinorAt_zero [CommRing R] [DecidableEq R]
 
 /-- Specializing the coefficient variable after elimination agrees with the
 formal-degree Mathlib resultant of the specialized inputs. -/
-theorem eval_resultant [CommRing R] [IsDomain R] [DecidableEq R]
+theorem eval_resultant [CommRing R] [DecidableEq R]
     [Div R] [Hex.ExactDivLaws R]
     (f g : DensePoly (DensePoly R)) (a : R) :
     eval (resultant f g) a =
@@ -294,7 +294,7 @@ theorem resultant_eq_zero_of_common_eval
 /-- The specialization law at default Mathlib degrees when neither outer
 leading coefficient vanishes. -/
 theorem eval_resultant_default
-    [CommRing R] [IsDomain R] [DecidableEq R]
+    [CommRing R] [DecidableEq R]
     [Div R] [Hex.ExactDivLaws R]
     (f g : DensePoly (DensePoly R)) (a : R)
     (hf : eval f.leadingCoeff a ≠ 0) (hg : eval g.leadingCoeff a ≠ 0) :

--- a/HexResultantMathlib/Sylvester.lean
+++ b/HexResultantMathlib/Sylvester.lean
@@ -246,7 +246,7 @@ end Subresultant
 
 /-- The executable and Mathlib resultants agree under dense-polynomial
 correspondence, with the executable default formal degrees made explicit. -/
-theorem toPolynomial_resultant [CommRing R] [IsDomain R] [DecidableEq R]
+theorem toPolynomial_resultant [CommRing R] [DecidableEq R]
     [Div R] [Hex.ExactDivLaws R] (f g : DensePoly R) :
     resultant f g =
       Polynomial.resultant (HexPolyMathlib.toPolynomial f)

--- a/SPEC/future-work.md
+++ b/SPEC/future-work.md
@@ -77,31 +77,6 @@ and normalization behaviour differ, and gcd or division of sparse inputs
 usually becomes dense. Keep explicit conversions until several real consumers
 show which operations a common interface must support.
 
-### Extended subresultant chain for gcd consumers
-
-Amend `hex-resultant` with the transformation that produces each Brown entry,
-not only the entries themselves. `hex-poly-z-gcd` and `hex-mv-gcd` both need
-it for their complete `splitBezout` fallback; the existing worker retains only
-each pseudo-remainder, so this is a real extension rather than an accessor:
-
-```lean
-/-- `(uₖ, vₖ, Sₖ)` for every stored Brown entry, with
-`uₖ * f + vₖ * g = Sₖ`. -/
-def subresultantChainExt [Zero R] [DecidableEq R] [One R] [Add R] [Sub R]
-    [Mul R] [Div R] (f g : DensePoly R) :
-    Array (DensePoly R × DensePoly R × DensePoly R)
-```
-
-The extension uses the unchanged Brown remainder recurrence and accumulates
-the two transformation cofactors through every pseudo-scaling and exact
-scalar division. Its correctness theorem requires `Lean.Grind.CommRing R`
-and `ExactDivLaws R`, proves the displayed identity for every entry, and
-proves the cofactor numerators are divisible by each Brown scalar before the
-executable division. Projection of the third components equals
-`subresultantChain f g`, including input ordering and zero conventions. The
-API belongs in `hex-resultant` so the two gcd libraries share one recurrence
-and one proof; it does not alter the resultant or discriminant contracts.
-
 ### Positive-characteristic multivariate squarefree decomposition
 
 Amend `hex-mv-gcd` with squarefree decomposition over perfect fields of

--- a/progress/20260826T125308Z_issue9663.md
+++ b/progress/20260826T125308Z_issue9663.md
@@ -15,9 +15,10 @@ extended-chain work landed in #9521 and the delta review in #9684.
   `eval_resultant`. Dropping the hypothesis from those two exposed the same
   finding on `toPolynomial_disc` and `eval_resultant_default`, which
   inherited it transitively; all four are now stated without it, and the
-  bridge's SPEC and README follow. `eval_resultant_eq_zero_of_common_root`
-  and `disc_mul` keep it, which they genuinely use. Every module of the
-  pair now reports "Linting passed".
+  `HexResultantMathlib` SPEC and README follow.
+  `eval_resultant_eq_zero_of_common_root` and `disc_mul` keep it, which
+  they genuinely use. Every module of the pair now reports
+  "Linting passed".
 - Docstring coverage: every public declaration in the core already had one.
   Added docstrings to the non-obvious private helpers behind the cofactor
   construction (the two column size bounds, the block-column coefficient
@@ -101,8 +102,8 @@ once: the SPEC title line and the README both listed only `hex-poly` and
 "are not matrices from `hex-matrix` or `hex-determinant`. Consequently the
 released dependency graph remains the one stated at the top of this SPEC."
 All three now describe the proof-side `hex-determinant` edge, and the file
-organisation entry for `DeterminantAlgebra.lean` names the
-`toMatrix`/`lastCofactor` bridge.
+organisation entry for `DeterminantAlgebra.lean` names
+`toMatrix`/`lastCofactor`.
 
 Downstream, `HexPolyZGcd` consumes the terminal entry for a
 `CoprimeWitness.constant`, not for `splitBezout`; only `HexMvGcd` builds

--- a/progress/20260826T125308Z_issue9663.md
+++ b/progress/20260826T125308Z_issue9663.md
@@ -10,9 +10,14 @@ extended-chain work landed in #9521 and the delta review in #9684.
   `Fraction.Rep` structure fields (`num`, `den`, `den_ne`), now documented.
   Every module reports "Linting passed" afterwards.
 - `HexResultantMathlib` carried one style-linter hit (`letI` where the goal
-  is a proposition, `Specialize.lean:64`), now `let`. Its remaining
-  `runLinter` findings are `unusedArguments` on `[IsDomain R]` in
-  `toPolynomial_resultant` and `eval_resultant`; see "Deferred" below.
+  is a proposition, `Specialize.lean:64`), now `let`, and
+  `unusedArguments` on `[IsDomain R]` in `toPolynomial_resultant` and
+  `eval_resultant`. Dropping the hypothesis from those two exposed the same
+  finding on `toPolynomial_disc` and `eval_resultant_default`, which
+  inherited it transitively; all four are now stated without it, and the
+  bridge's SPEC and README follow. `eval_resultant_eq_zero_of_common_root`
+  and `disc_mul` keep it, which they genuinely use. Every module of the
+  pair now reports "Linting passed".
 - Docstring coverage: every public declaration in the core already had one.
   Added docstrings to the non-obvious private helpers behind the cofactor
   construction (the two column size bounds, the block-column coefficient
@@ -27,8 +32,12 @@ extended-chain work landed in #9521 and the delta review in #9684.
   None is dead.
 - Names: no qualifier stacking. The longest names are Mathlib-idiomatic
   `foo_of_bar` forms.
-- Import hygiene: the thirteen modules form a linear chain with one
-  `public import` per edge plus three `import all` for private-lemma reuse.
+- Import hygiene: the thirteen modules import only their immediate
+  predecessors, with six `import all` for private-lemma reuse. The one
+  cross-library edge beyond `hex-poly`/`hex-basic` is
+  `DeterminantAlgebra.lean`'s `HexDeterminant.Adjugate`, which #9521
+  introduced for the cofactor kernel argument. `libraries.yml` records it;
+  the README and SPEC did not, and now do.
 - Native execution: no `native_decide`, no runtime oracle. Added a
   `#print axioms subresultantChainExt` pin beside the existing `resultant`
   and `disc` pins; all three depend only on `propext` and `Quot.sound`.
@@ -39,6 +48,11 @@ extended-chain work landed in #9521 and the delta review in #9684.
   `runChain` +1.3% to -3.6%. The first pass flagged `runChain` at param 12
   at +66.2%; a re-run under low load measured -0.0% at that rung with
   neighbours unchanged, so it was measurement noise, not a regression.
+  The four registered families cover `pseudoDivMod`, `subresultantChain`,
+  `resultant`, and `disc`; none exercises `subresultantChainExt`. Adding a
+  family is a Phase-4 registration change (`libraries.yml`'s `phase4`
+  block, gated by `check_phase4.py`) and belongs to its own issue, so the
+  regression claim here covers the four committed families only.
 - `hexresultant_bench verify`: 41 of 41 pass (the nineteen FLINT comparator
   targets need `python-flint`, installed locally in a venv).
 - Conformance: freshly emitted fixtures are byte-identical to
@@ -79,17 +93,26 @@ extended-chain work landed in #9521 and the delta review in #9684.
 This pass re-attests that the Phase-6 and Phase-7 exit criteria hold for the
 core as it now stands, so no bump is needed.
 
-## Deferred
+## Stale dependency claims
 
-`runLinter` reports `[IsDomain R]` as unused in
-`Hex.DensePoly.toPolynomial_resultant` and `Hex.DensePoly.eval_resultant`.
-Both signatures are pinned in `HexResultantMathlib/SPEC/hex-resultant-mathlib.md`
-and repeated in that library's README, and the surrounding correspondence
-family (`resultant_eq_leadingCoeff_mul_prod_roots`,
-`disc_ne_zero_iff_separable`) genuinely needs the hypothesis, so the two
-share it for signature parity. Dropping it from both was tried and the whole
-graph builds green, so weakening is available whenever the SPEC is amended to
-match; that is a contract change for its own issue, not for this audit.
+The `HexDeterminant.Adjugate` import #9521 added made three claims false at
+once: the SPEC title line and the README both listed only `hex-poly` and
+`hex-basic`, and the SPEC asserted that the generalized Sylvester objects
+"are not matrices from `hex-matrix` or `hex-determinant`. Consequently the
+released dependency graph remains the one stated at the top of this SPEC."
+All three now describe the proof-side `hex-determinant` edge, and the file
+organisation entry for `DeterminantAlgebra.lean` names the
+`toMatrix`/`lastCofactor` bridge.
+
+Downstream, `HexPolyZGcd` consumes the terminal entry for a
+`CoprimeWitness.constant`, not for `splitBezout`; only `HexMvGcd` builds
+`splitBezout`. The SPEC and chapter said both used `splitBezout` and are
+corrected. `HexMvGcd`'s milestone list named a nonexistent
+`Hex.Resultant.subresultantChainExt` and its repeated signature had lost the
+`[Zero R] [DecidableEq R]` binders it inherits from the source's `variable`
+block; both fixed. `HexPolyZGcd`'s SPEC still spoke of the operation as
+something that "should be written once" and of route 4 as waiting on
+hex-resultant; both are now present tense.
 
 ## Verification
 

--- a/progress/20260826T125308Z_issue9663.md
+++ b/progress/20260826T125308Z_issue9663.md
@@ -1,0 +1,104 @@
+# Issue #9663 progress
+
+Re-attestation of the `HexResultant` core through Phase 7, after the
+extended-chain work landed in #9521 and the delta review in #9684.
+
+## Phase-6 audit over the current core
+
+- Mathlib environment linter (`lake exe runLinter`) over all thirteen
+  `HexResultant.*` modules: two genuine `docBlame` hits on the
+  `Fraction.Rep` structure fields (`num`, `den`, `den_ne`), now documented.
+  Every module reports "Linting passed" afterwards.
+- `HexResultantMathlib` carried one style-linter hit (`letI` where the goal
+  is a proposition, `Specialize.lean:64`), now `let`. Its remaining
+  `runLinter` findings are `unusedArguments` on `[IsDomain R]` in
+  `toPolynomial_resultant` and `eval_resultant`; see "Deferred" below.
+- Docstring coverage: every public declaration in the core already had one.
+  Added docstrings to the non-obvious private helpers behind the cofactor
+  construction (the two column size bounds, the block-column coefficient
+  law, the two coefficient-vanishing bounds, and the three swap-transport
+  lemmas). Routine fold and array plumbing stays exempt per
+  `SPEC/design-principles.md`.
+- Dead declarations: a repo-wide reference scan over all 407 declarations
+  found sixteen with no textual use outside their own file. All sixteen are
+  `@[simp]`/`@[grind]`-tagged characterising lemmas or public API accessors
+  (`subresultantChainExt_bezout`/`_exact`/`_values`,
+  `subresultantChain_zero_right`, `Fraction.NonzeroOne.of_poly_ne_zero`).
+  None is dead.
+- Names: no qualifier stacking. The longest names are Mathlib-idiomatic
+  `foo_of_bar` forms.
+- Import hygiene: the thirteen modules form a linear chain with one
+  `public import` per edge plus three `import all` for private-lemma reuse.
+- Native execution: no `native_decide`, no runtime oracle. Added a
+  `#print axioms subresultantChainExt` pin beside the existing `resultant`
+  and `disc` pins; all three depend only on `propext` and `Quot.sound`.
+- Performance: `hexresultant_bench run --baseline
+  reports/bench-results/hex-resultant-82db24db-scientific.json` (same host,
+  `chungus2`) over the four scientific families. `runPseudoDiv` +1.0% to
+  +2.9%, `runResultant` +3.0% to -5.2%, `runDisc` +1.9% to -7.7%,
+  `runChain` +1.3% to -3.6%. The first pass flagged `runChain` at param 12
+  at +66.2%; a re-run under low load measured -0.0% at that rung with
+  neighbours unchanged, so it was measurement noise, not a regression.
+- `hexresultant_bench verify`: 41 of 41 pass (the nineteen FLINT comparator
+  targets need `python-flint`, installed locally in a venv).
+- Conformance: freshly emitted fixtures are byte-identical to
+  `conformance-fixtures/HexResultant/resultant.jsonl`, and
+  `scripts/oracle/resultant_flint_pari.py` checks 64 results with 0
+  failures against python-flint 0.9.0.
+
+## Stale `subresultantChainExt` prose
+
+- Removed the "Extended subresultant chain for gcd consumers" entry from
+  `SPEC/future-work.md`. It is implemented, proved, and consumed.
+- `HexResultant/README.md` claimed the Bezout contract was "stated but its
+  proof is in progress". Replaced with the three delivered laws, and added
+  the operation to the Functionality list.
+- `HexResultant/SPEC/hex-resultant.md` now says the gcd libraries consume
+  the chain rather than that it is their prerequisite.
+- `HexMvGcd/SPEC/hex-mv-gcd.md` pointed at the removed future-work entry
+  and said hex-resultant "does not compute" the cofactors. Retitled and
+  repointed at hex-resultant's Downstream contracts section.
+
+## Phase-7 audit
+
+- README quickstart build-checked through `lake env lean`; both `#guard`s
+  hold.
+- `HexManual/Chapters/HexResultant.lean` had no coverage of the extended
+  chain. Added a section covering `Entry`, `subresultantChainExt`, the
+  values law, `Law`, and the three consequence theorems, plus the consumer
+  boundary.
+- The Mathlib correspondence section was missing
+  `resultant_eq_zero_iff_common_root`, the classical vanishing criterion.
+  Added.
+- The chapter stays in the unreleased section;
+  `scripts/release/check_manual_split.py` agrees.
+
+## Phase state
+
+`libraries.yml` already records `HexResultant` at `done_through: 7` (#9684).
+This pass re-attests that the Phase-6 and Phase-7 exit criteria hold for the
+core as it now stands, so no bump is needed.
+
+## Deferred
+
+`runLinter` reports `[IsDomain R]` as unused in
+`Hex.DensePoly.toPolynomial_resultant` and `Hex.DensePoly.eval_resultant`.
+Both signatures are pinned in `HexResultantMathlib/SPEC/hex-resultant-mathlib.md`
+and repeated in that library's README, and the surrounding correspondence
+family (`resultant_eq_leadingCoeff_mul_prod_roots`,
+`disc_ne_zero_iff_separable`) genuinely needs the hypothesis, so the two
+share it for signature parity. Dropping it from both was tried and the whole
+graph builds green, so weakening is available whenever the SPEC is amended to
+match; that is a contract change for its own issue, not for this audit.
+
+## Verification
+
+- `lake build HexResultant HexResultantMathlib HexConformance HexManual`
+- `lake exe runLinter` on every `HexResultant.*` and `HexResultantMathlib.*`
+  module
+- `hexresultant_bench verify` and the committed-baseline regression run
+- `scripts/oracle/resultant_flint_pari.py` on freshly emitted fixtures
+- `check_dag.py`, `check_phase7.py`, `check_phase4.py`,
+  `check_file_line_counts.py`, `check_copyright_headers.py`,
+  `release/check_manual_split.py`
+- zero `sorry`, `axiom`, `native_decide`


### PR DESCRIPTION
This PR re-runs the Phase-6 and Phase-7 audits over the `HexResultant` core after the extended-chain work of #9521 and the delta review of #9684, and corrects the documentation that the extended chain left stale.

Two libraries become linter-clean. The `docBlame` linter reports structure fields individually, so `Fraction.Rep`'s `num`, `den`, and `den_ne` each gain a docstring; the bridge's one style hit becomes `let` instead of `letI`; and `[IsDomain R]` leaves `toPolynomial_resultant`, `eval_resultant`, `toPolynomial_disc`, and `eval_resultant_default`, none of which use it. `eval_resultant_eq_zero_of_common_root` and `disc_mul` keep it, which they do use. Every module of the pair now reports "Linting passed" under `lake exe runLinter`. The non-obvious private helpers behind the cofactor construction gain docstrings, and `subresultantChainExt` gains a `#print axioms` pin beside the existing `resultant` and `disc` pins.

The `HexDeterminant.Adjugate` import #9521 added made three claims false at once: the SPEC title line and the README both listed only `hex-poly` and `hex-basic`, and the SPEC asserted that the generalized Sylvester objects are not matrices from `hex-determinant` and that the released dependency graph was therefore unchanged. All three now describe the proof-side edge, and the file-organisation entry for `DeterminantAlgebra.lean` names the `toMatrix`/`lastCofactor` bridge.

`SPEC/future-work.md` loses the "Extended subresultant chain for gcd consumers" entry: the chain is implemented, proved, and consumed. The Resultant README replaces its "proof is in progress" paragraph with the three delivered laws and lists the operation under Functionality. On the consumer side, only `HexMvGcd` builds `splitBezout`; `HexPolyZGcd` reads the terminal entry for a `CoprimeWitness.constant`, and the SPEC and chapter said both used `splitBezout`. `HexMvGcd`'s SPEC pointed at the removed future-work entry, said hex-resultant "does not compute" the cofactors, named a nonexistent `Hex.Resultant.subresultantChainExt`, and had lost the `[Zero R] [DecidableEq R]` binders from its repeated signature; `HexPolyZGcd`'s still spoke of the operation as something that should be written and of route 4 as waiting on hex-resultant.

The manual chapter gains a section on the extended chain covering `Entry`, `subresultantChainExt`, the values law, `Law`, and the two consequence theorems, and its Mathlib correspondence section gains `resultant_eq_zero_iff_common_root`, the classical vanishing criterion, which it was missing. The chapter stays in the unreleased section.

A repo-wide reference scan over all 407 core declarations finds none dead: the sixteen with no textual use outside their own file are all `@[simp]`/`@[grind]`-tagged characterising lemmas or public API accessors. `libraries.yml` already records the core at `done_through: 7`, so this pass re-attests rather than bumps.

Verified on `chungus2`: `lake build HexResultant HexResultantMathlib HexConformance HexManual`; `lake exe runLinter` on every module of the pair; `hexresultant_bench verify` 41/41; the committed-baseline regression run against `reports/bench-results/hex-resultant-82db24db-scientific.json` (`runPseudoDiv` +1.0% to +2.9%, the other three families between +3.0% and -7.7%, one `runChain` rung that first measured +66.2% reproducing at -0.0% under low load); freshly emitted conformance fixtures byte-identical to the committed ones and 64/64 against python-flint; `check_dag.py`, `check_phase7.py`, `check_phase4.py`, `check_file_line_counts.py`, `check_copyright_headers.py`, `release/check_manual_split.py`; zero `sorry`, `axiom`, and `native_decide`.

The four registered bench families cover `pseudoDivMod`, `subresultantChain`, `resultant`, and `disc`; none exercises `subresultantChainExt`. Adding one is a Phase-4 registration change to `libraries.yml`'s `phase4` block, gated by `check_phase4.py`, so it belongs to its own issue and the regression claim here covers the four committed families only.

Closes #9663

🤖 Prepared with Claude Code