### PR TITLE
fix: make shared rho genuinely Brent-batched

### DIFF
--- a/HexIntFactor/Factor.lean
+++ b/HexIntFactor/Factor.lean
@@ -68,6 +68,14 @@ private def mergePowers (entries : List PrimePower) (into : List PrimePower) :
     List PrimePower :=
   entries.foldl (fun acc entry => insertPower entry acc) into
 
+namespace Internal
+
+/-- Rho restarts allocated by the complete-factorization dispatcher. The cap
+keeps Pollard p−1 and ECM reachable after rho exhaustion. -/
+def rhoRestartBudget (fuel : Nat) : Nat := min 8 fuel
+
+end Internal
+
 private structure SearchState where
   factors : List PrimePower
   residual : Nat
@@ -109,7 +117,7 @@ private def searchGo : Nat → List (Nat × Nat) → List PrimePower → Nat →
                 residual r' attempts powerRoutes
           | .error primeFailure =>
               match rhoSplit? m primeFailure.rand
-                  (min 1000000 ((fuel + 1) * (fuel + 1))) with
+                  (Internal.rhoRestartBudget (fuel + 1)) with
               | .ok (d, r') =>
                   searchGo fuel ((d, multiplier) :: (m / d, multiplier) :: stack)
                     factors residual r' (attempts + primeFailure.attempts + 1)

--- a/HexIntFactor/Factor.lean
+++ b/HexIntFactor/Factor.lean
@@ -71,8 +71,10 @@ private def mergePowers (entries : List PrimePower) (into : List PrimePower) :
 namespace Internal
 
 /-- Rho restarts allocated by the complete-factorization dispatcher. The cap
-keeps Pollard p−1 and ECM reachable after rho exhaustion. -/
-def rhoRestartBudget (fuel : Nat) : Nat := min 8 fuel
+keeps Pollard p−1 and ECM reachable after rho exhaustion, while the fuel side
+prevents a nearly exhausted search from manufacturing extra attempts. -/
+def rhoRestartBudget (fuel : Nat) : Nat :=
+  min Hex.Nat.Internal.rhoRestartCap fuel
 
 end Internal
 

--- a/HexIntFactor/SPEC/hex-int-factor.md
+++ b/HexIntFactor/SPEC/hex-int-factor.md
@@ -322,7 +322,9 @@ Floyd's (fewer function evaluations per step), and take
 serves many steps. The shared implementation flushes at 32 differences
 or a cycle boundary. A whole-modulus batch is replayed difference by
 difference, so a proper factor hidden inside that batch can still be
-recovered.
+recovered. A nontrivial batched gcd need not be prime: collisions for
+different prime factors in one batch can return their composite product,
+which the recursive dispatcher splits or certifies like any other divisor.
 
 Expected cost is `O(p^{1/2})` iterations to find a factor `p`, so
 `O(n^{1/4})` to split a semiprime. The batching constant matters: a gcd
@@ -333,15 +335,16 @@ primitive required is `Nat.gcd`, not extended GCD.
 [hex-finite-field](../../SPEC/Libraries/hex-finite-field.md), sited in hex-basic), following
 the same explicit-argument discipline: the draw is an argument, the
 retry budget is fuel, and a bad draw costs time and never correctness.
-The draw rejects `c = 0` and any starting point `x` satisfying
+The draw rejects `c = 0`, globally rejects the degenerate polynomial
+`x² - 2`, and rejects any other `(c, x)` pair satisfying
 `x² + c ≡ x (mod n)`, a fixed point that can be detected before the
-loop. In particular, `c = n - 2` is bad for the conventional start
-`x = 2` but is not globally blacklisted for every start.
+loop. An offset rejected for one fixed start remains available with
+another start.
 
 Complete-factorization dispatch allocates at most eight rho restarts to
 one unresolved cofactor. Exhausting that bounded attempt leaves Pollard
-`p − 1`, cyclotomic splitting, and ECM reachable; it does not spend a
-fuel-squared number of restarts before those routes can run.
+`p − 1` and ECM reachable; it does not spend a fuel-squared number of
+restarts before those routes can run.
 
 ### 2. Pollard `p − 1`
 

--- a/HexIntFactor/SPEC/hex-int-factor.md
+++ b/HexIntFactor/SPEC/hex-int-factor.md
@@ -319,7 +319,10 @@ about `10^{12}`: iterate
 `x ↦ x² + c (mod n)`, detect a cycle by Brent's method rather than
 Floyd's (fewer function evaluations per step), and take
 `gcd(|xᵢ − x_j|, n)` in batches of accumulated products so that one gcd
-serves many steps.
+serves many steps. The shared implementation flushes at 32 differences
+or a cycle boundary. A whole-modulus batch is replayed difference by
+difference, so a proper factor hidden inside that batch can still be
+recovered.
 
 Expected cost is `O(p^{1/2})` iterations to find a factor `p`, so
 `O(n^{1/4})` to split a semiprime. The batching constant matters: a gcd
@@ -334,6 +337,11 @@ The draw rejects `c = 0` and any starting point `x` satisfying
 `x² + c ≡ x (mod n)`, a fixed point that can be detected before the
 loop. In particular, `c = n - 2` is bad for the conventional start
 `x = 2` but is not globally blacklisted for every start.
+
+Complete-factorization dispatch allocates at most eight rho restarts to
+one unresolved cofactor. Exhausting that bounded attempt leaves Pollard
+`p − 1`, cyclotomic splitting, and ECM reachable; it does not spend a
+fuel-squared number of restarts before those routes can run.
 
 ### 2. Pollard `p − 1`
 
