### PR TITLE
fix: give smooth routes honest retry semantics

### DIFF
--- a/HexIntFactor/Ecm.lean
+++ b/HexIntFactor/Ecm.lean
@@ -224,9 +224,8 @@ structure EcmTrace where
   result : EcmResult
 deriving Repr, DecidableEq
 
-/-- Instrumented ECM attempt using an explicit requested stage backend. The
-trace records the backend that actually ran, including a safe natural fallback. -/
-def ecmTraceWith (backend : EcmBackend) (n sigma bound : Nat) : EcmTrace :=
+private def ecmTraceCoreWith (backend : EcmBackend)
+    (n sigma bound : Nat) : EcmTrace :=
   if n < 4 ∨ sigma < 6 then
     ⟨none, 0, 0, .noFactor⟩
   else
@@ -245,15 +244,27 @@ def ecmTraceWith (backend : EcmBackend) (n sigma bound : Nat) : EcmTrace :=
       let stage := stageGcdWith backend n bound curveNum curveDen u3 v3
       ⟨some stage.2, setup, stage.1, classifyGcd n stage.1⟩
 
+/-- Instrumented ECM attempt using an explicit requested stage backend. The
+trace records the backend that actually ran, including a safe natural fallback.
+The effective smoothness bound is always `smoothBound bound`. -/
+def ecmTraceWith (backend : EcmBackend) (n sigma bound : Nat) : EcmTrace :=
+  ecmTraceCoreWith backend n sigma (smoothBound bound)
+
 /-- Instrumented ECM attempt using the production backend selection. -/
 def ecmTrace (n sigma bound : Nat) : EcmTrace :=
   ecmTraceWith (ecmBackend n) n sigma bound
 
 end Internal
 
-/-- One Suyama-parameterized Montgomery ECM stage-1 attempt. -/
+/-- One Suyama-parameterized Montgomery ECM stage-1 attempt. Requests beyond
+`smoothBoundCap` are exactly capped to the complete prime-table range. -/
 def ecmStage1 (n sigma bound : Nat) : EcmResult :=
   (Internal.ecmTrace n sigma bound).result
+
+/-- Requests beyond the complete prime-table range are exactly capped. -/
+theorem ecmStage1_bound (n sigma bound : Nat) :
+    ecmStage1 n sigma bound = ecmStage1 n sigma (smoothBound bound) := by
+  simp [ecmStage1, Internal.ecmTrace, Internal.ecmTraceWith]
 
 private theorem classifyGcd_spec {n g d : Nat}
     (h : classifyGcd n g = .factor d) :
@@ -272,7 +283,8 @@ private theorem classifyGcd_spec {n g d : Nat}
 theorem ecmStage1_spec {n sigma bound d : Nat}
     (h : ecmStage1 n sigma bound = .factor d) :
     1 < d ∧ d < n ∧ d ∣ n := by
-  unfold ecmStage1 Internal.ecmTrace Internal.ecmTraceWith at h
+  unfold ecmStage1 Internal.ecmTrace Internal.ecmTraceWith
+    Internal.ecmTraceCoreWith at h
   split at h
   · cases h
   · dsimp only at h

--- a/HexIntFactor/Factor.lean
+++ b/HexIntFactor/Factor.lean
@@ -29,14 +29,18 @@ deriving Repr, DecidableEq
 
 /-- Checked partial data retained when complete search stops. -/
 structure PartialSnapshot where
+  /-- The retained partial factorization candidate. -/
   raw : PartialFactorization
   valid : checkPartial raw = true
 deriving Repr
 
 /-- Resumable factorization failure. -/
 structure FactorFailure where
+  /-- Semantic reason the complete or partial search stopped. -/
   stop : FactorStop
+  /-- Search attempts accumulated before stopping. -/
   attempts : Nat
+  /-- Generator state after every randomized attempt that actually ran. -/
   rand : Rand
   /-- Last checked partial aggregate, when the stopped route has one. -/
   snapshot : Option PartialSnapshot := none
@@ -75,6 +79,95 @@ keeps Pollard p−1 and ECM reachable after rho exhaustion, while the fuel side
 prevents a nearly exhausted search from manufacturing extra attempts. -/
 def rhoRestartBudget (fuel : Nat) : Nat :=
   min Hex.Nat.Internal.rhoRestartCap fuel
