### PR TITLE
fix: repair ECM projective arithmetic and word backend

### DIFF
--- a/HexIntFactor/Ecm.lean
+++ b/HexIntFactor/Ecm.lean
@@ -33,7 +33,9 @@ def ecmBackend (n : Nat) : EcmBackend :=
 
 /-- Projective Montgomery `x:z` coordinates. -/
 structure EcmPoint where
+  /-- Projective numerator coordinate. -/
   x : Nat
+  /-- Projective denominator coordinate. -/
   z : Nat
 deriving Repr, DecidableEq
 
@@ -47,66 +49,106 @@ deriving Repr, DecidableEq
 private def addMod (n a b : Nat) : Nat := (a + b) % n
 private def subMod (n a b : Nat) : Nat := (a + n - b % n) % n
 
-/-- One Montgomery multiplication after reducing and encoding both operands. -/
-private def mulModWordOdd (n a b : Nat) (p : UInt64) (hp : p % 2 = 1) : Nat :=
-  let ctx := MontCtx.mk p hp
-  let am := ctx.toMont (UInt64.ofNat (a % n))
-  let bm := ctx.toMont (UInt64.ofNat (b % n))
-  (ctx.fromMont (ctx.mulMont am bm)).toNat
-
-/-- Semantic modular multiplication selected by the explicit arithmetic
-dispatch. The word arm is the lowering point for `MontCtx`; large moduli use
-GMP-backed `Nat` multiplication and remainder. -/
-private def mulMod (backend : EcmBackend) (n a b : Nat) : Nat :=
-  match backend with
-  | .word =>
-      let p := UInt64.ofNat n
-      if _hfit : p.toNat = n then
-        if hodd : p % 2 = 1 then mulModWordOdd n a b p hodd
-        else (a * b) % n
-      else (a * b) % n
-  | .natural => (a * b) % n
-
-private def sqrMod (backend : EcmBackend) (n a : Nat) : Nat :=
-  mulMod backend n a a
+private def mulMod (n a b : Nat) : Nat := (a * b) % n
+private def sqrMod (n a : Nat) : Nat := mulMod n a a
 
 /-- Montgomery doubling with `A24 = numerator / denominator`, kept scaled so
 setup requires no modular inverse. -/
-private def xDouble (backend : EcmBackend) (n a24num a24den : Nat)
-    (p : EcmPoint) : EcmPoint :=
+private def xDouble (n a24num a24den : Nat) (p : EcmPoint) : EcmPoint :=
   let sum := addMod n p.x p.z
   let difference := subMod n p.x p.z
-  let aa := sqrMod backend n sum
-  let bb := sqrMod backend n difference
+  let aa := sqrMod n sum
+  let bb := sqrMod n difference
   let c := subMod n aa bb
-  ⟨mulMod backend n aa bb,
-    mulMod backend n c
-      (addMod n (mulMod backend n bb a24den)
-        (mulMod backend n a24num c))⟩
+  ⟨mulMod n (mulMod n aa bb) a24den,
+    mulMod n c (addMod n (mulMod n bb a24den) (mulMod n a24num c))⟩
 
 /-- Differential Montgomery addition: `difference` represents `p - q`. -/
-private def xAdd (backend : EcmBackend) (n : Nat)
-    (p q difference : EcmPoint) : EcmPoint :=
+private def xAdd (n : Nat) (p q difference : EcmPoint) : EcmPoint :=
   let a := addMod n p.x p.z
   let b := subMod n p.x p.z
   let c := addMod n q.x q.z
   let d := subMod n q.x q.z
-  let da := mulMod backend n d a
-  let cb := mulMod backend n c b
-  ⟨mulMod backend n difference.z (sqrMod backend n (addMod n da cb)),
-    mulMod backend n difference.x (sqrMod backend n (subMod n da cb))⟩
+  let da := mulMod n d a
+  let cb := mulMod n c b
+  ⟨mulMod n difference.z (sqrMod n (addMod n da cb)),
+    mulMod n difference.x (sqrMod n (subMod n da cb))⟩
 
