### PR TITLE
fix: make structural factor reductions complete

### DIFF
--- a/HexIntFactor/Factor.lean
+++ b/HexIntFactor/Factor.lean
@@ -104,8 +104,10 @@ private def searchGo : Nat → List (Nat × Nat) → List PrimePower → Nat →
         -- entries is an invariant of the current producers, not of their type.
         let candidate := (smallCandidate m).scale multiplier
         let powerRoutes := match candidate.route with
-          | .trial => powerRoutes
-          | .perfectPower => powerRoutes + 1
+          -- Split-produced stack entries are odd; the two-adic cases are
+          -- defensive if a future producer weakens that invariant.
+          | .trial | .twos => powerRoutes
+          | .perfectPower | .twosPower => powerRoutes + 1
         let factors := mergePowers candidate.factors factors
         let m := candidate.residualBase
         let multiplier := candidate.residualExponent
@@ -150,8 +152,8 @@ private def smallAttempt (n : Nat) (r : Rand) (fuel : Nat) :
     FactorAttempt n :=
   let candidate := smallCandidate n
   let powerRoutes := match candidate.route with
-    | .trial => 0
-    | .perfectPower => 1
+    | .trial | .twos => 0
+    | .perfectPower | .twosPower => 1
   let result := searchGo fuel
     [(candidate.residualBase, candidate.residualExponent)]
     candidate.factors 1 r 0 powerRoutes

--- a/HexIntFactor/SPEC/hex-int-factor.md
+++ b/HexIntFactor/SPEC/hex-int-factor.md
@@ -290,16 +290,21 @@ prerequisite, specified there and sited in hex-basic.
 
 ### 0. Structural reductions, always applied
 
-- **Powers of two**, by counting trailing zeros. One `Nat` operation
-  and it removes the factor that trial division would otherwise find
-  slowest per bit.
+- **Powers of two**, by a dedicated trailing-zero count followed by one
+  right shift. For positive `n`, the isolated lowest set bit is
+  `n XOR (n AND (n - 1))`, so its `log₂` is exactly the multiplicity of two.
+  The native `Nat` bit operations remove that factor before the table loop and
+  avoid repeating the generic `% p`/`/ p` producer for `p = 2`.
 - **Perfect powers.** If `n = m^k` for some `k ≥ 2`, factor `m` and
-  multiply the exponents. Detected by trying each prime `k ≤ log₂ n`
-  and taking an exact integer `k`th root by bounded binary search. The
+  multiply the exponents. Detection first tries every committed prime
+  exponent below `primeTableBound`, then every larger exponent through
+  `log₂ n`; the latter superset of the prime exponents keeps the finite table
+  from becoming a completeness boundary. Each exact integer root uses bounded
+  binary search with the upper bound `2^(⌊log₂ n / k⌋ + 1)`. The
   full structural pipeline is reapplied to every popped search-stack entry,
   including recursive cofactors produced by a split; its exponent is multiplied
-  by the entry's accumulated multiplicity before the result is merged. Strongly
-  recommended rather than mathematically required: an earlier draft
+  by the entry's accumulated multiplicity before the result is merged.
+  Strongly recommended rather than mathematically required: an earlier draft
   claimed Pollard `p − 1` and ECM "fail on prime powers, because the
   group they work in has no distinct primes to separate", and that is
   false. On `n = 9` with `a = 2` and `M = 2`, `p − 1` returns
@@ -925,22 +930,22 @@ the number of distinct primes, `B` a smoothness bound.
 
 | operation | cost | note |
 |---|---|---|
-| trailing-zero split | one big-`Nat` operation | not `O(1)` bit complexity |
-| perfect-power test | `O(b · b · M(b))` | `O(b)` roots, Newton each |
+| trailing-zero split | five bit operations on `b`-bit naturals | isolated-low-bit identity plus one shift; `O(b)` bit complexity |
+| perfect-power test | `O(b²)` bounded multiplications | the committed prime exponents plus only prime candidates above the table; a `k`th-root search has `O(b/k)` probes of a linear, early-aborting power loop |
 | trial division to `T` | `O(π(T))` divisions | `π(10^4) = 1229` |
 | Pollard rho | `O(√p)` iterations expected and one routine gcd per 32-step batch | `O(n^{1/4})` for a semiprime; cycle boundaries can flush shorter batches |
 | Pollard `p − 1` stage 1 | `O(B)` modular mults | `log M = Θ(B)`; smooth `p − 1` is sufficient but not decisive |
 | ECM stage 1, one curve | `O(B)` mults | scalar bit length is `Θ(B)`; success depends on the bound |