@@ -895,7 +903,7 @@ the number of distinct primes, `B` a smoothness bound.
 | trailing-zero split | one big-`Nat` operation | not `O(1)` bit complexity |
 | perfect-power test | `O(b · b · M(b))` | `O(b)` roots, Newton each |
 | trial division to `T` | `O(π(T))` divisions | `π(10^4) = 1229` |
-| Pollard rho | `O(√p)` iterations expected | `O(n^{1/4})` for a semiprime |
+| Pollard rho | `O(√p)` iterations expected and one routine gcd per 32-step batch | `O(n^{1/4})` for a semiprime; cycle boundaries can flush shorter batches |
 | Pollard `p − 1` stage 1 | `O(B)` modular mults | `log M = Θ(B)`; smooth `p − 1` is sufficient but not decisive |
 | ECM stage 1, one curve | `O(B)` mults | scalar bit length is `Θ(B)`; success depends on the bound |
 | `checkFactorization` | `O(k)` exponentiations plus `k` primality replays | `p^e` is `O(log e)` mults, not one |

--- a/HexManual/Chapters/HexPrimality.lean
+++ b/HexManual/Chapters/HexPrimality.lean
@@ -181,9 +181,8 @@ with the proof that it is about the requested number:
 {docstring Hex.Nat.primeCert?}
 
 The search factors `n - 1` with trial division against the table
-followed by Brent's variant of Pollard rho; the rho primitive is
-public (the planned hex-int-factor library will reuse it) and
-validates every factor it returns:
+followed by Brent's variant of Pollard rho; the rho primitive is public,
+reused by hex-int-factor, and validates every factor it returns:
 
 {docstring Hex.Nat.rhoFactor?}
 

--- a/HexPrimality/SPEC/hex-primality.md
+++ b/HexPrimality/SPEC/hex-primality.md
@@ -535,6 +535,18 @@ no proper factor was found, and makes no primality claim. It is public
 because hex-int-factor reuses this exact primitive; it does not certify
 that `d` is prime and makes no completeness claim.
 
+One restart uses Brent's power-of-two cycle schedule and accumulates up
+to 32 differences modulo `n` before taking a gcd. Cycle boundaries also
+flush a shorter batch. If a batched gcd is the whole modulus, the route
+replays just that batch one difference at a time; the caller accepts only
+a dynamically validated proper divisor. Each restart draws `c` from
+`[1, n - 1]` and a start from `[0, n - 1]`, rejecting the pair exactly
+when the start is a fixed point of `x ↦ x² + c`. Thus an offset that is
+bad for one start remains available for another. The rejection loop and
+each restart's inner work are bounded, and both current worklist consumers
+allocate at most eight rho restarts before retaining the residual or
+trying their later routes.
+
 `partialFactor` is **internal**, not part of the public API. An earlier
 draft exposed it with "no correctness theorem at all", which is safe
 only if every consumer checks everything, and its return type said