-private def scalarMul (backend : EcmBackend) (n a24num a24den : Nat)
-    (p : EcmPoint) : Nat → EcmPoint
-  | 0 => ⟨1, 0⟩
-  | 1 => p
+private def scalarPair (n a24num a24den : Nat)
+    (p : EcmPoint) : Nat → EcmPoint × EcmPoint
+  | 0 => (⟨1, 0⟩, p)
+  | 1 => (p, xDouble n a24num a24den p)
   | k + 2 =>
       let scalar := k + 2
-      let q := scalarMul backend n a24num a24den p (scalar / 2)
-      let twoq := xDouble backend n a24num a24den q
-      if scalar % 2 = 0 then twoq else xAdd backend n twoq q p
+      let pair := scalarPair n a24num a24den p (scalar / 2)
+      let sum := xAdd n pair.1 pair.2 p
+      if scalar % 2 = 0 then
+        (xDouble n a24num a24den pair.1, sum)
+      else
+        (sum, xDouble n a24num a24den pair.2)
 termination_by scalar => scalar
 decreasing_by omega
+
+private def scalarMul (n a24num a24den : Nat)
+    (p : EcmPoint) (scalar : Nat) : EcmPoint :=
+  if scalar = 0 then ⟨1, 0⟩
+  else (scalarPair n a24num a24den p scalar).1
+
+/-- Projective point whose coordinates stay in Montgomery representation. -/
+private structure EcmWordPoint where
+  x : UInt64
+  z : UInt64
+
+private def addWord (p a b : UInt64) : UInt64 :=
+  let gap := p - b
+  if gap ≤ a then a - gap else a + b
+
+private def subWord (p a b : UInt64) : UInt64 :=
+  if b ≤ a then a - b else p - (b - a)
+
+private def xDoubleWord {p : UInt64} (ctx : MontCtx p)
+    (a24num a24den : UInt64) (point : EcmWordPoint) : EcmWordPoint :=
+  let sum := addWord p point.x point.z
+  let difference := subWord p point.x point.z
+  let aa := ctx.mulMont sum sum
+  let bb := ctx.mulMont difference difference
+  let c := subWord p aa bb
+  ⟨ctx.mulMont (ctx.mulMont aa bb) a24den,
+    ctx.mulMont c (addWord p (ctx.mulMont bb a24den) (ctx.mulMont a24num c))⟩
+
+private def xAddWord {modulus : UInt64} (ctx : MontCtx modulus)
+    (p q difference : EcmWordPoint) : EcmWordPoint :=
+  let a := addWord modulus p.x p.z
+  let b := subWord modulus p.x p.z
+  let c := addWord modulus q.x q.z
+  let d := subWord modulus q.x q.z
+  let da := ctx.mulMont d a
+  let cb := ctx.mulMont c b
+  let sum := addWord modulus da cb
+  let difference' := subWord modulus da cb
+  ⟨ctx.mulMont difference.z (ctx.mulMont sum sum),
+    ctx.mulMont difference.x (ctx.mulMont difference' difference')⟩
+
+private def scalarPairWord {modulus : UInt64} (ctx : MontCtx modulus)
+    (a24num a24den : UInt64) (p : EcmWordPoint) :
+    Nat → EcmWordPoint × EcmWordPoint
+  | 0 => (⟨ctx.toMont 1, 0⟩, p)
+  | 1 => (p, xDoubleWord ctx a24num a24den p)
+  | k + 2 =>
+      let scalar := k + 2
+      let pair := scalarPairWord ctx a24num a24den p (scalar / 2)
+      let sum := xAddWord ctx pair.1 pair.2 p
+      if scalar % 2 = 0 then
+        (xDoubleWord ctx a24num a24den pair.1, sum)
+      else
+        (sum, xDoubleWord ctx a24num a24den pair.2)
+termination_by scalar => scalar
+decreasing_by omega
+
+private def scalarMulWord {modulus : UInt64} (ctx : MontCtx modulus)
+    (a24num a24den : UInt64) (p : EcmWordPoint) (scalar : Nat) : EcmWordPoint :=
+  if scalar = 0 then ⟨ctx.toMont 1, 0⟩
+  else (scalarPairWord ctx a24num a24den p scalar).1
 
 private def largestPower (q bound : Nat) : Nat → Nat → Nat
   | 0, acc => acc