-| `checkFactorization` | `O(k)` exponentiations plus `k` primality replays | `p^e` is `O(log e)` mults, not one |
+| `checkFactorization` | `O(Σ eᵢ)` bounded multiplications plus `k` primality replays | `boundedPowMul` is linear in the claimed exponent and aborts above the subject |
 | `checkOrder` | `O(k)` modular exponentiations plus `checkFactorization` | includes the order's primality replays |
 | `divisors` | `O(τ log τ)` | `τ = ∏(eᵢ + 1)` |
 | `sigma` | `O(k)` geometric sums | each entry uses `O(log r + log e)` multiplications for power argument `r`; for fixed `p` and `r`, its output has `Θ(e)` bits |
 | `totient` | `O(Σ log eᵢ)` multiplications | `k` certified prime-power contributions; no residue scan |
 | everything else in the divisor API | `O(k)` | excludes `divisors` |
 
-These are **arithmetic-operation counts on `Nat`**, not bit
-complexity: the operands are big integers throughout, `p^e` costs
-`O(log e)` multiplications rather than one, and the divisor functions
+These are **arithmetic-operation counts on `Nat`** except where the table says
+bit complexity explicitly: the operands are big integers throughout,
+`boundedPowMul` uses up to `e` multiplications for `p^e`, and the divisor functions
 are `O(k)` only if the output's bit length is ignored. A bit-complexity
 model would have to name a multiplication cost and multiply through,
 and this SPEC does not attempt one.
@@ -1047,13 +1052,16 @@ SPEC takes the cheaper route of using the installed pair.
 candidate goes through `checkFactorization`, and a broken route falls
 through to the next one, so a fixture passes even if ECM is entirely
 non-functional. The suite therefore needs route-level tests in Lean:
-that the perfect-power detector fired on a perfect power, that `p − 1`
+that the two-adic and perfect-power producers fired on their route-specific
+inputs, that `p − 1`
 distinguished proper-factor, `1`, and whole-modulus outcomes, that rho
 found the factor within the expected iteration count for a fixed seed,
 that ECM stage 1 distinguished its three gcd outcomes after a setup gcd of
 one (including stage-found proper-factor and whole-modulus cases), and that
 `cyclotomicSplit?` ran before the generic dispatch on a `b^n − 1`
-input. This is the same division
+input. The internal `countPowerRoutes` diagnostic counts perfect-power
+reductions: a pure two-adic split contributes zero, while a combined
+two-adic/perfect-power candidate contributes one. This is the same division
 [hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) makes, and it is worth more than the oracle
 half.
 

--- a/HexIntFactor/Small.lean
+++ b/HexIntFactor/Small.lean
@@ -27,8 +27,13 @@ def removePower (p n : Nat) : Nat → Nat × Nat
         (out.1 + 1, out.2)
       else (0, n)
 
-/-- Number of trailing zero bits, together with the odd cofactor. -/
-def splitTwos (n : Nat) : Nat × Nat := removePower 2 n (n.log2 + 1)
+/-- Number of trailing zero bits, together with the cofactor after one right
+shift. Zero maps to `(0, 0)`; every positive input produces an odd cofactor. -/
+def splitTwos (n : Nat) : Nat × Nat :=
+  if n = 0 then (0, 0)
+  else
+    let exponent := (n ^^^ (n &&& (n - 1))).log2
+    (exponent, n >>> exponent)
 
 private def trialGo : List Nat → Nat → List PrimePower × Nat
   | [], n => ([], n)
@@ -42,7 +47,7 @@ private def trialGo : List Nat → Nat → List PrimePower × Nat
 
 /-- Trial division against the complete committed primality table. -/
 def trialFactors (n : Nat) : List PrimePower × Nat :=
-  trialGo primeTable.toList n
+  if n = 0 then ([], 0) else trialGo primeTable.toList n
 
 private def rootGo (n k : Nat) : Nat → Nat → Nat → Option Nat
   | 0, lo, _ =>
@@ -66,7 +71,9 @@ private def rootGo (n k : Nat) : Nat → Nat → Nat → Option Nat
 /-- Exact positive `k`th root, found by bounded binary search. -/
 def exactRoot? (n k : Nat) : Option Nat :=
   if k < 2 then none
