### PR TITLE
chore: certify HexRealRootsMathlib through Phase 7

### DIFF
--- a/HexManual/Chapters/HexRealRoots.lean
+++ b/HexManual/Chapters/HexRealRoots.lean
@@ -44,6 +44,42 @@ elaborates, and produces a term whose type records the certified
 statements. No knowledge of Sturm chains, dyadic arithmetic, or
 squarefreeness is needed at the call site.
 
+# The Mathlib correspondence
+%%%
+tag := "hex-real-roots-mathlib"
+%%%
+
+The split between `HexRealRoots` and `HexRealRootsMathlib` is a trust and
+dependency boundary. `HexRealRoots` contains the Mathlib-free executable
+algorithm: dense integer polynomials, signed pseudo-remainder Sturm chains,
+dyadic sign evaluation, Descartes and Sturm search, and interval refinement.
+Its output is exact certificate data, but the computational package does not
+state that data in Mathlib's language of `Polynomial ℝ` and real roots.
+
+`HexRealRootsMathlib` supplies that interpretation. The abstract development
+proves Sturm's theorem for a generalized polynomial chain. The correspondence
+theorems then identify the executable chain with such a chain, identify
+integer and dyadic sign-variation computations with their real counterparts,
+and turn finite and infinite variation gaps into exact root counts. In
+particular, {name}`HexRealRootsMathlib.sturmChain_isSturmChain` connects the
+computed chain to the abstract theorem, while the literal replay API checks a
+supplied chain coefficient by coefficient. Isolation soundness and
+completeness package those counts as {name}`Hex.IsolatedRealRoots`, including
+one distinct root per half-open interval and coverage of every real root.
+
+The term elaborator sits precisely on this boundary. It evaluates the closed
+input and runs compiled search only while elaborating, to choose a squarefree
+core, a Sturm chain, and dyadic intervals. It then emits literal data and a
+call to {name}`Hex.IsolatedRealRoots.ofCertPretty`. Ordinary Lean `decide`
+proofs replay the chain, the per-interval counts, the total count, and endpoint
+ordering. The kernel therefore trusts neither the compiled search nor the
+Descartes dispatch. For repeated roots, a checked polynomial identity proves
+that the squarefree core and original polynomial have the same real zeros,
+and {name}`Hex.IsolatedRealRoots.congrRoots` transports the isolation across
+that equivalence. Inputs written as `Polynomial ℤ`, `Polynomial ℚ`, or
+`Polynomial ℝ` cross the same boundary through
+{name}`HexPolyZMathlib.toPolynomial` and a checked evaluation equivalence.
+
 # The `isolate_roots` elaborator
 %%%
 tag := "hex-real-roots-isolate"

--- a/HexManual/Chapters/HexRealRoots.lean
+++ b/HexManual/Chapters/HexRealRoots.lean
@@ -44,42 +44,6 @@ elaborates, and produces a term whose type records the certified
 statements. No knowledge of Sturm chains, dyadic arithmetic, or
 squarefreeness is needed at the call site.
 
-# The Mathlib correspondence
-%%%
-tag := "hex-real-roots-mathlib"
-%%%
-
-The split between `HexRealRoots` and `HexRealRootsMathlib` is a trust and
-dependency boundary. `HexRealRoots` contains the Mathlib-free executable
-algorithm: dense integer polynomials, signed pseudo-remainder Sturm chains,
-dyadic sign evaluation, Descartes and Sturm search, and interval refinement.
-Its output is exact certificate data, but the computational package does not
-state that data in Mathlib's language of `Polynomial ℝ` and real roots.
-
-`HexRealRootsMathlib` supplies that interpretation. The abstract development
-proves Sturm's theorem for a generalized polynomial chain. The correspondence
-theorems then identify the executable chain with such a chain, identify
-integer and dyadic sign-variation computations with their real counterparts,
-and turn finite and infinite variation gaps into exact root counts. In
-particular, {name}`HexRealRootsMathlib.sturmChain_isSturmChain` connects the
-computed chain to the abstract theorem, while the literal replay API checks a
-supplied chain coefficient by coefficient. Isolation soundness and
-completeness package those counts as {name}`Hex.IsolatedRealRoots`, including
-one distinct root per half-open interval and coverage of every real root.
-
-The term elaborator sits precisely on this boundary. It evaluates the closed
-input and runs compiled search only while elaborating, to choose a squarefree
-core, a Sturm chain, and dyadic intervals. It then emits literal data and a
-call to {name}`Hex.IsolatedRealRoots.ofCertPretty`. Ordinary Lean `decide`
-proofs replay the chain, the per-interval counts, the total count, and endpoint
-ordering. The kernel therefore trusts neither the compiled search nor the
-Descartes dispatch. For repeated roots, a checked polynomial identity proves
-that the squarefree core and original polynomial have the same real zeros,
-and {name}`Hex.IsolatedRealRoots.congrRoots` transports the isolation across
-that equivalence. Inputs written as `Polynomial ℤ`, `Polynomial ℚ`, or
-`Polynomial ℝ` cross the same boundary through
-{name}`HexPolyZMathlib.toPolynomial` and a checked evaluation equivalence.
-
 # The `isolate_roots` elaborator
 %%%
 tag := "hex-real-roots-isolate"
@@ -240,22 +204,36 @@ A polynomial with no real roots isolates as the empty vector, and a
 nonzero constant isolates as `n = 0` without ever entering the isolator.
 The zero polynomial is rejected, since every real number is a root.
 
-# How the certificate is checked
+# The Mathlib correspondence
 %%%
-tag := "hex-real-roots-certificate"
+tag := "hex-real-roots-mathlib"
 %%%
 
-The elaborator does the search at elaboration time with the compiled
-isolator, then emits a term the kernel re-checks. It does not ask the
-kernel to redo the search. The emitted term reifies the Sturm chain once
-as an array of integer-coefficient polynomials. The root-count fields
-reduce to sign-variation counts against that fixed chain: one count per
-interval for `unique_root`, and an endpoint-at-infinity count for the root
-total. These are `decide`-checked polynomial evaluations over the
-integers, so their kernel cost grows with the degree and the endpoint
-sizes, not with the number of bisections the search performed. The
-`ordered` field is cheaper still — an adjacent-pair comparison of the
-dyadic endpoints, no polynomial evaluation at all.
+The split between `HexRealRoots` and `HexRealRootsMathlib` is a trust and
+dependency boundary. `HexRealRoots` performs exact integer and dyadic
+computation without importing Mathlib. `HexRealRootsMathlib` interprets the
+result in Mathlib's language of `Polynomial ℝ` and real roots. Its abstract
+Sturm theorem is connected to the executable signed pseudo-remainder chain by
+the following headline correspondence.
+
+{docstring HexRealRootsMathlib.sturmChain_isSturmChain}
+
+The elaborator runs compiled search only to choose certificate data. It emits
+the integer polynomial, Sturm chain, and intervals as literals, then applies
+the replay constructor whose obligations are ordinary Lean propositions.
+
+{docstring Hex.IsolatedRealRoots.ofCert}
+
+The emitted top-level term uses {name}`Hex.IsolatedRealRoots.ofCertPretty`,
+which changes only the presentation of dyadic endpoints. The kernel checks
+the chain, each interval count, the total count, and interval ordering; it
+does not trust the compiled search or the Descartes dispatch. Inputs written
+as `Polynomial ℤ`, `Polynomial ℚ`, or `Polynomial ℝ` are connected to
+{name}`HexPolyZMathlib.toPolynomial` by a checked evaluation equivalence.
+Repeated-root inputs are isolated through a squarefree core and transported
+back with the following root-equivalence operation.
+
+{docstring Hex.IsolatedRealRoots.congrRoots}
 
 The interval endpoints are presented as reduced rational literals, and
 the identification of the emitted literals with the isolator's dyadic

--- a/HexRealRootsMathlib/ChainCorrespond.lean
+++ b/HexRealRootsMathlib/ChainCorrespond.lean
@@ -117,7 +117,7 @@ private theorem coeff_hornerPoly : ∀ (cs : List ℝ) (n : Nat),
       cases n with
       | zero => simp
       | succ m =>
