### PR TITLE
feat: relate core modular order to Mathlib orderOf

### DIFF
--- a/HexIntFactor/SPEC/hex-int-factor.md
+++ b/HexIntFactor/SPEC/hex-int-factor.md
@@ -1088,6 +1088,12 @@ theorem totient_eq {n} (F : CheckedFactorization n) :
 theorem sigma_eq, divisors_eq, radical_eq
 theorem squarefreePart_mathlib, squareDivisor_mathlib
 
+theorem orderOf_unitOfCoprime {a n} (hn : 1 < n) (ha : Nat.Coprime a n) :
+    orderOf (ZMod.unitOfCoprime a ha) = Hex.Nat.orderOf a n
+
+theorem orderOf_natCast {a n} (hn : 1 < n) :
+    orderOf (a : ZMod n) = Hex.Nat.orderOf a n
+
 theorem orderOf_eq {c} (h : checkOrder c = true) :
     orderOf (ZMod.unitOfCoprime c.base (coprime_of_checkOrder h)) = c.order
 ```
@@ -1109,10 +1115,15 @@ witness form -- `squarefreePart_mul_square` and `squareDivisor_spec`
 above --
 which the decision procedure does not produce.
 
-`orderOf_eq` needs a unit to speak about, and the coprimality that
-names one is derived rather than requested: `coprime_of_checkOrder`
-above supplies it from the accepted certificate, so the caller passes
-nothing extra.
+`orderOf_unitOfCoprime` is the function-level correspondence: it proves the
+general unit result directly from the positive-power/minimality
+characterisations on both sides, without computing an order or constructing a
+certificate. `orderOf_natCast` covers every underlying ring element: the
+coprime case follows from the unit result, while both sides are zero for a
+nonunit. The certificate specialization `orderOf_eq` composes that
+correspondence with
+`order_eq_of_checkOrder`; the coprimality needed to name the unit is derived
+by `coprime_of_checkOrder`, so the caller passes nothing extra.
 
 ## Milestones
 
@@ -1151,8 +1162,9 @@ nothing extra.
 6. **ECM stage 1.** Montgomery curves, Suyama parameterisation, the
    word/direct-`Nat` arithmetic dispatch, and its route-level tests.
 
-7. **The companion.** `factorization_eq` and its consequences plus
-   `orderOf_eq`. It adds no duplicate decidability instances. The
+7. **The companion.** `factorization_eq` and its consequences plus the general
+   `orderOf_unitOfCoprime` and `orderOf_natCast` correspondences and the
+   certificate specialization `orderOf_eq`. It adds no duplicate decidability instances. The
    factorization correspondence begins after milestone 1; divisor and
    order transports follow milestones 2 and 3 while later search routes
    proceed independently.
@@ -1175,7 +1187,7 @@ HexIntFactor/
 HexIntFactor.lean
 HexIntFactorMathlib/
   Factorization.lean -- factorization_eq, factors_eq and consequences
-  Order.lean        -- orderOf_eq
+  Order.lean        -- general and certificate-level orderOf correspondences
 HexIntFactorMathlib.lean
 ```
 

--- a/HexIntFactorMathlib/Order.lean
+++ b/HexIntFactorMathlib/Order.lean
@@ -5,7 +5,6 @@ Authors: Kim Morrison
 -/
 
 import HexIntFactor.Order
-import HexPrimalityMathlib.Prime
 import Mathlib.Data.ZMod.Basic
 import Mathlib.GroupTheory.OrderOfElement
 
@@ -32,29 +31,37 @@ private theorem unit_pow_iff {a n k : Nat} (ha : Nat.Coprime a n) :
     simpa only [Units.val_pow_eq_pow_val, Units.val_one,
       ZMod.coe_unitOfCoprime, Nat.cast_pow, Nat.cast_one] using hv
 
