### PR TITLE
feat: complete Mathlib factorization correspondences

### DIFF
--- a/HexIntFactor/SPEC/hex-int-factor.md
+++ b/HexIntFactor/SPEC/hex-int-factor.md
@@ -1078,14 +1078,23 @@ because nothing here reaches it.
 
 ```lean
 theorem factors_eq (F : Factorization) (h : checkFactorization F = true) :
-    F.subject.primeFactorsList = ... -- the multiset of listed primes with multiplicity
+    F.subject.primeFactorsList =
+      F.factors.flatMap fun e => List.replicate e.exponent e.prime
 
 theorem factorization_eq (F) (h : checkFactorization F = true) (p : Nat) :
-    F.subject.factorization p = (F.factors.find? (·.prime = p)).elim 0 (·.exponent)
+    F.subject.factorization p = (F.factors.find? (·.prime == p)).elim 0 (·.exponent)
+
+theorem CheckedFactorization.factorization_eq {n} (F : CheckedFactorization n) (p : Nat) :
+    n.factorization p = (F.raw.factors.find? (·.prime == p)).elim 0 (·.exponent)
+
+theorem CheckedFactorization.primeFactorsList_eq {n} (F : CheckedFactorization n) :
+    n.primeFactorsList =
+      F.raw.factors.flatMap fun e => List.replicate e.exponent e.prime
 
 theorem totient_eq {n} (F : CheckedFactorization n) :
     totient F = Nat.totient n
-theorem sigma_eq, divisors_eq, radical_eq
+theorem sigma_eq, divisors_eq, divisors_list_eq, numDivisors_eq_card
+theorem primeFactors_eq, radical_eq, isSquarefree_iff_squarefree
 theorem squarefreePart_mathlib, squareDivisor_mathlib
 
 theorem orderOf_unitOfCoprime {a n} (hn : 1 < n) (ha : Nat.Coprime a n) :
@@ -1098,14 +1107,21 @@ theorem orderOf_eq {c} (h : checkOrder c = true) :
     orderOf (ZMod.unitOfCoprime c.base (coprime_of_checkOrder h)) = c.order
 ```
 
-`factorization_eq` is the correspondence everything else goes through:
-Mathlib's `Nat.factorization` is a `Finsupp` and this library's is an
-ascending list, and once they agree pointwise every arithmetic-function
-theorem in Mathlib applies. The companion's job is one correspondence
-and a series of short consequences, not a redevelopment. Exact helper
-declaration names are read from the pinned Mathlib during implementation;
-the SPEC deliberately does not depend on remembered names that may be
-deprecated or absent.
+`factorization_eq` is the pointwise multiplicity correspondence and
+`factors_eq` is its canonical-list counterpart: Mathlib's
+`Nat.factorization` is a `Finsupp` and this library's factorization is an
+ascending prime-power list. They are outward-facing correspondences for
+downstream consumers; checked-data corollaries avoid exposing raw certificate
+bookkeeping at call sites. The arithmetic transports in this companion each
+compose the core's Mathlib-free semantic theorem -- such as `mem_divisors`,
+`totient_eq_count`, `sigma_eq_sum`, `isSquarefree_iff`, or
+`squareDivisor_spec` -- with checker facts about products, prime support, and
+multiplicity. `primeFactors_eq` exposes that support-shaped correspondence
+directly. The `find?` and `flatMap` expressions in the public statements are
+normal forms, not separately advertised executable operations. Exact Mathlib
+helper declaration names are read from the pinned Mathlib during
+implementation; the SPEC deliberately does not depend on remembered names
+that may be deprecated or absent.
 
 **No `DecidablePred Squarefree` instance on `Nat`.** Mathlib has one
 (`Mathlib/Data/Nat/Squarefree.lean:234`), so a second would be a
@@ -1162,9 +1178,10 @@ by `coprime_of_checkOrder`, so the caller passes nothing extra.
 6. **ECM stage 1.** Montgomery curves, Suyama parameterisation, the
    word/direct-`Nat` arithmetic dispatch, and its route-level tests.
 
-7. **The companion.** `factorization_eq` and its consequences plus the general
-   `orderOf_unitOfCoprime` and `orderOf_natCast` correspondences and the
-   certificate specialization `orderOf_eq`. It adds no duplicate decidability instances. The
+7. **The companion.** The pointwise, canonical-list, and prime-support
+   factorization correspondences; divisor and squarefree transports; the
+   general `orderOf_unitOfCoprime` and `orderOf_natCast` correspondences; and
+   the certificate specialization `orderOf_eq`. It adds no duplicate decidability instances. The
    factorization correspondence begins after milestone 1; divisor and
    order transports follow milestones 2 and 3 while later search routes
    proceed independently.