-          rw [Polynomial.coeff_add, Polynomial.coeff_C, if_neg (Nat.succ_ne_zero m),
+          rw [Polynomial.coeff_add, Polynomial.coeff_C, ite_eq_right (Nat.succ_ne_zero m),
             Polynomial.coeff_X_mul, coeff_hornerPoly cs m, zero_add, List.getD_cons_succ]
 
 private theorem getD_map_intCast : ∀ (L : List Int) (n : Nat),
@@ -170,11 +170,11 @@ theorem sign_dyadicSign (d : Dyadic) :
         rw [Dyadic.toRat_ofOdd_eq_mul_two_pow]; push_cast; ring
       rw [htr, Hex.dyadicSign]
       by_cases hlt : n < 0
-      · rw [if_pos hlt]
+      · rw [ite_eq_left hlt]
         rw [show ((-1 : Int) : ℝ) = -1 by norm_num,
           sign_neg (mul_neg_of_neg_of_pos (by exact_mod_cast hlt) h2), sign_neg (by norm_num)]
       · have hpos : 0 < n := lt_of_le_of_ne (by omega) (Ne.symm hn0)
-        rw [if_neg hlt]
+        rw [ite_eq_right hlt]
         rw [show ((1 : Int) : ℝ) = 1 by norm_num,
           sign_pos (mul_pos (by exact_mod_cast hpos) h2), sign_pos (by norm_num)]
 
@@ -218,9 +218,9 @@ private theorem signVar_cons_cons {a b : Int} (rest : List Int) (ha : a ≠ 0) (
     Hex.signVar (a :: b :: rest)
       = (if a * b < 0 then 1 else 0) + Hex.signVar (b :: rest) := by
   have fa : (a :: b :: rest).filter (· != 0) = a :: b :: rest.filter (· != 0) := by
-    rw [List.filter_cons, if_pos (by simpa using ha), List.filter_cons, if_pos (by simpa using hb)]
+    rw [List.filter_cons, ite_eq_left (by simpa using ha), List.filter_cons, ite_eq_left (by simpa using hb)]
   have fb : (b :: rest).filter (· != 0) = b :: rest.filter (· != 0) := by
-    rw [List.filter_cons, if_pos (by simpa using hb)]
+    rw [List.filter_cons, ite_eq_left (by simpa using hb)]
   unfold Hex.signVar
   rw [fa, fb]
   rfl
@@ -234,7 +234,7 @@ private theorem signVar_zeroFree : ∀ m : List Int, (∀ x ∈ m, x ≠ 0) →
   | [a], ha => by
       have ha0 : a ≠ 0 := ha a (by simp)
       unfold Hex.signVar
-      rw [List.filter_cons, if_pos (by simpa using ha0), List.filter_nil]
+      rw [List.filter_cons, ite_eq_left (by simpa using ha0), List.filter_nil]
       rfl
   | a :: b :: rest, hne => by
       have ha : a ≠ 0 := hne a (by simp)
@@ -246,8 +246,8 @@ private theorem signVar_zeroFree : ∀ m : List Int, (∀ x ∈ m, x ≠ 0) →
       have hcast : (a : ℝ) * (b : ℝ) = ((a * b : Int) : ℝ) := by push_cast; ring
       rw [hcast]
       by_cases h : a * b < 0
-      · rw [if_pos h, if_pos (by exact_mod_cast h)]
-      · rw [if_neg h, if_neg (by exact_mod_cast h)]
+      · rw [ite_eq_left h, ite_eq_left (by exact_mod_cast h)]
+      · rw [ite_eq_right h, ite_eq_right (by exact_mod_cast h)]
 
 /-- `signVar` reads only the zero-filtered list, so it is unchanged by
 pre-filtering out zeros. -/
@@ -310,8 +310,8 @@ theorem toPolynomial_shift {R : Type*} [CommRing R] [DecidableEq R]
   rw [HexPolyMathlib.coeff_toPolynomial, Hex.DensePoly.coeff_shift, mul_comm,
     Polynomial.coeff_mul_X_pow']
   by_cases h : k ≤ n
-  · rw [if_neg (by omega), if_pos h, HexPolyMathlib.coeff_toPolynomial]
-  · rw [if_pos (by omega), if_neg h]; rfl
+  · rw [ite_eq_right (by omega), ite_eq_left h, HexPolyMathlib.coeff_toPolynomial]
+  · rw [ite_eq_left (by omega), ite_eq_right h]; rfl
 
 /-- The real cast of a scalar multiple. -/
 theorem toPolyℝ_scale (c : Int) (p : Hex.ZPoly) :
@@ -333,8 +333,8 @@ theorem toPolyℝ_shift (k : Nat) (p : Hex.ZPoly) :
   ext n
   rw [coeff_toPolyℝ, Hex.DensePoly.coeff_shift, mul_comm, Polynomial.coeff_mul_X_pow']
   by_cases h : k ≤ n
-  · rw [if_neg (show ¬ n < k by omega), if_pos h, coeff_toPolyℝ]
-  · rw [if_pos (show n < k by omega), if_neg h]; exact Int.cast_zero
+  · rw [ite_eq_right (show ¬ n < k by omega), ite_eq_left h, coeff_toPolyℝ]
+  · rw [ite_eq_left (show n < k by omega), ite_eq_right h]; exact Int.cast_zero
 
 /-- The real cast of a difference. -/
 theorem toPolyℝ_sub (p q : Hex.ZPoly) :
@@ -392,9 +392,9 @@ private theorem spemAux_relate (g : Hex.ZPoly) (hg : g.leadingCoeff ≠ 0) :
            else if (r.degree?).getD 0 < (g.degree?).getD 0 then r
            else Hex.ZPoly.spemAux g fuel (Hex.ZPoly.spemStep g r)) := rfl
       by_cases h0 : r.isZero
-      · exact ⟨1, 0, one_pos, by rw [hunf, if_pos h0]; simp⟩
+      · exact ⟨1, 0, one_pos, by rw [hunf, ite_eq_left h0]; simp⟩
       · by_cases h1 : (r.degree?).getD 0 < (g.degree?).getD 0
-        · exact ⟨1, 0, one_pos, by rw [hunf, if_neg h0, if_pos h1]; simp⟩
+        · exact ⟨1, 0, one_pos, by rw [hunf, ite_eq_right h0, ite_eq_left h1]; simp⟩
         · obtain ⟨c', Q', hc', hrel'⟩ := ih (Hex.ZPoly.spemStep g r)
           refine ⟨c' * ((if g.leadingCoeff < 0 then -g.leadingCoeff
                     else g.leadingCoeff : Int) : ℝ),
@@ -402,7 +402,7 @@ private theorem spemAux_relate (g : Hex.ZPoly) (hg : g.leadingCoeff ≠ 0) :
                     else r.leadingCoeff : Int) : ℝ)
                 * Polynomial.X ^ ((r.degree?).getD 0 - (g.degree?).getD 0) + Q',
               mul_pos hc' habs, ?_⟩