@@ -116,13 +158,23 @@ private def largestPower (q bound : Nat) : Nat → Nat → Nat
 private def smoothPower (q bound : Nat) : Nat :=
   largestPower q bound (bound.log2 + 1) q
 
-private def stageMultiply (backend : EcmBackend) (n bound a24num a24den : Nat) :
+private def stageMultiply (n bound a24num a24den : Nat) :
     List Nat → EcmPoint → EcmPoint
   | [], p => p
   | q :: qs, p =>
       if q ≤ bound then
-        stageMultiply backend n bound a24num a24den qs
-          (scalarMul backend n a24num a24den p (smoothPower q bound))
+        stageMultiply n bound a24num a24den qs
+          (scalarMul n a24num a24den p (smoothPower q bound))
+      else p
+
+private def stageMultiplyWord {modulus : UInt64} (ctx : MontCtx modulus)
+    (bound : Nat) (a24num a24den : UInt64) :
+    List Nat → EcmWordPoint → EcmWordPoint
+  | [], p => p
+  | q :: qs, p =>
+      if q ≤ bound then
+        stageMultiplyWord ctx bound a24num a24den qs
+          (scalarMulWord ctx a24num a24den p (smoothPower q bound))
       else p
 
 private def classifyGcd (n g : Nat) : EcmResult :=
@@ -130,54 +182,95 @@ private def classifyGcd (n g : Nat) : EcmResult :=
   else if 1 < g ∧ g < n ∧ n % g = 0 then .factor g
   else .whole
 
-/-- One Suyama-parameterized Montgomery ECM stage-1 attempt. -/
-def ecmStage1 (n sigma bound : Nat) : EcmResult :=
-  if n < 4 ∨ sigma < 6 then .noFactor
+private def stageGcdNat (n bound curveNum curveDen u3 v3 : Nat) : Nat :=
+  let p := stageMultiply n bound curveNum (4 * curveDen % n)
+    primeTable.toList ⟨u3, v3⟩
+  Nat.gcd p.z n
+
+private def stageGcd (n bound curveNum curveDen u3 v3 : Nat) : Nat :=
+  match ecmBackend n with
+  | .natural => stageGcdNat n bound curveNum curveDen u3 v3
+  | .word =>
+      let modulus := UInt64.ofNat n
+      if _hfit : modulus.toNat = n then
+        if hodd : modulus % 2 = 1 then
+          let ctx := MontCtx.mk modulus hodd
+          let a24num := ctx.toMont (UInt64.ofNat curveNum)
+          let a24den := ctx.toMont (UInt64.ofNat (4 * curveDen % n))
+          let p := stageMultiplyWord ctx bound a24num a24den primeTable.toList
+            ⟨ctx.toMont (UInt64.ofNat u3), ctx.toMont (UInt64.ofNat v3)⟩
+          Nat.gcd (ctx.fromMont p.z).toNat n
+        else
+          stageGcdNat n bound curveNum curveDen u3 v3
+      else
+        stageGcdNat n bound curveNum curveDen u3 v3
+
+namespace Internal
+
+/-- Route-level observations from one ECM attempt. The zero stage gcd means
+the attempt stopped before stage multiplication. -/
+structure EcmTrace where
+  /-- Arithmetic backend selected for the stage. -/
+  backend : EcmBackend
+  /-- Gcd of the Suyama setup denominator and the modulus. -/
+  setupGcd : Nat
+  /-- Stage-boundary gcd, or zero when setup stopped the attempt. -/
+  stageGcd : Nat
+  /-- Public result obtained by classifying the applicable gcd. -/
+  result : EcmResult
+deriving Repr, DecidableEq
+
+/-- Instrumented ECM attempt used by route-level conformance checks. -/
+def ecmTrace (n sigma bound : Nat) : EcmTrace :=
+  let backend := ecmBackend n
+  if n < 4 ∨ sigma < 6 then
+    ⟨backend, 0, 0, .noFactor⟩
   else
-    let backend := ecmBackend n
     let u := (sigma * sigma + n - 5) % n
     let v := (4 * sigma) % n