+
+/-- Maximum combined number of Pollard `p - 1` and ECM attempts at one
+dispatcher entry. The caller's fuel may lower this further. -/
+def smoothAttemptCap : Nat := 8
+
+/-- One observable attempt made by the smooth-factor routes. -/
+inductive SmoothEvent where
+  | pMinusOne (base bound : Nat) (result : PMinusOneResult)
+  | ecm (sigma bound : Nat) (result : EcmResult)
+deriving Repr, DecidableEq
+
+/-- Result and exact attempt trace of the smooth-factor dispatcher. -/
+structure SmoothSearch where
+  /-- Dynamically validated factor returned by one route, when found. -/
+  factor : Option Nat
+  /-- Generator state after every attempted randomized curve. -/
+  rand : Rand
+  /-- Attempts in execution order; its length is the dispatcher's charge. -/
+  events : List SmoothEvent
+deriving Repr, DecidableEq
+
+private structure SmoothPhase where
+  factor : Option Nat
+  events : List SmoothEvent
+
+private def pMinusOneAttemptCap : Nat := 4
+private def smoothInitialBound : Nat := 64
+private def smoothBases : List Nat := [2, 3, 5, 7]
+private def ecmSigmaRange : Nat := 256
+
+private def raiseSmoothBound (bound : Nat) : Nat :=
+  smoothBound (8 * bound)
+
+private def lowerSmoothBound (bound : Nat) : Nat :=
+  max 2 (bound / 8)
+
+private def pMinusOneGo (n : Nat) : Nat → Nat → Nat → SmoothPhase
+  | 0, _, _ => ⟨none, []⟩
+  | fuel + 1, baseIndex, bound =>
+      match smoothBases[baseIndex]? with
+      | none => ⟨none, []⟩
+      | some base =>
+          let result := pMinusOneFactor n base bound
+          let event := SmoothEvent.pMinusOne base bound result
+          match result with
+          | .factor d => ⟨some d, [event]⟩
+          | .noFactor =>
+              let nextBound := raiseSmoothBound bound
+              if nextBound = bound then ⟨none, [event]⟩
+              else
+                let rest := pMinusOneGo n fuel baseIndex nextBound
+                ⟨rest.factor, event :: rest.events⟩
+          | .whole =>
+              let rest := pMinusOneGo n fuel (baseIndex + 1)
+                (lowerSmoothBound bound)
+              ⟨rest.factor, event :: rest.events⟩
+
+private def ecmGo (n : Nat) : Nat → Nat → Rand → SmoothSearch
+  | 0, _, r => ⟨none, r, []⟩
+  | fuel + 1, bound, r =>
+      let draw := r.next
+      let sigma := 6 + draw.1.toNat % ecmSigmaRange
+      let result := ecmStage1 n sigma bound
+      let event := SmoothEvent.ecm sigma bound result
+      match result with
+      | .factor d => ⟨some d, draw.2, [event]⟩
+      | .noFactor =>
+          let nextBound := raiseSmoothBound bound
+          if nextBound = bound then ⟨none, draw.2, [event]⟩
+          else
+            let rest := ecmGo n fuel nextBound draw.2
+            ⟨rest.factor, rest.rand, event :: rest.events⟩
+      | .whole =>
+          let rest := ecmGo n fuel bound draw.2
+          ⟨rest.factor, rest.rand, event :: rest.events⟩
+
+/-- Run the production p−1 base/bound ladder followed by randomized ECM
+curves. Gcd one raises the next bound. Whole modulus changes the p−1 base and
+lowers its bound, or changes the ECM curve at the retained bound. Total
+attempts are bounded by both `fuel` and `smoothAttemptCap`. -/
+def smoothSearch (n : Nat) (r : Rand) (fuel : Nat) : SmoothSearch :=
+  let budget := min smoothAttemptCap fuel
+  let p1 := pMinusOneGo n (min pMinusOneAttemptCap budget) 0
+    smoothInitialBound
+  match p1.factor with
+  | some d => ⟨some d, r, p1.events⟩
+  | none =>
+      let ecm := ecmGo n (budget - p1.events.length) smoothInitialBound r
+      ⟨ecm.factor, ecm.rand, p1.events ++ ecm.events⟩
 
 end Internal
 