-          rw [hunf, if_neg h0, if_neg h1, Polynomial.C_mul]
+          rw [hunf, ite_eq_right h0, ite_eq_right h1, Polynomial.C_mul]
           have key : toPolyℝ (Hex.ZPoly.spemAux g fuel (Hex.ZPoly.spemStep g r))
               = Polynomial.C c' * toPolyℝ (Hex.ZPoly.spemStep g r) - Q' * toPolyℝ g := by
             rw [hrel']; ring
@@ -533,7 +533,7 @@ private theorem spem_of_degree_zero (f : Hex.ZPoly) {g : Hex.ZPoly} (hg : g ≠ 
 
 /-- One `spemStep` strictly drops the degree (or reaches zero): the sign
 management makes the two leading terms cancel exactly. Proved over `ℝ` via
-`Polynomial.degree_sub_lt` and transferred back through `natDegree_toPolyℝ`. -/
+`Polynomial.degree_sub_lt_left` and transferred back through `natDegree_toPolyℝ`. -/
 private theorem spemStep_degree_lt {g r : Hex.ZPoly} (hg : g ≠ 0) (hr : r ≠ 0)
     (hge : (g.degree?).getD 0 ≤ (r.degree?).getD 0) :
     Hex.ZPoly.spemStep g r = 0 ∨
@@ -577,7 +577,7 @@ private theorem spemStep_degree_lt {g r : Hex.ZPoly} (hg : g ≠ 0) (hr : r ≠ 
   have hA0 : A ≠ 0 := mul_ne_zero (Polynomial.C_ne_zero.mpr ha0) hPr0
   have hlt : (toPolyℝ (Hex.ZPoly.spemStep g r)).degree < (toPolyℝ r).degree := by
     rw [hstep, ← hdegA]
-    exact Polynomial.degree_sub_lt (hdegA.trans hdegB.symm) hA0 hlceq
+    exact Polynomial.degree_sub_lt_left (hdegA.trans hdegB.symm) hA0 hlceq
   have hstep0 : toPolyℝ (Hex.ZPoly.spemStep g r) ≠ 0 :=
     fun h => hz (toPolyℝ_eq_zero_iff.mp h)
   have hnat := Polynomial.natDegree_lt_natDegree hstep0 hlt
@@ -605,10 +605,10 @@ private theorem spemAux_degree {g : Hex.ZPoly} (hg : g ≠ 0)
            else if (r.degree?).getD 0 < (g.degree?).getD 0 then r
            else Hex.ZPoly.spemAux g fuel (Hex.ZPoly.spemStep g r)) := rfl
       by_cases h0 : r.isZero
-      · left; rw [hunf, if_pos h0]; exact isZero_iff_eq_zero.mp h0
+      · left; rw [hunf, ite_eq_left h0]; exact isZero_iff_eq_zero.mp h0
       · by_cases h1 : (r.degree?).getD 0 < (g.degree?).getD 0
-        · right; rw [hunf, if_neg h0, if_pos h1]; exact h1
-        · rw [hunf, if_neg h0, if_neg h1]
+        · right; rw [hunf, ite_eq_right h0, ite_eq_left h1]; exact h1
+        · rw [hunf, ite_eq_right h0, ite_eq_right h1]
           have hr : r ≠ 0 := fun h => h0 (isZero_iff_eq_zero.mpr h)
           have hge : (g.degree?).getD 0 ≤ (r.degree?).getD 0 := not_lt.mp h1
           rcases spemStep_degree_lt hg hr hge with hz | hlt
@@ -697,8 +697,8 @@ private theorem sturmChainAux_toList (fuel : ℕ) (prev cur : Hex.ZPoly)
                   (acc.push (-(Hex.ZPoly.primitivePart (Hex.ZPoly.spem prev cur))))) := rfl
       rw [hunf, chainList]
       by_cases h : (Hex.ZPoly.spem prev cur).isZero
-      · rw [if_pos h, if_pos h, List.append_nil]
-      · rw [if_neg h, if_neg h, ih, Array.toList_push, List.append_assoc,
+      · rw [ite_eq_left h, ite_eq_left h, List.append_nil]
+      · rw [ite_eq_right h, ite_eq_right h, ih, Array.toList_push, List.append_assoc,
           List.cons_append, List.nil_append]
 
 /-- For a positive-degree `p`, the executable Sturm chain is
@@ -815,12 +815,12 @@ private theorem chainList_nonzero :
       intro prev cur hprev hcur q hq
       rw [chainList] at hq
       by_cases h : (Hex.ZPoly.spem prev cur).isZero
-      · rw [if_pos h] at hq
+      · rw [ite_eq_left h] at hq
         simp only [List.mem_cons, List.not_mem_nil, or_false] at hq
         rcases hq with rfl | rfl
         · exact hprev
         · exact hcur
-      · rw [if_neg h] at hq
+      · rw [ite_eq_right h] at hq
         have hr : Hex.ZPoly.spem prev cur ≠ 0 := fun hh => h (isZero_iff_eq_zero.mpr hh)
         rcases List.mem_cons.mp hq with rfl | hq'
         · exact hprev
@@ -848,9 +848,9 @@ private theorem chainList_triples :
       intro prev cur hcur i a b c ha hb hc
       rw [chainList] at ha hb hc
       by_cases h : (Hex.ZPoly.spem prev cur).isZero
-      · rw [if_pos h, List.getElem?_cons_succ, List.getElem?_cons_succ] at hc
+      · rw [ite_eq_left h, List.getElem?_cons_succ, List.getElem?_cons_succ] at hc
         simp at hc
-      · rw [if_neg h] at ha hb hc
+      · rw [ite_eq_right h] at ha hb hc
         have hr : Hex.ZPoly.spem prev cur ≠ 0 := fun hh => h (isZero_iff_eq_zero.mpr hh)
         cases i with
         | zero =>
@@ -891,7 +891,7 @@ private theorem chainList_pairs_coprime :
       intro prev cur hcur hco i a b ha hb
       rw [chainList] at ha hb
       by_cases h : (Hex.ZPoly.spem prev cur).isZero
-      · rw [if_pos h] at ha hb
+      · rw [ite_eq_left h] at ha hb
         cases i with
         | zero =>
             obtain rfl : prev = a := by simpa using ha
@@ -900,7 +900,7 @@ private theorem chainList_pairs_coprime :
         | succ j =>
             rw [List.getElem?_cons_succ, List.getElem?_cons_succ] at hb
             simp at hb
-      · rw [if_neg h] at ha hb
+      · rw [ite_eq_right h] at ha hb
         have hr : Hex.ZPoly.spem prev cur ≠ 0 := fun hh => h (isZero_iff_eq_zero.mpr hh)
         obtain ⟨c₀, k, Q, hc₀, _, hrel⟩ := chain_step hcur hr
         have hco' : IsCoprime (toPolyℝ cur)
@@ -933,7 +933,7 @@ private theorem chainList_last_unit :
       intro prev cur hcur hfuel hco z hz
       rw [chainList] at hz
       by_cases h : (Hex.ZPoly.spem prev cur).isZero
-      · rw [if_pos h, List.getLast?_cons_cons] at hz
+      · rw [ite_eq_left h, List.getLast?_cons_cons] at hz
         obtain rfl : cur = z := by simpa using hz
         have hr0 : Hex.ZPoly.spem prev cur = 0 := isZero_iff_eq_zero.mp h
         have hne : toPolyℝ cur ≠ 0 := fun hh => hcur (toPolyℝ_eq_zero_iff.mp hh)
@@ -956,7 +956,7 @@ private theorem chainList_last_unit :
               _ = Polynomial.C c⁻¹ * (Q * toPolyℝ cur) := by rw [hrel]
               _ = toPolyℝ cur * (Polynomial.C c⁻¹ * Q) := by ring
           exact hco.isUnit_of_dvd' hdvd dvd_rfl
-      · rw [if_neg h, List.getLast?_cons_cons] at hz
+      · rw [ite_eq_right h, List.getLast?_cons_cons] at hz
         have hr : Hex.ZPoly.spem prev cur ≠ 0 := fun hh => h (isZero_iff_eq_zero.mpr hh)
         obtain ⟨c₀, k, Q, hc₀, _, hrel⟩ := chain_step hcur hr
         have hco' : IsCoprime (toPolyℝ cur)
@@ -1026,7 +1026,7 @@ private theorem chainList_seeds_coprime :
       by_cases h : (Hex.ZPoly.spem prev cur).isZero
       · -- The loop stops: the chain is `[prev, cur]`, so `cur` is the terminal unit.
         have hz : (prev :: cur :: chainList (fuel + 1) prev cur).getLast? = some cur := by
-          rw [chainList, if_pos h]; rfl
+          rw [chainList, ite_eq_left h]; rfl
         obtain ⟨w, hw⟩ := hunit cur hz
         exact ⟨0, ↑w⁻¹, by rw [← hw]; simp⟩
       · have hr : Hex.ZPoly.spem prev cur ≠ 0 := fun hh => h (isZero_iff_eq_zero.mpr hh)
@@ -1055,7 +1055,7 @@ private theorem chainList_seeds_coprime :
               = some z → IsUnit (toPolyℝ z) := by
           intro z hz
           apply hunit z
-          rw [chainList, if_neg h, List.getLast?_cons_cons]
+          rw [chainList, ite_eq_right h, List.getLast?_cons_cons]
           exact hz
         have hco_tail : IsCoprime (toPolyℝ cur)
             (toPolyℝ (-(Hex.ZPoly.primitivePart (Hex.ZPoly.spem prev cur)))) :=
@@ -1500,11 +1500,11 @@ theorem sturmVarNegInf_eq (chain : Array Hex.ZPoly) :
   simp only [Function.comp_apply]
   rw [leadingCoeff_toPolyℝ, natDegree_toPolyℝ]
   by_cases hpar : (Hex.DensePoly.degree? q).getD 0 % 2 = 1
-  · rw [if_pos hpar, (Nat.odd_iff.mpr hpar).neg_one_pow, mul_neg_one, mul_neg_one]
+  · rw [ite_eq_left hpar, (Nat.odd_iff.mpr hpar).neg_one_pow, mul_neg_one, mul_neg_one]
     have h2 : ((-(Hex.DensePoly.leadingCoeff q).sign : Int) : ℝ)
         = -(((Hex.DensePoly.leadingCoeff q).sign : Int) : ℝ) := by push_cast; ring
     rw [h2, Left.sign_neg, Left.sign_neg, sign_intCast_sign]
-  · rw [if_neg hpar, (Nat.even_iff.mpr (by omega)).neg_one_pow, mul_one, mul_one]
+  · rw [ite_eq_right hpar, (Nat.even_iff.mpr (by omega)).neg_one_pow, mul_one, mul_one]
     exact sign_intCast_sign _
 
 /-- **Root count correspondence.** For positive-degree, rationally squarefree

--- a/HexRealRootsMathlib/DescartesParity.lean
+++ b/HexRealRootsMathlib/DescartesParity.lean
@@ -120,8 +120,8 @@ private lemma countP_deg_one {f : ℝ[X]} (hf : IsMonicOfDegree f 1) :
       rw [trailingCoeff_eq_coeff_zero hne, hcoeff]
     rw [htc, ← Multiset.cons_zero, Multiset.countP_cons, Multiset.countP_zero, zero_add]
     rcases lt_or_gt_of_ne hbz with h | h
-    · rw [if_pos (show (0 : ℝ) < -b by linarith), sign_neg h, if_neg (by decide)]
-    · rw [if_neg (show ¬ (0 : ℝ) < -b by linarith), sign_pos h, if_pos rfl]
+    · rw [ite_eq_left (show (0 : ℝ) < -b by linarith), sign_neg h, ite_eq_right (by decide)]
+    · rw [ite_eq_right (show ¬ (0 : ℝ) < -b by linarith), sign_pos h, ite_eq_left rfl]
 
 /-- A monic degree-two real polynomial with no real root has a positive trailing (constant)
 coefficient. -/
@@ -167,7 +167,7 @@ private lemma countP_deg_two {f : ℝ[X]} (hf : IsMonicOfDegree f 2) :
       rw [Multiset.eq_zero_iff_forall_notMem]
       exact fun x hx => hroot x (isRoot_of_mem_roots hx)
     rw [hroots, Multiset.countP_zero,
-      if_pos (sign_pos (trailingCoeff_pos_of_no_root hf hroot))]
+      ite_eq_left (sign_pos (trailingCoeff_pos_of_no_root hf hroot))]
 
 /-- Core (monic case): the number of positive roots of a monic real polynomial is congruent
 modulo two to the indicator of its trailing coefficient's sign. -/
@@ -249,8 +249,8 @@ theorem signVariations_modTwo {P : ℝ[X]} (hP : P ≠ 0) :
         rw [← hmc, he, coeff_zero]
       have hlctc : P.trailingCoeff = P.leadingCoeff := by
         simp only [trailingCoeff, leadingCoeff, hnt]
-      rw [he, signVariations_zero, leadingCoeff_zero, sign_zero, neg_zero, if_neg hslc, hlctc,
-        if_pos rfl]
+      rw [he, signVariations_zero, leadingCoeff_zero, sign_zero, neg_zero, ite_eq_right hslc, hlctc,
+        ite_eq_left rfl]
     · have hltd : P.eraseLead.natDegree < d := by
         rw [← hd]
         rcases eraseLead_natDegree_lt_or_eraseLead_eq_zero P with h' | h'
@@ -268,9 +268,8 @@ theorem signVariations_parity (P : ℝ[X]) (hP : P ≠ 0) :
     P.roots.countP (0 < ·) ≡ P.signVariations [MOD 2] :=
   (countP_pos_modTwo hP).trans (signVariations_modTwo hP).symm
 
-set_option linter.unusedVariables false in
 /-- No sign variations forces no positive roots. -/
-theorem countP_pos_eq_zero_of_signVariations_eq_zero {P : ℝ[X]} (hP : P ≠ 0)
+theorem countP_pos_eq_zero_of_signVariations_eq_zero {P : ℝ[X]}
     (h : P.signVariations = 0) : P.roots.countP (0 < ·) = 0 :=
   Nat.le_zero.mp (h ▸ roots_countP_pos_le_signVariations P)
 

--- a/HexRealRootsMathlib/Drivers.lean
+++ b/HexRealRootsMathlib/Drivers.lean
@@ -186,7 +186,7 @@ theorem refine1_isolates_same (hp : Hex.ZPoly.SquareFreeRat p)
     have href : iso.refine1.interval = (⟨lo, m, hlm⟩ : Hex.DyadicInterval) := by
       show (Hex.RealRootIsolation.refine1 iso).interval = _
       unfold Hex.RealRootIsolation.refine1 Hex.RealRootIsolation.refine1With
-      rw [dif_pos hlm, dif_pos hCLraw]
+      rw [dite_eq_left hlm, dite_eq_left hCLraw]
       rfl
     have hCR : Hex.sturmCount p ⟨m, hi, hmh⟩ = 0 := by omega
     refine ⟨fun r hr => ?_, ?_⟩
@@ -209,7 +209,7 @@ theorem refine1_isolates_same (hp : Hex.ZPoly.SquareFreeRat p)
     have href : iso.refine1.interval = (⟨m, hi, hmh⟩ : Hex.DyadicInterval) := by
       show (Hex.RealRootIsolation.refine1 iso).interval = _
       unfold Hex.RealRootIsolation.refine1 Hex.RealRootIsolation.refine1With
-      rw [dif_pos hlm, dif_neg hCLraw_neg, dif_pos hmh, dif_pos hCRraw]
+      rw [dite_eq_left hlm, dite_eq_right hCLraw_neg, dite_eq_left hmh, dite_eq_left hCRraw]
       rfl
     refine ⟨fun r hr => ?_, ?_⟩
     · rw [href]
@@ -289,7 +289,7 @@ private theorem toReal_le_two_pow_ceilLog2Dyadic (x : Dyadic) (hx : 0 < Dyadic.t
     have hcl : Hex.ceilLog2Dyadic (Dyadic.ofOdd n k hn)
         = (Hex.ceilLog2Nat n.toNat : Int) - k := by
       show (if n ≤ 0 then (0 : Int) else (Hex.ceilLog2Nat n.toNat : Int) - k) = _
-      rw [if_neg (by omega)]
+      rw [ite_eq_right (by omega)]
     have hnle : (n : ℝ) ≤ (2 : ℝ) ^ (Hex.ceilLog2Nat n.toNat) := by
       have hnat := le_two_pow_ceilLog2Nat n.toNat
       have hcast : (n.toNat : ℝ) ≤ (2 : ℝ) ^ (Hex.ceilLog2Nat n.toNat) := by exact_mod_cast hnat
@@ -468,7 +468,7 @@ private theorem sturmVisit_spec (hdeg : 1 ≤ (p.degree?).getD 0)
            else none) := rfl
     by_cases h0 : Hex.sturmVarAt (Hex.ZPoly.sturmChain p) lo
         = Hex.sturmVarAt (Hex.ZPoly.sturmChain p) hi
-    · refine ⟨#[], by rw [hunf, if_pos h0], by simp [h0], ?_, ?_, ?_⟩
+    · refine ⟨#[], by rw [hunf, ite_eq_left h0], by simp [h0], ?_, ?_, ?_⟩
       · intro i j hij; exact absurd i.isLt (by simp)
       · intro I hI; simp at hI
       · intro I hI; simp at hI
@@ -477,7 +477,7 @@ private theorem sturmVisit_spec (hdeg : 1 ≤ (p.degree?).getD 0)
       · have hraw : (Hex.sturmVarAt (Hex.ZPoly.sturmChain p) lo : Int)
             - Hex.sturmVarAt (Hex.ZPoly.sturmChain p) hi = 1 := by omega
         refine ⟨#[⟨⟨lo, hi, hlt⟩, hraw⟩],
-          by rw [hunf, if_neg h0, if_pos h1, dif_pos hlt, dif_pos hraw],
+          by rw [hunf, ite_eq_right h0, ite_eq_left h1, dite_eq_left hlt, dite_eq_left hraw],
           by simp [h1], ?_, ?_, ?_⟩
         · intro i j hij
           have hi1 : (i : ℕ) < 1 := i.isLt
@@ -530,7 +530,7 @@ private theorem sturmVisit_spec (hdeg : 1 ≤ (p.degree?).getD 0)
                | some right => some (left ++ right)) := rfl
     by_cases h0 : Hex.sturmVarAt (Hex.ZPoly.sturmChain p) lo
         = Hex.sturmVarAt (Hex.ZPoly.sturmChain p) hi