--- a/HexIntFactorMathlib/Factorization.lean
+++ b/HexIntFactorMathlib/Factorization.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 import HexIntFactor.Divisors
 import HexPrimalityMathlib.Prime
+import Mathlib.Data.Finset.Sort
 import Mathlib.Data.Nat.Factorization.Basic
 import Mathlib.Data.Nat.Squarefree
 import Mathlib.Data.Nat.Totient
@@ -17,12 +18,8 @@ namespace Hex
 
 namespace Nat
 
-/-- Exponent stored for `p`, or zero when `p` is absent. -/
-def factorExponent (F : Factorization) (p : Nat) : Nat :=
-  (F.factors.find? fun e => e.prime == p).elim 0 (·.exponent)
-
 /-- The listed primes, repeated according to their checked exponents. -/
-def expandedFactors (F : Factorization) : List Nat :=
+private def expandedFactors (F : Factorization) : List Nat :=
   F.factors.flatMap fun e => List.replicate e.exponent e.prime
 
 private theorem expandedFactors_prod (F : Factorization) :
@@ -40,6 +37,21 @@ private theorem prime_of_mem_expandedFactors (F : Factorization)
   simp only [expandedFactors, List.mem_flatMap, List.mem_replicate] at hp
   obtain ⟨e, he, _, rfl⟩ := hp
   exact prime_iff.mp (checkFactorization_prime h e he)
+
+private theorem expandedFactors_sorted (F : Factorization)
+    (h : checkFactorization F = true) :
+    (expandedFactors F).SortedLE := by
+  apply List.Pairwise.sortedLE
+  rw [expandedFactors, List.pairwise_flatMap]
+  constructor
+  · intro e he
+    exact List.pairwise_replicate_of_refl
+  · apply (checkFactorization_sorted h).imp
+    intro e f hef x hx y hy
+    simp only [List.mem_replicate] at hx hy
+    rcases hx with ⟨_, rfl⟩
+    rcases hy with ⟨_, rfl⟩
+    exact Nat.le_of_lt hef
 
 /-- A listed exponent is exactly Mathlib's multiplicity. -/
 theorem factorization_entry (F : Factorization)
@@ -59,8 +71,8 @@ theorem factorization_entry (F : Factorization)
 pointwise. -/
 theorem factorization_eq (F : Factorization)
     (h : checkFactorization F = true) (p : Nat) :
-    F.subject.factorization p = factorExponent F p := by
-  unfold factorExponent
+    F.subject.factorization p =
+      (F.factors.find? fun e => e.prime == p).elim 0 (·.exponent) := by
   cases hfind : F.factors.find? (fun e => e.prime == p) with
   | some e =>
     simp only [Option.elim_some]
@@ -80,14 +92,38 @@ theorem factorization_eq (F : Factorization)
       simp [hep] at hreject
     · exact Nat.factorization_eq_zero_of_not_prime F.subject hp
 
-/-- Mathlib's factor list is the multiset obtained by repeating each checked
-prime according to its exponent. -/
+/-- Pointwise factorization correspondence for checked data. -/
+theorem CheckedFactorization.factorization_eq {n : Nat}
+    (F : CheckedFactorization n) (p : Nat) :
+    n.factorization p =
+      (F.raw.factors.find? fun e => e.prime == p).elim 0 (·.exponent) := by
+  calc
+    n.factorization p = F.raw.subject.factorization p :=
+      (congrArg (fun m => m.factorization p) F.subject_eq).symm
+    _ = _ := Hex.Nat.factorization_eq F.raw F.valid p
+
+/-- Mathlib's canonical sorted factor list is obtained by repeating each
+checked prime according to its exponent. -/
 theorem factors_eq (F : Factorization) (h : checkFactorization F = true) :
