### PR TITLE
fix: meter successful factor-search attempts

### DIFF
--- a/HexIntFactor/Cyclotomic.lean
+++ b/HexIntFactor/Cyclotomic.lean
@@ -26,7 +26,9 @@ deriving Repr, DecidableEq
 
 /-- One candidate cyclotomic value `Φ_index(base)`. -/
 structure CyclotomicPart where
+  /-- Cyclotomic index `d`. -/
   index : Nat
+  /-- Candidate value `Φ_d(b)` at the requested base. -/
   value : Nat
 deriving Repr, DecidableEq
 
@@ -113,7 +115,8 @@ deriving Repr, DecidableEq
 namespace Internal
 
 /-- Retry a power target only after ordinary subproblem exhaustion. An
-invariant rejection is propagated with its original diagnostic scope. -/
+invariant rejection is propagated with its original diagnostic scope; a
+failed retry adds the earlier and fallback attempt subtotals. -/
 def retryPower? (target : Nat) (failure : FactorFailure) (fuel : Nat) :
     Except FactorFailure (CheckedFactorization target × Rand × PowerRoute) :=
   match failure.stop with
@@ -121,7 +124,10 @@ def retryPower? (target : Nat) (failure : FactorFailure) (fuel : Nat) :
   | .zero | .incomplete =>
       match factor? target failure.rand fuel with
       | .ok (F, r') => .ok (F, r', .generic)
-      | .error fallback => .error fallback
+      | .error fallback =>
+          .error { fallback with
+            attempts := failure.attempts + fallback.attempts
+            metered := failure.metered && fallback.metered }
 
 end Internal
 