-    · refine ⟨#[], by rw [hunf, if_pos h0], by simp [h0], ?_, ?_, ?_⟩
+    · refine ⟨#[], by rw [hunf, ite_eq_left h0], by simp [h0], ?_, ?_, ?_⟩
       · intro i j hij; exact absurd i.isLt (by simp)
       · intro I hI; simp at hI
       · intro I hI; simp at hI
@@ -539,7 +539,7 @@ private theorem sturmVisit_spec (hdeg : 1 ≤ (p.degree?).getD 0)
       · have hraw : (Hex.sturmVarAt (Hex.ZPoly.sturmChain p) lo : Int)
             - Hex.sturmVarAt (Hex.ZPoly.sturmChain p) hi = 1 := by omega
         refine ⟨#[⟨⟨lo, hi, hlt⟩, hraw⟩],
-          by rw [hunf, if_neg h0, if_pos h1, dif_pos hlt, dif_pos hraw],
+          by rw [hunf, ite_eq_right h0, ite_eq_left h1, dite_eq_left hlt, dite_eq_left hraw],
           by simp [h1], ?_, ?_, ?_⟩
         · intro i j hij
           have hi1 : (i : ℕ) < 1 := i.isLt
@@ -582,7 +582,7 @@ private theorem sturmVisit_spec (hdeg : 1 ≤ (p.degree?).getD 0)
             ≤ Hex.sturmVarAt (Hex.ZPoly.sturmChain p) ((lo + hi) >>> (1 : Int)) :=
           sturmVarAt_le hdeg hp hmh
         refine ⟨left ++ right, ?_, ?_, ?_, ?_, ?_⟩
-        · rw [hunf, if_neg h0, if_neg h1, hLeq, hReq]
+        · rw [hunf, ite_eq_right h0, ite_eq_right h1, hLeq, hReq]
         · rw [Array.size_append, hLsize, hRsize]
           omega
         · -- The concatenation stays sorted: `left`'s uppers sit below the
@@ -623,7 +623,7 @@ theorem assemble?_isSome {chain : Array Hex.ZPoly}
     (hsize : arr.size = Hex.sturmVarNegInf chain - Hex.sturmVarPosInf chain) :
     (Hex.assemble? p chain hchain arr).isSome := by
   unfold Hex.assemble?
-  rw [dif_pos hord, dif_pos hsize]
+  rw [dite_eq_left hord, dite_eq_left hsize]
   rfl
 
 /-- `isolateSturm?` on positive-degree squarefree input is the top `sturmVisit`
@@ -639,7 +639,7 @@ private theorem isolateSturm?_eq {d : Nat} (hd : p.degree? = some (d + 1))
         | some arr => Hex.assemble? p (Hex.ZPoly.sturmChain p) rfl arr) := by
   unfold Hex.isolateSturm?
   simp only [hd]
-  rw [if_pos hp]
+  rw [ite_eq_left hp]
   rfl
 
 /-! # Driver completeness -/

--- a/HexRealRootsMathlib/IsolateRoots.lean
+++ b/HexRealRootsMathlib/IsolateRoots.lean
@@ -330,7 +330,7 @@ reconcile the two explicit polynomials in `x`.
 This is a pointwise evaluation bridge, not a `Polynomial` identity: it works on
 closed literal data with integer coefficients and does not attempt to match
 `Polynomial` structure. -/