-    (F.subject.primeFactorsList : Multiset Nat) = expandedFactors F := by
-  apply Multiset.coe_eq_coe.mpr
-  exact (Nat.primeFactorsList_unique
-    (expandedFactors_prod F |>.trans (checkFactorization_prod h))
-    (prime_of_mem_expandedFactors F h)).symm
+    F.subject.primeFactorsList =
+      F.factors.flatMap fun e => List.replicate e.exponent e.prime := by
+  change F.subject.primeFactorsList = expandedFactors F
+  apply List.Perm.eq_of_sortedLE
+  · exact Nat.primeFactorsList_sorted _
+  · exact expandedFactors_sorted F h
+  · exact (Nat.primeFactorsList_unique
+      (expandedFactors_prod F |>.trans (checkFactorization_prod h))
+      (prime_of_mem_expandedFactors F h)).symm
+
+/-- Canonical factor-list correspondence for checked data. -/
+theorem CheckedFactorization.primeFactorsList_eq {n : Nat}
+    (F : CheckedFactorization n) :
+    n.primeFactorsList =
+      F.raw.factors.flatMap fun e => List.replicate e.exponent e.prime := by
+  calc
+    n.primeFactorsList = F.raw.subject.primeFactorsList :=
+      (congrArg Nat.primeFactorsList F.subject_eq).symm
+    _ = _ := factors_eq F.raw F.valid
 
 /-- A base absent from the checked list has zero Mathlib multiplicity. -/
 theorem factorization_absent (F : Factorization)
@@ -95,7 +131,6 @@ theorem factorization_absent (F : Factorization)
     (hmem : ∀ e ∈ F.factors, e.prime ≠ p) :
     F.subject.factorization p = 0 := by
   rw [factorization_eq F h]
-  unfold factorExponent
   rw [List.find?_eq_none.mpr]
   · rfl
   · intro e he
@@ -109,6 +144,22 @@ theorem divisors_eq {n : Nat} (F : CheckedFactorization n) :
   simp only [List.mem_toFinset, Hex.Nat.mem_divisors F,
     _root_.Nat.mem_divisors]
   exact ⟨fun hd => ⟨hd, hn⟩, And.left⟩
+
+/-- The checked divisor enumeration is Mathlib's divisor finset in ascending
+order. -/
+theorem divisors_list_eq {n : Nat} (F : CheckedFactorization n) :
+    (divisors F).toList = n.divisors.sort (· ≤ ·) := by
+  symm
+  rw [← divisors_eq F]
+  exact (List.toFinset_sort (r := (· ≤ ·)) (divisors_nodup F)).2
+    (divisors_sorted F)
+
+/-- The checked divisor count is the cardinality of Mathlib's divisor
+finset. -/
+theorem numDivisors_eq_card {n : Nat} (F : CheckedFactorization n) :
+    numDivisors F = n.divisors.card := by
+  rw [numDivisors_eq_size, ← Array.length_toList,
+    ← List.toFinset_card_of_nodup (divisors_nodup F), divisors_eq F]
 
 /-- The checked totient agrees with Mathlib's Euler totient. -/
 theorem totient_eq {n : Nat} (F : CheckedFactorization n) :
@@ -125,24 +176,27 @@ theorem sigma_eq {n k : Nat} (F : CheckedFactorization n) :
     sigma F k = ∑ d ∈ n.divisors, d ^ k := by
   rw [sigma_eq_sum, ← List.sum_toFinset _ (divisors_nodup F), divisors_eq F]
 
+/-- The checked prime bases are Mathlib's distinct prime factors. -/
+theorem primeFactors_eq {n : Nat} (F : CheckedFactorization n) :
+    (F.raw.factors.map fun e => e.prime).toFinset = n.primeFactors := by
+  have hn : n ≠ 0 := F.pos.ne'
+  ext p
+  simp only [List.mem_toFinset, List.mem_map, Nat.mem_primeFactors_of_ne_zero hn]
+  constructor
+  · rintro ⟨e, he, rfl⟩
+    exact ⟨prime_iff.mp (checkFactorization_prime F.valid e he),
+      by simpa [F.subject_eq] using
+        (checkFactorization_primeSupport F.valid
+          (checkFactorization_prime F.valid e he)).mpr ⟨e, he, rfl⟩⟩
+  · rintro ⟨hp, hpn⟩
+    obtain ⟨e, he, hep⟩ :=
+      (checkFactorization_primeSupport F.valid (prime_iff.mpr hp)).mp
+        (by simpa [F.subject_eq] using hpn)
+    exact ⟨e, he, hep⟩
+
 /-- The checked radical is Mathlib's product of the distinct prime factors. -/
 theorem radical_eq {n : Nat} (F : CheckedFactorization n) :
     radical F = ∏ p ∈ n.primeFactors, p := by