@@ -557,7 +569,8 @@ private theorem partialFactor_prod (n r fuel) (hn : 0 < n) :
 ```
 
 hex-int-factor reuses `rhoFactor?` rather than introducing a second rho.
-Brent's cycle detection is already part of the lower primitive; the
+Brent's batched cycle detection and whole-modulus recovery are already
+part of the lower primitive; the
 higher library adds structural reductions, ECM, complete-factorization
 assembly, and their dispatch. The routes by which its advances flow
 back into this library's search are fixed below.

--- a/HexPrimality/SPEC/hex-primality.md
+++ b/HexPrimality/SPEC/hex-primality.md
@@ -540,12 +540,11 @@ to 32 differences modulo `n` before taking a gcd. Cycle boundaries also
 flush a shorter batch. If a batched gcd is the whole modulus, the route
 replays just that batch one difference at a time; the caller accepts only
 a dynamically validated proper divisor. Each restart draws `c` from
-`[1, n - 1]` and a start from `[0, n - 1]`, rejecting the pair exactly
-when the start is a fixed point of `x ↦ x² + c`. Thus an offset that is
-bad for one start remains available for another. The rejection loop and
-each restart's inner work are bounded, and both current worklist consumers
-allocate at most eight rho restarts before retaining the residual or
-trying their later routes.
+`[1, n - 1]` and a start from `[0, n - 1]`. It globally rejects the
+degenerate map `x ↦ x² - 2`; other offsets are rejected only with a start
+that makes a fixed point of `x ↦ x² + c`. The rejection loop and each
+restart's inner work are bounded. Both current worklist consumers share an
+eight-restart cap before retaining the residual or trying later routes.
 
 `partialFactor` is **internal**, not part of the public API. An earlier
 draft exposed it with "no correctness theorem at all", which is safe

--- a/HexPrimality/Search.lean
+++ b/HexPrimality/Search.lean
@@ -31,6 +31,11 @@ resume rather than replay a failed stream. It is public because
 hex-int-factor reuses this exact primitive; it does not certify that the
 factor is prime and makes no completeness claim.
 
+Each restart uses Brent's power-of-two anchor schedule, accumulates at most
+32 differences per routine gcd, and replays a whole-modulus batch to recover
+an individual divisor. Restart draws exclude degenerate polynomials and
+fixed starting points before entering the bounded loop.
+
 `partialFactor` is internal: trial division by the committed table, then
 Brent rho over a worklist, with everything unsplittable multiplied into the
 residual. Its one theorem is the product invariant its certificate-search
@@ -79,6 +84,25 @@ private structure BrentResult where
   /-- Whole-modulus batches replayed by this terminating result. -/
   recoveries : Nat
 
+/-- Mutable state of one Brent restart, grouped so call sites cannot silently
+transpose the cycle and batch counters. The two small counters intentionally
+travel through the production loop: conformance then observes the exact route
+rather than a duplicated tracing implementation that can drift from it. -/
+private structure BrentState where
+  fuel : Nat
+  x : Nat
+  y : Nat
+  r : Nat
+  k : Nat
+  q : Nat
+  batchStart : Nat
+  batchCount : Nat
+  steps : Nat
+  gcds : Nat
+
+private def brentStart (start fuel : Nat) : BrentState :=
+  ⟨fuel, start, start, 1, 0, 1, start, 0, 0, 0⟩
+
 /-- Replay one failed batch difference by difference when its accumulated gcd
 is the whole modulus. -/
 private def brentRecover (n c x : Nat) :
@@ -93,10 +117,9 @@ private def brentRecover (n c x : Nat) :
 /-- Brent cycle search inside one restart. Differences are multiplied modulo
 `n` and share one gcd per batch. If a batch gcd is `n`, `brentRecover`
 replays only that batch to recover the first nontrivial individual gcd. -/
-private def brentGo (n c : Nat) :
-    Nat → Nat → Nat → Nat → Nat → Nat → Nat → Nat → Nat → Nat → BrentResult
-  | 0, _, _, _, _, _, _, _, steps, gcds => ⟨none, steps, gcds, 0⟩
-  | fuel + 1, x, y, r, k, q, batchStart, batchCount, steps, gcds =>
+private def brentGo (n c : Nat) : BrentState → BrentResult
+  | ⟨0, _, _, _, _, _, _, _, steps, gcds⟩ => ⟨none, steps, gcds, 0⟩
+  | ⟨fuel + 1, x, y, r, k, q, batchStart, batchCount, steps, gcds⟩ =>
       let y' := rhoNext n c y
       let difference := (x + n - y') % n
       let q' := q * difference % n
@@ -107,16 +130,19 @@ private def brentGo (n c : Nat) :
         let d := Nat.gcd q' n
         if d = 1 then
           if cycleDone then
-            brentGo n c fuel y' y' (r * 2) 0 1 y' 0 (steps + 1) (gcds + 1)
+            brentGo n c ⟨fuel, y', y', r * 2, 0, 1, y', 0,
+              steps + 1, gcds + 1⟩
           else
-            brentGo n c fuel x y' r k' 1 y' 0 (steps + 1) (gcds + 1)
+            brentGo n c ⟨fuel, x, y', r, k', 1, y', 0,
+              steps + 1, gcds + 1⟩
         else if d < n then
           ⟨some d, steps + 1, gcds + 1, 0⟩
         else
           brentRecover n c x batchCount' batchStart (steps + 1) (gcds + 1)
       else
-        brentGo n c fuel x y' r k' q' batchStart batchCount'
-          (steps + 1) gcds
+        brentGo n c ⟨fuel, x, y', r, k', q', batchStart, batchCount',
+          steps + 1, gcds⟩
+termination_by state => state.fuel
 
 /-- Inner iteration budget for one Brent restart: scaled past the expected
 `n^(1/4)` cycle length for small `n`, capped at `2^22` so one restart is
@@ -129,7 +155,7 @@ private def rhoInnerFuel (n : Nat) : Nat :=
 
 /-- One accepted restart draw together with its advanced random state. -/
 private structure RhoDraw where
-  /-- Nonzero polynomial offset in `[1, n - 1]`. -/
+  /-- Nonzero, nondegenerate polynomial offset below `n`. -/
   c : Nat
   /-- Starting point below the modulus. -/
   start : Nat
@@ -145,16 +171,20 @@ private def rhoDrawGo (n : Nat) : Nat → Nat → Rand → RhoDraw
       let startDraw := cDraw.2.next
       let c := cDraw.1.toNat % (n - 1) + 1
       let start := startDraw.1.toNat % n
-      if rhoNext n c start = start then
+      if c + 2 = n ∨ rhoNext n c start = start then
         rhoDrawGo n fuel (rejections + 1) startDraw.2
       else ⟨c, start, startDraw.2, rejections⟩
 
-/-- Draw a nonzero polynomial offset and reject the pair, rather than the
-offset globally, when the chosen start is a fixed point. -/
+/-- Draw a nonzero polynomial offset, globally reject the degenerate
+`x ↦ x² - 2`, and reject other draws only when the chosen start is a fixed
+point. -/
 private def rhoDraw (n : Nat) (r : Rand) : RhoDraw :=
   rhoDrawGo n 8 0 r
 
 namespace Internal
+
+/-- Shared maximum rho restart allocation for current worklist consumers. -/
+def rhoRestartCap : Nat := 8
 
 /-- Deterministic Brent instrumentation for route-level conformance tests. -/
 structure RhoTrace where
@@ -166,15 +196,14 @@ structure RhoTrace where
   gcds : Nat
   /-- Whole-modulus batches replayed. -/
   recoveries : Nat
-deriving Repr, DecidableEq
 
 /-- Run one explicitly parameterized Brent restart and report its batching
 counters. -/
 def rhoTrace (n c start fuel : Nat) : RhoTrace :=
-  let result := brentGo n c fuel start start 1 0 1 start 0 0 0
+  let result := brentGo n c (brentStart start fuel)
   ⟨result.factor, result.steps, result.gcds, result.recoveries⟩
 
-/-- Inspect the pair-specific rejection count of the deterministic draw. -/
+/-- Inspect the rejection count of the deterministic restart draw. -/
 def rhoDrawTrace (n : Nat) (r : Rand) : Nat × Nat × Nat :=
   let draw := rhoDraw n r
   (draw.c, draw.start, draw.rejections)
@@ -185,8 +214,7 @@ private def rhoTry (n : Nat) : Nat → Nat → Rand → Except RhoFailure (Nat �
   | 0, attempts, r => .error ⟨.exhausted, attempts, r⟩
   | tries + 1, attempts, r =>
       let draw := rhoDraw n r
-      match (brentGo n draw.c (rhoInnerFuel n) draw.start draw.start
-          1 0 1 draw.start 0 0 0).factor with
+      match (brentGo n draw.c (brentStart draw.start (rhoInnerFuel n))).factor with
       | some d =>
           if 1 < d then
             if d < n then
@@ -196,11 +224,12 @@ private def rhoTry (n : Nat) : Nat → Nat → Rand → Except RhoFailure (Nat �
           else rhoTry n tries (attempts + 1) draw.rand
       | none => rhoTry n tries (attempts + 1) draw.rand
 
-/-- A dynamically validated proper-factor candidate by Brent rho. `fuel`
-bounds the restart attempts; each restart draws a fresh polynomial offset
-and starting point and runs a cycle budget scaled to `n^(1/4)` and capped
-at `2^22` (see `rhoInnerFuel`), so exhaustion arrives rather than hangs
-when the smallest factor is out of rho's reach. Every
+/-- A dynamically validated proper-factor candidate by batched Brent rho.
+`fuel` bounds restart attempts. Each restart draws a fresh polynomial and
+starting point, accumulates up to 32 differences per gcd, and replays a
+whole-modulus batch difference by difference. Its cycle budget is scaled to
+`n^(1/4)` and capped at `2^22` (see `rhoInnerFuel`), so exhaustion arrives
+rather than hangs when the smallest factor is out of rho's reach. Every
 success is validated (`1 < d < n` and `d ∣ n`) before it is returned, so
 randomness and fuel affect only whether a factor is found. -/
 def rhoFactor? (n : Nat) (r : Rand) (fuel : Nat) :
@@ -355,7 +384,7 @@ private theorem insertFactor_prod (p : Nat) :
         simp [Nat.mul_left_comm]
 
 /-- Restart budget for each rho call inside the worklist. -/
-private def rhoRestartBudget : Nat := 8
+private def rhoRestartBudget : Nat := Internal.rhoRestartCap
 
 /-- The rho worklist: pop a pending number, drop it if it is `1`, keep it
 as a claimed factor if the filter calls it prime, split it if rho finds a

--- a/HexPrimality/Search.lean
+++ b/HexPrimality/Search.lean
@@ -89,7 +89,6 @@ transpose the cycle and batch counters. The two small counters intentionally
 travel through the production loop: conformance then observes the exact route
 rather than a duplicated tracing implementation that can drift from it. -/
 private structure BrentState where
-  fuel : Nat
   x : Nat
   y : Nat
   r : Nat
@@ -100,11 +99,14 @@ private structure BrentState where
   steps : Nat
   gcds : Nat
 
-private def brentStart (start fuel : Nat) : BrentState :=
-  ⟨fuel, start, start, 1, 0, 1, start, 0, 0, 0⟩
+private def brentStart (start : Nat) : BrentState :=
+  { x := start, y := start, r := 1, k := 0, q := 1,
+    batchStart := start, batchCount := 0, steps := 0, gcds := 0 }
 
 /-- Replay one failed batch difference by difference when its accumulated gcd
-is the whole modulus. -/
+is the whole modulus. The zero-fuel `none` result is unreachable from
+`brentGo`: a whole-modulus product of batch differences guarantees that at
+least one replayed difference has nontrivial gcd. -/
 private def brentRecover (n c x : Nat) :
     Nat → Nat → Nat → Nat → BrentResult
   | 0, _, steps, gcds => ⟨none, steps, gcds, 1⟩
@@ -117,32 +119,39 @@ private def brentRecover (n c x : Nat) :
 /-- Brent cycle search inside one restart. Differences are multiplied modulo
 `n` and share one gcd per batch. If a batch gcd is `n`, `brentRecover`
 replays only that batch to recover the first nontrivial individual gcd. -/
-private def brentGo (n c : Nat) : BrentState → BrentResult
-  | ⟨0, _, _, _, _, _, _, _, steps, gcds⟩ => ⟨none, steps, gcds, 0⟩
-  | ⟨fuel + 1, x, y, r, k, q, batchStart, batchCount, steps, gcds⟩ =>
-      let y' := rhoNext n c y
-      let difference := (x + n - y') % n
-      let q' := q * difference % n
-      let k' := k + 1
-      let batchCount' := batchCount + 1
-      let cycleDone := r ≤ k'
+private def brentGo (n c : Nat) : Nat → BrentState → BrentResult
+  | 0, state => ⟨none, state.steps, state.gcds, 0⟩
+  | fuel + 1, state =>
+      let y' := rhoNext n c state.y
+      let difference := (state.x + n - y') % n
+      let q' := state.q * difference % n
+      let k' := state.k + 1
+      let batchCount' := state.batchCount + 1
+      let cycleDone := state.r ≤ k'
       if rhoBatchSize ≤ batchCount' ∨ cycleDone then
         let d := Nat.gcd q' n
         if d = 1 then
           if cycleDone then
-            brentGo n c ⟨fuel, y', y', r * 2, 0, 1, y', 0,
-              steps + 1, gcds + 1⟩
+            brentGo n c fuel
+              { x := y', y := y', r := state.r * 2,
+                k := 0, q := 1, batchStart := y', batchCount := 0,
+                steps := state.steps + 1, gcds := state.gcds + 1 }
           else
-            brentGo n c ⟨fuel, x, y', r, k', 1, y', 0,
-              steps + 1, gcds + 1⟩
+            brentGo n c fuel
+              { x := state.x, y := y', r := state.r, k := k',
+                q := 1, batchStart := y', batchCount := 0,
+                steps := state.steps + 1, gcds := state.gcds + 1 }
         else if d < n then
-          ⟨some d, steps + 1, gcds + 1, 0⟩
+          ⟨some d, state.steps + 1, state.gcds + 1, 0⟩
         else
-          brentRecover n c x batchCount' batchStart (steps + 1) (gcds + 1)
+          brentRecover n c state.x batchCount' state.batchStart
+            (state.steps + 1) (state.gcds + 1)
       else
-        brentGo n c ⟨fuel, x, y', r, k', q', batchStart, batchCount',
-          steps + 1, gcds⟩
-termination_by state => state.fuel
+        brentGo n c fuel
+          { x := state.x, y := y', r := state.r, k := k',
+            q := q', batchStart := state.batchStart,
+            batchCount := batchCount', steps := state.steps + 1,
+            gcds := state.gcds }
 
 /-- Inner iteration budget for one Brent restart: scaled past the expected
 `n^(1/4)` cycle length for small `n`, capped at `2^22` so one restart is
@@ -200,7 +209,7 @@ structure RhoTrace where
 /-- Run one explicitly parameterized Brent restart and report its batching
 counters. -/
 def rhoTrace (n c start fuel : Nat) : RhoTrace :=
-  let result := brentGo n c (brentStart start fuel)
+  let result := brentGo n c fuel (brentStart start)
   ⟨result.factor, result.steps, result.gcds, result.recoveries⟩
 
 /-- Inspect the rejection count of the deterministic restart draw. -/
@@ -214,7 +223,7 @@ private def rhoTry (n : Nat) : Nat → Nat → Rand → Except RhoFailure (Nat �
   | 0, attempts, r => .error ⟨.exhausted, attempts, r⟩
   | tries + 1, attempts, r =>
       let draw := rhoDraw n r
-      match (brentGo n draw.c (brentStart draw.start (rhoInnerFuel n))).factor with
+      match (brentGo n draw.c (rhoInnerFuel n) (brentStart draw.start)).factor with
       | some d =>
           if 1 < d then
             if d < n then

--- a/HexPrimality/Search.lean
+++ b/HexPrimality/Search.lean
@@ -63,18 +63,60 @@ structure RhoFailure where
   rand : Rand
 deriving Repr
 
-/-- Brent cycle search inside one restart: the anchor `x` is re-pinned to
-the hare at each power-of-two step count. Returns the first nontrivial gcd
-encountered (possibly `n` itself when the cycle closes without exposing a
-factor; the caller validates). -/
-private def brentGo (n c : Nat) : Nat → Nat → Nat → Nat → Nat → Option Nat
-  | 0, _, _, _, _ => none
-  | fuel + 1, x, y, r, k =>
-      let y' := (y * y + c) % n
+/-- Polynomial step used by one rho restart. -/
+private def rhoNext (n c y : Nat) : Nat := (y * y + c) % n
+
+/-- Number of differences accumulated before a routine Brent gcd. -/
+private def rhoBatchSize : Nat := 32
+
+private structure BrentResult where
+  /-- A candidate divisor found by this restart, if any. -/
+  factor : Option Nat
+  /-- Polynomial evaluations performed, including recovery replay. -/
+  steps : Nat
+  /-- Gcd computations performed, including recovery replay. -/
+  gcds : Nat
+  /-- Whole-modulus batches replayed by this terminating result. -/
+  recoveries : Nat
+
+/-- Replay one failed batch difference by difference when its accumulated gcd
+is the whole modulus. -/
+private def brentRecover (n c x : Nat) :
+    Nat → Nat → Nat → Nat → BrentResult
+  | 0, _, steps, gcds => ⟨none, steps, gcds, 1⟩
+  | fuel + 1, y, steps, gcds =>
+      let y' := rhoNext n c y
       let d := Nat.gcd ((x + n - y') % n) n
-      if 1 < d then some d
-      else if k + 1 < r then brentGo n c fuel x y' r (k + 1)
-      else brentGo n c fuel y' y' (r * 2) 0
+      if 1 < d then ⟨some d, steps + 1, gcds + 1, 1⟩
+      else brentRecover n c x fuel y' (steps + 1) (gcds + 1)
+
+/-- Brent cycle search inside one restart. Differences are multiplied modulo
+`n` and share one gcd per batch. If a batch gcd is `n`, `brentRecover`
+replays only that batch to recover the first nontrivial individual gcd. -/
+private def brentGo (n c : Nat) :
+    Nat → Nat → Nat → Nat → Nat → Nat → Nat → Nat → Nat → Nat → BrentResult
+  | 0, _, _, _, _, _, _, _, steps, gcds => ⟨none, steps, gcds, 0⟩
+  | fuel + 1, x, y, r, k, q, batchStart, batchCount, steps, gcds =>
+      let y' := rhoNext n c y
+      let difference := (x + n - y') % n
+      let q' := q * difference % n
+      let k' := k + 1
+      let batchCount' := batchCount + 1
+      let cycleDone := r ≤ k'
+      if rhoBatchSize ≤ batchCount' ∨ cycleDone then
+        let d := Nat.gcd q' n
+        if d = 1 then
+          if cycleDone then
+            brentGo n c fuel y' y' (r * 2) 0 1 y' 0 (steps + 1) (gcds + 1)
+          else
+            brentGo n c fuel x y' r k' 1 y' 0 (steps + 1) (gcds + 1)
+        else if d < n then
+          ⟨some d, steps + 1, gcds + 1, 0⟩
+        else
+          brentRecover n c x batchCount' batchStart (steps + 1) (gcds + 1)
+      else
+        brentGo n c fuel x y' r k' q' batchStart batchCount'
+          (steps + 1) gcds
 
 /-- Inner iteration budget for one Brent restart: scaled past the expected
 `n^(1/4)` cycle length for small `n`, capped at `2^22` so one restart is
@@ -85,27 +127,74 @@ outlives the caller. Runtime only, so `Nat.sqrt` is fine here. -/
 private def rhoInnerFuel (n : Nat) : Nat :=
   min (16 * (Nat.sqrt (Nat.sqrt n) + 2)) (1 <<< 22)
 
-/-- Draw the restart parameters: a polynomial offset in `[1, n - 3]`, a
-starting point below `n`, and the advanced state. Search seeding, so the
-slight modulo bias is irrelevant. -/
-private def rhoDraw (n : Nat) (r : Rand) : Nat × Nat × Rand :=
-  (r.next.1.toNat % (n - 3) + 1,
-    r.next.2.next.1.toNat % n,
-    r.next.2.next.2)
+/-- One accepted restart draw together with its advanced random state. -/
+private structure RhoDraw where
+  /-- Nonzero polynomial offset in `[1, n - 1]`. -/
+  c : Nat
+  /-- Starting point below the modulus. -/
+  start : Nat
+  /-- State after all accepted and rejected pair draws. -/
+  rand : Rand
+  /-- Fixed-point pairs rejected before accepting this draw. -/
+  rejections : Nat
+
+private def rhoDrawGo (n : Nat) : Nat → Nat → Rand → RhoDraw
+  | 0, rejections, r => ⟨1, 0, r, rejections⟩
+  | fuel + 1, rejections, r =>
+      let cDraw := r.next
+      let startDraw := cDraw.2.next
+      let c := cDraw.1.toNat % (n - 1) + 1
+      let start := startDraw.1.toNat % n
+      if rhoNext n c start = start then
+        rhoDrawGo n fuel (rejections + 1) startDraw.2
+      else ⟨c, start, startDraw.2, rejections⟩
+
+/-- Draw a nonzero polynomial offset and reject the pair, rather than the
+offset globally, when the chosen start is a fixed point. -/
+private def rhoDraw (n : Nat) (r : Rand) : RhoDraw :=
+  rhoDrawGo n 8 0 r
+
+namespace Internal
+
+/-- Deterministic Brent instrumentation for route-level conformance tests. -/
+structure RhoTrace where
+  /-- Candidate divisor returned by the restart, if any. -/
+  factor : Option Nat
+  /-- Polynomial evaluations, including recovery replay. -/
+  steps : Nat
+  /-- Batched and recovery gcd computations. -/
+  gcds : Nat
+  /-- Whole-modulus batches replayed. -/
+  recoveries : Nat
+deriving Repr, DecidableEq
+
+/-- Run one explicitly parameterized Brent restart and report its batching
+counters. -/
+def rhoTrace (n c start fuel : Nat) : RhoTrace :=
+  let result := brentGo n c fuel start start 1 0 1 start 0 0 0
+  ⟨result.factor, result.steps, result.gcds, result.recoveries⟩
+
+/-- Inspect the pair-specific rejection count of the deterministic draw. -/
+def rhoDrawTrace (n : Nat) (r : Rand) : Nat × Nat × Nat :=
+  let draw := rhoDraw n r
+  (draw.c, draw.start, draw.rejections)
+
+end Internal
 
 private def rhoTry (n : Nat) : Nat → Nat → Rand → Except RhoFailure (Nat × Rand)
   | 0, attempts, r => .error ⟨.exhausted, attempts, r⟩
   | tries + 1, attempts, r =>
-      match brentGo n (rhoDraw n r).1 (rhoInnerFuel n) (rhoDraw n r).2.1
-          (rhoDraw n r).2.1 1 0 with
+      let draw := rhoDraw n r
+      match (brentGo n draw.c (rhoInnerFuel n) draw.start draw.start
+          1 0 1 draw.start 0 0 0).factor with
       | some d =>
           if 1 < d then
             if d < n then
-              if n % d = 0 then .ok (d, (rhoDraw n r).2.2)
-              else rhoTry n tries (attempts + 1) (rhoDraw n r).2.2
-            else rhoTry n tries (attempts + 1) (rhoDraw n r).2.2
-          else rhoTry n tries (attempts + 1) (rhoDraw n r).2.2
-      | none => rhoTry n tries (attempts + 1) (rhoDraw n r).2.2
+              if n % d = 0 then .ok (d, draw.rand)
+              else rhoTry n tries (attempts + 1) draw.rand
+            else rhoTry n tries (attempts + 1) draw.rand
+          else rhoTry n tries (attempts + 1) draw.rand
+      | none => rhoTry n tries (attempts + 1) draw.rand
 
 /-- A dynamically validated proper-factor candidate by Brent rho. `fuel`
 bounds the restart attempts; each restart draws a fresh polynomial offset
@@ -131,6 +220,7 @@ private theorem rhoTry_spec {n : Nat} :
   | succ tries ih =>
       intro attempts r d r' h
       unfold rhoTry at h
+      dsimp only at h
       split at h
       · split at h
         · split at h

--- a/conformance/HexIntFactor/Conformance.lean
+++ b/conformance/HexIntFactor/Conformance.lean
@@ -173,7 +173,7 @@ private def recursivePowerCandidate : SmallCandidate :=
 #guard recursivePowerCandidate.factors.isEmpty
 #guard recursivePowerCandidate.residualBase == 10037
 #guard recursivePowerCandidate.residualExponent == 6
-#guard Hex.Nat.Internal.countPowerRoutes recursivePowerInput (Rand.ofSeed 17) == 1
+#guard Hex.Nat.Internal.countPowerRoutes recursivePowerInput (Rand.ofSeed 1) == 1
 #guard Hex.Nat.Internal.countPowerRoutes 0 (Rand.ofSeed 17) == 0
 #guard (match factor? recursivePowerInput (Rand.ofSeed 17) with
   | .ok (F, _) =>
@@ -217,6 +217,27 @@ example {n base bound d : Nat}
 #guard (match rhoSplit? 91 (Rand.ofSeed 1) 16 with
   | .ok (d, _) => decide (1 < d) && decide (d < 91) && 91 % d == 0
   | .error _ => false)
+
+-- Routine gcds are genuinely batched: this fixed restart performs 95
+-- polynomial steps but only seven gcds.
+private def rhoBatchTrace : Hex.Nat.Internal.RhoTrace :=
+  Hex.Nat.Internal.rhoTrace 100160063 1 2 256
+
+#guard rhoBatchTrace.factor == some 10007
+#guard rhoBatchTrace.steps == 95
+#guard rhoBatchTrace.gcds == 7
+
+-- A whole-modulus batch is replayed and recovers the proper factor 3.
+private def rhoRecoveryTrace : Hex.Nat.Internal.RhoTrace :=
+  Hex.Nat.Internal.rhoTrace 9 1 0 32
+
+#guard rhoRecoveryTrace.factor == some 3
+#guard rhoRecoveryTrace.recoveries == 1
+
+-- Seed 213 first draws the fixed pair `(c, x) = (71, 61)` modulo 91; the
+-- route rejects it and advances to a non-fixed pair.
+#guard Hex.Nat.Internal.rhoDrawTrace 91 (Rand.ofSeed 213) == (37, 6, 1)
+#guard Hex.Nat.Internal.rhoRestartBudget 1000000 == 8
 
 -- A malformed aggregate is exposed as an invariant failure, rather than
 -- being replaced by an empty partial answer or ordinary exhaustion.

--- a/conformance/HexIntFactor/Conformance.lean
+++ b/conformance/HexIntFactor/Conformance.lean
@@ -174,9 +174,10 @@ private def recursivePowerCandidate : SmallCandidate :=
 #guard recursivePowerCandidate.residualBase == 10037
 #guard recursivePowerCandidate.residualExponent == 6
 -- Batched rho may return a composite divisor when two collisions share a
--- batch. One seed pins both the recursive power-route count and final replay.
+-- batch. Seed 17 therefore changed the route count after batching; seed 1
+-- pins that count while the final checked factorization remains unchanged.
 #guard Hex.Nat.Internal.countPowerRoutes recursivePowerInput (Rand.ofSeed 1) == 1
-#guard Hex.Nat.Internal.countPowerRoutes 0 (Rand.ofSeed 17) == 0
+#guard Hex.Nat.Internal.countPowerRoutes 0 (Rand.ofSeed 1) == 0
 #guard (match factor? recursivePowerInput (Rand.ofSeed 1) with
   | .ok (F, _) =>
       F.raw.factors.map (fun entry => (entry.prime, entry.exponent)) ==

--- a/conformance/HexIntFactor/Conformance.lean
+++ b/conformance/HexIntFactor/Conformance.lean
@@ -173,9 +173,11 @@ private def recursivePowerCandidate : SmallCandidate :=
 #guard recursivePowerCandidate.factors.isEmpty
 #guard recursivePowerCandidate.residualBase == 10037
 #guard recursivePowerCandidate.residualExponent == 6
+-- Batched rho may return a composite divisor when two collisions share a
+-- batch. One seed pins both the recursive power-route count and final replay.
 #guard Hex.Nat.Internal.countPowerRoutes recursivePowerInput (Rand.ofSeed 1) == 1
 #guard Hex.Nat.Internal.countPowerRoutes 0 (Rand.ofSeed 17) == 0
-#guard (match factor? recursivePowerInput (Rand.ofSeed 17) with
+#guard (match factor? recursivePowerInput (Rand.ofSeed 1) with
   | .ok (F, _) =>
       F.raw.factors.map (fun entry => (entry.prime, entry.exponent)) ==
         [(10009, 1), (10037, 2)]
@@ -218,26 +220,8 @@ example {n base bound d : Nat}
   | .ok (d, _) => decide (1 < d) && decide (d < 91) && 91 % d == 0
   | .error _ => false)
 
--- Routine gcds are genuinely batched: this fixed restart performs 95
--- polynomial steps but only seven gcds.
-private def rhoBatchTrace : Hex.Nat.Internal.RhoTrace :=
-  Hex.Nat.Internal.rhoTrace 100160063 1 2 256
-
-#guard rhoBatchTrace.factor == some 10007
-#guard rhoBatchTrace.steps == 95
-#guard rhoBatchTrace.gcds == 7
-
--- A whole-modulus batch is replayed and recovers the proper factor 3.
-private def rhoRecoveryTrace : Hex.Nat.Internal.RhoTrace :=
-  Hex.Nat.Internal.rhoTrace 9 1 0 32
-
-#guard rhoRecoveryTrace.factor == some 3
-#guard rhoRecoveryTrace.recoveries == 1
-
--- Seed 213 first draws the fixed pair `(c, x) = (71, 61)` modulo 91; the
--- route rejects it and advances to a non-fixed pair.
-#guard Hex.Nat.Internal.rhoDrawTrace 91 (Rand.ofSeed 213) == (37, 6, 1)
 #guard Hex.Nat.Internal.rhoRestartBudget 1000000 == 8
+#guard Hex.Nat.Internal.rhoRestartBudget 3 == 3
 
 -- A malformed aggregate is exposed as an invariant failure, rather than
 -- being replaced by an empty partial answer or ordinary exhaustion.

--- a/conformance/HexPrimality/Conformance.lean
+++ b/conformance/HexPrimality/Conformance.lean
@@ -19,6 +19,7 @@ Covered operations:
 - `Hex.Nat.isPrime` / `Hex.Nat.isPrime?`
 - `Hex.Nat.checkPrime` on `PrimeCert` values
 - `Hex.Nat.primeCert?`
+- `Hex.Nat.rhoFactor?` and its batched-Brent route instrumentation
 - `Hex.Nat.millerRabin` / `Hex.Nat.isProbablePrime`
 - `Hex.Nat.isTablePrime`
 - `Hex.Nat.primesIn`
@@ -97,6 +98,33 @@ open Hex.Nat
 #guard (match primeCert? 2147483649 (Hex.Rand.ofSeed 0) 8 with
         | .error f => f.stop == .composite
         | .ok _ => false)
+
+-- Routine gcds are genuinely batched: this fixed restart performs 95
+-- polynomial steps but only seven gcds.
+private def rhoBatchTrace : Hex.Nat.Internal.RhoTrace :=
+  Hex.Nat.Internal.rhoTrace 100160063 1 2 256
+
+#guard rhoBatchTrace.factor == some 10007
+#guard rhoBatchTrace.steps == 95
+#guard rhoBatchTrace.gcds == 7
+#guard (match rhoFactor? 100160063 (Hex.Rand.ofSeed 1) 8 with
+  | .ok (d, _) => 1 < d && d < 100160063 && 100160063 % d == 0
+  | .error _ => false)
+
+-- A whole-modulus batch is replayed and recovers the proper factor 3.
+private def rhoRecoveryTrace : Hex.Nat.Internal.RhoTrace :=
+  Hex.Nat.Internal.rhoTrace 9 1 0 32
+
+#guard rhoRecoveryTrace.factor == some 3
+#guard rhoRecoveryTrace.recoveries == 1
+
+-- Seed 213 first draws the fixed pair `(c, x) = (71, 61)` modulo 91; the
+-- route rejects it and advances to a non-fixed pair.
+#guard Hex.Nat.Internal.rhoDrawTrace 91 (Hex.Rand.ofSeed 213) == (37, 6, 1)
+-- Seed 40 first draws the globally degenerate offset `c = n - 2` and then
+-- advances to the usable pair `(81, 74)`.
+#guard Hex.Nat.Internal.rhoDrawTrace 91 (Hex.Rand.ofSeed 40) == (81, 74, 1)
+#guard Hex.Nat.Internal.rhoRestartCap == 8
 
 -- Miller-Rabin filter behaviour on the adversarial families.
 #guard isProbablePrime 561 = false

--- a/conformance/HexPrimality/Conformance.lean
+++ b/conformance/HexPrimality/Conformance.lean
@@ -111,6 +111,10 @@ private def rhoBatchTrace : Hex.Nat.Internal.RhoTrace :=
   | .ok (d, _) => 1 < d && d < 100160063 && 100160063 % d == 0
   | .error _ => false)
 
+-- Collisions for 11 and 13 share the cycle-boundary batch, so the route
+-- returns their proper composite product rather than pretending it is prime.
+#guard (Hex.Nat.Internal.rhoTrace 2431 1 1 32).factor == some 143
+
 -- A whole-modulus batch is replayed and recovers the proper factor 3.
 private def rhoRecoveryTrace : Hex.Nat.Internal.RhoTrace :=
   Hex.Nat.Internal.rhoTrace 9 1 0 32


### PR DESCRIPTION
Closes #9696.

This replaces the per-step gcd loop in the shared rho primitive with 32-difference Brent batches, flushes partial batches at cycle boundaries, and replays a whole-modulus batch one difference at a time. Restart draws reject fixed-point pairs, as well as the globally degenerate `x² - 2` map, while preserving the advanced random state. HexIntFactor caps rho at the shared eight-restart limit so p−1 and ECM remain reachable.

Deterministic internal traces in the owning HexPrimality conformance suite exercise batching, whole-modulus recovery, a proper composite batch gcd, fixed-pair rejection, degenerate-polynomial rejection, and the shared cap. HexIntFactor separately pins high- and low-fuel dispatcher budgets. Both governing SPECs record the exact route, composite-divisor consequence, and cost model.

Two independent fresh Claude Opus passes found no algorithmic blocker and hand-verified the batch schedule, recovery, draws, and budget. All concrete findings were addressed through `fa0692a0e`: corrected route claims and degenerate-polynomial prose, moved guards to their owning library, added public and composite-divisor coverage, converted mutable Brent transitions to fully named state construction, unified the cap, documented the recovery invariant and exact-route counters, updated manual/public docs, aligned fixed-seed guards, and removed an unused deriving instance.

Verification:
- `lake build HexPrimality.Search HexPrimality.Conformance HexIntFactor.Conformance HexPrimalityMathlib HexManual` (full 10,311-job manual graph)
- `lake exe runLinter HexPrimality.Search`
- `lake exe hexintfactor_bench verify` (all 11 targets)
- `lake exe hexintfactor_bench run Hex.IntFactorBench.runRho`
- `lake exe hexintfactor_bench run Hex.IntFactorBench.runRho --signal-floor-multiplier 1.0 --warmup-fraction 0.0`
- `python3 scripts/check_file_line_counts.py --base origin/main`
- `git diff --check`

The rho ladder completed every declared size (about 1.7µs, 1.8ms, and 26ms locally); its scientific verdict remains inconclusive because the three-point seed-specific ladder does not fit the current asymptotic model. That pre-existing Phase-4 benchmark-contract work is owned by #9634; #9696 requires the smoke gate, which passes.

`lake exe runLinter HexIntFactor.Factor` also ran; it reports only the repository's ten pre-existing `docBlame` findings in imported `Ecm`, `Factor`, and `Small` structures, with none on the new declaration.