+/-- The Mathlib order of a residue-class unit agrees with the Mathlib-free
+natural order. -/
+theorem orderOf_unitOfCoprime {a n : Nat} (hn : 1 < n)
+    (ha : Nat.Coprime a n) :
+    _root_.orderOf (ZMod.unitOfCoprime a ha) = Hex.Nat.orderOf a n := by
+  have hpos : 0 < Hex.Nat.orderOf a n := Hex.Nat.orderOf_pos hn ha
+  apply (_root_.orderOf_eq_iff hpos).2
+  constructor
+  · exact (unit_pow_iff ha).2 (Hex.Nat.orderOf_pow_mod hpos)
+  · intro k hkn hk hpow
+    exact Hex.Nat.orderOf_min hpos k hk hkn ((unit_pow_iff ha).1 hpow)
+
+/-- The Mathlib order of a natural-number residue agrees with the Mathlib-free
+natural order, including the zero value for nonunits. -/
+theorem orderOf_natCast {a n : Nat} (hn : 1 < n) :
+    _root_.orderOf (a : ZMod n) = Hex.Nat.orderOf a n := by
+  by_cases ha : Nat.Coprime a n
+  · rw [← orderOf_unitOfCoprime hn ha]
+    simpa only [ZMod.coe_unitOfCoprime] using
+      (_root_.orderOf_units (y := ZMod.unitOfCoprime a ha))
+  · have hz : Hex.Nat.orderOf a n = 0 :=
+      Nat.eq_zero_of_not_pos fun h => ha (coprime_of_orderOf_pos h)
+    rw [hz, _root_.orderOf_eq_zero_iff]
+    exact fun h => ha ((ZMod.isUnit_iff_coprime a n).1 h.isUnit)
+
 /-- A checked natural order is the order of the corresponding Mathlib unit. -/
 theorem orderOf_eq {c : OrderCert} (h : checkOrder c = true) :
     _root_.orderOf
         (ZMod.unitOfCoprime c.base (coprime_of_checkOrder h)) = c.order := by
-  let ha := coprime_of_checkOrder h
-  have hn : 0 < c.modulus :=
-    _root_.Nat.zero_lt_of_lt (checkOrder_one_lt_modulus h)
-  apply orderOf_eq_of_pow_and_pow_div_prime (checkOrder_order_pos h)
-  · apply (unit_pow_iff ha).2
-    have hpow := checkOrder_pow h
-    rw [HexArith.powModNat_eq _ _ _ hn] at hpow
-    exact hpow
-  · intro q hq hqDvd hunit
-    have hqLocal : Prime q := prime_iff.mpr hq
-    have hqRaw : q ∣ c.orderFac.subject := by
-      simpa [checkOrder_orderFac_subject h] using hqDvd
-    obtain ⟨e, he, heq⟩ :=
-      (checkFactorization_primeSupport (checkOrder_orderFac h) hqLocal).mp hqRaw
-    have hbad := (unit_pow_iff ha).1 hunit
-    rw [← heq] at hbad
-    have hne := checkOrder_pow_div_prime h e he
-    rw [HexArith.powModNat_eq _ _ _ hn] at hne
-    exact hne hbad
+  rw [orderOf_unitOfCoprime (checkOrder_one_lt_modulus h)
+    (coprime_of_checkOrder h), order_eq_of_checkOrder h]
 
 end Nat
 


### PR DESCRIPTION
Closes #9702

## Summary
- prove `orderOf_unitOfCoprime` for every nontrivial modulus and coprime base
- prove `orderOf_natCast` for every natural residue, including the nonunit case where both APIs return zero
- derive the checked-certificate specialization by composition with the core checker theorem
- remove the obsolete primality-correspondence import and record the complete function-level API in the governing SPEC

## Verification
- `lake build HexIntFactorMathlib`
- `lake exe runLinter HexIntFactorMathlib.Order`
- `python3 scripts/check_file_line_counts.py`
- banned-token scan across both libraries
- `git diff --check`

## Independent review
A fresh Claude Opus source review found no correctness issue. It recommended generalizing the ring-element theorem to non-coprime residues and removing the stale import/SPEC references; this revision incorporates those findings and builds/lints cleanly.