-    let u3 := mulMod backend n (sqrMod backend n u) u
-    let v3 := mulMod backend n (sqrMod backend n v) v
-    let curveNum := mulMod backend n
-      (mulMod backend n (sqrMod backend n (subMod n v u)) (subMod n v u))
+    let u3 := mulMod n (sqrMod n u) u
+    let v3 := mulMod n (sqrMod n v) v
+    let vu := subMod n v u
+    let curveNum := mulMod n (mulMod n (sqrMod n vu) vu)
       (addMod n (3 * u % n) v)
-    let curveDen := mulMod backend n (4 * u3 % n) v
+    let curveDen := mulMod n (4 * u3 % n) v
     let setup := Nat.gcd curveDen n
-    if setup != 1 then classifyGcd n setup
+    if setup != 1 then
+      ⟨backend, setup, 0, classifyGcd n setup⟩
     else
-      -- `A24 = curveNum / (4 * curveDen)`.
-      let p := stageMultiply backend n bound curveNum (4 * curveDen % n)
-        primeTable.toList ⟨u3, v3⟩
-      classifyGcd n (Nat.gcd p.z n)
+      let stage := stageGcd n bound curveNum curveDen u3 v3
+      ⟨backend, setup, stage, classifyGcd n stage⟩
+
+end Internal
+
+/-- One Suyama-parameterized Montgomery ECM stage-1 attempt. -/
+def ecmStage1 (n sigma bound : Nat) : EcmResult :=
+  (Internal.ecmTrace n sigma bound).result
+
+private theorem classifyGcd_spec {n g d : Nat}
+    (h : classifyGcd n g = .factor d) :
+    1 < d ∧ d < n ∧ d ∣ n := by
+  unfold classifyGcd at h
+  split at h
+  · cases h
+  · split at h
+    · rename_i _ hg
+      injection h with heq
+      subst d
+      exact ⟨hg.1, hg.2.1, Nat.dvd_of_mod_eq_zero hg.2.2⟩
+    · cases h
 
 /-- Every ECM factor result is a dynamically validated proper divisor. -/
 theorem ecmStage1_spec {n sigma bound d : Nat}
     (h : ecmStage1 n sigma bound = .factor d) :
     1 < d ∧ d < n ∧ d ∣ n := by
-  unfold ecmStage1 at h
+  unfold ecmStage1 Internal.ecmTrace at h
   split at h
   · cases h
   · dsimp only at h
     split at h
-    · unfold classifyGcd at h
-      split at h
-      · cases h
-      · split at h
-        · rename_i _ _ hg
-          injection h with heq
-          subst d
-          exact ⟨hg.1, hg.2.1, Nat.dvd_of_mod_eq_zero hg.2.2⟩
-        · cases h
-    · unfold classifyGcd at h
-      split at h
-      · cases h
-      · split at h
-        · rename_i _ _ hg
-          injection h with heq
-          subst d
-          exact ⟨hg.1, hg.2.1, Nat.dvd_of_mod_eq_zero hg.2.2⟩
-        · cases h
+    · exact classifyGcd_spec h
+    · exact classifyGcd_spec h
 
 end Nat
 end Hex

--- a/HexIntFactor/Ecm.lean
+++ b/HexIntFactor/Ecm.lean
@@ -99,22 +99,25 @@ private structure EcmWordPoint where
   x : UInt64
   z : UInt64
 
-private def addWord (p a b : UInt64) : UInt64 :=
-  let gap := p - b
+/-- Add residues known to be reduced modulo `modulus`, without word overflow. -/
+private def addWord (modulus a b : UInt64) : UInt64 :=
+  let gap := modulus - b
   if gap ≤ a then a - gap else a + b
 
-private def subWord (p a b : UInt64) : UInt64 :=
-  if b ≤ a then a - b else p - (b - a)
+/-- Subtract residues known to be reduced modulo `modulus`, without word overflow. -/
+private def subWord (modulus a b : UInt64) : UInt64 :=
+  if b ≤ a then a - b else modulus - (b - a)
 
-private def xDoubleWord {p : UInt64} (ctx : MontCtx p)
+private def xDoubleWord {modulus : UInt64} (ctx : MontCtx modulus)
     (a24num a24den : UInt64) (point : EcmWordPoint) : EcmWordPoint :=