@@ -125,26 +218,20 @@ private def searchGo : Nat → List (Nat × Nat) → List PrimePower → Nat →
                     factors residual r' (attempts + primeFailure.attempts + 1)
                     powerRoutes
               | .error rhoFailure =>
-                  match pMinusOneFactor m 2 (min primeTableBound (64 * (fuel + 1))) with
-                  | .factor d =>
+                  let smooth := Internal.smoothSearch m rhoFailure.rand (fuel + 1)
+                  match smooth.factor with
+                  | some d =>
                       searchGo fuel ((d, multiplier) :: (m / d, multiplier) :: stack)
-                        factors residual rhoFailure.rand
-                        (attempts + primeFailure.attempts + rhoFailure.attempts + 1)
+                        factors residual smooth.rand
+                        (attempts + primeFailure.attempts + rhoFailure.attempts +
+                          smooth.events.length)
                         powerRoutes
-                  | .noFactor | .whole =>
-                      match ecmStage1 m (6 + attempts % 64)
-                          (min primeTableBound (64 * (fuel + 1))) with
-                      | .factor d =>
-                          searchGo fuel
-                            ((d, multiplier) :: (m / d, multiplier) :: stack)
-                            factors residual rhoFailure.rand
-                            (attempts + primeFailure.attempts + rhoFailure.attempts + 1)
-                            powerRoutes
-                      | .noFactor | .whole =>
-                          searchGo fuel stack factors (residual * m ^ multiplier)
-                            rhoFailure.rand
-                            (attempts + primeFailure.attempts + rhoFailure.attempts + 1)
-                            powerRoutes
+                  | none =>
+                      searchGo fuel stack factors (residual * m ^ multiplier)
+                        smooth.rand
+                        (attempts + primeFailure.attempts + rhoFailure.attempts +
+                          smooth.events.length)
+                        powerRoutes
 
 private def smallAttempt (n : Nat) (r : Rand) (fuel : Nat) :
     FactorAttempt n :=

--- a/HexIntFactor/SPEC/hex-int-factor.md
+++ b/HexIntFactor/SPEC/hex-int-factor.md
@@ -371,6 +371,15 @@ the implementation must distinguish: `g = 1` (increase `B`, retry, or
 fall through), `1 < g < n` (a factor), `g = n` (the exponent killed
 every component; retry with a different base or a smaller `B`).
 
+The public bound is explicit rather than aspirational. `smoothBoundCap` is
+the conservative cap `primeTableBound - 1`, inside the range where the
+committed table is certified to contain every prime at or below the bound, and
+`smoothBound B = min B smoothBoundCap`. Both the selected primes and their
+prime-power exponents use that same effective bound. In particular a request
+above the cap is not the former hybrid that omitted large primes while still
+raising table primes to powers derived from the larger request. The theorem
+`pMinusOneStage1_bound` states exact equality with the capped call.
+
 The success condition is about the **order of `a` modulo `p`**, not
 about `p − 1`: stage 1 finds `p` when `ord_p(a) ∣ M`. That is implied
 by `p − 1` being `B`-smooth and is strictly weaker than it, so an
@@ -393,6 +402,14 @@ same is true of the moduli in the Cunningham tables generally. So it
 runs before ECM and after rho, and the benchmark family "`b^n ± 1`"
 below is the one that justifies its place.
 
+At one unresolved dispatcher entry, p−1 receives at most four attempts from
+the combined smooth-route budget. It starts with base `2` and bound `64`.
+A no-factor result multiplies the bound by eight up to `smoothBoundCap`, then
+falls through if the cap made no change. A whole-modulus result lowers the
+bound by a factor of eight (not below `2`) and advances through bases
+`[2, 3, 5, 7]`. A proper factor stops the ladder immediately. These are
+attempts, not hidden retries inside one nominal route call.
+
 ### 3. The elliptic curve method
 
 For factors past rho's reach. Montgomery curves in **projective `x:z`
@@ -413,6 +430,16 @@ distinguish exactly as in `p − 1`: `gcd = 1` is no information,
 Suyama setup does need one inversion or gcd. And the primitive required
 is `Nat.gcd`, not Bézout coefficients, so the relevant hex-arith export
 is the gcd rather than `HexArith.Int.extGcd`.
