### PR TITLE
fix: make cyclotomic splitting single-pass

### DIFF
--- a/HexIntFactor/Cyclotomic.lean
+++ b/HexIntFactor/Cyclotomic.lean
@@ -43,7 +43,7 @@ private def divisorIndices (n : Nat) : List Nat :=
 private def properValueProduct (i : Nat) (prior : List Nat)
     (values : Array Nat) : Nat :=
   prior.foldl (fun acc d =>
-    if i % d = 0 then acc * values.getD d 1 else acc) 1
+    if i % d = 0 then acc * values.getD d 0 else acc) 1
 
 /-- Fill the required divisor-closed indices once, in ascending order. The
 array gives constant-time access to every previously computed proper divisor;
@@ -55,7 +55,8 @@ private def buildValues (b : Nat) : List Nat → List Nat → Array Nat → Arra
       let value := (b ^ i - 1) / denominator
       buildValues b rest (i :: prior) (values.set! i value)
 
-private def valueTable (b limit : Nat) (indices : List Nat) : Array Nat :=
+private def valueTable (b : Nat) (indices : List Nat) : Array Nat :=
+  let limit := indices.foldl max 0
   buildValues b indices [] (Array.replicate (limit + 1) 0)
 
 /-- Recursive Nat candidate for `Φ_d(b)`. -/
@@ -63,7 +64,7 @@ def cyclotomicValue (b d : Nat) : Nat :=
   if d = 0 then 0
   else
     let indices := divisorIndices d
-    (valueTable b d indices).getD d 0
+    (valueTable b indices).getD d 0
 
 private def splitIndices (n : Nat) (sign : Sign) (all : List Nat) : List Nat :=
   match sign with
@@ -79,7 +80,7 @@ def cyclotomicSplit? (b n : Nat) (sign : Sign) :
   else
     let limit : Nat := match sign with | .minus => n | .plus => 2 * n
     let all : List Nat := divisorIndices limit
-    let values : Array Nat := valueTable b limit all
+    let values : Array Nat := valueTable b all
     let parts : List CyclotomicPart := (splitIndices n sign all).map fun d =>
       ⟨d, values.getD d 0⟩
     let target := powerTarget b n sign
@@ -139,8 +140,7 @@ def retryPower? (target : Nat) (failure : FactorFailure) (fuel : Nat) :
       | .ok (F, r') => .ok (F, r', .generic)
       | .error fallback =>
           .error { fallback with
-            attempts := failure.attempts + fallback.attempts
-            metered := failure.metered && fallback.metered }
+            attempts := failure.attempts + fallback.attempts }
 
 /-- A scoped checker rejection is propagated unchanged and never retried as
 generic exhaustion. -/
@@ -156,8 +156,7 @@ theorem retryPower?_fallback {target : Nat} {failure fallback : FactorFailure}
     (hfactor : factor? target failure.rand fuel = .error fallback) :
     retryPower? target failure fuel = .error
       { fallback with
-        attempts := failure.attempts + fallback.attempts
-        metered := failure.metered && fallback.metered } := by
+        attempts := failure.attempts + fallback.attempts } := by
   cases h : failure.stop <;> simp_all [retryPower?]
 
 end Internal
@@ -224,15 +223,47 @@ def factorPower? (b n : Nat) (sign : Sign) (r : Rand)
   | .ok (F, r', _) => .ok (F, r')
   | .error failure => .error failure
 