-  let sum := addWord p point.x point.z
-  let difference := subWord p point.x point.z
+  let sum := addWord modulus point.x point.z
+  let difference := subWord modulus point.x point.z
   let aa := ctx.mulMont sum sum
   let bb := ctx.mulMont difference difference
-  let c := subWord p aa bb
+  let c := subWord modulus aa bb
   ⟨ctx.mulMont (ctx.mulMont aa bb) a24den,
-    ctx.mulMont c (addWord p (ctx.mulMont bb a24den) (ctx.mulMont a24num c))⟩
+    ctx.mulMont c
+      (addWord modulus (ctx.mulMont bb a24den) (ctx.mulMont a24num c))⟩
 
 private def xAddWord {modulus : UInt64} (ctx : MontCtx modulus)
     (p q difference : EcmWordPoint) : EcmWordPoint :=
@@ -187,9 +190,10 @@ private def stageGcdNat (n bound curveNum curveDen u3 v3 : Nat) : Nat :=
     primeTable.toList ⟨u3, v3⟩
   Nat.gcd p.z n
 
-private def stageGcd (n bound curveNum curveDen u3 v3 : Nat) : Nat :=
-  match ecmBackend n with
-  | .natural => stageGcdNat n bound curveNum curveDen u3 v3
+private def stageGcdWith (backend : EcmBackend)
+    (n bound curveNum curveDen u3 v3 : Nat) : Nat × EcmBackend :=
+  match backend with
+  | .natural => (stageGcdNat n bound curveNum curveDen u3 v3, .natural)
   | .word =>
       let modulus := UInt64.ofNat n
       if _hfit : modulus.toNat = n then
@@ -199,20 +203,20 @@ private def stageGcd (n bound curveNum curveDen u3 v3 : Nat) : Nat :=
           let a24den := ctx.toMont (UInt64.ofNat (4 * curveDen % n))
           let p := stageMultiplyWord ctx bound a24num a24den primeTable.toList
             ⟨ctx.toMont (UInt64.ofNat u3), ctx.toMont (UInt64.ofNat v3)⟩
-          Nat.gcd (ctx.fromMont p.z).toNat n
+          (Nat.gcd (ctx.fromMont p.z).toNat n, .word)
         else
-          stageGcdNat n bound curveNum curveDen u3 v3
+          (stageGcdNat n bound curveNum curveDen u3 v3, .natural)
       else
-        stageGcdNat n bound curveNum curveDen u3 v3
+        (stageGcdNat n bound curveNum curveDen u3 v3, .natural)
 
 namespace Internal
 
 /-- Route-level observations from one ECM attempt. The zero stage gcd means
 the attempt stopped before stage multiplication. -/
 structure EcmTrace where
-  /-- Arithmetic backend selected for the stage. -/
-  backend : EcmBackend
-  /-- Gcd of the Suyama setup denominator and the modulus. -/
+  /-- Arithmetic backend that actually executed the stage, or none before it. -/
+  stageBackend : Option EcmBackend
+  /-- Setup gcd, or zero when argument validation stopped the attempt. -/
   setupGcd : Nat
   /-- Stage-boundary gcd, or zero when setup stopped the attempt. -/
   stageGcd : Nat
@@ -220,11 +224,11 @@ structure EcmTrace where
   result : EcmResult
 deriving Repr, DecidableEq
 
-/-- Instrumented ECM attempt used by route-level conformance checks. -/
-def ecmTrace (n sigma bound : Nat) : EcmTrace :=
-  let backend := ecmBackend n
+/-- Instrumented ECM attempt using an explicit requested stage backend. The
+trace records the backend that actually ran, including a safe natural fallback. -/
+def ecmTraceWith (backend : EcmBackend) (n sigma bound : Nat) : EcmTrace :=
   if n < 4 ∨ sigma < 6 then
-    ⟨backend, 0, 0, .noFactor⟩
+    ⟨none, 0, 0, .noFactor⟩
   else
     let u := (sigma * sigma + n - 5) % n
     let v := (4 * sigma) % n
@@ -236,10 +240,14 @@ def ecmTrace (n sigma bound : Nat) : EcmTrace :=
     let curveDen := mulMod n (4 * u3 % n) v
     let setup := Nat.gcd curveDen n
     if setup != 1 then