+
+ECM uses the same `smoothBound` contract, recorded by
+`ecmStage1_bound`. After the p−1 ladder, every remaining attempt in the
+combined budget draws a fresh Suyama parameter
+`sigma = 6 + word % 256` and advances `Rand` exactly once. It starts at
+bound `64`; gcd one raises the next bound eightfold, while whole modulus
+changes curve at the retained bound. A no-factor result at the cap falls
+through. Thus the production route is genuinely multi-curve
+and deterministic replay from a fixed state includes both the parameters and
+the final state.
 
 The stage keeps `A24 = a24num / a24den` scaled throughout. If
 `AA = (X + Z)²`, `BB = (X - Z)²`, and `C = AA - BB`, doubling is
@@ -459,6 +486,14 @@ reachable -- deliberately so. Per design principle 8 that is the third
 remedy, propagating the failure upward, and it is the right one here:
 there is no fallback that is correct-but-slow, because trial division
 past `10^{18}` is not slow, it is unavailable.
+
+The p−1 and ECM ladders share `min fuel 8` attempts at each unresolved
+cofactor, with at most four assigned to p−1 and the unused remainder assigned
+to ECM. Their execution-order event list is the accounting source: its length
+is added on factor success and exhaustion alike, and its final `Rand` is
+threaded into every continuation. Checker rejection retains the attempt total
+already accumulated by the producing search; it does not replay a curve or
+replace the advanced state.
 
 `FactorStop.rejected` is deliberately separate: it means a final aggregate
 failed its certificate checker. At the generic partial-acceptance boundary it
@@ -1051,7 +1086,9 @@ that the perfect-power detector fired on a perfect power, that `p − 1`
 distinguished proper-factor, `1`, and whole-modulus outcomes, that rho
 found the factor within the expected iteration count for a fixed seed,
 that ECM stage 1 distinguished its three gcd outcomes after a setup gcd of
-one (including stage-found proper-factor and whole-modulus cases), and that
+one (including stage-found proper-factor and whole-modulus cases), that a
+fixed-seed smooth-route schedule exercised the p−1 and ECM no-factor/whole
+retry branches with exact event accounting and advanced random state, and that
 `cyclotomicSplit?` ran before the generic dispatch on a `b^n − 1`
 input. This is the same division
 [hex-mv-gcd](../../HexMvGcd/SPEC/hex-mv-gcd.md) makes, and it is worth more than the oracle

--- a/HexPrimality/PMinusOne.lean
+++ b/HexPrimality/PMinusOne.lean
@@ -26,6 +26,18 @@ inductive PMinusOneResult where
   | whole
 deriving Repr, DecidableEq
 
+/-- Conservative smoothness cap inside the range where prime-table
+completeness follows directly from `q < primeTableBound`. -/
+def smoothBoundCap : Nat := primeTableBound - 1
+
+/-- Clamp a requested stage-1 bound to the complete committed-table range. -/
+def smoothBound (bound : Nat) : Nat := min bound smoothBoundCap
+
+@[simp]
+theorem smoothBound_idem (bound : Nat) :
+    smoothBound (smoothBound bound) = smoothBound bound := by
+  simp [smoothBound, Nat.min_assoc]
+
 private def largestPower (q bound : Nat) : Nat → Nat → Nat
   | 0, acc => acc
   | fuel + 1, acc =>
@@ -42,10 +54,7 @@ private def raiseSmooth (n bound : Nat) : List Nat → Nat → Nat
           (HexArith.powModNat x (stageExponent q bound) n)
       else x
 
-/-- One deterministic Pollard `p - 1` stage-1 attempt.  Invalid bases or
-moduli return `noFactor`; a gcd equal to the modulus is reported separately
-as `whole`. -/
-def pMinusOneStage1 (n base bound : Nat) : PMinusOneResult :=
+private def pMinusOneStage1Core (n base bound : Nat) : PMinusOneResult :=
   if n < 4 ∨ base ≤ 1 ∨ n ≤ base then .noFactor
   else
     let initial := Nat.gcd base n
@@ -58,11 +67,24 @@ def pMinusOneStage1 (n base bound : Nat) : PMinusOneResult :=
       else if 1 < g ∧ g < n ∧ n % g = 0 then .factor g
       else .whole
 