-  else rootGo n k (n.log2 + 2) 1 (n + 1)
+  else
+    let rootBits := n.log2 / k + 1
+    rootGo n k (rootBits + 2) 1 ((1 : Nat) <<< rootBits)
 
 private def perfectPowerGo (n maxExponent : Nat) : List Nat → Option (Nat × Nat)
   | [] => none
@@ -74,28 +81,53 @@ private def perfectPowerGo (n maxExponent : Nat) : List Nat → Option (Nat × N
       if maxExponent < k then none
       else
         match exactRoot? n k with
-        | some base => if 1 < base then some (base, k) else none
+        | some base =>
+            if 1 < base then some (base, k)
+            else perfectPowerGo n maxExponent ks
         | none => perfectPowerGo n maxExponent ks
 
-/-- Detect `n = base^exponent` with prime `exponent ≥ 2`.  Trying only prime
-exponents is complete for perfect powers. -/
+private def perfectPowerAboveTable (n : Nat) : Nat → Option (Nat × Nat)
+  | 0 => none
+  | k + 1 =>
+      if k + 1 < primeTableBound then none
+      else if !isPrime (k + 1) then perfectPowerAboveTable n k
+      else
+        match exactRoot? n (k + 1) with
+        | some base =>
+            if 1 < base then some (base, k + 1)
+            else perfectPowerAboveTable n k
+        | none => perfectPowerAboveTable n k
+
+/-- Detect `n = base^exponent` with `exponent ≥ 2`. The committed prime
+exponents cover the table range; a descending scan covers every larger prime
+exponent through `n.log2`. Testing prime exponents is complete because every
+composite exponent has a prime divisor. -/
 def perfectPower? (n : Nat) : Option (Nat × Nat) :=
   if n < 4 then none
-  else perfectPowerGo n n.log2 primeTable.toList
+  else
+    match perfectPowerGo n n.log2 primeTable.toList with
+    | some power => some power
+    | none => perfectPowerAboveTable n n.log2
 
 /-- Which structural producer made a small-route candidate. -/
 inductive SmallRoute where
   | trial
+  | twos
   | perfectPower
+  | twosPower
 deriving Repr, DecidableEq
 
 /-- Trial-produced prime powers plus a possibly powered residual.  The
 `residualBase`/`residualExponent` split lets the caller certify a large prime
 base after perfect-power reduction and then restore its multiplicity. -/
 structure SmallCandidate where
+  /-- Prime powers completely removed by structural and table routes. -/
   factors : List PrimePower
+  /-- Cofactor base still requiring primality or splitting work. -/
   residualBase : Nat
+  /-- Multiplicity to restore after factoring `residualBase`. -/
   residualExponent : Nat
+  /-- Structural route taken before returning the candidate. -/
   route : SmallRoute
 deriving Repr
 
@@ -108,8 +140,9 @@ def SmallCandidate.scale (candidate : SmallCandidate) (multiplier : Nat) :
     residualExponent := candidate.residualExponent * multiplier
     route := candidate.route }
 
-/-- Apply perfect-power reduction before table trial division. -/
-def smallCandidate (n : Nat) : SmallCandidate :=
+/-- Apply perfect-power reduction before table trial division to an odd
+cofactor. -/
+private def oddCandidate (n : Nat) : SmallCandidate :=
   match perfectPower? n with
   | some (base, exponent) =>
       let out := trialFactors base
@@ -123,6 +156,22 @@ def smallCandidate (n : Nat) : SmallCandidate :=
         residualBase := out.2
         residualExponent := 1
         route := .trial }
+
+/-- Remove the full power of two, then apply perfect-power reduction and table
+trial division to the odd cofactor. -/
+def smallCandidate (n : Nat) : SmallCandidate :=
+  let twos := splitTwos n
+  if twos.1 = 0 then oddCandidate n
+  else
+    let odd := oddCandidate twos.2
+    { factors := ⟨twos.1, .small 2⟩ :: odd.factors
+      residualBase := odd.residualBase
+      residualExponent := odd.residualExponent
+      route := match odd.route with
+        | .perfectPower => .twosPower
+        | .trial => .twos
+        -- `oddCandidate` currently returns only the preceding two routes.
+        | .twos | .twosPower => .twos }
 
 end Nat
 