-      ⟨backend, setup, 0, classifyGcd n setup⟩
+      ⟨none, setup, 0, classifyGcd n setup⟩
     else
-      let stage := stageGcd n bound curveNum curveDen u3 v3
-      ⟨backend, setup, stage, classifyGcd n stage⟩
+      let stage := stageGcdWith backend n bound curveNum curveDen u3 v3
+      ⟨some stage.2, setup, stage.1, classifyGcd n stage.1⟩
+
+/-- Instrumented ECM attempt using the production backend selection. -/
+def ecmTrace (n sigma bound : Nat) : EcmTrace :=
+  ecmTraceWith (ecmBackend n) n sigma bound
 
 end Internal
 
@@ -264,7 +272,7 @@ private theorem classifyGcd_spec {n g d : Nat}
 theorem ecmStage1_spec {n sigma bound d : Nat}
     (h : ecmStage1 n sigma bound = .factor d) :
     1 < d ∧ d < n ∧ d ∣ n := by
-  unfold ecmStage1 Internal.ecmTrace at h
+  unfold ecmStage1 Internal.ecmTrace Internal.ecmTraceWith at h
   split at h
   · cases h
   · dsimp only at h

--- a/HexIntFactor/SPEC/hex-int-factor.md
+++ b/HexIntFactor/SPEC/hex-int-factor.md
@@ -414,6 +414,23 @@ Suyama setup does need one inversion or gcd. And the primitive required
 is `Nat.gcd`, not Bézout coefficients, so the relevant hex-arith export
 is the gcd rather than `HexArith.Int.extGcd`.
 
+The stage keeps `A24 = a24num / a24den` scaled throughout. If
+`AA = (X + Z)²`, `BB = (X - Z)²`, and `C = AA - BB`, doubling is
+
+```
+X₂ = AA * BB * a24den
+Z₂ = C * (BB * a24den + a24num * C)
+```
+
+modulo the input. The denominator multiplies both projective coordinates;
+omitting it from `X₂` changes the represented point. Scalar multiplication
+maintains the adjacent pair `(mP, (m+1)P)`. For an even scalar it returns
+`(2mP, (2m+1)P)`, and for an odd scalar it returns
+`((2m+1)P, (2m+2)P)`, using differential addition with the original `P`.
+This is the invariant required by `xADD`; independently recursing to `mP`
+and passing `P` as the difference between `2mP` and `mP` is valid only when
+`m = 1`.
+
 Lenstra's analysis, https://annals.math.princeton.edu/1987/126-3/p09,
 is the source for the dependence on the smallest prime factor.
 
@@ -427,7 +444,12 @@ existing Montgomery context is `UInt64`-only and is not claimed to be an
 arbitrary-precision backend. The ECM benchmark family must show that the
 direct-`Nat` route is useful before this milestone is complete; a future
 stage 2 or a failed benchmark is the point at which to specify a separate
-big-integer modular context.
+big-integer modular context. On the word route, one context is constructed
+after setup, the curve constants and initial point enter Montgomery
+representation once, every stage multiplication stays there, and only the
+final `z` coordinate is decoded for the boundary gcd. Context construction
+or representation conversion inside the scalar-multiplication loop is not
+the word backend specified here.
 
 ### 4. Fuel, and what failure means
 
@@ -1028,7 +1050,8 @@ non-functional. The suite therefore needs route-level tests in Lean:
 that the perfect-power detector fired on a perfect power, that `p − 1`
 distinguished proper-factor, `1`, and whole-modulus outcomes, that rho
 found the factor within the expected iteration count for a fixed seed,
-that ECM stage 1 distinguished its three gcd outcomes, and that
+that ECM stage 1 distinguished its three gcd outcomes after a setup gcd of
+one (including stage-found proper-factor and whole-modulus cases), and that
 `cyclotomicSplit?` ran before the generic dispatch on a `b^n − 1`
 input. This is the same division
 [hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) makes, and it is worth more than the oracle

--- a/conformance/HexIntFactor/Conformance.lean
+++ b/conformance/HexIntFactor/Conformance.lean
@@ -224,7 +224,7 @@ example {n base bound d : Nat}
 private def ecmStageFactorTrace : Hex.Nat.Internal.EcmTrace :=
   Hex.Nat.Internal.ecmTrace 51 13 5
 