+/-- One deterministic Pollard `p - 1` stage-1 attempt. Invalid bases or
+moduli return `noFactor`; a gcd equal to the modulus is reported separately
+as `whole`. The effective smoothness bound is `smoothBound bound`, never an
+incomplete extension beyond the committed prime table. -/
+def pMinusOneStage1 (n base bound : Nat) : PMinusOneResult :=
+  pMinusOneStage1Core n base (smoothBound bound)
+
+/-- Requests beyond the complete prime-table range are exactly capped. -/
+theorem pMinusOneStage1_bound (n base bound : Nat) :
+    pMinusOneStage1 n base bound =
+      pMinusOneStage1 n base (smoothBound bound) := by
+  simp [pMinusOneStage1]
+
 /-- Every reported factor is a dynamically checked proper divisor. -/
 theorem pMinusOneStage1_spec {n base bound d : Nat}
     (h : pMinusOneStage1 n base bound = .factor d) :
     1 < d ∧ d < n ∧ d ∣ n := by
-  unfold pMinusOneStage1 at h
+  unfold pMinusOneStage1 pMinusOneStage1Core at h
   split at h
   · cases h
   · dsimp only at h

--- a/HexPrimality/SPEC/hex-primality.md
+++ b/HexPrimality/SPEC/hex-primality.md
@@ -593,7 +593,10 @@ without inverting the proof dependency, in three ways:
    Pollard `p − 1` stage 1 joins it beside rho when hex-int-factor
    lands, under the same dynamically validated proper-factor contract
    and resumable-failure shape: both libraries want it, and it widens