@@ -164,7 +170,11 @@ private def factorPowerTarget? (target : Nat) (parts? : Option (List CyclotomicP
               culprit := some ⟨target, entries, 1⟩
               metered := false }
       | .error failure =>
-          Internal.retryPower? target failure fuel
+          -- `factor?` does not expose successful-search counts. A failure in
+          -- a later part therefore omits the work spent on earlier parts;
+          -- retain the diagnostic, but do not advertise that subtotal as
+          -- exact when the generic continuation later stops.
+          Internal.retryPower? target { failure with metered := false } fuel
   | none =>
       match factor? target r fuel with
       | .ok (F, r') => .ok (F, r', .generic)

--- a/HexIntFactor/Factor.lean
+++ b/HexIntFactor/Factor.lean
@@ -38,7 +38,8 @@ deriving Repr
 structure FactorFailure where
   /-- Semantic reason the complete or partial search stopped. -/
   stop : FactorStop
-  /-- Search attempts accumulated before stopping. -/
+  /-- Search attempts accumulated before stopping: rho restarts, certificate
+  witness candidates, p−1 calls, and ECM curves, including successful ones. -/
   attempts : Nat
   /-- Generator state after every randomized attempt that actually ran. -/
   rand : Rand
@@ -207,18 +208,20 @@ private def searchGo : Nat → List (Nat × Nat) → List PrimePower → Nat →
         if m = 1 then
           searchGo fuel stack factors residual r attempts powerRoutes
         else
-          match primeCert? m r (fuel + 1) with
-          | .ok (cert, r') =>
+          match Internal.primeCertCounted? m r (fuel + 1) with
+          | .ok certified =>
               searchGo fuel stack
-                (insertPower ⟨multiplier, cert.raw⟩ factors)
-                residual r' attempts powerRoutes
+                (insertPower ⟨multiplier, certified.cert.raw⟩ factors)
+                residual certified.rand (attempts + certified.attempts) powerRoutes
           | .error primeFailure =>
-              match rhoSplit? m primeFailure.rand
+              match Internal.rhoSplitCounted? m primeFailure.rand
                   (Internal.rhoRestartBudget (fuel + 1)) with
-              | .ok (d, r') =>
-                  searchGo fuel ((d, multiplier) :: (m / d, multiplier) :: stack)
-                    factors residual r' (attempts + primeFailure.attempts + 1)
-                    powerRoutes
+              | .ok split =>
+                  searchGo fuel
+                    ((split.factor, multiplier) ::
+                      (m / split.factor, multiplier) :: stack)
+                    factors residual split.rand
+                    (attempts + primeFailure.attempts + split.attempts) powerRoutes
               | .error rhoFailure =>
                   let smooth := Internal.smoothSearch m rhoFailure.rand (fuel + 1)
                   match smooth.factor with

--- a/HexIntFactor/Rho.lean
+++ b/HexIntFactor/Rho.lean
@@ -21,6 +21,21 @@ def rhoSplit? (n : Nat) (r : Rand) (fuel : Nat) :
     Except RhoFailure (Nat × Rand) :=
   rhoFactor? n r fuel
 
+namespace Internal
+
+/-- Try the shared Brent-rho search while retaining its exact restart count. -/
+def rhoSplitCounted? (n : Nat) (r : Rand) (fuel : Nat) :
+    Except RhoFailure RhoSuccess :=
+  rhoFactorCounted? n r fuel
+
+/-- Every counted adapter success is a proper divisor. -/
+theorem rhoSplitCounted?_spec {n : Nat} {r : Rand} {fuel : Nat}
+    {success : RhoSuccess} (h : rhoSplitCounted? n r fuel = .ok success) :
+    1 < success.factor ∧ success.factor < n ∧ success.factor ∣ n :=
+  rhoFactorCounted?_spec h
+
+end Internal
+
 /-- Every rho adapter success is a proper divisor. -/
 theorem rhoSplit?_spec {n : Nat} {r r' : Rand} {fuel d : Nat}
     (h : rhoSplit? n r fuel = .ok (d, r')) :

--- a/HexIntFactor/SPEC/hex-int-factor.md
+++ b/HexIntFactor/SPEC/hex-int-factor.md
@@ -577,9 +577,23 @@ aggregate that failed `checkPartial`. Such a failure is returned as
 failure case explicit. At `n = 0` no object satisfying `0 < subject` and
 `subject = n` exists, and `FactorStop.zero` reports that fact instead of
 returning checked data about another number. A generic-search failure retains
-its advanced state and exact attempt count, while success returns the state
-alongside the checked data, so a caller never repeats a failed random stream
-accidentally.
+its advanced state and exact attempt count. The dispatcher's attempt unit is
+one Brent-rho restart, one primality-certificate witness candidate, one p−1
+base/bound call, or one ECM curve, including the successful attempt in each
+route. Certificate search also accumulates its internal rho restarts and
+recursive child witnesses. Structural reductions, table lookup,
+Miller--Rabin filtering, and checker replay are deterministic work rather than
+search attempts. Counted internal success shapes preserve these totals across
+continuations without changing the compatible public pair-returning APIs.
+Success returns the state alongside the checked data, so a caller never
+repeats a failed random stream accidentally.
+
+The current cyclotomic wrapper cannot recover attempt counts for successfully
+factored parts from the compatible pair-returning `factor?` API. If a later
+part or its generic continuation stops, the wrapper therefore preserves the
+failure and generator state but sets `metered := false`; it never presents the
+remaining subtotal as exact. Outside the cyclotomic wrapper, the generic
+dispatcher and its checker-rejection boundary remain exactly metered.
 
 `factor?` uses the same partial-candidate acceptance boundary: it propagates
 `FactorStop.zero` or `FactorStop.rejected`, converts residual one to the complete

--- a/HexPrimality/SPEC/hex-primality.md
+++ b/HexPrimality/SPEC/hex-primality.md
@@ -524,7 +524,28 @@ def rhoFactor? (n : Nat) (r : Rand) (fuel : Nat) :
 theorem rhoFactor?_spec {n d r r' fuel}
     (h : rhoFactor? n r fuel = .ok (d, r')) :
     1 < d ∧ d < n ∧ d ∣ n
+
+structure Internal.RhoSuccess where
+  factor   : Nat
+  attempts : Nat
+  rand     : Rand
+
+def Internal.rhoFactorCounted? (n : Nat) (r : Rand) (fuel : Nat) :
+    Except RhoFailure Internal.RhoSuccess
+
+theorem Internal.rhoFactorCounted?_spec {n r fuel success}
+    (h : Internal.rhoFactorCounted? n r fuel = .ok success) :
+    1 < success.factor ∧ success.factor < n ∧ success.factor ∣ n
 ```
+
+The compatible pair-returning API is backed by the counted internal result
+`Internal.RhoSuccess`, whose `factor`, `attempts`, and `rand` fields are
+returned by `Internal.rhoFactorCounted?`. One attempt is one accepted restart
+draw and Brent run, including the successful restart; rejection draws used to
+choose that restart remain part of the same attempt. The ordinary
+`rhoFactor?` projection does not rerun the search or alter its final state.
+The deterministic even-input shortcut returns factor `2` with zero attempts
+and an unchanged generator because it runs no restart.
 
 `rhoFactor?` validates range and divisibility before returning.
 Randomness and fuel affect only whether it finds a factor. The advanced
@@ -747,6 +768,18 @@ structure NextPrimeFailure where
 
 def defaultPrimeFuel (n : Nat) : Nat
 
+structure Internal.PrimeCertSuccess (n : Nat) where
+  cert     : CheckedPrimeCert n
+  attempts : Nat
+  rand     : Rand
+
+def Internal.primeCertCounted? (n : Nat) (r : Rand) (fuel : Nat) :
+    Except PrimeCertFailure (Internal.PrimeCertSuccess n)
+
+theorem Internal.primeCertCounted?_composite {n r fuel f}
+    (hresult : Internal.primeCertCounted? n r fuel = .error f)
+    (hstop : f.stop = .composite) : ¬ Prime n
+
 def primeCert? (n : Nat) (r : Rand) (fuel : Nat) :
     Except PrimeCertFailure (CheckedPrimeCert n × Rand)
 def checkPrime (c : PrimeCert) : Bool
@@ -801,9 +834,16 @@ count and advanced state. The theorem records that a success is the
 division or a failed Miller-Rabin base, from `.exhausted`, which makes
 no primality claim. Exhaustion is reachable: the certificate search needs `n - 1`
 factored past a square root (or a cube root), and there are `n` for
-which that is out of reach. `PrimeCertFailure` retains the advanced
-state and attempt count because `partialFactor` runs Pollard rho; success
-returns the state alongside the certificate. The failure propagates
+which that is out of reach. `PrimeCertFailure` retains the advanced state and
+exact attempt count because `partialFactor` runs Pollard rho.
+`Internal.primeCertCounted?` also exposes that count on success, while
+`primeCert?` is its compatibility projection. Certificate metering counts
+every rho restart and every tried witness candidate, including successful
+ones, throughout recursive child construction; deterministic table lookup,
+Miller--Rabin filtering, and checker replay are not search attempts. Earlier
+successful child and witness searches are accumulated before a later failure,
+and both entry points return the same advanced state without duplicate work.
+The failure propagates
 rather than being papered over, which is
 design principle 8's third remedy again.
 

--- a/HexPrimality/Search.lean
+++ b/HexPrimality/Search.lean
@@ -195,6 +195,17 @@ namespace Internal
 /-- Shared maximum rho restart allocation for current worklist consumers. -/
 def rhoRestartCap : Nat := 8
 
+/-- A validated rho factor together with the exact number of restarts and
+the generator state after those restarts. -/
+structure RhoSuccess where
+  /-- Dynamically validated proper factor. -/
+  factor : Nat
+  /-- Restarts executed, including the successful restart. -/
+  attempts : Nat
+  /-- Generator state after all restart draws. -/
+  rand : Rand
+deriving Repr
+
 /-- Deterministic Brent instrumentation for route-level conformance tests. -/
 structure RhoTrace where
   /-- Candidate divisor returned by the restart, if any. -/
@@ -219,7 +230,8 @@ def rhoDrawTrace (n : Nat) (r : Rand) : Nat × Nat × Nat :=
 
 end Internal
 
-private def rhoTry (n : Nat) : Nat → Nat → Rand → Except RhoFailure (Nat × Rand)
+private def rhoTry (n : Nat) : Nat → Nat → Rand →
+    Except RhoFailure Internal.RhoSuccess
   | 0, attempts, r => .error ⟨.exhausted, attempts, r⟩
   | tries + 1, attempts, r =>
       let draw := rhoDraw n r
@@ -227,11 +239,23 @@ private def rhoTry (n : Nat) : Nat → Nat → Rand → Except RhoFailure (Nat �
       | some d =>
           if 1 < d then
             if d < n then
-              if n % d = 0 then .ok (d, draw.rand)
+              if n % d = 0 then .ok ⟨d, attempts + 1, draw.rand⟩
               else rhoTry n tries (attempts + 1) draw.rand
             else rhoTry n tries (attempts + 1) draw.rand
           else rhoTry n tries (attempts + 1) draw.rand
       | none => rhoTry n tries (attempts + 1) draw.rand
+
+namespace Internal
+
+/-- A dynamically validated proper-factor candidate by batched Brent rho,
+with its exact restart count. -/
+def rhoFactorCounted? (n : Nat) (r : Rand) (fuel : Nat) :
+    Except RhoFailure RhoSuccess :=
+  if n < 4 then .error ⟨.invalidInput, 0, r⟩
+  else if n % 2 = 0 then .ok ⟨2, 0, r⟩
+  else rhoTry n fuel 0 r
+
+end Internal
 
 /-- A dynamically validated proper-factor candidate by batched Brent rho.
 `fuel` bounds restart attempts. Each restart draws a fresh polynomial and
@@ -243,20 +267,21 @@ success is validated (`1 < d < n` and `d ∣ n`) before it is returned, so
 randomness and fuel affect only whether a factor is found. -/
 def rhoFactor? (n : Nat) (r : Rand) (fuel : Nat) :
     Except RhoFailure (Nat × Rand) :=
-  if n < 4 then .error ⟨.invalidInput, 0, r⟩
-  else if n % 2 = 0 then .ok (2, r)
-  else rhoTry n fuel 0 r
+  match Internal.rhoFactorCounted? n r fuel with
+  | .error failure => .error failure
+  | .ok success => .ok (success.factor, success.rand)
 
 private theorem rhoTry_spec {n : Nat} :
-    ∀ (tries attempts : Nat) (r : Rand) {d : Nat} {r' : Rand},
-      rhoTry n tries attempts r = .ok (d, r') → 1 < d ∧ d < n ∧ d ∣ n := by
+    ∀ (tries attempts : Nat) (r : Rand) {success : Internal.RhoSuccess},
+      rhoTry n tries attempts r = .ok success →
+        1 < success.factor ∧ success.factor < n ∧ success.factor ∣ n := by
   intro tries
   induction tries with
   | zero =>
-      intro attempts r d r' h
+      intro attempts r success h
       simp [rhoTry] at h
   | succ tries ih =>
-      intro attempts r d r' h
+      intro attempts r success h
       unfold rhoTry at h
       dsimp only at h
       split at h
@@ -265,19 +290,19 @@ private theorem rhoTry_spec {n : Nat} :
           · split at h
             · rename_i dd h1 h2 h3
               injection h with h
-              injection h with hd hr
-              subst hd
+              subst h
               exact ⟨h1, h2, Nat.dvd_of_mod_eq_zero h3⟩
             · exact ih _ _ h
           · exact ih _ _ h
         · exact ih _ _ h
       · exact ih _ _ h
 
-/-- The one theorem about the rho primitive: a success is a validated
-proper factor. -/
-theorem rhoFactor?_spec {n d : Nat} {r r' : Rand} {fuel : Nat}
-    (h : rhoFactor? n r fuel = .ok (d, r')) : 1 < d ∧ d < n ∧ d ∣ n := by
-  unfold rhoFactor? at h
+/-- A counted rho success is a validated proper factor. -/
+theorem Internal.rhoFactorCounted?_spec {n : Nat} {r : Rand} {fuel : Nat}
+    {success : Internal.RhoSuccess}
+    (h : Internal.rhoFactorCounted? n r fuel = .ok success) :
+    1 < success.factor ∧ success.factor < n ∧ success.factor ∣ n := by
+  unfold Internal.rhoFactorCounted? at h
   by_cases h4 : n < 4
   · rw [if_pos h4] at h
     cases h
@@ -285,11 +310,24 @@ theorem rhoFactor?_spec {n d : Nat} {r r' : Rand} {fuel : Nat}
     by_cases heven : n % 2 = 0
     · rw [if_pos heven] at h
       injection h with h
-      injection h with hd hr
-      subst hd
+      cases h
+      change 1 < 2 ∧ 2 < n ∧ 2 ∣ n
       exact ⟨by omega, by omega, Nat.dvd_of_mod_eq_zero heven⟩
     · rw [if_neg heven] at h
       exact rhoTry_spec fuel 0 r h
+
+/-- The one theorem about the rho primitive: a success is a validated
+proper factor. -/
+theorem rhoFactor?_spec {n d : Nat} {r r' : Rand} {fuel : Nat}
+    (h : rhoFactor? n r fuel = .ok (d, r')) : 1 < d ∧ d < n ∧ d ∣ n := by
+  unfold rhoFactor? at h
+  split at h
+  · cases h
+  · rename_i success hsuccess
+    injection h with h
+    injection h with hd hr
+    subst hd
+    exact Internal.rhoFactorCounted?_spec hsuccess
 
 /-! The internal partial factorization. -/
 
@@ -395,38 +433,49 @@ private theorem insertFactor_prod (p : Nat) :
 /-- Restart budget for each rho call inside the worklist. -/
 private def rhoRestartBudget : Nat := Internal.rhoRestartCap
 
+/-- Internal partial-factor worklist result with exact randomized work. -/
+private structure RhoPhaseResult where
+  factors : List (Nat × Nat)
+  residual : Nat
+  rand : Rand
+  attempts : Nat
+
 /-- The rho worklist: pop a pending number, drop it if it is `1`, keep it
 as a claimed factor if the filter calls it prime, split it if rho finds a
 factor, and multiply it into the residual otherwise. Fuel exhaustion dumps
 the remaining stack into the residual, preserving the product exactly. -/
 private def rhoPhase :
-    Nat → List Nat → List (Nat × Nat) → Nat → Rand →
-      (List (Nat × Nat) × Nat) × Rand
-  | 0, stack, acc, residual, r => ((acc, listProd stack * residual), r)
-  | _ + 1, [], acc, residual, r => ((acc, residual), r)
-  | fuel + 1, m :: stack, acc, residual, r =>
-      if m = 1 then rhoPhase fuel stack acc residual r
+    Nat → List Nat → List (Nat × Nat) → Nat → Rand → Nat → RhoPhaseResult
+  | 0, stack, acc, residual, r, attempts =>
+      ⟨acc, listProd stack * residual, r, attempts⟩
+  | _ + 1, [], acc, residual, r, attempts => ⟨acc, residual, r, attempts⟩
+  | fuel + 1, m :: stack, acc, residual, r, attempts =>
+      if m = 1 then rhoPhase fuel stack acc residual r attempts
       else if isProbablePrime m then
-        rhoPhase fuel stack (insertFactor m acc) residual r
+        rhoPhase fuel stack (insertFactor m acc) residual r attempts
       else
-        match rhoFactor? m r rhoRestartBudget with
-        | .ok (d, r') => rhoPhase fuel (d :: m / d :: stack) acc residual r'
-        | .error f => rhoPhase fuel stack acc (residual * m) f.rand
+        match Internal.rhoFactorCounted? m r rhoRestartBudget with
+        | .ok success =>
+            rhoPhase fuel (success.factor :: m / success.factor :: stack) acc
+              residual success.rand (attempts + success.attempts)
+        | .error f =>
+            rhoPhase fuel stack acc (residual * m) f.rand (attempts + f.attempts)
 
 private theorem rhoPhase_prod :
     ∀ (fuel : Nat) (stack : List Nat) (acc : List (Nat × Nat))
       (residual : Nat) (r : Rand),
-      prodPows (rhoPhase fuel stack acc residual r).1.1 *
-          (rhoPhase fuel stack acc residual r).1.2 =
+      ∀ attempts : Nat,
+      prodPows (rhoPhase fuel stack acc residual r attempts).factors *
+          (rhoPhase fuel stack acc residual r attempts).residual =
         prodPows acc * listProd stack * residual := by
   intro fuel
   induction fuel with
   | zero =>
-      intro stack acc residual r
+      intro stack acc residual r attempts
       simp only [rhoPhase]
       rw [Nat.mul_assoc]
   | succ fuel ih =>
-      intro stack acc residual r
+      intro stack acc residual r attempts
       match stack with
       | [] =>
           simp [rhoPhase, listProd]
@@ -443,10 +492,13 @@ private theorem rhoPhase_prod :
               simp [Nat.mul_assoc, Nat.mul_comm, Nat.mul_left_comm]
             · rw [if_neg hp]
               split
-              · rename_i d r' hok
+              · rename_i success hok
                 rw [ih]
-                obtain ⟨hd1, hdlt, hddvd⟩ := rhoFactor?_spec hok
-                have hdm : d * (m / d * listProd stack) = m * listProd stack := by
+                obtain ⟨hd1, hdlt, hddvd⟩ :=
+                  Internal.rhoFactorCounted?_spec hok
+                have hdm : success.factor *
+                    (m / success.factor * listProd stack) =
+                    m * listProd stack := by
                   rw [← Nat.mul_assoc, Nat.mul_div_cancel' hddvd]
                 simp only [listProd]
                 rw [hdm]
@@ -454,24 +506,28 @@ private theorem rhoPhase_prod :
                 simp only [listProd]
                 simp [Nat.mul_assoc, Nat.mul_comm]
 
+/-- Internal partial factorization and the search work that produced it. -/
+private structure PartialSearch where
+  raw : PartialFactors
+  rand : Rand
+  attempts : Nat
+
 /-- Trial division by the committed table, then Brent rho over a worklist,
 with `fuel` bounding the worklist steps. Everything the search cannot split
 multiplies into the residual. Internal; certificate search is the only
-consumer, and hex-int-factor builds its own assembly over `rhoFactor?`. -/
+consumer, and hex-int-factor builds its own assembly over the counted rho
+adapter. -/
 private def partialFactor (n : Nat) (r : Rand) (fuel : Nat) :
-    PartialFactors × Rand :=
-  (⟨(rhoPhase fuel [(trialGo primeTable.toList [] n).2]
-        (trialGo primeTable.toList [] n).1 1 r).1.1,
-    (rhoPhase fuel [(trialGo primeTable.toList [] n).2]
-        (trialGo primeTable.toList [] n).1 1 r).1.2⟩,
-    (rhoPhase fuel [(trialGo primeTable.toList [] n).2]
-        (trialGo primeTable.toList [] n).1 1 r).2)
+    PartialSearch :=
+  let trial := trialGo primeTable.toList [] n
+  let phase := rhoPhase fuel [trial.2] trial.1 1 r 0
+  ⟨⟨phase.factors, phase.residual⟩, phase.rand, phase.attempts⟩
 
 /-- The product invariant: the claimed powers times the residual recover the
 input exactly. This is the one fact certificate search needs. -/
 private theorem partialFactor_prod (n : Nat) (r : Rand) (fuel : Nat) :
-    prodPows (partialFactor n r fuel).1.factors *
-      (partialFactor n r fuel).1.residual = n := by
+    prodPows (partialFactor n r fuel).raw.factors *
+      (partialFactor n r fuel).raw.residual = n := by
   unfold partialFactor
   dsimp only
   rw [rhoPhase_prod]
@@ -495,10 +551,10 @@ partial factorization's product invariant exercised at runtime. -/
         | .error f => f.stop == .exhausted
         | _ => false)
 set_option maxRecDepth 10000 in  -- table walks inside partialFactor
-#guard (let pf := (partialFactor 720 (Rand.ofSeed 1) 32).1
+#guard (let pf := (partialFactor 720 (Rand.ofSeed 1) 32).raw
         pf.factors.foldl (fun a x => a * x.1 ^ x.2) 1 * pf.residual == 720)
 set_option maxRecDepth 10000 in
-#guard (let pf := (partialFactor (97 * 101 * 101) (Rand.ofSeed 2) 32).1
+#guard (let pf := (partialFactor (97 * 101 * 101) (Rand.ofSeed 2) 32).raw
         pf.factors.foldl (fun a x => a * x.1 ^ x.2) 1 * pf.residual ==
           97 * 101 * 101)
 
@@ -517,8 +573,8 @@ deriving Repr, DecidableEq
 structure PrimeCertFailure where
   /-- Why the search stopped. -/
   stop : PrimeCertStop
-  /-- Attempts consumed by the subsearch that failed; earlier successful
-  subsearches (witnesses found, factors split) are not accumulated. -/
+  /-- Randomized attempts consumed by the complete invocation, including
+  successful subsearches completed before this failure. -/
   attempts : Nat
   /-- The advanced generator state. -/
   rand : Rand
@@ -526,7 +582,7 @@ deriving Repr
 
 /-- A resumable bounded-decision failure. -/
 structure PrimeDecisionFailure where
-  /-- Attempts consumed by the failing certificate subsearch (see
+  /-- Attempts consumed by the complete certificate invocation (see
   `PrimeCertFailure.attempts`). -/
   attempts : Nat
   /-- The advanced generator state. -/
@@ -546,17 +602,24 @@ deriving Repr
 the bit length. A starting point, to be revisited by the bench. -/
 def defaultPrimeFuel (n : Nat) : Nat := 2 * n.log2 + 16
 
+/-- A private non-dependent counted result. Public counted shapes remain
+specialized so their factor and indexed-certificate fields have stable names. -/
+private structure Counted (α : Type) where
+  value : α
+  attempts : Nat
+  rand : Rand
+
 /-- Witness-search budget per factor entry. -/
 private def witnessBudget : Nat := 32
 
 /-- Search a base for one factor entry, checking with the same compiled
 `checkWitness` the certificate checker replays. -/
 private def witnessGo (n q : Nat) :
-    Nat → Nat → Rand → Except PrimeCertFailure (Nat × Rand)
+    Nat → Nat → Rand → Except PrimeCertFailure (Counted Nat)
   | 0, attempts, r => .error ⟨.exhausted, attempts, r⟩
   | t + 1, attempts, r =>
       if checkWitness n q (r.next.1.toNat % (n - 3) + 2) then
-        .ok (r.next.1.toNat % (n - 3) + 2, r.next.2)
+        .ok ⟨r.next.1.toNat % (n - 3) + 2, attempts + 1, r.next.2⟩
       else witnessGo n q t (attempts + 1) r.next.2
 
 /-- Assemble the cube-root node for the factored part `F`: the cofactor
@@ -579,28 +642,31 @@ factored and every claimed prime-power entry becomes a certified child with
 a searched witness. The assembled node is validated by the public wrapper,
 never trusted from here. -/
 private def primeCertGo (fuel n : Nat) (r : Rand) :
-    Except PrimeCertFailure (PrimeCert × Rand) :=
+    Except PrimeCertFailure (Counted PrimeCert) :=
   match fuel with
   | 0 => .error ⟨.exhausted, 0, r⟩
   | fuel + 1 =>
       if n < 2 then .error ⟨.composite, 0, r⟩
       else if n < primeTableBound then
-        if isTablePrime n then .ok (.small n, r)
+        if isTablePrime n then .ok ⟨.small n, 0, r⟩
         else .error ⟨.composite, 0, r⟩
       else
         match defaultBases.find? (fun a => !(millerRabin n a)) with
         | some _ => .error ⟨.composite, 0, r⟩
         | none =>
-            match assembleGo fuel n
-                (partialFactor (n - 1) r (2 * n.log2 + 8)).1.factors []
-                (partialFactor (n - 1) r (2 * n.log2 + 8)).2 with
+            let factored := partialFactor (n - 1) r (2 * n.log2 + 8)
+            match assembleGo fuel n factored.raw.factors [] factored.attempts
+                factored.rand with
             | .error f => .error f
-            | .ok (entries, r') =>
-                match certProduct (n - 1) entries with
-                | none => .error ⟨.exhausted, 0, r'⟩
+            | .ok assembled =>
+                match certProduct (n - 1) assembled.value with
+                | none => .error ⟨.exhausted, assembled.attempts, assembled.rand⟩
                 | some F =>
-                    if n < F * F then .ok (.pock n entries, r')
-                    else .ok (mkPock3 n F entries, r')
+                    if n < F * F then
+                      .ok ⟨.pock n assembled.value, assembled.attempts,
+                        assembled.rand⟩
+                    else .ok ⟨mkPock3 n F assembled.value, assembled.attempts,
+                      assembled.rand⟩
 termination_by (fuel, 0)
 
 /-- Certify every claimed factor entry: a recursive child certificate and a
@@ -608,21 +674,51 @@ witness base per entry. A child failure is reported as exhaustion: the
 child's compositeness would only mean the untrusted factorization guessed
 wrong, never that `n` is composite. -/
 private def assembleGo (fuel n : Nat) :
-    List (Nat × Nat) → List (Nat × Nat × PrimeCert) → Rand →
-      Except PrimeCertFailure (List (Nat × Nat × PrimeCert) × Rand)
-  | [], acc, r => .ok (acc.reverse, r)
-  | (q, e) :: rest, acc, r =>
-      if e = 0 then assembleGo fuel n rest acc r
+    List (Nat × Nat) → List (Nat × Nat × PrimeCert) → Nat → Rand →
+      Except PrimeCertFailure (Counted (List (Nat × Nat × PrimeCert)))
+  | [], acc, attempts, r => .ok ⟨acc.reverse, attempts, r⟩
+  | (q, e) :: rest, acc, attempts, r =>
+      if e = 0 then assembleGo fuel n rest acc attempts r
       else
         match primeCertGo fuel q r with
-        | .error f => .error ⟨.exhausted, f.attempts, f.rand⟩
-        | .ok (cq, r1) =>
-            match witnessGo n q witnessBudget 0 r1 with
-            | .error f => .error f
-            | .ok (a, r2) => assembleGo fuel n rest ((a, e - 1, cq) :: acc) r2
+        | .error f => .error ⟨.exhausted, attempts + f.attempts, f.rand⟩
+        | .ok child =>
+            match witnessGo n q witnessBudget 0 child.rand with
+            | .error f =>
+                .error ⟨f.stop, attempts + child.attempts + f.attempts, f.rand⟩
+            | .ok witness =>
+                assembleGo fuel n rest
+                  ((witness.value, e - 1, child.value) :: acc)
+                  (attempts + child.attempts + witness.attempts) witness.rand
 termination_by l => (fuel, l.length + 1)
 
 end
+
+namespace Internal
+
+/-- A checked primality certificate together with the exact number of
+randomized rho restarts and witness candidates used to construct it. -/
+structure PrimeCertSuccess (n : Nat) where
+  /-- Kernel-replayable checked certificate. -/
+  cert : CheckedPrimeCert n
+  /-- Randomized attempts used throughout the recursive construction. -/
+  attempts : Nat
+  /-- Generator state after those attempts. -/
+  rand : Rand
+
+/-- Bounded certificate search retaining exact successful-attempt metering. -/
+def primeCertCounted? (n : Nat) (r : Rand) (fuel : Nat) :
+    Except PrimeCertFailure (PrimeCertSuccess n) :=
+  match primeCertGo fuel n r with
+  | .error f => .error f
+  | .ok result =>
+      if hs : result.value.subject = n then
+        if hv : checkPrime result.value = true then
+          .ok ⟨⟨result.value, hs, hv⟩, result.attempts, result.rand⟩
+        else .error ⟨.exhausted, result.attempts, result.rand⟩
+      else .error ⟨.exhausted, result.attempts, result.rand⟩
+
+end Internal
 
 /-- Bounded certificate search. A success is a `CheckedPrimeCert`, so a
 certificate for one number can never answer a request about another; a
@@ -630,13 +726,9 @@ certificate for one number can never answer a request about another; a
 `.exhausted` failure makes no claim and carries the advanced state. -/
 def primeCert? (n : Nat) (r : Rand) (fuel : Nat) :
     Except PrimeCertFailure (CheckedPrimeCert n × Rand) :=
-  match primeCertGo fuel n r with
-  | .error f => .error f
-  | .ok (c, r') =>
-      if hs : c.subject = n then
-        if hv : checkPrime c = true then .ok (⟨c, hs, hv⟩, r')
-        else .error ⟨.exhausted, 0, r'⟩
-      else .error ⟨.exhausted, 0, r'⟩
+  match Internal.primeCertCounted? n r fuel with
+  | .error failure => .error failure
+  | .ok success => .ok (success.cert, success.rand)
 
 private theorem witnessGo_error_stop {n q : Nat} :
     ∀ (t attempts : Nat) (r : Rand) {f : PrimeCertFailure},
@@ -656,30 +748,31 @@ private theorem witnessGo_error_stop {n q : Nat} :
       · exact ih _ _ h
 
 private theorem assembleGo_error_stop {fuel n : Nat} :
-    ∀ (l : List (Nat × Nat)) (acc : List (Nat × Nat × PrimeCert)) (r : Rand)
-      {f : PrimeCertFailure},
-      assembleGo fuel n l acc r = .error f → f.stop = .exhausted := by
+    ∀ (l : List (Nat × Nat)) (acc : List (Nat × Nat × PrimeCert))
+      (attempts : Nat) (r : Rand) {f : PrimeCertFailure},
+      assembleGo fuel n l acc attempts r = .error f → f.stop = .exhausted := by
   intro l
   induction l with
   | nil =>
-      intro acc r f h
+      intro acc attempts r f h
       simp [assembleGo] at h
   | cons a rest ih =>
-      intro acc r f h
+      intro acc attempts r f h
       obtain ⟨q, e⟩ := a
       unfold assembleGo at h
       split at h
-      · exact ih _ _ h
+      · exact ih _ _ _ h
       · split at h
         · injection h with h
           subst h
           rfl
         · split at h
           next f' hwit =>
+            have hfstop := witnessGo_error_stop _ _ _ hwit
             injection h with h
-            subst h
-            exact witnessGo_error_stop _ _ _ hwit
-          next => exact ih _ _ h
+            cases h
+            exact hfstop
+          next => exact ih _ _ _ h
 
 private theorem primeCertGo_composite {fuel n : Nat} {r : Rand}
     {f : PrimeCertFailure} (h : primeCertGo fuel n r = .error f)
@@ -715,11 +808,12 @@ private theorem primeCertGo_composite {fuel n : Nat} {r : Rand}
             exact absurd (millerRabin_eq_true_of_prime hp) (by
               rw [this]
               exact Bool.false_ne_true)
-          · split at h
+          · dsimp only at h
+            split at h
             · rename_i f' herr
               injection h with h
               subst h
-              rw [assembleGo_error_stop _ _ _ herr] at hstop
+              rw [assembleGo_error_stop _ _ _ _ herr] at hstop
               cases hstop
             · split at h
               · injection h with h
@@ -727,13 +821,12 @@ private theorem primeCertGo_composite {fuel n : Nat} {r : Rand}
                 cases hstop
               · split at h <;> cases h
 
-/-- A `.composite` failure is a verdict: the input is not prime. Justified
-by size, table completeness, or a failed Miller-Rabin base; never by
-anything the untrusted search merely failed to do. -/
-theorem primeCert?_composite {n : Nat} {r : Rand} {fuel : Nat}
-    {f : PrimeCertFailure} (hresult : primeCert? n r fuel = .error f)
+/-- A counted `.composite` failure is a verdict: the input is not prime. -/
+theorem Internal.primeCertCounted?_composite {n : Nat} {r : Rand} {fuel : Nat}
+    {f : PrimeCertFailure}
+    (hresult : Internal.primeCertCounted? n r fuel = .error f)
     (hstop : f.stop = .composite) : ¬ Prime n := by
-  unfold primeCert? at hresult
+  unfold Internal.primeCertCounted? at hresult
   split at hresult
   · rename_i f' herr
     injection hresult with h
@@ -748,6 +841,20 @@ theorem primeCert?_composite {n : Nat} {r : Rand} {fuel : Nat}
     · injection hresult with h
       subst h
       cases hstop
+
+/-- A `.composite` failure is a verdict: the input is not prime. Justified
+by size, table completeness, or a failed Miller-Rabin base; never by
+anything the untrusted search merely failed to do. -/
+theorem primeCert?_composite {n : Nat} {r : Rand} {fuel : Nat}
+    {f : PrimeCertFailure} (hresult : primeCert? n r fuel = .error f)
+    (hstop : f.stop = .composite) : ¬ Prime n := by
+  unfold primeCert? at hresult
+  split at hresult
+  · rename_i f' herr
+    injection hresult with h
+    subst h
+    exact Internal.primeCertCounted?_composite herr hstop
+  · cases hresult
 
 /-- Exact trial division handles everything below this; a placeholder until
 the bench measures the crossover with the certificate path. -/

--- a/conformance/HexIntFactor/Conformance.lean
+++ b/conformance/HexIntFactor/Conformance.lean
@@ -415,6 +415,21 @@ private def smoothCapTrace : Hex.Nat.Internal.SmoothSearch :=
 -- distinct incomplete stop and retains the same checked aggregate.
 private def starvedInput : Nat := 1000003 * 1000033
 
+-- One large prime is certified after the first split, then fuel exhaustion
+-- retains that checked entry. The failure total includes both the successful
+-- certificate work and the preceding split rather than dropping either.
+private def retainedCertInput : Nat := starvedInput * 1000037
+
+#guard (match factor? retainedCertInput (Rand.ofSeed 3) (fuel := 3) with
+  | .error failure =>
+      failure.stop == .incomplete && failure.metered &&
+        failure.attempts == 6 &&
+        failure.rand == ((Rand.ofSeed 3).words 8).2 &&
+        match failure.snapshot with
+        | some saved => saved.raw.factors.length == 1 && checkPartial saved.raw
+        | none => false
+  | .ok _ => false)
+
 #guard (match factorPartial? starvedInput (Rand.ofSeed 3) (fuel := 0) with
   | .ok (F, _) => checkPartial F.raw && F.raw.residual == starvedInput
   | .error _ => false)
@@ -441,6 +456,12 @@ private def starvedInput : Nat := 1000003 * 1000033
   | .ok (_, _, route) => route == .cyclotomic
   | .error _ => false)
 
+-- A stopped generic continuation cannot recover successful earlier-part
+-- counts from the compatible factor API, so it is explicitly unmetered.
+#guard (match factorPowerWithRoute? 2 32 .minus (Rand.ofSeed 1) (fuel := 0) with
+  | .error failure => failure.stop == .incomplete && !failure.metered
+  | .ok _ => false)
+
 -- A rejected cyclotomic subproblem is propagated, never retried as generic
 -- exhaustion for the outer target.
 private def rejectedPart : FactorFailure :=
@@ -456,6 +477,14 @@ private def rejectedPart : FactorFailure :=
           match failure.culprit with
           | some rejected => rejected.subject == 7
           | none => false
+  | .ok _ => false)
+
+-- Standalone retry accounting adds the earlier exact subtotal to the generic
+-- continuation rather than silently replacing it with retry-only work.
+#guard (match Hex.Nat.Internal.retryPower? starvedInput
+    { stop := .incomplete, attempts := 4, rand := Rand.ofSeed 11 } 1 with
+  | .error failure =>
+      failure.stop == .incomplete && failure.attempts == 5 && failure.metered
   | .ok _ => false)
 
 #guard (match factor? 4826808 (Rand.ofSeed 7) with

--- a/conformance/HexPrimality/Conformance.lean
+++ b/conformance/HexPrimality/Conformance.lean
@@ -19,7 +19,8 @@ Covered operations:
 - `Hex.Nat.isPrime` / `Hex.Nat.isPrime?`
 - `Hex.Nat.checkPrime` on `PrimeCert` values
 - `Hex.Nat.primeCert?`
-- `Hex.Nat.rhoFactor?` and its batched-Brent route instrumentation
+- `Hex.Nat.rhoFactor?`, its counted internal form, and batched-Brent route
+  instrumentation
 - `Hex.Nat.millerRabin` / `Hex.Nat.isProbablePrime`
 - `Hex.Nat.isTablePrime`
 - `Hex.Nat.primesIn`
@@ -98,6 +99,46 @@ open Hex.Nat
 #guard (match primeCert? 2147483649 (Hex.Rand.ofSeed 0) 8 with
         | .error f => f.stop == .composite
         | .ok _ => false)
+
+-- Counted compatibility forms retain successful randomized work without
+-- changing the ordinary pair-returning entry points.
+#guard (match Internal.rhoFactorCounted? 9 (Hex.Rand.ofSeed 2) 8 with
+  | .ok success => success.factor == 3 && success.attempts == 4
+  | .error _ => false)
+
+#guard (match Internal.primeCertCounted? 1000003
+    (Hex.Rand.ofSeed 3) 16 with
+  | .ok success =>
+      success.attempts == 8 &&
+        success.rand == ((Hex.Rand.ofSeed 3).words 8).2
+  | .error _ => false)
+
+-- Fuel two certifies an earlier child and finds its witness before a later
+-- recursive child exhausts. The failure retains that successful work.
+#guard (match Internal.primeCertCounted? 1000003
+    (Hex.Rand.ofSeed 3) 2 with
+  | .error failure =>
+      failure.stop == .exhausted && failure.attempts == 2 &&
+        failure.rand == ((Hex.Rand.ofSeed 3).words 2).2
+  | .ok _ => false)
+
+-- A deeper child consumes its own randomized subtotal before exhaustion;
+-- the parent retains both its earlier witness and that child subtotal.
+#guard (match Internal.primeCertCounted? 1000000007
+    (Hex.Rand.ofSeed 3) 3 with
+  | .error failure =>
+      failure.stop == .exhausted && failure.attempts == 7 &&
+        failure.rand == ((Hex.Rand.ofSeed 3).words 7).2
+  | .ok _ => false)
+
+-- This strong pseudoprime passes the fixed Miller--Rabin screen, then its
+-- first certificate witness search consumes all 32 candidates. The retained
+-- total also includes the preceding four partial-factor rho restarts.
+#guard (match Internal.primeCertCounted? 3317044064679887385961981
+    (Hex.Rand.ofSeed 0) 2 with
+  | .error failure =>
+      failure.stop == .exhausted && failure.attempts == 36
+  | .ok _ => false)
 
 -- Routine gcds are genuinely batched: this fixed restart performs 95
 -- polynomial steps but only seven gcds.


### PR DESCRIPTION
Fixes #9715

## Summary

- retain exact successful Brent-rho restart counts through compatible counted internal results
- accumulate successful and failed primality-certificate search work across recursive witnesses and factor splits
- thread exact counts into HexIntFactor continuations, incomplete snapshots, and checker rejection without rerunning searches
- specify the attempt unit and add fixed-seed multi-restart and retained-certificate conformance guards

## Verification

- `lake build HexPrimality HexIntFactor HexIntFactor.Conformance`
- `lake exe runLinter HexPrimality.Search`
- `lake exe runLinter HexIntFactor.Rho`
- `lake exe runLinter HexIntFactor.Factor`
- `lake exe hexintfactor_bench verify`
- banned-token and diff checks