-#guard ecmStageFactorTrace.backend == .word
+#guard ecmStageFactorTrace.stageBackend == some .word
 #guard ecmStageFactorTrace.setupGcd == 1
 #guard ecmStageFactorTrace.stageGcd == 3
 #guard ecmStageFactorTrace.result == .factor 3
@@ -232,7 +232,7 @@ private def ecmStageFactorTrace : Hex.Nat.Internal.EcmTrace :=
 private def ecmStageWholeTrace : Hex.Nat.Internal.EcmTrace :=
   Hex.Nat.Internal.ecmTrace 33 8 5
 
-#guard ecmStageWholeTrace.backend == .word
+#guard ecmStageWholeTrace.stageBackend == some .word
 #guard ecmStageWholeTrace.setupGcd == 1
 #guard ecmStageWholeTrace.stageGcd == 33
 #guard ecmStageWholeTrace.result == .whole
@@ -241,17 +241,41 @@ private def ecmStageNoFactorTrace : Hex.Nat.Internal.EcmTrace :=
   Hex.Nat.Internal.ecmTrace 289 13 5
 
 #guard ecmStageNoFactorTrace.setupGcd == 1
+#guard ecmStageNoFactorTrace.stageBackend == some .word
 #guard ecmStageNoFactorTrace.stageGcd == 1
 #guard ecmStageNoFactorTrace.result == .noFactor
 
--- The direct-`Nat` backend also reaches stage multiplication beyond one word.
-private def ecmNaturalTrace : Hex.Nat.Internal.EcmTrace :=
-  Hex.Nat.Internal.ecmTrace (2 ^ 64 + 1) 6 2
+-- Explicitly running the duplicate direct-`Nat` arithmetic on the same inputs
+-- must agree with the word implementation at both observable boundaries.
+private def ecmStageFactorNatTrace : Hex.Nat.Internal.EcmTrace :=
+  Hex.Nat.Internal.ecmTraceWith .natural 51 13 5
 
-#guard ecmNaturalTrace.backend == .natural
+#guard ecmStageFactorNatTrace.setupGcd == ecmStageFactorTrace.setupGcd
+#guard ecmStageFactorNatTrace.stageGcd == ecmStageFactorTrace.stageGcd
+#guard ecmStageFactorNatTrace.result == ecmStageFactorTrace.result
+#guard ecmStageFactorNatTrace.stageBackend == some .natural
+
+private def ecmStageWholeNatTrace : Hex.Nat.Internal.EcmTrace :=
+  Hex.Nat.Internal.ecmTraceWith .natural 33 8 5
+
+#guard ecmStageWholeNatTrace.stageGcd == ecmStageWholeTrace.stageGcd
+#guard ecmStageWholeNatTrace.result == ecmStageWholeTrace.result
+
+private def ecmStageNoFactorNatTrace : Hex.Nat.Internal.EcmTrace :=
+  Hex.Nat.Internal.ecmTraceWith .natural 289 13 5
+
+#guard ecmStageNoFactorNatTrace.stageGcd == ecmStageNoFactorTrace.stageGcd
+#guard ecmStageNoFactorNatTrace.result == ecmStageNoFactorTrace.result
+
+-- The production direct-`Nat` backend also executes a discriminating odd-
+-- scalar stage beyond one word. The old formulas yielded stage gcd `51`.
+private def ecmNaturalTrace : Hex.Nat.Internal.EcmTrace :=
+  Hex.Nat.Internal.ecmTrace (51 * (2 ^ 64 + 1)) 13 5
+
+#guard ecmNaturalTrace.stageBackend == some .natural
 #guard ecmNaturalTrace.setupGcd == 1
-#guard ecmNaturalTrace.stageGcd == 1
-#guard ecmNaturalTrace.result == .noFactor
+#guard ecmNaturalTrace.stageGcd == 3
+#guard ecmNaturalTrace.result == .factor 3
 
 #guard (match rhoSplit? 91 (Rand.ofSeed 1) 16 with
   | .ok (d, _) => decide (1 < d) && decide (d < 91) && 91 % d == 0