-/-- Every power-route success is a checked factorization of the requested
-signed power target. -/
-theorem factorPowerWithRoute?_spec {b n : Nat} {sign : Sign} {r r' : Rand}
+/-- A result tagged as cyclotomic came from an available checked split, rather
+than from generic fallback. -/
+theorem factorPowerWithRoute?_cyclotomic {b n : Nat} {sign : Sign} {r r' : Rand}
     {fuel : Nat} {F : CheckedFactorization (powerTarget b n sign)}
-    {route : PowerRoute}
-    (_h : factorPowerWithRoute? b n sign r fuel = .ok (F, r', route)) :
-    F.raw.subject = powerTarget b n sign ∧
-      checkFactorization F.raw = true :=
-  ⟨F.subject_eq, F.valid⟩
+    (h : factorPowerWithRoute? b n sign r fuel = .ok (F, r', .cyclotomic)) :
+    ∃ parts, cyclotomicSplit? b n sign = some parts := by
+  cases sign with
+  | minus =>
+      change factorPowerTarget? (b ^ n - 1) (cyclotomicSplit? b n .minus)
+          r fuel = _ at h
+      cases hparts : cyclotomicSplit? b n .minus with
+      | none =>
+          simp only [hparts, factorPowerTarget?] at h
+          cases hfactor : factor? (b ^ n - 1) r fuel with
+          | error failure =>
+              rw [hfactor] at h
+              simp only [Except.map] at h
+              cases h
+          | ok result =>
+              rcases result with ⟨G, s⟩
+              rw [hfactor] at h
+              simp only [Except.map] at h
+              cases h
+      | some parts => exact ⟨parts, rfl⟩
+  | plus =>
+      change factorPowerTarget? (b ^ n + 1) (cyclotomicSplit? b n .plus)
+          r fuel = _ at h
+      cases hparts : cyclotomicSplit? b n .plus with
+      | none =>
+          simp only [hparts, factorPowerTarget?] at h
+          cases hfactor : factor? (b ^ n + 1) r fuel with
+          | error failure =>
+              rw [hfactor] at h
+              simp only [Except.map] at h
+              cases h
+          | ok result =>
+              rcases result with ⟨G, s⟩
+              rw [hfactor] at h
+              simp only [Except.map] at h
+              cases h
+      | some parts => exact ⟨parts, rfl⟩
 
 /-- The convenience projection preserves every failure unchanged, including
 scoped checker rejection and accumulated retry diagnostics. -/

--- a/HexIntFactor/Cyclotomic.lean
+++ b/HexIntFactor/Cyclotomic.lean
@@ -272,6 +272,7 @@ theorem factorPowerWithRoute?_cyclotomic {b n : Nat} {sign : Sign} {r r' : Rand}
           rw [hfactor] at h
           simp only [Except.map] at h
           cases h
+
 end Nat
 
 end Hex

--- a/HexIntFactor/Cyclotomic.lean
+++ b/HexIntFactor/Cyclotomic.lean
@@ -59,13 +59,6 @@ private def valueTable (b : Nat) (indices : List Nat) : Array Nat :=
   let limit := indices.foldl max 0
   buildValues b indices [] (Array.replicate (limit + 1) 0)
 
-/-- Recursive Nat candidate for `Φ_d(b)`. -/
-def cyclotomicValue (b d : Nat) : Nat :=
-  if d = 0 then 0
-  else
-    let indices := divisorIndices d
-    (valueTable b indices).getD d 0
-
 private def splitIndices (n : Nat) (sign : Sign) (all : List Nat) : List Nat :=
   match sign with
   | .minus => all
@@ -223,48 +216,6 @@ def factorPower? (b n : Nat) (sign : Sign) (r : Rand)
   | .ok (F, r', _) => .ok (F, r')
   | .error failure => .error failure
 
-/-- A result tagged as cyclotomic came from an available checked split, rather
-than from generic fallback. -/
-theorem factorPowerWithRoute?_cyclotomic {b n : Nat} {sign : Sign} {r r' : Rand}
-    {fuel : Nat} {F : CheckedFactorization (powerTarget b n sign)}
-    (h : factorPowerWithRoute? b n sign r fuel = .ok (F, r', .cyclotomic)) :
-    ∃ parts, cyclotomicSplit? b n sign = some parts := by
-  cases sign with
-  | minus =>
-      change factorPowerTarget? (b ^ n - 1) (cyclotomicSplit? b n .minus)
-          r fuel = _ at h
-      cases hparts : cyclotomicSplit? b n .minus with
-      | none =>
-          simp only [hparts, factorPowerTarget?] at h
-          cases hfactor : factor? (b ^ n - 1) r fuel with
-          | error failure =>
-              rw [hfactor] at h
-              simp only [Except.map] at h
-              cases h
-          | ok result =>
-              rcases result with ⟨G, s⟩
-              rw [hfactor] at h
-              simp only [Except.map] at h
-              cases h
-      | some parts => exact ⟨parts, rfl⟩
-  | plus =>
-      change factorPowerTarget? (b ^ n + 1) (cyclotomicSplit? b n .plus)
-          r fuel = _ at h
-      cases hparts : cyclotomicSplit? b n .plus with
-      | none =>
-          simp only [hparts, factorPowerTarget?] at h
-          cases hfactor : factor? (b ^ n + 1) r fuel with
-          | error failure =>
-              rw [hfactor] at h
-              simp only [Except.map] at h
-              cases h
-          | ok result =>
-              rcases result with ⟨G, s⟩
-              rw [hfactor] at h
-              simp only [Except.map] at h
-              cases h
-      | some parts => exact ⟨parts, rfl⟩
-
 /-- The convenience projection preserves every failure unchanged, including
 scoped checker rejection and accumulated retry diagnostics. -/
 theorem factorPower?_error_iff {b n : Nat} {sign : Sign} {r : Rand}
@@ -302,6 +253,25 @@ theorem factorPowerWithRoute?_generic {b n : Nat} {sign : Sign} {r : Rand}
       rw [hparts]
       simp only [factorPowerTarget?, powerTarget]
 
+/-- A cyclotomic-tagged result implies that the checked split was available. -/
+theorem factorPowerWithRoute?_cyclotomic {b n : Nat} {sign : Sign} {r r' : Rand}
+    {fuel : Nat} {F : CheckedFactorization (powerTarget b n sign)}
+    (h : factorPowerWithRoute? b n sign r fuel = .ok (F, r', .cyclotomic)) :
+    ∃ parts, cyclotomicSplit? b n sign = some parts := by
+  cases hparts : cyclotomicSplit? b n sign with
+  | some parts => exact ⟨parts, rfl⟩
+  | none =>
+      rw [factorPowerWithRoute?_generic hparts] at h
+      cases hfactor : factor? (powerTarget b n sign) r fuel with
+      | error failure =>
+          rw [hfactor] at h
+          simp only [Except.map] at h
+          cases h
+      | ok result =>
+          rcases result with ⟨G, s⟩
+          rw [hfactor] at h
+          simp only [Except.map] at h
+          cases h
 end Nat
 
 end Hex

--- a/HexIntFactor/Cyclotomic.lean
+++ b/HexIntFactor/Cyclotomic.lean
@@ -24,6 +24,11 @@ inductive Sign where
   | plus
 deriving Repr, DecidableEq
 
+/-- The natural-number target denoted by a signed power form. -/
+def powerTarget (b n : Nat) : Sign → Nat
+  | .minus => b ^ n - 1
+  | .plus => b ^ n + 1
+
 /-- One candidate cyclotomic value `Φ_index(base)`. -/
 structure CyclotomicPart where
   /-- Cyclotomic index `d`. -/
@@ -32,29 +37,38 @@ structure CyclotomicPart where
   value : Nat
 deriving Repr, DecidableEq
 
-private def properValueProduct (i : Nat) (values : List Nat) : Nat :=
-  (List.range (i - 1)).foldl (fun acc j =>
-    let d := j + 1
-    if i % d = 0 then acc * values.getD j 1 else acc) 1
+private def divisorIndices (n : Nat) : List Nat :=
+  (List.range n).map (· + 1) |>.filter fun d => n % d = 0
 
-private def buildValues (b : Nat) : Nat → List Nat
-  | 0 => []
-  | n + 1 =>
-      let previous := buildValues b n
-      let i := n + 1
-      previous ++ [(b ^ i - 1) / properValueProduct i previous]
+private def properValueProduct (i : Nat) (prior : List Nat)
+    (values : Array Nat) : Nat :=
+  prior.foldl (fun acc d =>
+    if i % d = 0 then acc * values.getD d 1 else acc) 1
+
+/-- Fill the required divisor-closed indices once, in ascending order. The
+array gives constant-time access to every previously computed proper divisor;
+`prior` contains exactly the filled indices, in reverse order. -/
+private def buildValues (b : Nat) : List Nat → List Nat → Array Nat → Array Nat
+  | [], _, values => values
+  | i :: rest, prior, values =>
+      let denominator := properValueProduct i prior values
+      let value := (b ^ i - 1) / denominator
+      buildValues b rest (i :: prior) (values.set! i value)
+
+private def valueTable (b limit : Nat) (indices : List Nat) : Array Nat :=
+  buildValues b indices [] (Array.replicate (limit + 1) 0)
 
 /-- Recursive Nat candidate for `Φ_d(b)`. -/
 def cyclotomicValue (b d : Nat) : Nat :=
-  if d = 0 then 0 else (buildValues b d).getD (d - 1) 0
+  if d = 0 then 0
+  else
+    let indices := divisorIndices d
+    (valueTable b d indices).getD d 0
 
-private def splitIndices (n : Nat) (sign : Sign) : List Nat :=
+private def splitIndices (n : Nat) (sign : Sign) (all : List Nat) : List Nat :=
   match sign with
-  | .minus =>
-      (List.range n).map (· + 1) |>.filter fun d => n % d = 0
-  | .plus =>
-      (List.range (2 * n)).map (· + 1) |>.filter fun d =>
-        2 * n % d = 0 && n % d ≠ 0
+  | .minus => all
+  | .plus => all.filter fun d => n % d ≠ 0
 
 /-- Candidate split of `b^n - 1` or `b^n + 1`, guarded by an exact product
 check and rejected on the degenerate domains. -/
@@ -63,11 +77,12 @@ def cyclotomicSplit? (b n : Nat) (sign : Sign) :
   if b < 2 then none
   else if n = 0 then none
   else
-    let parts := (splitIndices n sign).map fun d =>
-      ⟨d, cyclotomicValue b d⟩
-    let target := match sign with
-      | .minus => b ^ n - 1
-      | .plus => b ^ n + 1
+    let limit : Nat := match sign with | .minus => n | .plus => 2 * n
+    let all : List Nat := divisorIndices limit
+    let values : Array Nat := valueTable b limit all
+    let parts : List CyclotomicPart := (splitIndices n sign all).map fun d =>
+      ⟨d, values.getD d 0⟩
+    let target := powerTarget b n sign
     if (parts.map (·.value)).prod = target then some parts else none
 
 /-- Every returned cyclotomic candidate has the requested domain and exact
@@ -77,9 +92,7 @@ theorem cyclotomicSplit?_prod {b n : Nat} {sign : Sign}
     (h : cyclotomicSplit? b n sign = some parts) :
     2 ≤ b ∧ 0 < n ∧
       (parts.map (·.value)).prod =
-        match sign with
-        | .minus => b ^ n - 1
-        | .plus => b ^ n + 1 := by
+        powerTarget b n sign := by
   by_cases hb : b < 2
   · simp [cyclotomicSplit?, hb] at h
   by_cases hn : n = 0
@@ -129,29 +142,48 @@ def retryPower? (target : Nat) (failure : FactorFailure) (fuel : Nat) :
             attempts := failure.attempts + fallback.attempts
             metered := failure.metered && fallback.metered }
 
+/-- A scoped checker rejection is propagated unchanged and never retried as
+generic exhaustion. -/
+theorem retryPower?_rejected {target : Nat} {failure : FactorFailure}
+    {fuel : Nat} (hstop : failure.stop = .rejected) :
+    retryPower? target failure fuel = .error failure := by
+  simp [retryPower?, hstop]
+
+/-- A failed generic continuation preserves its diagnostics while adding the
+exact earlier part-search subtotal. -/
+theorem retryPower?_fallback {target : Nat} {failure fallback : FactorFailure}
+    {fuel : Nat} (hstop : failure.stop ≠ .rejected)
+    (hfactor : factor? target failure.rand fuel = .error fallback) :
+    retryPower? target failure fuel = .error
+      { fallback with
+        attempts := failure.attempts + fallback.attempts
+        metered := failure.metered && fallback.metered } := by
+  cases h : failure.stop <;> simp_all [retryPower?]
+
 end Internal
 
-private def insertPartPower (entry : PrimePower) : List PrimePower → List PrimePower
-  | [] => [entry]
-  | current :: rest =>
-      if entry.prime < current.prime then entry :: current :: rest
-      else if entry.prime = current.prime then
-        { current with exponent := current.exponent + entry.exponent } :: rest
-      else current :: insertPartPower entry rest
-
-private def mergePartPowers (source target : List PrimePower) : List PrimePower :=
-  source.foldl (fun acc entry => insertPartPower entry acc) target
+/-- Canonical merged entries and exact search state for a completed suffix of
+cyclotomic parts. -/
+private structure PartFactors where
+  entries : List PrimePower
+  attempts : Nat
+  rand : Rand
 
 private def factorParts (fuel : Nat) : List CyclotomicPart → Rand →
-    Except FactorFailure (List PrimePower × Rand)
-  | [], r => .ok ([], r)
+    Except FactorFailure PartFactors
+  | [], r => .ok ⟨[], 0, r⟩
   | part :: parts, r =>
-      match factor? part.value r fuel with
+      match Internal.factorCounted? part.value r fuel with
       | .error failure => .error failure
-      | .ok (F, r') =>
-          match factorParts fuel parts r' with
-          | .error failure => .error failure
-          | .ok (entries, r'') => .ok (mergePartPowers F.raw.factors entries, r'')
+      | .ok current =>
+          match factorParts fuel parts current.rand with
+          | .error failure =>
+              .error { failure with
+                attempts := current.attempts + failure.attempts }
+          | .ok rest =>
+              .ok ⟨Internal.mergePowers current.factorization.raw.factors
+                  rest.entries,
+                current.attempts + rest.attempts, rest.rand⟩
 
 private def factorPowerTarget? (target : Nat) (parts? : Option (List CyclotomicPart))
     (r : Rand) (fuel : Nat) :
@@ -159,48 +191,85 @@ private def factorPowerTarget? (target : Nat) (parts? : Option (List CyclotomicP
   match parts? with
   | some parts =>
       match factorParts fuel parts r with
-      | .ok (entries, r') =>
-          let raw : Factorization := ⟨target, entries⟩
+      | .ok factored =>
+          let raw : Factorization := ⟨target, factored.entries⟩
           if h : checkFactorization raw = true then
-            .ok (⟨raw, rfl, h⟩, r', .cyclotomic)
+            .ok (⟨raw, rfl, h⟩, factored.rand, .cyclotomic)
           else .error
             { stop := .rejected
-              attempts := 0
-              rand := r'
-              culprit := some ⟨target, entries, 1⟩
-              metered := false }
+              attempts := factored.attempts
+              rand := factored.rand
+              culprit := some ⟨target, factored.entries, 1⟩ }
       | .error failure =>
-          -- `factor?` does not expose successful-search counts. A failure in
-          -- a later part therefore omits the work spent on earlier parts;
-          -- retain the diagnostic, but do not advertise that subtotal as
-          -- exact when the generic continuation later stops.
-          Internal.retryPower? target { failure with metered := false } fuel
+          Internal.retryPower? target failure fuel
   | none =>
-      match factor? target r fuel with
-      | .ok (F, r') => .ok (F, r', .generic)
-      | .error failure => .error failure
+      (factor? target r fuel).map fun (F, r') => (F, r', .generic)
 
 /-- Factor a declared `b^n ± 1` form, trying its checked cyclotomic pieces
 before the generic dispatch. The route tag makes this ordering testable. -/
 def factorPowerWithRoute? (b n : Nat) (sign : Sign) (r : Rand)
-    (fuel : Nat := defaultFuel (b ^ n + 1)) :
+    (fuel : Nat := defaultFuel (powerTarget b n sign)) :
     Except FactorFailure
-      (CheckedFactorization
-        (match sign with | .minus => b ^ n - 1 | .plus => b ^ n + 1) ×
-       Rand × PowerRoute) :=
+      (CheckedFactorization (powerTarget b n sign) × Rand × PowerRoute) :=
   match sign with
   | .minus => factorPowerTarget? (b ^ n - 1) (cyclotomicSplit? b n .minus) r fuel
   | .plus => factorPowerTarget? (b ^ n + 1) (cyclotomicSplit? b n .plus) r fuel
 
 /-- Convenience projection that hides the diagnostic route tag. -/
 def factorPower? (b n : Nat) (sign : Sign) (r : Rand)
-    (fuel : Nat := defaultFuel (b ^ n + 1)) :
+    (fuel : Nat := defaultFuel (powerTarget b n sign)) :
     Except FactorFailure
-      (CheckedFactorization
-        (match sign with | .minus => b ^ n - 1 | .plus => b ^ n + 1) × Rand) :=
+      (CheckedFactorization (powerTarget b n sign) × Rand) :=
   match factorPowerWithRoute? b n sign r fuel with
   | .ok (F, r', _) => .ok (F, r')
   | .error failure => .error failure
+
+/-- Every power-route success is a checked factorization of the requested
+signed power target. -/
+theorem factorPowerWithRoute?_spec {b n : Nat} {sign : Sign} {r r' : Rand}
+    {fuel : Nat} {F : CheckedFactorization (powerTarget b n sign)}
+    {route : PowerRoute}
+    (_h : factorPowerWithRoute? b n sign r fuel = .ok (F, r', route)) :
+    F.raw.subject = powerTarget b n sign ∧
+      checkFactorization F.raw = true :=
+  ⟨F.subject_eq, F.valid⟩
+
+/-- The convenience projection preserves every failure unchanged, including
+scoped checker rejection and accumulated retry diagnostics. -/
+theorem factorPower?_error_iff {b n : Nat} {sign : Sign} {r : Rand}
+    {fuel : Nat} {failure : FactorFailure} :
+    factorPower? b n sign r fuel = .error failure ↔
+      factorPowerWithRoute? b n sign r fuel = .error failure := by
+  unfold factorPower?
+  split <;> simp_all
+
+/-- A projected success is exactly a routed success with the diagnostic tag
+hidden. -/
+theorem factorPower?_ok_iff {b n : Nat} {sign : Sign} {r r' : Rand}
+    {fuel : Nat} {F : CheckedFactorization (powerTarget b n sign)} :
+    factorPower? b n sign r fuel = .ok (F, r') ↔
+      ∃ route, factorPowerWithRoute? b n sign r fuel = .ok (F, r', route) := by
+  unfold factorPower?
+  split <;> simp_all
+
+/-- If no checked cyclotomic candidate exists, the route is exactly the
+ordinary generic factorization search tagged as generic. -/
+theorem factorPowerWithRoute?_generic {b n : Nat} {sign : Sign} {r : Rand}
+    {fuel : Nat} (hparts : cyclotomicSplit? b n sign = none) :
+    factorPowerWithRoute? b n sign r fuel =
+      (factor? (powerTarget b n sign) r fuel).map fun (F, r') =>
+        (F, r', .generic) := by
+  cases sign with
+  | minus =>
+      change factorPowerTarget? (b ^ n - 1) (cyclotomicSplit? b n .minus)
+          r fuel = _
+      rw [hparts]
+      simp only [factorPowerTarget?, powerTarget]
+  | plus =>
+      change factorPowerTarget? (b ^ n + 1) (cyclotomicSplit? b n .plus)
+          r fuel = _
+      rw [hparts]
+      simp only [factorPowerTarget?, powerTarget]
 
 end Nat
 

--- a/HexIntFactor/Factor.lean
+++ b/HexIntFactor/Factor.lean
@@ -47,8 +47,6 @@ structure FactorFailure where
   snapshot : Option PartialSnapshot := none
   /-- Raw aggregate rejected by a checker, when rejection caused the stop. -/
   culprit : Option PartialFactorization := none
-  /-- Whether `attempts` is an exact count for the stopped route. -/
-  metered : Bool := true
 deriving Repr
 
 /-- Default search budget, scaled by input bit length. -/

--- a/HexIntFactor/Factor.lean
+++ b/HexIntFactor/Factor.lean
@@ -61,7 +61,11 @@ private structure FactorAttempt (n : Nat) where
   attempts : Nat
   powerRoutes : Nat
 
-private def insertPower (entry : PrimePower) : List PrimePower → List PrimePower
+namespace Internal
+
+/-- Insert one certified prime-power entry into a sorted, duplicate-free list,
+adding exponents when the prime is already present. -/
+def insertPower (entry : PrimePower) : List PrimePower → List PrimePower
   | [] => [entry]
   | current :: rest =>
       if entry.prime < current.prime then entry :: current :: rest
@@ -69,11 +73,11 @@ private def insertPower (entry : PrimePower) : List PrimePower → List PrimePow
         { current with exponent := current.exponent + entry.exponent } :: rest
       else current :: insertPower entry rest
 
-private def mergePowers (entries : List PrimePower) (into : List PrimePower) :
+/-- Merge certified prime-power entries into the canonical sorted list,
+combining every duplicate prime by exponent addition. -/
+def mergePowers (entries : List PrimePower) (into : List PrimePower) :
     List PrimePower :=
   entries.foldl (fun acc entry => insertPower entry acc) into
-
-namespace Internal
 
 /-- Rho restarts allocated by the complete-factorization dispatcher. The cap
 keeps Pollard p−1 and ECM reachable after rho exhaustion, while the fuel side
@@ -202,7 +206,7 @@ private def searchGo : Nat → List (Nat × Nat) → List PrimePower → Nat →
           -- defensive if a future producer weakens that invariant.
           | .trial | .twos => powerRoutes
           | .perfectPower | .twosPower => powerRoutes + 1
-        let factors := mergePowers candidate.factors factors
+        let factors := Internal.mergePowers candidate.factors factors
         let m := candidate.residualBase
         let multiplier := candidate.residualExponent
         if m = 1 then
@@ -211,7 +215,7 @@ private def searchGo : Nat → List (Nat × Nat) → List PrimePower → Nat →
           match Internal.primeCertCounted? m r (fuel + 1) with
           | .ok certified =>
               searchGo fuel stack
-                (insertPower ⟨multiplier, certified.cert.raw⟩ factors)
+                (Internal.insertPower ⟨multiplier, certified.cert.raw⟩ factors)
                 residual certified.rand (attempts + certified.attempts) powerRoutes
           | .error primeFailure =>
               match Internal.rhoSplitCounted? m primeFailure.rand
@@ -296,6 +300,38 @@ theorem acceptPartial?_error {n hn raw hs r attempts f}
     refine ⟨rfl, rfl, hbad, ?_⟩
     simp
 
+/-- A complete checked factorization with the exact search work and generator
+state that produced it. -/
+structure FactorSuccess (n : Nat) where
+  /-- Kernel-replayable checked factorization. -/
+  factorization : CheckedFactorization n
+  /-- Randomized search attempts, including every successful subsearch. -/
+  attempts : Nat
+  /-- Generator state after all randomized work. -/
+  rand : Rand
+
+/-- Complete factorization retaining exact successful-attempt metering. -/
+def factorCounted? (n : Nat) (r : Rand) (fuel : Nat := defaultFuel n) :
+    Except FactorFailure (FactorSuccess n) :=
+  if hn : n = 0 then .error { stop := .zero, attempts := 0, rand := r }
+  else
+    let out := smallAttempt n r fuel
+    match acceptPartial? n (Nat.pos_of_ne_zero hn) out.raw
+        out.subject_eq out.rand out.attempts with
+    | .error failure => .error failure
+    | .ok (F, r') =>
+        if hr : F.raw.residual = 1 then
+          let raw : Factorization := ⟨n, F.raw.factors⟩
+          have hv : checkFactorization raw = true := by
+            simpa [raw, F.subject_eq] using
+              checkFactorization_of_checkPartial F.valid hr
+          .ok ⟨⟨raw, rfl, hv⟩, out.attempts, r'⟩
+        else .error
+          { stop := .incomplete
+            attempts := out.attempts
+            rand := r'
+            snapshot := some ⟨F.raw, F.valid⟩ }
+
 end Internal
 
 /-- Return checked partial data for positive input, or expose a rejected
@@ -311,24 +347,9 @@ def factorPartial? (n : Nat) (r : Rand) (fuel : Nat := defaultFuel n) :
 /-- Complete factorization when the checked partial residual is `1`. -/
 def factor? (n : Nat) (r : Rand) (fuel : Nat := defaultFuel n) :
     Except FactorFailure (CheckedFactorization n × Rand) :=
-  if hn : n = 0 then .error { stop := .zero, attempts := 0, rand := r }
-  else
-    let out := smallAttempt n r fuel
-    match Internal.acceptPartial? n (Nat.pos_of_ne_zero hn) out.raw
-        out.subject_eq out.rand out.attempts with
-    | .error failure => .error failure
-    | .ok (F, r') =>
-        if _hr : F.raw.residual = 1 then
-          let raw : Factorization := ⟨n, F.raw.factors⟩
-          have hv : checkFactorization raw = true := by
-            simpa [raw, F.subject_eq] using
-              checkFactorization_of_checkPartial F.valid _hr
-          .ok (⟨raw, rfl, hv⟩, r')
-        else .error
-          { stop := .incomplete
-            attempts := out.attempts
-            rand := r'
-            snapshot := some ⟨F.raw, F.valid⟩ }
+  match Internal.factorCounted? n r fuel with
+  | .error failure => .error failure
+  | .ok success => .ok (success.factorization, success.rand)
 
 /-- Partial search errors are either the distinguished zero input or an
 internal candidate rejection. -/

--- a/HexIntFactor/SPEC/hex-int-factor.md
+++ b/HexIntFactor/SPEC/hex-int-factor.md
@@ -513,9 +513,9 @@ conformance tests. Genuine incomplete failures retain the checked aggregate in
 propagates rejection rather than retrying it as though it were exhaustion. A
 rejection propagated from a cyclotomic part remains scoped to that subproblem;
 a rejected merged cyclotomic aggregate records the target candidate and random
-state. Its successful subsearch attempts are not exposed by `factor?`, so its
-placeholder count is marked unavailable by `metered = false` rather than being
-presented as an exact total.
+state. The internal counted-success shape retains the successful subsearch
+attempts that the compatible public `factor?` pair omits, so cyclotomic
+continuations and aggregate rejection report exact totals with `metered = true`.
 
 A partial answer is more useful than no answer, so the search also
 exposes
@@ -588,12 +588,12 @@ continuations without changing the compatible public pair-returning APIs.
 Success returns the state alongside the checked data, so a caller never
 repeats a failed random stream accidentally.
 
-The current cyclotomic wrapper cannot recover attempt counts for successfully
-factored parts from the compatible pair-returning `factor?` API. If a later
-part or its generic continuation stops, the wrapper therefore preserves the
-failure and generator state but sets `metered := false`; it never presents the
-remaining subtotal as exact. Outside the cyclotomic wrapper, the generic
-dispatcher and its checker-rejection boundary remain exactly metered.
+The cyclotomic wrapper uses the internal `factorCounted?` result, which carries
+the exact attempt count on success without changing the public pair-returning
+`factor?` API. Every successfully factored part is added to a later failure or
+generic-continuation total, and the advanced generator state is threaded in
+the same order. Thus generic and cyclotomic dispatcher failures, including
+their checker-rejection boundaries, remain exactly metered.
 
 `factor?` uses the same partial-candidate acceptance boundary: it propagates
 `FactorStop.zero` or `FactorStop.rejected`, converts residual one to the complete
@@ -637,6 +637,8 @@ roughly `2 log p` bits in place of one of `6 log p` bits.
 ```lean
 inductive Sign where | minus | plus
 
+def powerTarget (b n : Nat) : Sign → Nat
+
 /-- One candidate cyclotomic part: its index `d` and proposed value
 `Φ_d(b)`. Exact cyclotomic semantics are conformance-tested, not trusted by
 the factorization route. -/
@@ -651,8 +653,19 @@ def cyclotomicSplit? (b n : Nat) (sign : Sign) : Option (List CyclotomicPart)
 theorem cyclotomicSplit?_prod {b n sign parts}
     (h : cyclotomicSplit? b n sign = some parts) :
     2 ≤ b ∧ 0 < n ∧
-      (parts.map (·.value)).prod =
-        match sign with | .minus => b ^ n - 1 | .plus => b ^ n + 1
+      (parts.map (·.value)).prod = powerTarget b n sign
+
+inductive PowerRoute where | cyclotomic | generic
+
+def factorPowerWithRoute? (b n : Nat) (sign : Sign) (r : Rand)
+    (fuel : Nat := defaultFuel (powerTarget b n sign)) :
+    Except FactorFailure
+      (CheckedFactorization (powerTarget b n sign) × Rand × PowerRoute)
+
+def factorPower? (b n : Nat) (sign : Sign) (r : Rand)
+    (fuel : Nat := defaultFuel (powerTarget b n sign)) :
+    Except FactorFailure
+      (CheckedFactorization (powerTarget b n sign) × Rand)
 ```
 
 An enum rather than a `Bool`, and a named pair rather than
@@ -682,6 +695,15 @@ because it is the natural fast candidate algorithm; a separate
 Mathlib-free formalization of cyclotomic-polynomial identities is not a
 prerequisite for this checked search optimization.
 
+For one split, the implementation enumerates the divisor-closed index set once
+in ascending order, fills a dense array through the largest required index,
+and reuses each prior value by constant-time lookup. It does not recursively
+rebuild divisor prefixes for every selected part. If `D` is that index set,
+candidate construction performs `O(max D + |D|²)` small index tests/lookups,
+plus one natural power and up to `|D|` big-integer multiplications per filled
+index. The final exact-product check and factorization checker remain the
+trusted boundary; the complexity statement is about the untrusted producer.
+
 The two computations of `Φ_d(b)`, this one in `Nat` and
 [hex-cyclotomic](../../SPEC/Libraries/hex-cyclotomic.md)'s evaluation of the constructed
 polynomial, are independent and must agree. The comparison lives in that
@@ -692,7 +714,16 @@ separately can produce the same prime twice with different exponents.
 A merge pass -- collect, group by prime, sum exponents, sort -- runs
 before the candidate `Factorization` is offered to `checkFactorization`,
 which requires strictly ascending distinct bases and would otherwise
-reject a correct answer.
+reject a correct answer. The generic dispatcher and power-form wrapper share
+the same canonical insertion/merge helper.
+
+`factorPowerWithRoute?` attempts the checked split before the generic route;
+`factorPower?` only hides that diagnostic tag. Their characterising lemmas
+state that every success is checked for `powerTarget`, projection preserves
+successes and errors exactly, and a rejected/absent split uses the documented
+scoped-rejection or generic-fallback behaviour. The default fuel is computed
+from the selected sign's target, so the minus path never constructs
+`b^n + 1` merely to choose its budget.
 
 Two things this does not do, and they bound the claim.
 
@@ -985,6 +1016,7 @@ the number of distinct primes, `B` a smoothness bound.
 | Pollard rho | `O(√p)` iterations expected and one routine gcd per 32-step batch | `O(n^{1/4})` for a semiprime; cycle boundaries can flush shorter batches |
 | Pollard `p − 1` stage 1 | `O(B)` modular mults | `log M = Θ(B)`; smooth `p − 1` is sufficient but not decisive |
 | ECM stage 1, one curve | `O(B)` mults | scalar bit length is `Θ(B)`; success depends on the bound |
+| cyclotomic candidate table | `O(m + d²)` index work plus big-integer powers/products | `m` is the largest required index and `d` the number of its divisors; one ascending divisor-closed table is shared by all selected parts |
 | `checkFactorization` | `O(Σ eᵢ)` bounded multiplications plus `k` primality replays | `boundedPowMul` is linear in the claimed exponent and aborts above the subject |
 | `checkOrder` | `O(k)` modular exponentiations plus `checkFactorization` | includes the order's primality replays |
 | `divisors` | `O(τ log τ)` | `τ = ∏(eᵢ + 1)` |

--- a/HexIntFactor/SPEC/hex-int-factor.md
+++ b/HexIntFactor/SPEC/hex-int-factor.md
@@ -266,7 +266,6 @@ structure FactorFailure where
   rand     : Rand
   snapshot : Option PartialSnapshot := none
   culprit  : Option PartialFactorization := none
-  metered   : Bool := true
 
 def defaultFuel (n : Nat) : Nat
 
@@ -515,7 +514,7 @@ rejection propagated from a cyclotomic part remains scoped to that subproblem;
 a rejected merged cyclotomic aggregate records the target candidate and random
 state. The internal counted-success shape retains the successful subsearch
 attempts that the compatible public `factor?` pair omits, so cyclotomic
-continuations and aggregate rejection report exact totals with `metered = true`.
+continuations and aggregate rejection report exact totals.
 
 A partial answer is more useful than no answer, so the search also
 exposes
@@ -593,7 +592,7 @@ the exact attempt count on success without changing the public pair-returning
 `factor?` API. Every successfully factored part is added to a later failure or
 generic-continuation total, and the advanced generator state is threaded in
 the same order. Thus generic and cyclotomic dispatcher failures, including
-their checker-rejection boundaries, remain exactly metered.
+their checker-rejection boundaries, retain exact attempt totals.
 
 `factor?` uses the same partial-candidate acceptance boundary: it propagates
 `FactorStop.zero` or `FactorStop.rejected`, converts residual one to the complete
@@ -718,12 +717,14 @@ reject a correct answer. The generic dispatcher and power-form wrapper share
 the same canonical insertion/merge helper.
 
 `factorPowerWithRoute?` attempts the checked split before the generic route;
-`factorPower?` only hides that diagnostic tag. Their characterising lemmas
-state that every success is checked for `powerTarget`, projection preserves
-successes and errors exactly, and a rejected/absent split uses the documented
+`factorPower?` only hides that diagnostic tag. Its indexed result type carries
+the checked `powerTarget` guarantee. The characterising lemmas state that a
+cyclotomic-tagged success has a checked split, projection preserves successes
+and errors exactly, and a rejected/absent split uses the documented
 scoped-rejection or generic-fallback behaviour. The default fuel is computed
-from the selected sign's target, so the minus path never constructs
-`b^n + 1` merely to choose its budget.
+from the selected sign's target, so the minus path neither constructs
+`b^n + 1` nor uses its budget; at a power-of-two boundary this gives the minus
+target four fewer fuel units than the former plus-based default.
 
 Two things this does not do, and they bound the claim.
 

--- a/HexIntFactor/SPEC/hex-int-factor.md
+++ b/HexIntFactor/SPEC/hex-int-factor.md
@@ -1297,7 +1297,7 @@ by `coprime_of_checkOrder`, so the caller passes nothing extra.
    route description), with route-level tests written before the code.
 
 5. **The cyclotomic candidate.** `cyclotomicSplit?`, its checked product
-   theorem, the recursive evaluation candidate, and the `b^n ± 1`
+   theorem, the ascending evaluation table, and the `b^n ± 1`
    benchmark family. Ahead of ECM because it is cheaper and directly
    serves the motivating family.
 

--- a/conformance/HexIntFactor/Conformance.lean
+++ b/conformance/HexIntFactor/Conformance.lean
@@ -422,7 +422,7 @@ private def retainedCertInput : Nat := starvedInput * 1000037
 
 #guard (match factor? retainedCertInput (Rand.ofSeed 3) (fuel := 3) with
   | .error failure =>
-      failure.stop == .incomplete && failure.metered &&
+      failure.stop == .incomplete &&
         failure.attempts == 6 &&
         failure.rand == ((Rand.ofSeed 3).words 8).2 &&
         match failure.snapshot with
@@ -452,6 +452,7 @@ private def retainedCertInput : Nat := starvedInput * 1000037
   | some parts => parts.map (·.value) == [5, 13]
   | none => false)
 
+-- The repeated factor `3` in the minus split is merged before checker replay.
 #guard (match factorPowerWithRoute? 2 6 .minus (Rand.ofSeed 1) with
   | .ok (F, _, route) =>
       route == .cyclotomic &&
@@ -464,12 +465,11 @@ private def retainedCertInput : Nat := starvedInput * 1000037
         F.raw.factors.map (fun e => (e.prime, e.exponent)) == [(5, 1), (13, 1)]
   | .error _ => false)
 
--- The repeated factor `3` in the minus split is merged before checker replay.
 -- A stopped continuation includes successful earlier-part work and remains
--- exactly metered, even when every charged search subtotal happens to be zero.
+-- exactly accounted, even when every charged search subtotal happens to be zero.
 #guard (match factorPowerWithRoute? 2 32 .minus (Rand.ofSeed 1) (fuel := 0) with
   | .error failure =>
-      failure.stop == .incomplete && failure.attempts == 0 && failure.metered
+      failure.stop == .incomplete && failure.attempts == 0
   | .ok _ => false)
 
 -- Here `Φ_19(2)` succeeds after eight charged attempts, `Φ_57(2)` stops
@@ -478,7 +478,7 @@ private def retainedCertInput : Nat := starvedInput * 1000037
 -- omits.
 #guard (match factorPowerWithRoute? 2 57 .minus (Rand.ofSeed 1) (fuel := 3) with
   | .error failure =>
-      failure.stop == .incomplete && failure.attempts == 25 && failure.metered
+      failure.stop == .incomplete && failure.attempts == 25
   | .ok _ => false)
 
 -- Degenerate split input uses the ordinary dispatcher, and the route tag makes
@@ -498,7 +498,7 @@ private def rejectedPart : FactorFailure :=
 
 #guard (match Hex.Nat.Internal.retryPower? 63 rejectedPart 0 with
   | .error failure =>
-      failure.stop == .rejected && failure.attempts == 4 && failure.metered &&
+      failure.stop == .rejected && failure.attempts == 4 &&
         failure.rand == Rand.ofSeed 11 &&
           match failure.culprit with
           | some rejected => rejected.subject == 7
@@ -508,7 +508,7 @@ private def rejectedPart : FactorFailure :=
 example : Hex.Nat.Internal.retryPower? 63 rejectedPart 0 = .error rejectedPart :=
   Hex.Nat.Internal.retryPower?_rejected (by decide)
 
-#check factorPowerWithRoute?_spec
+#check factorPowerWithRoute?_cyclotomic
 #check factorPower?_error_iff
 #check factorPower?_ok_iff
 #check factorPowerWithRoute?_generic
@@ -518,7 +518,7 @@ example : Hex.Nat.Internal.retryPower? 63 rejectedPart 0 = .error rejectedPart :
 #guard (match Hex.Nat.Internal.retryPower? starvedInput
     { stop := .incomplete, attempts := 4, rand := Rand.ofSeed 11 } 1 with
   | .error failure =>
-      failure.stop == .incomplete && failure.attempts == 5 && failure.metered
+      failure.stop == .incomplete && failure.attempts == 5
   | .ok _ => false)
 
 #guard (match factor? 4826808 (Rand.ofSeed 7) with

--- a/conformance/HexIntFactor/Conformance.lean
+++ b/conformance/HexIntFactor/Conformance.lean
@@ -453,14 +453,40 @@ private def retainedCertInput : Nat := starvedInput * 1000037
   | none => false)
 
 #guard (match factorPowerWithRoute? 2 6 .minus (Rand.ofSeed 1) with
-  | .ok (_, _, route) => route == .cyclotomic
+  | .ok (F, _, route) =>
+      route == .cyclotomic &&
+        F.raw.factors.map (fun e => (e.prime, e.exponent)) == [(3, 2), (7, 1)]
   | .error _ => false)
 
--- A stopped generic continuation cannot recover successful earlier-part
--- counts from the compatible factor API, so it is explicitly unmetered.
+#guard (match factorPowerWithRoute? 2 6 .plus (Rand.ofSeed 1) with
+  | .ok (F, _, route) =>
+      route == .cyclotomic &&
+        F.raw.factors.map (fun e => (e.prime, e.exponent)) == [(5, 1), (13, 1)]
+  | .error _ => false)
+
+-- The repeated factor `3` in the minus split is merged before checker replay.
+-- A stopped continuation includes successful earlier-part work and remains
+-- exactly metered, even when every charged search subtotal happens to be zero.
 #guard (match factorPowerWithRoute? 2 32 .minus (Rand.ofSeed 1) (fuel := 0) with
-  | .error failure => failure.stop == .incomplete && !failure.metered
+  | .error failure =>
+      failure.stop == .incomplete && failure.attempts == 0 && failure.metered
   | .ok _ => false)
+
+-- Here `Φ_19(2)` succeeds after eight charged attempts, `Φ_57(2)` stops
+-- after twelve, and the generic continuation adds five more. This guards the
+-- successful-part subtotal that the public pair-returning API intentionally
+-- omits.
+#guard (match factorPowerWithRoute? 2 57 .minus (Rand.ofSeed 1) (fuel := 3) with
+  | .error failure =>
+      failure.stop == .incomplete && failure.attempts == 25 && failure.metered
+  | .ok _ => false)
+
+-- Degenerate split input uses the ordinary dispatcher, and the route tag makes
+-- the fallback observable rather than inferring it from end-to-end success.
+#guard (match factorPowerWithRoute? 2 0 .plus (Rand.ofSeed 1) with
+  | .ok (F, _, route) =>
+      route == .generic && F.raw.subject == powerTarget 2 0 .plus
+  | .error _ => false)
 
 -- A rejected cyclotomic subproblem is propagated, never retried as generic
 -- exhaustion for the outer target.
@@ -478,6 +504,14 @@ private def rejectedPart : FactorFailure :=
           | some rejected => rejected.subject == 7
           | none => false
   | .ok _ => false)
+
+example : Hex.Nat.Internal.retryPower? 63 rejectedPart 0 = .error rejectedPart :=
+  Hex.Nat.Internal.retryPower?_rejected (by decide)
+
+#check factorPowerWithRoute?_spec
+#check factorPower?_error_iff
+#check factorPower?_ok_iff
+#check factorPowerWithRoute?_generic
 
 -- Standalone retry accounting adds the earlier exact subtotal to the generic
 -- continuation rather than silently replacing it with retry-only work.


### PR DESCRIPTION
Closes #9699.\n\n- computes each required cyclotomic value once in an ascending divisor-closed array\n- shares canonical prime-power merging with the generic dispatcher\n- retains exact successful-part attempt counts across cyclotomic failure and fallback\n- adds signed-target/result/fallback lemmas and route-level conformance for both signs, overlap, fallback, rejection, and exact accounting\n- documents the default-fuel choice and producer complexity in the SPEC\n\nVerification:\n- `lake build HexIntFactor HexIntFactorMathlib HexConformance`\n- `lake exe hexintfactor_bench list`\n- `lake exe hexintfactor_bench verify`\n- `python3 scripts/check_file_line_counts.py`\n- `python3 scripts/check_copyright_headers.py`\n- banned-token and `git diff --check` scans