-   `partialFactor`'s reach cheaply. ECM stays downstream; curve
+   `partialFactor`'s reach cheaply. Its public smoothness request is capped by
+   `smoothBound B = min B (primeTableBound - 1)`, so the committed table
+   contains every required prime and `pMinusOneStage1_bound` identifies every
+   larger request with that capped call. ECM stays downstream; curve
    arithmetic is a real dependency, not a shared primitive.
 3. **An optional search hook**, deferred until hex-int-factor exists to
    consume it. A `primeCert?With

--- a/conformance/HexIntFactor/Conformance.lean
+++ b/conformance/HexIntFactor/Conformance.lean
@@ -207,6 +207,18 @@ private def iteratedPower : Nat := 10009 ^ 8
 #guard pMinusOneFactor 25 2 2 == .noFactor
 #guard pMinusOneFactor 15 4 2 == .whole
 
+#guard smoothBoundCap == primeTableBound - 1
+#guard smoothBound (primeTableBound + 1000) == smoothBoundCap
+
+example (n base bound : Nat) :
+    pMinusOneStage1 n base bound =
+      pMinusOneStage1 n base (smoothBound bound) :=
+  pMinusOneStage1_bound n base bound
+
+example (n sigma bound : Nat) :
+    ecmStage1 n sigma bound = ecmStage1 n sigma (smoothBound bound) :=
+  ecmStage1_bound n sigma bound
+
 example {n base bound d : Nat}
     (h : pMinusOneFactor n base bound = .factor d) :
     1 < d ∧ d < n ∧ d ∣ n :=
@@ -281,6 +293,80 @@ private def ecmNaturalTrace : Hex.Nat.Internal.EcmTrace :=
 -- modulus does not fit, rather than claiming that Montgomery arithmetic ran.
 #guard (Hex.Nat.Internal.ecmTraceWith .word
   (51 * (2 ^ 64 + 1)) 13 5).stageBackend == some .natural
+
+-- One fixed-seed production schedule covers both retry responses for each
+-- smooth route. Pollard p−1 changes base and lowers the bound on `whole`,
+-- while gcd one raises it. ECM always draws a fresh curve; it raises the bound
+-- after gcd one and retains the bound after whole modulus.
+private def smoothRetryTrace : Hex.Nat.Internal.SmoothSearch :=
+  Hex.Nat.Internal.smoothSearch 11 (Rand.ofSeed 0) 8
+
+#guard smoothRetryTrace.events == [
+  .pMinusOne 2 64 .whole,
+  .pMinusOne 3 8 .whole,
+  .pMinusOne 5 2 .noFactor,
+  .pMinusOne 5 16 .whole,
+  .ecm 181 64 .whole,
+  .ecm 250 64 .whole,
+  .ecm 85 64 .whole,
+  .ecm 242 64 .whole]
+#guard smoothRetryTrace.factor.isNone
+#guard smoothRetryTrace.events.length == Hex.Nat.Internal.smoothAttemptCap
+#guard smoothRetryTrace.rand == ((Rand.ofSeed 0).words 4).2
+#guard smoothRetryTrace ==
+  Hex.Nat.Internal.smoothSearch 11 (Rand.ofSeed 0) 8
+
+-- A successful deterministic p−1 attempt charges one event and consumes no
+-- randomness; an ECM success charges all preceding retries and one draw.
+private def smoothPMinusOneTrace : Hex.Nat.Internal.SmoothSearch :=
+  Hex.Nat.Internal.smoothSearch 243 (Rand.ofSeed 9) 8
+
+#guard smoothPMinusOneTrace.events == [.pMinusOne 2 64 (.factor 81)]
+#guard smoothPMinusOneTrace.factor == some 81
+#guard smoothPMinusOneTrace.rand == Rand.ofSeed 9
+
+private def smoothEcmTrace : Hex.Nat.Internal.SmoothSearch :=
+  Hex.Nat.Internal.smoothSearch 10051 (Rand.ofSeed 0) 8
+
+#guard smoothEcmTrace.events == [
+  .pMinusOne 2 64 .whole,
+  .pMinusOne 3 8 .noFactor,
+  .pMinusOne 3 64 .whole,
+  .pMinusOne 5 8 .noFactor,
+  .ecm 181 64 (.factor 19)]
+#guard smoothEcmTrace.factor == some 19
+#guard smoothEcmTrace.rand == (Rand.ofSeed 0).next.2
+
+private def smoothZeroFuelTrace : Hex.Nat.Internal.SmoothSearch :=
+  Hex.Nat.Internal.smoothSearch 11 (Rand.ofSeed 4) 0
+
+#guard smoothZeroFuelTrace.events.isEmpty
+#guard smoothZeroFuelTrace.factor.isNone
+#guard smoothZeroFuelTrace.rand == Rand.ofSeed 4
+
+-- A smaller budget truncates the deterministic p−1 phase itself. It neither
+-- manufactures ECM attempts nor advances the generator.
+private def smoothThreeFuelTrace : Hex.Nat.Internal.SmoothSearch :=
+  Hex.Nat.Internal.smoothSearch 11 (Rand.ofSeed 4) 3
+
+#guard smoothThreeFuelTrace.events == [
+  .pMinusOne 2 64 .whole,
+  .pMinusOne 3 8 .whole,
+  .pMinusOne 5 2 .noFactor]
+#guard smoothThreeFuelTrace.factor.isNone
+#guard smoothThreeFuelTrace.events.length == 3
+#guard smoothThreeFuelTrace.rand == Rand.ofSeed 4
+
+-- A production-shaped p−1 miss climbs through every scheduled bound and
+-- executes the cap-equality fall-through before ECM receives the remainder.
+private def smoothCapTrace : Hex.Nat.Internal.SmoothSearch :=
+  Hex.Nat.Internal.smoothSearch (20123 * 20183) (Rand.ofSeed 7) 8
+
+#guard smoothCapTrace.events.take 4 == [
+  .pMinusOne 2 64 .noFactor,
+  .pMinusOne 2 512 .noFactor,
+  .pMinusOne 2 4096 .noFactor,
+  .pMinusOne 2 smoothBoundCap .noFactor]
 
 #guard (match rhoSplit? 91 (Rand.ofSeed 1) 16 with
   | .ok (d, _) => decide (1 < d) && decide (d < 91) && 91 % d == 0


### PR DESCRIPTION
Closes #9698

- cap Pollard p−1 and ECM stage-1 bounds to the complete committed prime-table domain
- replace the fixed one-shot dispatcher with a fuel-bounded p−1 base/bound ladder and randomized multi-curve ECM schedule
- distinguish no-factor and whole-modulus retry policies while threading exact event counts and Rand state
- add fixed-seed route guards for both retry branches, success, exhaustion, and short fuel
- document the executable bound and scheduling contracts in both governing SPECs

Verification:
- `lake build HexPrimality HexIntFactor HexIntFactor.Conformance`
- `lake exe hexintfactor_bench verify`
- focused linters and file-line-count check
- banned-token and diff checks