--- a/conformance/HexIntFactor/Conformance.lean
+++ b/conformance/HexIntFactor/Conformance.lean
@@ -277,6 +277,11 @@ private def ecmNaturalTrace : Hex.Nat.Internal.EcmTrace :=
 #guard ecmNaturalTrace.stageGcd == 3
 #guard ecmNaturalTrace.result == .factor 3
 
+-- An explicitly requested word route reports the natural backend when the
+-- modulus does not fit, rather than claiming that Montgomery arithmetic ran.
+#guard (Hex.Nat.Internal.ecmTraceWith .word
+  (51 * (2 ^ 64 + 1)) 13 5).stageBackend == some .natural
+
 #guard (match rhoSplit? 91 (Rand.ofSeed 1) 16 with
   | .ok (d, _) => decide (1 < d) && decide (d < 91) && 91 % d == 0
   | .error _ => false)

--- a/conformance/HexIntFactor/Conformance.lean
+++ b/conformance/HexIntFactor/Conformance.lean
@@ -217,6 +217,42 @@ example {n base bound d : Nat}
 #guard ecmStage1 6 7 2 == .factor 2
 #guard ecmStage1 4 6 2 == .whole
 
+-- These attempts all pass Suyama setup and execute the smooth scalar stage.
+-- The factor and whole cases distinguish the invariant-preserving adjacent-
+-- multiple ladder and correctly homogenized doubling formulas from the former
+-- recurrence; their old outcomes were respectively `whole` and `factor 3`.
+private def ecmStageFactorTrace : Hex.Nat.Internal.EcmTrace :=
+  Hex.Nat.Internal.ecmTrace 51 13 5
+
+#guard ecmStageFactorTrace.backend == .word
+#guard ecmStageFactorTrace.setupGcd == 1
+#guard ecmStageFactorTrace.stageGcd == 3
+#guard ecmStageFactorTrace.result == .factor 3
+
+private def ecmStageWholeTrace : Hex.Nat.Internal.EcmTrace :=
+  Hex.Nat.Internal.ecmTrace 33 8 5
+
+#guard ecmStageWholeTrace.backend == .word
+#guard ecmStageWholeTrace.setupGcd == 1
+#guard ecmStageWholeTrace.stageGcd == 33
+#guard ecmStageWholeTrace.result == .whole
+
+private def ecmStageNoFactorTrace : Hex.Nat.Internal.EcmTrace :=
+  Hex.Nat.Internal.ecmTrace 289 13 5
+
+#guard ecmStageNoFactorTrace.setupGcd == 1
+#guard ecmStageNoFactorTrace.stageGcd == 1
+#guard ecmStageNoFactorTrace.result == .noFactor
+
+-- The direct-`Nat` backend also reaches stage multiplication beyond one word.
+private def ecmNaturalTrace : Hex.Nat.Internal.EcmTrace :=
+  Hex.Nat.Internal.ecmTrace (2 ^ 64 + 1) 6 2
+
+#guard ecmNaturalTrace.backend == .natural
+#guard ecmNaturalTrace.setupGcd == 1
+#guard ecmNaturalTrace.stageGcd == 1
+#guard ecmNaturalTrace.result == .noFactor
+
 #guard (match rhoSplit? 91 (Rand.ofSeed 1) 16 with
   | .ok (d, _) => decide (1 < d) && decide (d < 91) && 91 % d == 0
   | .error _ => false)


### PR DESCRIPTION
Closes #9697

## Summary

- correct scaled Montgomery doubling and replace the invalid odd-scalar recurrence with an adjacent-pair ladder
- retain one `MontCtx` and Montgomery representation across the entire word-sized stage
- expose exact setup/stage gcd instrumentation and add route guards that distinguish the old defective arithmetic
- document the formulas, ladder invariant, and backend boundary in the SPEC

## Verification

- `lake build HexIntFactor HexIntFactor.Conformance`
- `lake exe runLinter HexIntFactor.Ecm`
- `lake exe hexintfactor_bench verify`
- `python3 scripts/check_file_line_counts.py`
- `python3 scripts/check_dag.py`
- banned-token scan over `HexIntFactor` and its conformance module
- `git diff --check`