--- a/conformance/HexIntFactor/Conformance.lean
+++ b/conformance/HexIntFactor/Conformance.lean
@@ -155,10 +155,22 @@ example :
 #guard squareDivisor checkedPow64 == 2 ^ 32
 #guard !isSquarefree checked12
 
-#guard (smallCandidate (2 ^ 20)).route == .perfectPower
+#guard splitTwos 0 == (0, 0)
+#guard splitTwos 99 == (0, 99)
+#guard splitTwos (2 ^ 20) == (20, 1)
+#guard splitTwos (3 * 2 ^ 20) == (20, 3)
+#guard (trialFactors 0).1.isEmpty && (trialFactors 0).2 == 0
+#guard (smallCandidate (2 ^ 20)).route == .twos
+#guard (smallCandidate (2 ^ 20)).factors.map
+  (fun entry => (entry.prime, entry.exponent)) == [(2, 20)]
+#guard exactRoot? 65025 2 == some 255
+#guard exactRoot? 759375 5 == some 15
+#guard perfectPower? (2 ^ 9973) == some (2, 9973)
+#guard (perfectPower? (2 ^ 10000)).isSome
+#guard perfectPower? (2 ^ 10009) == some (2, 10009)
 #guard (smallCandidate (3 ^ 13)).route == .perfectPower
 #guard (smallCandidate (1000003 ^ 2)).route == .perfectPower
-#guard (smallCandidate ((6 ^ 5) ^ 3)).route == .perfectPower
+#guard (smallCandidate ((6 ^ 5) ^ 3)).route == .twosPower
 
 -- The subject is not a perfect power, but this exact split leaves a square
 -- cofactor. The same structural producer used for every popped search entry
@@ -178,6 +190,8 @@ private def recursivePowerCandidate : SmallCandidate :=
 -- pins that count while the final checked factorization remains unchanged.
 #guard Hex.Nat.Internal.countPowerRoutes recursivePowerInput (Rand.ofSeed 1) == 1
 #guard Hex.Nat.Internal.countPowerRoutes 0 (Rand.ofSeed 1) == 0
+#guard Hex.Nat.Internal.countPowerRoutes (2 ^ 20) (Rand.ofSeed 1) == 0
+#guard Hex.Nat.Internal.countPowerRoutes ((6 ^ 5) ^ 3) (Rand.ofSeed 1) == 1
 #guard (match factor? recursivePowerInput (Rand.ofSeed 1) with
   | .ok (F, _) =>
       F.raw.factors.map (fun entry => (entry.prime, entry.exponent)) ==
@@ -187,7 +201,7 @@ private def recursivePowerCandidate : SmallCandidate :=
 private def nestedPowerCandidate : SmallCandidate :=
   (smallCandidate ((6 ^ 5) ^ 3)).scale 2
 
-#guard nestedPowerCandidate.route == .perfectPower
+#guard nestedPowerCandidate.route == .twosPower
 #guard nestedPowerCandidate.factors.map (fun entry => (entry.prime, entry.exponent)) ==
   [(2, 30), (3, 30)]
 #guard nestedPowerCandidate.residualBase == 1


### PR DESCRIPTION
Closes #9695

## Summary
- route powers of two through a dedicated native-`Nat` isolated-low-bit count and shift before generic trial division
- tighten exact-root upper bounds, test committed prime exponents first, then scan every exponent at and above the finite table boundary
- return an honest empty/zero result from public `trialFactors 0`
- preserve compound two-adic/perfect-power evidence, sorted factors, route accounting, and recursive multiplicity scaling
- correct the SPEC from Newton/repeated-squaring claims to the actual bounded binary search with a linear early-aborting power loop
- add boundary guards below/at/above `primeTableBound`, two-adic edge guards, and end-to-end route-count guards

## Verification
- `lake build HexIntFactor HexIntFactor.Conformance` (16.7s wall; conformance target 13s with the new ~10k-bit guards)
- `lake exe runLinter HexIntFactor.Small`
- `python3 scripts/check_file_line_counts.py`
- banned-token scan across `HexIntFactor`
- `git diff --check`

## Independent review
Fresh Claude Opus review confirmed the ordering, multiplicity, zero-boundary, and completeness arguments, then identified an exponent-bound off-by-one, malformed prose, an inefficient `Int.trailingZeros` route, and incorrect repeated-squaring costs. This revision addresses all blockers, adds its requested boundary/route guards, and measures their build cost.