-  have hn : n ≠ 0 := F.pos.ne'
-  have hset : (F.raw.factors.map fun e => e.prime).toFinset = n.primeFactors := by
-    ext p
-    simp only [List.mem_toFinset, List.mem_map, Nat.mem_primeFactors_of_ne_zero hn]
-    constructor
-    · rintro ⟨e, he, rfl⟩
-      exact ⟨prime_iff.mp (checkFactorization_prime F.valid e he),
-        by simpa [F.subject_eq] using
-          (checkFactorization_primeSupport F.valid
-            (checkFactorization_prime F.valid e he)).mpr ⟨e, he, rfl⟩⟩
-    · rintro ⟨hp, hpn⟩
-      obtain ⟨e, he, hep⟩ :=
-        (checkFactorization_primeSupport F.valid (prime_iff.mpr hp)).mp
-          (by simpa [F.subject_eq] using hpn)
-      exact ⟨e, he, hep⟩
   have hnodup : (F.raw.factors.map fun e => e.prime).Nodup := by
     rw [List.nodup_iff_pairwise_ne]
     simpa only [List.pairwise_map] using
@@ -155,7 +209,18 @@ theorem radical_eq {n : Nat} (F : CheckedFactorization n) :
       symm
       simpa [Function.comp_def] using
         List.prod_toFinset (fun p : Nat => p) hnodup
-    _ = ∏ p ∈ n.primeFactors, p := by simp [hset]
+    _ = ∏ p ∈ n.primeFactors, p := by simp [primeFactors_eq F]
+
+/-- The checked squarefree decision agrees with Mathlib's squarefree
+predicate. -/
+theorem isSquarefree_iff_squarefree {n : Nat} (F : CheckedFactorization n) :
+    isSquarefree F = true ↔ Squarefree n := by
+  rw [Hex.Nat.isSquarefree_iff, Nat.squarefree_iff_prime_squarefree]
+  constructor
+  · intro h q hq hq2
+    exact h q (prime_iff.mpr hq) (by simpa [Nat.pow_two] using hq2)
+  · intro h q hq hq2
+    exact h q (prime_iff.mp hq) (by simpa [Nat.pow_two] using hq2)
 
 /-- Mathlib recognizes the computed squarefree part as squarefree. -/
 theorem squarefreePart_mathlib {n : Nat} (F : CheckedFactorization n) :

--- a/SPEC/Libraries/hex-cyclotomic.md
+++ b/SPEC/Libraries/hex-cyclotomic.md
@@ -857,10 +857,8 @@ theorem prod_divisors_eq {n : Nat} (F : CheckedFactorization n) :
         (fun dp => HexPolyMathlib.toPolynomial dp.2)).foldl (· * ·) 1 = X ^ n - 1
 ```
 
-`toPolynomial_cyclotomic` is the correspondence everything else goes
-through, exactly as `factorization_eq` is for
-[hex-int-factor](hex-int-factor.md). The rest are short
-consequences of it together with Mathlib's `natDegree_cyclotomic`,
+`toPolynomial_cyclotomic` is the central correspondence for this layer. The
+rest are short consequences of it together with Mathlib's `natDegree_cyclotomic`,
 `cyclotomic.irreducible`, `cyclotomic.irreducible_rat`, and
 `prod_cyclotomic_eq_X_pow_sub_one`. Exact helper names are read from the
 pinned Mathlib during implementation. The SPEC does not depend on


### PR DESCRIPTION
Closes #9701

## Summary
- strengthen `factors_eq` from multiset equality to canonical sorted list equality and add checked-data pointwise/list corollaries
- add proof-only transports for ordered divisors, divisor count, prime support, and squarefreeness
- promote `primeFactors_eq` and route `radical_eq` through it
- delete the dead exponent helper and keep only a private proof normalization for expanded factors, preserving a proof-only public companion surface
- document the actual semantic/support proof routes and correct the stale cross-SPEC hub analogy

## Verification
- `lake build HexIntFactor HexIntFactorMathlib`
- `lake exe runLinter HexIntFactorMathlib.Factorization`
- `python3 scripts/check_file_line_counts.py`
- banned-token scan across both libraries
- `git diff --check`
- confirmed no companion conformance or bench target was introduced

## Independent review
Fresh Claude Opus review found the proofs sound, including the subject-1 and ordering edge cases. It identified incomplete route prose, a dead private helper, missing checked-data corollaries, and a buried prime-support theorem; all substantive findings are incorporated in this revision.