-macro "isolate_roots_bridge" : tactic =>
+macro (name := isolateRootsBridge) "isolate_roots_bridge" : tactic =>
   `(tactic|
     (intro x
      rw [HexRealRootsMathlib.aeval_toPolynomial_ofCoeffs]

--- a/HexRealRootsMathlib/IsolateRootsElab.lean
+++ b/HexRealRootsMathlib/IsolateRootsElab.lean
@@ -97,7 +97,7 @@ pushing `aeval` through the user polynomial's `X / C / + / − / * / ^ / neg`
 structure, then closing with `ring`. Deliberately avoids `mul_eq_zero`, so a
 factored user polynomial (e.g. Wilkinson) does not collapse into a root
 disjunction. -/
-macro "aeval_ring_eq" : tactic =>
+macro (name := aevalRingEq) "aeval_ring_eq" : tactic =>
   `(tactic|
     (simp only [HexRealRootsMathlib.aeval_toPolynomial_ofCoeffs]
      simp [Hex.DensePoly.coeff_ofCoeffs, Finset.sum_range_succ, Finset.sum_range_zero,
@@ -106,11 +106,11 @@ macro "aeval_ring_eq" : tactic =>
 
 /-- Prove `∀ x, aeval x P = 0 ↔ aeval x Q = 0` for reified/closed literal
 polynomials by reducing to the underlying evaluation equality. -/
-macro "aeval_iff_bridge" : tactic =>
+macro (name := aevalIffBridge) "aeval_iff_bridge" : tactic =>
   `(tactic| (intro x; refine Iff.of_eq (congrArg (· = 0) ?_); aeval_ring_eq))
 
 /-- Bridge tactic for the reified product identities `aevalIff_radical` consumes. -/
-macro "isolate_roots_prod" : tactic =>
+macro (name := isolateRootsProd) "isolate_roots_prod" : tactic =>
   `(tactic| (intro x; aeval_ring_eq))
 
 namespace IsolateRoots
@@ -199,8 +199,11 @@ meta def divExactInt (num den : Array Int) : Option (Array Int) := Id.run do
 polynomial (the square-free core, when a swap happened), its Sturm chain, and the
 per-root dyadic endpoints. -/
 structure IsoData where
+  /-- The reified polynomial whose roots are isolated. -/
   poly       : Hex.ZPoly
+  /-- The executable Sturm chain used to certify the result. -/
   chain      : Array Hex.ZPoly
+  /-- One dyadic interval for each distinct real root. -/
   endpoints  : Array (Dyadic × Dyadic)
 
 /-- Run the compiled isolator on `f` (assumed square-free with a nonzero
@@ -495,6 +498,8 @@ meta def elabIsolate (widthStx : Option (TSyntax `term)) (pStx : TSyntax `term)
 syntax (name := isolateRoots) "isolate_roots"
   (atomic("(" "width" ":=") term ")")? term : term
 
+/-- Elaborate `isolate_roots`, run the compiled search, and emit a replay term
+whose certificate obligations are checked by Lean. -/
 @[term_elab isolateRoots]
 meta def elabIsolateRoots : TermElab := fun stx expectedType? => do
   match stx with

--- a/HexRealRootsMathlib/IsolateRootsElabTests.lean
+++ b/HexRealRootsMathlib/IsolateRootsElabTests.lean
@@ -24,42 +24,42 @@ namespace HexRealRootsMathlib.ElabTests
 def x4m2 : ZPoly := DensePoly.ofCoeffs #[(-2 : Int), 0, 0, 0, 1]
 
 /-- Bare isolation of `x⁴ − 2` as a `ZPoly`. -/
-noncomputable def iso_zpoly := isolate_roots x4m2
+noncomputable def isoZPoly := isolate_roots x4m2
 
 /-- `x⁴ − 2` over `Polynomial ℝ`, bare. -/
-noncomputable def iso_real := isolate_roots (X ^ 4 - 2 : Polynomial ℝ)
+noncomputable def isoReal := isolate_roots (X ^ 4 - 2 : Polynomial ℝ)
 
 /-- `x⁴ − 2`, every root refined to width `2^(-20)`. -/
-noncomputable def iso_w20 := isolate_roots (width := 2 ^ (-20 : ℤ)) (X ^ 4 - 2 : Polynomial ℝ)
+noncomputable def isoW20 := isolate_roots (width := 2 ^ (-20 : ℤ)) (X ^ 4 - 2 : Polynomial ℝ)
 
 /-- `x⁴ − 2`, width `1/1000`. -/
-noncomputable def iso_w1000 := isolate_roots (width := 1 / 1000) (X ^ 4 - 2 : Polynomial ℝ)
+noncomputable def isoW1000 := isolate_roots (width := 1 / 1000) (X ^ 4 - 2 : Polynomial ℝ)
 
 /-- `x⁴ − 2`, width `10^(-2)`. -/
-noncomputable def iso_w100 := isolate_roots (width := 10 ^ (-2 : ℤ)) (X ^ 4 - 2 : Polynomial ℝ)
+noncomputable def isoW100 := isolate_roots (width := 10 ^ (-2 : ℤ)) (X ^ 4 - 2 : Polynomial ℝ)
 
 /-- `x⁴ − 2` as a `ZPoly`, refined to width `2^(-20)`. -/
-noncomputable def iso_zpoly_w20 := isolate_roots (width := 2 ^ (-20 : ℤ)) x4m2
+noncomputable def isoZPolyW20 := isolate_roots (width := 2 ^ (-20 : ℤ)) x4m2
 
 /-! # Coefficient rings -/
 
 /-- Wilkinson-6 `∏_{i=1}^{6}(x − i)` over `Polynomial ℤ`. -/
-noncomputable def iso_wilkinson :=
+noncomputable def isoWilkinson :=
   isolate_roots ((X - 1) * (X - 2) * (X - 3) * (X - 4) * (X - 5) * (X - 6) : Polynomial ℤ)
 
 /-- A `Polynomial ℚ` case: `2x² − 3x + 1 = (2x − 1)(x − 1)`. -/
-noncomputable def iso_rat := isolate_roots (2 * X ^ 2 - 3 * X + 1 : Polynomial ℚ)
+noncomputable def isoRat := isolate_roots (2 * X ^ 2 - 3 * X + 1 : Polynomial ℚ)
 
 /-! # Non-squarefree (exercises the core transport) -/
 
 /-- `(x − 1)²(x − 3)` over `Polynomial ℤ`: two distinct real roots. -/
-noncomputable def iso_nonsqfree :=
+noncomputable def isoNonsqfree :=
   isolate_roots ((X - 1) ^ 2 * (X - 3) : Polynomial ℤ)
 
 /-! # Nonzero constant -/
 
 /-- A nonzero constant has no real roots: the empty isolation. -/
-noncomputable def iso_const := isolate_roots (7 : Polynomial ℝ)
+noncomputable def isoConst := isolate_roots (7 : Polynomial ℝ)
 
 /-! # Consumption demos -/
 
@@ -210,7 +210,7 @@ example :
 /-- **Expected-type inference.** When the expected type pins the coefficient
 ring, the polynomial argument needs no type ascription: `X ^ 4 - 2` alone
 elaborates as a `Polynomial ℝ`. -/
-noncomputable def x4_inferred : Hex.IsolatedRealRoots (X ^ 4 - 2 : Polynomial ℝ) 2 :=
+noncomputable def x4Inferred : Hex.IsolatedRealRoots (X ^ 4 - 2 : Polynomial ℝ) 2 :=
   isolate_roots (X ^ 4 - 2)
 
 /-- A `ZPoly` argument still elaborates under an expected type (the ring hint
@@ -225,8 +225,8 @@ noncomputable example :
 computes an isolation's endpoints to their literals, so `unique_root` closes a
 concrete theorem with one `simpa`. -/
 example : ∃! x : ℝ, x ^ 4 - 2 = 0 ∧ (0 : ℝ) < x ∧ x ≤ 4 := by
-  simpa [x4_inferred] using x4_inferred.unique_root 1
+  simpa [x4Inferred] using x4Inferred.unique_root 1
 
 /-- The `ordered` field, consumed with bare `Nat` indices. -/
-example : (x4_inferred.intervals[0]).2 ≤ (x4_inferred.intervals[1]).1 := by
-  simpa using x4_inferred.ordered 0 1 (by decide)
+example : (x4Inferred.intervals[0]).2 ≤ (x4Inferred.intervals[1]).1 := by
+  simpa using x4Inferred.ordered 0 1 (by decide)

--- a/HexRealRootsMathlib/IsolateRootsTests.lean
+++ b/HexRealRootsMathlib/IsolateRootsTests.lean
@@ -62,7 +62,7 @@ theorem sqfree_x4m2 : ZPoly.SquareFreeRat x4m2 :=
   squareFreeRat_of_hasSquarefreeSturmChain _ (by decide)
 
 /-- The complete run of `x⁴ − 2`: the two isolate? intervals `(-4, 0]`, `(0, 4]`. -/
-def run_x4m2 : RealRootIsolations x4m2 where
+def runX4m2 : RealRootIsolations x4m2 where
   isolations :=
     #[⟨⟨Dyadic.ofInt (-4), Dyadic.ofInt 0, by decide⟩, by decide⟩,
       ⟨⟨Dyadic.ofInt 0, Dyadic.ofInt 4, by decide⟩, by decide⟩]
@@ -70,27 +70,27 @@ def run_x4m2 : RealRootIsolations x4m2 where
   complete := by decide
 
 /-- `x⁴ − 2` isolated via `IsolatedRealRoots.of`. -/
-noncomputable def iso_x4m2_of :
-    IsolatedRealRoots (HexPolyZMathlib.toPolynomial x4m2) run_x4m2.isolations.size :=
-  IsolatedRealRoots.of x4m2 (ne_zero_of_size_ne_zero (by decide)) sqfree_x4m2 run_x4m2
+noncomputable def isoX4m2Of :
+    IsolatedRealRoots (HexPolyZMathlib.toPolynomial x4m2) runX4m2.isolations.size :=
+  IsolatedRealRoots.of x4m2 (ne_zero_of_size_ne_zero (by decide)) sqfree_x4m2 runX4m2
 
 /-! # The replay constructor `IsolatedRealRoots.ofCert` on `x⁴ − 2` -/
 
 /-- The reified Sturm chain of `x⁴ − 2`: `[x⁴ − 2, x³, 1]`. -/
-def chain_x4m2 : Array ZPoly :=
+def chainX4m2 : Array ZPoly :=
   #[DensePoly.ofCoeffs #[(-2 : Int), 0, 0, 0, 1],
     DensePoly.ofCoeffs #[(0 : Int), 0, 0, 1],
     DensePoly.ofCoeffs #[(1 : Int)]]
 
 /-- `x⁴ − 2` isolated via the replay constructor: every field a `decide` on the
 reified chain. -/
-noncomputable def iso_x4m2_replay :
+noncomputable def isoX4m2Replay :
     IsolatedRealRoots (HexPolyZMathlib.toPolynomial x4m2) 2 :=
-  IsolatedRealRoots.ofCert (chain := chain_x4m2)
+  IsolatedRealRoots.ofCert (chain := chainX4m2)
     (iso := ⟨#[⟨⟨Dyadic.ofInt (-4), Dyadic.ofInt 0, by decide⟩,
-                RealRootIsolation.count_one_of_cert (chain := chain_x4m2) (by decide) _ (by decide)⟩,
+                RealRootIsolation.count_one_of_cert (chain := chainX4m2) (by decide) _ (by decide)⟩,
               ⟨⟨Dyadic.ofInt 0, Dyadic.ofInt 4, by decide⟩,
-                RealRootIsolation.count_one_of_cert (chain := chain_x4m2) (by decide) _ (by decide)⟩],
+                RealRootIsolation.count_one_of_cert (chain := chainX4m2) (by decide) _ (by decide)⟩],
         rfl⟩)
     (hsize := by decide) (hsf := by decide) (hcert := by decide)
     (hordered := by decide) (hcomplete := by decide)
@@ -104,26 +104,26 @@ def q : ZPoly := DensePoly.ofCoeffs #[(-3 : Int), 7, -5, 1]
 def qcore : ZPoly := DensePoly.ofCoeffs #[(3 : Int), -4, 1]
 
 /-- The Sturm chain of the squarefree core: `[x² − 4x + 3, x − 2, 1]`. -/
-def chain_qcore : Array ZPoly :=
+def chainQcore : Array ZPoly :=
   #[DensePoly.ofCoeffs #[(3 : Int), -4, 1],
     DensePoly.ofCoeffs #[(-2 : Int), 1],
     DensePoly.ofCoeffs #[(1 : Int)]]
 
 /-- The squarefree core isolated via replay: roots in `(0, 2]` and `(2, 4]`. -/
-noncomputable def iso_qcore_replay :
+noncomputable def isoQcoreReplay :
     IsolatedRealRoots (HexPolyZMathlib.toPolynomial qcore) 2 :=
-  IsolatedRealRoots.ofCert (chain := chain_qcore)
+  IsolatedRealRoots.ofCert (chain := chainQcore)
     (iso := ⟨#[⟨⟨Dyadic.ofInt 0, Dyadic.ofInt 2, by decide⟩,
-                RealRootIsolation.count_one_of_cert (chain := chain_qcore) (by decide) _ (by decide)⟩,
+                RealRootIsolation.count_one_of_cert (chain := chainQcore) (by decide) _ (by decide)⟩,
               ⟨⟨Dyadic.ofInt 2, Dyadic.ofInt 4, by decide⟩,
-                RealRootIsolation.count_one_of_cert (chain := chain_qcore) (by decide) _ (by decide)⟩],
+                RealRootIsolation.count_one_of_cert (chain := chainQcore) (by decide) _ (by decide)⟩],
         rfl⟩)
     (hsize := by decide) (hsf := by decide) (hcert := by decide)
     (hordered := by decide) (hcomplete := by decide)
 
 /-- `(x − 1)²(x − 3)` and its squarefree core share the same real roots. Proven
 here by explicit factoring; in the elaborator this bridge is
-`aevalIff_squareFreeCore` (see `transport_via_squareFreeCore` below), whose
+`aevalIff_squareFreeCore` (see `transportViaSquareFreeCore` below), whose
 `squareFreeCore q = qcore` step is a meta-level equality since `squareFreeCore`
 is intentionally outside the kernel-reducible replay closure. -/
 theorem qcore_same_roots (x : ℝ) :
@@ -143,15 +143,15 @@ theorem qcore_same_roots (x : ℝ) :
 
 /-- `(x − 1)²(x − 3)` isolated: replay on the squarefree core, transported onto
 `q` by `congrRoots`. -/
-noncomputable def iso_q :
+noncomputable def isoQ :
     IsolatedRealRoots (HexPolyZMathlib.toPolynomial q) 2 :=
-  IsolatedRealRoots.congrRoots qcore_same_roots iso_qcore_replay
+  IsolatedRealRoots.congrRoots qcore_same_roots isoQcoreReplay
 
 /-- The production transport for a non-squarefree input: `congrRoots` along
 `aevalIff_squareFreeCore` carries an isolation of the squarefree core onto the
 original polynomial. Exercises the exact `congrRoots (aevalIff_squareFreeCore …)`
 composition the elaborator emits. -/
-noncomputable def transport_via_squareFreeCore
+noncomputable def transportViaSquareFreeCore
     (H : IsolatedRealRoots (HexPolyZMathlib.toPolynomial (Hex.ZPoly.squareFreeCore q)) 2) :
     IsolatedRealRoots (HexPolyZMathlib.toPolynomial q) 2 :=
   IsolatedRealRoots.congrRoots
@@ -160,7 +160,7 @@ noncomputable def transport_via_squareFreeCore
 /-! # `IsolatedRealRoots.constant` -/
 
 /-- A nonzero constant has no real roots: the empty isolation. -/
-def iso_const : IsolatedRealRoots (Polynomial.C (3 : ℝ)) 0 :=
+def isoConst : IsolatedRealRoots (Polynomial.C (3 : ℝ)) 0 :=
   IsolatedRealRoots.constant (by simp)
 
 end HexRealRootsMathlib.Tests

--- a/HexRealRootsMathlib/MobiusCorrespond.lean
+++ b/HexRealRootsMathlib/MobiusCorrespond.lean
@@ -420,7 +420,7 @@ private theorem countP_roots_eq_sum (f : Polynomial ℝ) (p : ℝ → Prop)
   · ext x
     simp [Multiset.mem_toFinset, and_comm]
   · rw [Finset.mem_filter, Multiset.mem_toFinset] at hx
-    rw [Multiset.count_filter, if_pos hx.2]
+    rw [Multiset.count_filter, ite_eq_left hx.2]
 
 /-- **Windowed root-count correspondence over `ℝ`.** For `a < b`, `P ≠ 0`, and
 `natDegree P ≤ n`, the number of positive roots of the transform (with
@@ -618,11 +618,11 @@ private theorem countSignChanges_destutter' : ∀ (m : List ℝ) (a : ℝ), a �
       rw [Sturm.countSignChanges_cons_cons, List.map_cons]
       by_cases hsab : SignType.sign a ≠ SignType.sign b
       · rw [List.destutter'_cons_pos _ hsab, List.length_cons,
-          if_pos ((mul_neg_iff_sign_ne ha hb).mpr hsab), hIH, Nat.add_sub_cancel]
+          ite_eq_left ((mul_neg_iff_sign_ne ha hb).mpr hsab), hIH, Nat.add_sub_cancel]
         exact Nat.add_sub_cancel'
           (List.length_pos_of_ne_nil (List.destutter'_ne_nil _ _))
       · rw [List.destutter'_cons_neg _ hsab,
-          if_neg (fun h => hsab ((mul_neg_iff_sign_ne ha hb).mp h)), Nat.zero_add,
+          ite_eq_right (fun h => hsab ((mul_neg_iff_sign_ne ha hb).mp h)), Nat.zero_add,
           not_not.mp hsab]
         exact hIH
 
@@ -845,7 +845,7 @@ private theorem toPolyℝ_linear (u : Int) :
   | 0 => simp [Array.getD]
   | 1 => simp [Array.getD]
   | (k + 2) =>
-      rw [if_neg (by omega), if_neg (by omega), add_zero,
+      rw [ite_eq_right (by omega), ite_eq_right (by omega), add_zero,
         Array.getD_eq_getD_getElem?, Array.getElem?_eq_none (by simp), Option.getD_none]
       exact Int.cast_zero
 
@@ -861,7 +861,7 @@ private theorem toPolyℝ_cleared (p : Hex.ZPoly) (s : Nat) :
   rw [coeff_toPolyℝ, Hex.DensePoly.coeff_ofList,
     HexPolyMathlib.list_getD_map_range_zero, coeff_C_mul, comp_C_mul_X_coeff, coeff_toPolyℝ]
   by_cases hj : j < p.size
-  · rw [if_pos hj]
+  · rw [ite_eq_left hj]
     have hkey : ((2:ℝ) ^ (-(s:ℤ))) ^ j = ((2:ℝ) ^ (s * j))⁻¹ := by
       rw [zpow_neg, zpow_natCast, inv_pow, ← pow_mul]
     have hsplit : s * (p.size - 1) = s * (p.size - 1 - j) + s * j := by
@@ -870,7 +870,7 @@ private theorem toPolyℝ_cleared (p : Hex.ZPoly) (s : Nat) :
     push_cast
     have h2 : ((2:ℝ) ^ (s * j)) ≠ 0 := by positivity
     field_simp
-  · rw [if_neg hj, Hex.DensePoly.coeff_eq_zero_of_size_le p (by omega),
+  · rw [ite_eq_right hj, Hex.DensePoly.coeff_eq_zero_of_size_le p (by omega),
       show (Zero.zero : ℤ) = 0 from rfl, Int.cast_zero]
     ring
 
@@ -886,8 +886,8 @@ private theorem toPolyℝ_reversed (q : Hex.ZPoly) (n : Nat)
   rw [coeff_toPolyℝ, Hex.DensePoly.coeff_ofList,
     HexPolyMathlib.list_getD_map_range_zero, coeff_reflect]
   by_cases hj : j < n + 1
-  · rw [if_pos hj, revAt_le (by omega), coeff_toPolyℝ]
-  · rw [if_neg hj, revAt_eq_self_of_lt (by omega),
+  · rw [ite_eq_left hj, revAt_le (by omega), coeff_toPolyℝ]
+  · rw [ite_eq_right hj, revAt_eq_self_of_lt (by omega),
       Polynomial.coeff_eq_zero_of_natDegree_lt (by omega)]
     exact Int.cast_zero
 
@@ -949,7 +949,7 @@ private theorem toPolyℝ_mobiusSteps (p : Hex.ZPoly) (α β : Int) (s : Nat)
                 (p.size - 1 - i))))
           (Hex.DensePoly.ofCoeffs #[(1 : Int), 1]) := by
     unfold mobiusSteps
-    rw [if_neg (by omega)]
+    rw [ite_eq_right (by omega)]
   have hdeg' : (toPolyℝ (Hex.ZPoly.dilate (α - β)
       (Hex.DensePoly.compose
         (Hex.DensePoly.ofList

--- a/HexRealRootsMathlib/README.md
+++ b/HexRealRootsMathlib/README.md
@@ -23,11 +23,7 @@ rev = "main"
 
 ```lean
 import HexRealRootsMathlib
-```
 
-# Functionality
-
-```lean
 open Hex Polynomial
 
 noncomputable def roots :=
@@ -36,6 +32,8 @@ noncomputable def roots :=
 example : roots.intervals =
     #v[((0 : ℚ), (2 : ℚ)), ((2 : ℚ), (4 : ℚ))] := rfl
 ```
+
+# Functionality
 
 The input may be a closed `Hex.ZPoly` or a closed integer-coefficient
 `Polynomial ℤ`, `Polynomial ℚ`, or `Polynomial ℝ` expression. Repeated roots

--- a/HexRealRootsMathlib/Separation.lean
+++ b/HexRealRootsMathlib/Separation.lean
@@ -120,8 +120,8 @@ theorem toReal_shiftRight (x : Dyadic) (i : Int) :
 theorem le_two_pow_ceilLog2Nat (m : Nat) : m ≤ 2 ^ Hex.ceilLog2Nat m := by
   unfold Hex.ceilLog2Nat
   by_cases hm : m ≤ 1
-  · rw [if_pos hm]; simpa using hm
-  · rw [if_neg hm]
+  · rw [ite_eq_left hm]; simpa using hm
+  · rw [ite_eq_right hm]
     have hm2 : 2 ≤ m := by omega
     have hne : m - 1 ≠ 0 := by omega
     have := (Nat.log2_lt hne).1 (Nat.lt_succ_self (m - 1).log2)
@@ -462,7 +462,7 @@ theorem sepPrec_separates (p : Hex.ZPoly)
   have hsp : Hex.sepPrec p = ((ℓ.length + 2) * Hex.ceilLog2Nat ℓ.length + 1) / 2
       + (ℓ.length - 1) * Hex.ceilLog2Nat (Hex.ZPoly.coeffL2NormBound p) + 3 := by
     simp only [Hex.sepPrec, hdeg?]
-    rw [if_neg (show ¬ ℓ.length ≤ 1 by omega)]
+    rw [ite_eq_right (show ¬ ℓ.length ≤ 1 by omega)]
   set E := ((ℓ.length + 2) * Hex.ceilLog2Nat ℓ.length + 1) / 2
       + (ℓ.length - 1) * Hex.ceilLog2Nat (Hex.ZPoly.coeffL2NormBound p) with hEdef
   have hEx : (1 : ℝ) ≤ (2 : ℝ) ^ E * ‖z₁ - z₂‖ := by

--- a/HexRealRootsMathlib/SimpleRealRoot.lean
+++ b/HexRealRootsMathlib/SimpleRealRoot.lean
@@ -138,14 +138,14 @@ private theorem overlaps_iff_real (i₁ i₂ : Hex.RefinedRealIsolation p) :
       = Dyadic.toReal (if i₁.1.interval.lower ≤ i₂.1.interval.lower
           then i₂.1.interval.lower else i₁.1.interval.lower) := by
     by_cases h : i₁.1.interval.lower ≤ i₂.1.interval.lower
-    · rw [if_pos h, max_eq_right (toReal_le_toReal h)]
-    · rw [if_neg h, max_eq_left (toReal_le_of_not_le h)]
+    · rw [ite_eq_left h, max_eq_right (toReal_le_toReal h)]
+    · rw [ite_eq_right h, max_eq_left (toReal_le_of_not_le h)]
   have hmin : min (Dyadic.toReal i₁.1.interval.upper) (Dyadic.toReal i₂.1.interval.upper)
       = Dyadic.toReal (if i₁.1.interval.upper ≤ i₂.1.interval.upper
           then i₁.1.interval.upper else i₂.1.interval.upper) := by
     by_cases h : i₁.1.interval.upper ≤ i₂.1.interval.upper
-    · rw [if_pos h, min_eq_left (toReal_le_toReal h)]
-    · rw [if_neg h, min_eq_right (toReal_le_of_not_le h)]
+    · rw [ite_eq_left h, min_eq_left (toReal_le_toReal h)]
+    · rw [ite_eq_right h, min_eq_right (toReal_le_of_not_le h)]
   rw [hmax, hmin, toReal_lt_toReal_iff]
   exact Iff.rfl
 

--- a/HexRealRootsMathlib/SturmChainDefs.lean
+++ b/HexRealRootsMathlib/SturmChainDefs.lean
@@ -99,8 +99,8 @@ theorem countSignChanges_congr {l₁ l₂ : List ℝ}
       have hiff : (a * c < 0) ↔ (b * d < 0) := by
         rw [← sign_eq_neg_one_iff, ← sign_eq_neg_one_iff, sign_mul, sign_mul, hab, hcd]
       by_cases hc : a * c < 0
-      · rw [if_pos hc, if_pos (hiff.mp hc), ih]
-      · rw [if_neg hc, if_neg (fun h => hc (hiff.mpr h)), ih]
+      · rw [ite_eq_left hc, ite_eq_left (hiff.mp hc), ih]
+      · rw [ite_eq_right hc, ite_eq_right (fun h => hc (hiff.mpr h)), ih]
 
 /-- Dropping the zero entries commutes with a pointwise sign-equal
 correspondence: the filtered lists remain pointwise sign-equal. -/
@@ -177,8 +177,8 @@ theorem signVariations_cons_pos {a : ℝ} (l : List ℝ) (ha : a ≠ 0) :
       simp only [Option.elim_some]
       congr 1
       by_cases hlt : a * b < 0
-      · rw [if_pos hlt, if_pos (sign_mul_eq_neg_one.mpr hlt)]
-      · rw [if_neg hlt, if_neg (fun h => hlt (sign_mul_eq_neg_one.mp h))]
+      · rw [ite_eq_left hlt, ite_eq_left (sign_mul_eq_neg_one.mpr hlt)]
+      · rw [ite_eq_right hlt, ite_eq_right (fun h => hlt (sign_mul_eq_neg_one.mp h))]
 
 /-- A local sign-pattern relation between two real lists: they agree entry by
 entry except that a nonzero entry flanked by two opposite-sign neighbours may
@@ -227,7 +227,7 @@ theorem SVRel.signVariations_eq {L M : List ℝ} (h : SVRel L M) :
       simp only [Option.elim_some]
       rw [← add_assoc, ih.1]
       congr 1
-      rw [← hsx, ← hsy, if_pos hopp]
+      rw [← hsx, ← hsy, ite_eq_left hopp]
       exact svrel_flank_arith _ _ _ hopp (fun h => hX (sign_eq_zero_iff.mp h))
     · rw [firstSign_cons_ne (X :: y :: l) hx, firstSign_cons_ne (0 :: y' :: m) hx', hsx]
 

--- a/HexRealRootsMathlib/SturmTheorem.lean
+++ b/HexRealRootsMathlib/SturmTheorem.lean
@@ -330,13 +330,13 @@ theorem sturmVar_root_cross (_hp : p ≠ 0) (_hsf : Squarefree p)
       = 1 + signVariations ((q :: tail).map (Polynomial.eval a))
     rw [signVariations_cons_pos _ hpa]
     simp only [List.map_cons]
-    rw [firstSign_cons_ne _ hqa, Option.elim_some, if_pos hsignA]
+    rw [firstSign_cons_ne _ hqa, Option.elim_some, ite_eq_left hsignA]
   have hSVb : sturmVar (p :: q :: tail) b = sturmVar (q :: tail) b := by
     show signVariations (p.eval b :: (q :: tail).map (Polynomial.eval b))
       = signVariations ((q :: tail).map (Polynomial.eval b))
     rw [signVariations_cons_pos _ hpb]
     simp only [List.map_cons]
-    rw [firstSign_cons_ne _ hqb, Option.elim_some, if_neg hsignB, zero_add]
+    rw [firstSign_cons_ne _ hqb, Option.elim_some, ite_eq_right hsignB, zero_add]
   have hSVr : sturmVar (p :: q :: tail) r = sturmVar (q :: tail) r := by
     show signVariations (p.eval r :: (q :: tail).map (Polynomial.eval r))
       = signVariations ((q :: tail).map (Polynomial.eval r))

--- a/HexRealRootsMathlib/TwoCircle.lean
+++ b/HexRealRootsMathlib/TwoCircle.lean
@@ -135,9 +135,9 @@ theorem descartes_node_count (hdeg : 1 ≤ (p.degree?).getD 0)
       = if (toPolyℝ p).IsRoot b then 1 else 0 := by
     rw [Multiset.filter_eq', Multiset.card_replicate]
     by_cases hbroot : (toPolyℝ p).IsRoot b
-    · rw [if_pos hbroot,
+    · rw [ite_eq_left hbroot,
         Multiset.count_eq_one_of_mem hnodup (Polynomial.mem_roots'.mpr ⟨hP0, hbroot⟩)]
-    · rw [if_neg hbroot, Multiset.count_eq_zero.mpr
+    · rw [ite_eq_right hbroot, Multiset.count_eq_zero.mpr
         (fun hm => hbroot (Polynomial.mem_roots'.mp hm).2)]
   have hsplit : ((toPolyℝ p).roots.filter (fun r => a < r ∧ r ≤ b)).card
       = ((toPolyℝ p).roots.filter (fun r => a < r ∧ r < b)).card
@@ -198,15 +198,15 @@ private theorem node_candidate (hdeg : 1 ≤ (p.degree?).getD 0)
   simp only [Bool.or_eq_true, Bool.and_eq_true] at hC
   rcases hC with ⟨hV0, hbz⟩ | ⟨hV1, hbz⟩
   · have hSV0 : Polynomial.signVariations M = 0 := by rw [← hV]; simpa using hV0
-    have hcp := Polynomial.countP_pos_eq_zero_of_signVariations_eq_zero hMne hSV0
+    have hcp := Polynomial.countP_pos_eq_zero_of_signVariations_eq_zero hSV0
     have hroot : (toPolyℝ p).IsRoot (Dyadic.toReal hi) := (bZero_iff hi).mp hbz
-    rw [hcnt, hcp, if_pos hroot]; norm_num
+    rw [hcnt, hcp, ite_eq_left hroot]; norm_num
   · have hSV1 : Polynomial.signVariations M = 1 := by rw [← hV]; simpa using hV1
     have hcp := Polynomial.countP_pos_eq_one_of_signVariations_eq_one hMne hSV1
     have hbzf : (Hex.dyadicSign (p.evalDyadic hi) == 0) = false := by simpa using hbz
     have hnroot : ¬ (toPolyℝ p).IsRoot (Dyadic.toReal hi) := fun hr => by
       rw [(bZero_iff hi).mpr hr] at hbzf; exact absurd hbzf (by decide)
-    rw [hcnt, hcp, if_neg hnroot]; norm_num
+    rw [hcnt, hcp, ite_eq_right hnroot]; norm_num
 
 /-- **Discard rows are truthful.** When the dispatch Boolean is `false` with
 `V = 0` (so `p(hi) ≠ 0`), the exact Sturm count is `0`, so the node's emitted
@@ -235,8 +235,8 @@ private theorem node_discard (hdeg : 1 ≤ (p.degree?).getD 0)
   have hnroot : ¬ (toPolyℝ p).IsRoot (Dyadic.toReal hi) := fun hr => by
     rw [(bZero_iff hi).mpr hr] at hbzf; exact absurd hbzf (by decide)
   have hSV0 : Polynomial.signVariations M = 0 := by rw [← hV]; exact hV0
-  have hcp := Polynomial.countP_pos_eq_zero_of_signVariations_eq_zero hMne hSV0
-  rw [hcnt, hcp, if_neg hnroot]; norm_num
+  have hcp := Polynomial.countP_pos_eq_zero_of_signVariations_eq_zero hSV0
+  rw [hcnt, hcp, ite_eq_right hnroot]; norm_num
 
 /-! # Depth-budget refutation of the bisecting rows -/
 
@@ -363,7 +363,7 @@ theorem bisect_refute_double (hdeg : 1 ≤ (p.degree?).getD 0)
   rw [← hM] at hcnt
   have h2 : (Hex.sturmVarAt (Hex.ZPoly.sturmChain p) lo : Int)
       - Hex.sturmVarAt (Hex.ZPoly.sturmChain p) hi = 2 := by
-    rw [hcnt, hcp, if_pos hroot]; norm_num
+    rw [hcnt, hcp, ite_eq_left hroot]; norm_num
   have hle := sturmCount_le_one hdeg hp ⟨lo, hi, hlt⟩ hw
   have hle' : (Hex.sturmVarAt (Hex.ZPoly.sturmChain p) lo : Int)
       - Hex.sturmVarAt (Hex.ZPoly.sturmChain p) hi ≤ 1 := hle
@@ -409,11 +409,11 @@ private theorem descartesVisit_spec (hdeg : 1 ≤ (p.degree?).getD 0)
               some #[]
             else none)
           else some #[]) := rfl
-    rw [dif_pos hlt] at hunf
+    rw [dite_eq_left hlt] at hunf
     by_cases hC : dispatchC p lo hi hlt = true
     · -- candidate leaf
       have hcert := node_candidate hdeg hp hlt hC
-      rw [if_pos hC, dif_pos hcert] at hunf
+      rw [ite_eq_left hC, dite_eq_left hcert] at hunf
       refine ⟨#[⟨⟨lo, hi, hlt⟩, by exact hcert⟩], hunf, ?_, ?_, ?_, ?_⟩
       · simp only [Array.size_singleton]; omega
       · intro i j hij
@@ -428,7 +428,7 @@ private theorem descartesVisit_spec (hdeg : 1 ≤ (p.degree?).getD 0)
         simp only [List.mem_toArray, List.mem_singleton] at hI
         subst hI; exact dle_refl hi
     · -- either discard leaf or a refuted bisect
-      rw [if_neg hC] at hunf
+      rw [ite_eq_right hC] at hunf
       have hCfalse : dispatchC p lo hi hlt = false := by
         cases h : dispatchC p lo hi hlt with
         | false => rfl
@@ -436,7 +436,7 @@ private theorem descartesVisit_spec (hdeg : 1 ≤ (p.degree?).getD 0)
       by_cases hV0 : Hex.descartesVar (Hex.mobiusTransform p ⟨lo, hi, hlt⟩) = 0
       · -- discard leaf
         have hcert := node_discard hdeg hp hlt hCfalse hV0
-        rw [if_pos hV0] at hunf
+        rw [ite_eq_left hV0] at hunf
         refine ⟨#[], hunf, ?_, ?_, ?_, ?_⟩
         · simp only [Array.size_empty]; omega
         · intro i j hij; exact absurd i.isLt (by simp)
@@ -444,7 +444,7 @@ private theorem descartesVisit_spec (hdeg : 1 ≤ (p.degree?).getD 0)
         · intro I hI; simp at hI
       · -- bisect at depth 0: refuted
         exfalso
-        rw [if_neg hV0] at hunf
+        rw [ite_eq_right hV0] at hunf
         rcases Nat.lt_or_ge (Hex.descartesVar (Hex.mobiusTransform p ⟨lo, hi, hlt⟩)) 2 with hV2 | hV2
         · have hV1 : Hex.descartesVar (Hex.mobiusTransform p ⟨lo, hi, hlt⟩) = 1 := by omega
           have hbz : (Hex.dyadicSign (p.evalDyadic hi) == 0) = true := by
@@ -472,10 +472,10 @@ private theorem descartesVisit_spec (hdeg : 1 ≤ (p.degree?).getD 0)
                 | none => none
                 | some right => some (left ++ right))
           else some #[]) := rfl
-    rw [dif_pos hlt] at hunf
+    rw [dite_eq_left hlt] at hunf
     by_cases hC : dispatchC p lo hi hlt = true
     · have hcert := node_candidate hdeg hp hlt hC
-      rw [if_pos hC, dif_pos hcert] at hunf
+      rw [ite_eq_left hC, dite_eq_left hcert] at hunf
       refine ⟨#[⟨⟨lo, hi, hlt⟩, by exact hcert⟩], hunf, ?_, ?_, ?_, ?_⟩
       · simp only [Array.size_singleton]; omega
       · intro i j hij
@@ -489,21 +489,21 @@ private theorem descartesVisit_spec (hdeg : 1 ≤ (p.degree?).getD 0)
       · intro I hI
         simp only [List.mem_toArray, List.mem_singleton] at hI
         subst hI; exact dle_refl hi
-    · rw [if_neg hC] at hunf
+    · rw [ite_eq_right hC] at hunf
       have hCfalse : dispatchC p lo hi hlt = false := by
         cases h : dispatchC p lo hi hlt with
         | false => rfl
         | true => exact absurd h hC
       by_cases hV0 : Hex.descartesVar (Hex.mobiusTransform p ⟨lo, hi, hlt⟩) = 0
       · have hcert := node_discard hdeg hp hlt hCfalse hV0
-        rw [if_pos hV0] at hunf
+        rw [ite_eq_left hV0] at hunf
         refine ⟨#[], hunf, ?_, ?_, ?_, ?_⟩
         · simp only [Array.size_empty]; omega
         · intro i j hij; exact absurd i.isLt (by simp)
         · intro I hI; simp at hI
         · intro I hI; simp at hI
       · -- bisect: recurse into the two halves
-        rw [if_neg hV0] at hunf
+        rw [ite_eq_right hV0] at hunf
         have hlm : lo < (lo + hi) >>> (1 : Int) := lower_lt_midpoint ⟨lo, hi, hlt⟩
         have hmh : (lo + hi) >>> (1 : Int) < hi := midpoint_lt_upper ⟨lo, hi, hlt⟩
         have hmidR : Dyadic.toReal ((lo + hi) >>> (1 : Int))
@@ -589,7 +589,7 @@ private theorem isolateDescartes?_isSome_of_degree_pos (hdeg : 1 ≤ (p.degree?)
           | some arr => Hex.assemble? p (Hex.ZPoly.sturmChain p) rfl arr) := by
     unfold Hex.isolateDescartes?
     simp only [hd]
-    rw [if_pos hp]
+    rw [ite_eq_left hp]
     rfl
   rw [heq, hvisit]
   exact assemble?_isSome rfl arr hord hsize'

--- a/HexRealRootsMathlib/TwoCircleRegion.lean
+++ b/HexRealRootsMathlib/TwoCircleRegion.lean
@@ -114,7 +114,7 @@ theorem not_inTwoCircle_iff_mem_sector (a b : ℝ) (w : ℂ) (hw : w ≠ (b : �
   have hv0 : ((b : ℂ) - w) ≠ 0 := sub_ne_zero.mpr fun h => hw h.symm
   have hN0 : 0 < Complex.normSq ((b : ℂ) - w) := Complex.normSq_pos.mpr hv0
   unfold InTwoCircle
-  simp only [sector, Set.mem_setOf_eq]
+  simp only [sector, Set.mem_ofPred_eq]
   set s : ℂ := (w - (a : ℂ)) * (starRingEnd ℂ) ((b : ℂ) - w) with hsdef
   set N : ℝ := Complex.normSq ((b : ℂ) - w) with hNdef
   have hzeq : (w - (a : ℂ)) / ((b : ℂ) - w) = s / (N : ℂ) := by
@@ -210,9 +210,10 @@ example : ¬ InTwoCircle 0 2 0 := by
   simp only [InTwoCircle, seed_re, seed_im, not_or, not_lt]
   norm_num
 
-/-- The two disc centres `(a+b)/2 ± i·(b−a)/(2√3)`. -/
+/-- The upper disc centre `(a+b)/2 + i·(b−a)/(2√3)`. -/
 noncomputable def centrePos (a b : ℝ) : ℂ :=
   ((a + b) / 2 : ℝ) + Complex.I * ((b - a) / (2 * Real.sqrt 3) : ℝ)
+/-- The lower disc centre `(a+b)/2 − i·(b−a)/(2√3)`. -/
 noncomputable def centreNeg (a b : ℝ) : ℂ :=
   ((a + b) / 2 : ℝ) - Complex.I * ((b - a) / (2 * Real.sqrt 3) : ℝ)
 

--- a/HexRealRootsMathlib/TwoCircleSector.lean
+++ b/HexRealRootsMathlib/TwoCircleSector.lean
@@ -479,7 +479,7 @@ theorem signVariations_eq_zero_of_coeff_nonneg {P : ℝ[X]} (h : ∀ i, 0 ≤ P.
         have : SignType.sign P.eraseLead.leadingCoeff = -1 := by
           rw [← neg_neg (SignType.sign P.eraseLead.leadingCoeff), ← hcon]
         exact absurd (sign_eq_neg_one_iff.mp this) (not_lt.mpr (heLcoeff _))
-      rw [signVariations_eq_eraseLead_add_ite hP, if_neg hite, add_zero]
+      rw [signVariations_eq_eraseLead_add_ite hP, ite_eq_right hite, add_zero]
       exact ih _ (lt_of_le_of_lt (eraseLead_natDegree_le P) (by omega)) heLcoeff rfl
 
 /-- **The threshold bound.** If the coefficients of `P` are nonpositive below an
@@ -522,7 +522,7 @@ theorem signVariations_le_one_of_coeff_threshold {P : ℝ[X]} {θ : ℕ}
         push Not at hcon
         have hne : P.eraseLead.natDegree ≠ P.natDegree := by omega
         have hcoeff : P.eraseLead.leadingCoeff = P.coeff P.eraseLead.natDegree := by
-          rw [leadingCoeff, eraseLead_coeff, if_neg hne]
+          rw [leadingCoeff, eraseLead_coeff, ite_eq_right hne]
         rw [hcoeff] at heL
         exact absurd (h2 _ hcon) (not_le.mpr heL)
       have hnn : ∀ i, 0 ≤ (-P.eraseLead).coeff i := by
@@ -546,7 +546,7 @@ theorem signVariations_le_one_of_coeff_threshold {P : ℝ[X]} {θ : ℕ}
         have : SignType.sign P.eraseLead.leadingCoeff = -1 := by
           rw [← neg_neg (SignType.sign P.eraseLead.leadingCoeff), ← hcon]
         exact absurd (sign_eq_neg_one_iff.mp this) (not_lt.mpr heL)
-      rw [signVariations_eq_eraseLead_add_ite hP, if_neg hite, add_zero]
+      rw [signVariations_eq_eraseLead_add_ite hP, ite_eq_right hite, add_zero]
       have h1' : ∀ i < θ, P.eraseLead.coeff i ≤ 0 := by
         intro i hi
         rw [eraseLead_coeff]
@@ -648,7 +648,7 @@ theorem PosLogConcave.signVariations_X_pow_mul_X_sub_C_mul (hA : PosLogConcave A
       · exact h1 _ (by omega)
       · exact le_refl 0
     · intro i hi
-      rw [coeff_X_pow_mul', if_pos (by omega)]
+      rw [coeff_X_pow_mul', ite_eq_left (by omega)]
       exact h2 _ (by omega)
 
 /-! # Assembly -/
@@ -742,7 +742,7 @@ theorem signVariations_le_one_of_sector {P : ℝ[X]} (hP : P ≠ 0)
       rw [hmapQeq, roots_mul (hmapQeq ▸ map_ne_zero hQne), roots_X_sub_C,
         Multiset.singleton_add]
     have hMcount : (M.map (algebraMap ℝ ℂ)).roots.countP (· ∉ sector) = 0 := by
-      rw [hrootsQ, Multiset.countP_cons, if_pos (hwr ▸ hwout)] at hcount
+      rw [hrootsQ, Multiset.countP_cons, ite_eq_left (hwr ▸ hwout)] at hcount
       omega
     have hMplc : PosLogConcave M := by
       apply posLogConcave_of_aeval_mem_sector hMm hM0

--- a/libraries.yml
+++ b/libraries.yml
@@ -694,7 +694,7 @@ libraries:
   HexMatrixMathlib:
     deps: [HexMatrix]
     mathlib: true
-    done_through: 7
+    done_through: 6
     status: active
     phase4:
       input_families:
@@ -707,7 +707,7 @@ libraries:
   HexRowReduceMathlib:
     deps: [HexMatrixMathlib, HexRowReduce]
     mathlib: true
-    done_through: 6
+    done_through: 5
     status: active
   HexDeterminantMathlib:
     deps: [HexBareiss, HexDeterminant, HexMatrixMathlib]
@@ -1008,7 +1008,7 @@ libraries:
   HexRealRootsMathlib:
     deps: [HexRealRoots, HexPolyZMathlib]
     mathlib: true
-    done_through: 5
+    done_through: 7
     status: active
     proof_probes: [bench/HexRealRootsMathlib/ProofProbe]
   HexRCF:

--- a/libraries.yml
+++ b/libraries.yml
@@ -1008,7 +1008,7 @@ libraries:
   HexRealRootsMathlib:
     deps: [HexRealRoots, HexPolyZMathlib]
     mathlib: true
-    done_through: 4
+    done_through: 5
     status: active
     proof_probes: [bench/HexRealRootsMathlib/ProofProbe]
   HexRCF:

--- a/libraries.yml
+++ b/libraries.yml
@@ -694,7 +694,7 @@ libraries:
   HexMatrixMathlib:
     deps: [HexMatrix]
     mathlib: true
-    done_through: 6
+    done_through: 7
     status: active
     phase4:
       input_families:

--- a/libraries.yml
+++ b/libraries.yml
@@ -707,7 +707,7 @@ libraries:
   HexRowReduceMathlib:
     deps: [HexMatrixMathlib, HexRowReduce]
     mathlib: true
-    done_through: 5
+    done_through: 6
     status: active
   HexDeterminantMathlib:
     deps: [HexBareiss, HexDeterminant, HexMatrixMathlib]

--- a/progress/20260826T235540Z_issue9657.md
+++ b/progress/20260826T235540Z_issue9657.md
@@ -1,0 +1,54 @@
+# HexRealRootsMathlib Phases 5–7 (#9657)
+
+## Accomplished
+
+`HexRealRootsMathlib.done_through` advances from 4 to 7 after separate Phase 5,
+6, and 7 gates.
+
+- Phase 5: the complete public and development trust surface is free of
+  `sorry`, `axiom`, and `native_decide`. The library, conformance modules,
+  elaborator tests, replay tests, and ordinary proof probes build on the
+  pinned Lean 4.34.0-rc2 toolchain.
+- Phase 6: audited the abstract Sturm theorem, executable-chain
+  correspondence, literal replay constructors, isolation soundness and
+  completeness, squarefree transport, and elaborator emission path. Compiled
+  search supplies data only; emitted proof terms use ordinary `decide` to
+  replay `SturmChainCert`, interval counts, completeness, and ordering.
+  Removed one unused theorem hypothesis, fixed generated macro names and
+  missing public docstrings, normalized published test declaration names, and
+  replaced all deprecated conditional/degree/set theorem aliases in the
+  library. No private declaration is unreferenced, and the explicit imports
+  are justified by the abstract, executable, or `import all` unfolding
+  surfaces documented beside them.
+- Phase 7: added the exact `# The Mathlib correspondence` section to the
+  shared manual chapter with source-linked docstrings for the headline chain,
+  replay, and root-transport APIs. The README quickstart now includes a
+  complete executable example and was build-checked as a temporary Lake
+  module.
+
+## Audit evidence
+
+`lake exe runLinter` was run on every `HexRealRootsMathlib` module. All
+actionable `docBlame`, `defsWithUnderscore`, and `unusedArguments` findings
+were eliminated. Six pre-existing `simpNF` reports remain on intentional cast
+and coefficient convenience lemmas; this category is also present in the
+already-certified sibling `HexGFqRing` and is non-gating by the worker-flow
+calibration rule.
+
+The fresh-module harness completed all nine proof-probe pairs with six samples
+each and no partial or exhausted pair. Every candidate reported exactly
+`propext`, `Classical.choice`, and `Quot.sound`; no arm timed out. This was a
+diagnostic busy-host run, not a replacement for the release-quality
+designated-host artifact. The historical artifact still has the report's
+recorded SHA-256
+`599a14c3971313d86ae23005d96b3484b963ef17535205a7012cd3be672cec3c`.
+
+The required aggregate build and the DAG, Phase 7, manual-split, published
+trust-surface, and released-manifest checks pass. An independent Claude Opus
+review confirmed the Lean changes and trust claims, caught two counters that
+had matched unrelated entries in `libraries.yml`, and those entries were
+restored before merge.
+
+## Remaining work
+
+None for issue #9657.


### PR DESCRIPTION
Closes #9657

## Summary

- certify Phase 5 after the complete public/development umbrella, conformance, tests, and replay probes build without sorry
- audit the Sturm correspondence and certificate/elaborator surface for Phase 6; remove deprecated theorem uses, an unnecessary hypothesis, generated-name lint, and missing docs while preserving the checked replay boundary
- add the exact Mathlib correspondence manual section, compile-check the README quickstart, and advance HexRealRootsMathlib from done_through 4 to 7
- incorporate Claude Opus review: correct phase-counter targeting, add durable audit evidence, and pull canonical API docstrings into the manual

## API note

The zero-sign-variation theorem no longer takes an unused nonzero hypothesis, which strengthens its statement but changes the call arity. Published test fixture declarations were also normalized from snake_case to Lean-style camelCase.

## Verification

- lake build HexRealRootsMathlib HexRealRootsMathlibReplayProbe HexConformance HexManual
- lake build HexRealRootsMathlib HexRealRootsMathlib.IsolateRootsTests HexRealRootsMathlib.IsolateRootsElabTests
- six-sample diagnostic fresh-module sweep across all nine proof-probe pairs; all 54 pairs completed, with candidates reporting only propext, Classical.choice, and Quot.sound
- README quickstart built as a temporary Lake module
- complete runLinter audit of every HexRealRootsMathlib module; all actionable docBlame, defsWithUnderscore, and unusedArguments findings resolved
- scripts/check_dag.py
- scripts/check_phase7.py
- scripts/release/check_manual_split.py
- scripts/release/check_trust_surface.py
- scripts/release/check_released_manifest.py