### PR TITLE
chore: certify HexRoots and HexRealRoots through Phases 6 and 7

### DIFF
--- a/HexManual/Chapters/HexRealRoots.lean
+++ b/HexManual/Chapters/HexRealRoots.lean
@@ -44,6 +44,26 @@ elaborates, and produces a term whose type records the certified
 statements. No knowledge of Sturm chains, dyadic arithmetic, or
 squarefreeness is needed at the call site.
 
+# Mathlib-free execution
+%%%
+tag := "hex-real-roots-core"
+%%%
+
+The computational package exposes {name}`Hex.isolate?`, which tries Descartes
+search before falling back to Sturm bisection. The
+{name}`Hex.isolateDescartes?` and {name}`Hex.isolateSturm?` variants select one
+engine explicitly; {name}`Hex.rootCount` and {name}`Hex.sturmCount` expose the
+exact counting operations. These functions run in native Lean and need no
+external oracle at runtime.
+
+The core isolators reject the zero polynomial; positive-degree inputs must be
+squarefree, while nonzero constants have no roots and return an empty
+isolation. Every emitted interval carries executable evidence for its Sturm
+count, ordering, and contribution to the certified total. The core package
+checks that finite evidence, while `HexRealRootsMathlib` supplies the theorem
+connecting it to roots of `Polynomial ℝ` and handles squarefree reduction for
+the elaborator below.
+
 # The `isolate_roots` elaborator
 %%%
 tag := "hex-real-roots-isolate"
@@ -150,12 +170,21 @@ example : True := by
 tag := "hex-real-roots-width"
 %%%
 
-The natural intervals are only as tight as the isolator needed to
-separate the roots. Passing `(width := x)` refines every interval to width
-at most `x`, still with exact rational endpoints. The width may be written
-as a fraction, a power of two, or a decimal power: `1/1000`, `2^(-20)`,
-`10^(-2)` all work. Refining `x⁴ − 2` to width `2⁻²⁰` places the positive
-root in an interval of width exactly `2⁻²⁰`:
+The natural intervals are only as tight as the isolator needed to separate the
+roots. Passing `(width := x)` refines every interval to width at most `x`,
+still with exact rational endpoints. The width must be a closed, strictly
+positive rational expression; a free variable, zero, or a negative value is
+rejected during elaboration. It may be written as a fraction, a power of two,
+or a decimal power: `1/1000`, `2 ^ (-20 : ℤ)`, and `10 ^ (-2 : ℤ)` all work.
+
+Internally the elaborator chooses the least nonnegative `k` with `2⁻ᵏ ≤ x` and
+refines to that binary target. Widths above one therefore request `k = 0`,
+which still refines any wider natural interval to width at most one;
+refinement only narrows, so a coarse request cannot undo the isolator's
+separation. A non-dyadic request can produce a strictly narrower interval than
+requested. Targets finer than `2⁻⁴⁰⁹⁶` are rejected as pathological. Refining
+`x⁴ − 2` to width `2⁻²⁰` places the positive root in an interval of width
+exactly `2⁻²⁰`:
 
 ```lean
 open Hex Polynomial

--- a/HexManual/Chapters/HexRoots.lean
+++ b/HexManual/Chapters/HexRoots.lean
@@ -100,6 +100,16 @@ Newton-Kantorovich witness alone, `.pellet` for the Pellet witness alone, and
 fallback. The explicit single-form strategies let either certificate be
 selected or benchmarked on its own; callers with no such need pick the default.
 
+The precision is an integer lower bound on each returned square's `prec`, so
+its half-width is at most `2⁻ᵖʳᵉᶜ`. The driver also floors this target at the
+polynomial's separation precision; asking for a coarser or even negative
+precision never makes distinct roots overlap, and the returned squares may be
+finer than requested. For a nonzero simple-root polynomial every strategy
+succeeds by the companion completeness theorem. Multiple roots do not satisfy
+the precondition: callers that need them use {name}`Hex.isolateAll?`, whose
+successful output may contain Pellet clusters and whose `none` records failure
+to reach the certified emission condition within its structural fuel.
+
 Each returned atom is one square with its certificate. The certified region
 depends on which disjunct fired, so consumers rely only on the shared
 consequence: exactly one root lies in the certified region, and that region
@@ -180,8 +190,8 @@ tag := "hex-roots-refine"
 %%%
 
 The precision the driver reaches is only as fine as separating the roots
-required, floored at the target. To sharpen a single root without re-running
-the whole isolator, refine its atom directly:
+required, with the target as a lower bound. To sharpen a single root without
+re-running the whole isolator, refine its atom directly:
 
 {docstring Hex.DyadicRootIsolation.refineTo?}
 

--- a/HexRealRoots/Cert.lean
+++ b/HexRealRoots/Cert.lean
@@ -80,7 +80,7 @@ theorem certTail_sound :
     intro acc h hfuel
     obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
     simp only [certTail] at h
-    simp only [sturmChainAux, h, if_true, List.append_nil]
+    simp only [sturmChainAux, h, _root_.ite_true, List.append_nil]
   | cons next rest ih =>
     intro acc h hfuel
     rw [List.length_cons] at hfuel
@@ -91,7 +91,7 @@ theorem certTail_sound :
     have hnz2 : ¬ ((spem prev cur).isZero = true) := by rw [hnz]; exact Bool.false_ne_true
     have hstep := ih f cur next (acc.push next) htail (by omega)
     simp only [sturmChainAux]
-    rw [if_neg hnz2, ← hnext, hstep]
+    rw [_root_.ite_eq_right hnz2, ← hnext, hstep]
     simp [Array.toList_push]
 
 /-- A decidable executable certificate that `chain` is the Sturm chain of `p`,
@@ -157,7 +157,7 @@ theorem cert_imp_eq {p : ZPoly} {chain : Array ZPoly}
   have hne : p.size ≠ 0 := by omega
   have hdeg : p.degree? = some (p.size - 1) := by
     unfold DensePoly.degree?
-    rw [dif_neg hne]
+    rw [_root_.dite_eq_right hne]
   obtain ⟨m, hm2⟩ : ∃ m, p.size - 1 = m + 1 := ⟨p.size - 2, by omega⟩
   have hchain_eq : sturmChain p =
       sturmChainAux p.size (primitivePart p) (primitivePart (DensePoly.derivative p))
@@ -217,7 +217,7 @@ theorem adjacent_step {p : ZPoly} {arr : Array (RealRootIsolation p)}
     (arr[i]'(by omega)).interval.upper ≤ (arr[i + 1]'hi).interval.lower := by
   have hmem : i ∈ List.range (arr.size - 1) := List.mem_range.mpr (by omega)
   have hstep := (List.all_eq_true.mp h) i hmem
-  simp only [hi, dif_pos] at hstep
+  simp only [hi, _root_.dite_eq_left] at hstep
   exact of_decide_eq_true hstep
 
 /-- The transitivity walk: `orderedAdjacent` (adjacent pairs) upgrades to the

--- a/HexRealRoots/README.md
+++ b/HexRealRoots/README.md
@@ -1,16 +1,14 @@
 # hex-real-roots
 
-Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
-library for Lean 4. The aim is fast executable code, fully verified, built
-with spec-driven development.
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra library
+for Lean 4. The aim is fast executable code, fully verified, built with
+spec-driven development.
 
-Certified real-root isolation for dense integer polynomials, implemented in
-Lean 4 without Mathlib.
-
-Every result is a sorted half-open dyadic interval `(lo, hi]` carrying an exact
-Sturm-count witness that it contains one root. A complete output additionally
-certifies that the intervals are pairwise disjoint and that their number equals
-the total real-root count.
+Certified real-root isolation for dense integer polynomials, built on
+[`hex-poly-z`](https://github.com/leanprover/hex-poly-z) without Mathlib. Each
+half-open dyadic interval carries an exact Sturm-count witness; the
+[`hex-real-roots-mathlib`](https://github.com/leanprover/hex-real-roots-mathlib)
+companion proves the semantic isolation guarantees and provides `isolate_roots`.
 
 # Quickstart
 
@@ -23,11 +21,7 @@ rev = "main"
 
 ```lean
 import HexRealRoots
-```
 
-# Functionality
-
-```lean
 open Hex
 
 def p : ZPoly := DensePoly.ofCoeffs #[-2, 0, 0, 0, 1]
@@ -35,15 +29,14 @@ def p : ZPoly := DensePoly.ofCoeffs #[-2, 0, 0, 0, 1]
 #eval (isolate? p).map (fun roots => roots.isolations.size)
 ```
 
-The stable executable API is:
+# Functionality
 
-```lean
-Hex.isolate?          -- Descartes search, certified by Sturm; Sturm fallback
-Hex.isolateSturm?     -- direct Sturm bisection
-Hex.isolateDescartes? -- Descartes-only search, still Sturm-certified
-Hex.rootCount         -- exact total real-root count
-Hex.sturmCount        -- exact count in one half-open interval
-```
+- `Hex.isolate?` tries the Descartes search first and falls back to Sturm.
+- `Hex.isolateSturm?` runs direct Sturm bisection.
+- `Hex.isolateDescartes?` runs only the Descartes search, while still
+  certifying every emitted interval with Sturm.
+- `Hex.rootCount` computes the exact total real-root count.
+- `Hex.sturmCount` computes the exact count in one half-open interval.
 
 `isolate?` rejects the zero polynomial and, at the core level, expects a
 squarefree positive-degree input. Nonzero constants produce an empty result.
@@ -62,7 +55,7 @@ speed, not trust.
 All endpoint evaluation is exact dyadic Horner arithmetic. There are no floats,
 numerical tolerances, or interval-arithmetic assumptions in the certificate.
 
-# Reference manual
+Reference material:
 
 - [SPEC](SPEC/hex-real-roots.md) — Sturm convention, engines, totality, and
   performance budgets.
@@ -70,8 +63,8 @@ numerical tolerances, or interval-arithmetic assumptions in the certificate.
 - `bench/HexRealRoots/` — deterministic real-root workloads.
 - `conformance/HexRealRoots/` — fixtures checked against python-flint.
 
-For semantic theorems and the user-facing elaborator, use
-[`hex-real-roots-mathlib`](https://github.com/leanprover/hex-real-roots-mathlib).
+For semantic theorems and the user-facing elaborator, use the companion
+package linked above.
 
 # Contributing
 

--- a/HexRoots/README.md
+++ b/HexRoots/README.md
@@ -1,17 +1,14 @@
 # hex-roots
 
-Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
-library for Lean 4. The aim is fast executable code, fully verified, built
-with spec-driven development.
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra library
+for Lean 4. The aim is fast executable code, fully verified, built with
+spec-driven development.
 
-Certified complex-root isolation for dense integer polynomials, implemented in
-Lean 4 without Mathlib.
-
-Each result is a dyadic square plus an exact certificate that its selected
-region contains one simple root. The driver supports two certificate forms:
-Newton--Kantorovich contraction on a square and Pellet/Rouché root counting on
-a circumscribed disc. Search may use approximate placement hints, but every
-accepted atom is rechecked with exact dyadic arithmetic.
+Certified complex-root isolation for dense integer polynomials, built on
+[`hex-poly-z`](https://github.com/leanprover/hex-poly-z) without Mathlib. Each
+dyadic square carries an exact Newton--Kantorovich or Pellet certificate; the
+[`hex-roots-mathlib`](https://github.com/leanprover/hex-roots-mathlib)
+companion proves its semantic root-count guarantees.
 
 # Quickstart
 
@@ -24,11 +21,7 @@ rev = "main"
 
 ```lean
 import HexRoots
-```
 
-# Functionality
-
-```lean
 open Hex
 
 def p : ZPoly := DensePoly.ofCoeffs #[-1, -1, 0, 1]
@@ -40,20 +33,19 @@ def roots : Option (Array (DyadicRootIsolation p)) :=
     none
 ```
 
-`Hex.isolate p h precision strategy` returns pairwise-disjoint atoms for a
-polynomial whose roots are simple. A nonzero constant returns an empty array;
-the zero polynomial returns `none`. The simple-root test is executable and
-decidable.
+# Functionality
 
-Use `.nkThenPellet` for the general strategy, `.nk` to select only the
-Newton--Kantorovich certificate, or `.pellet` to select only Pellet. Returned
-atoms can be refined independently with
-`Hex.DyadicRootIsolation.refineTo?`.
+- `Hex.isolate p h precision strategy` returns pairwise-disjoint atoms for a
+  polynomial whose roots are simple. A nonzero constant returns an empty
+  array; the zero polynomial returns `none`.
+- `Hex.HasOnlySimpleRoots` is an executable, decidable precondition.
+- `.nkThenPellet` is the general strategy; `.nk` and `.pellet` select a single
+  certificate form.
+- `Hex.DyadicRootIsolation.refineTo?` refines one returned atom independently.
 
 The option type is an honest computational boundary: the core package does not
-silently assume completeness. The companion package
-[`hex-roots-mathlib`](https://github.com/leanprover/hex-roots-mathlib) proves
-that every nonzero squarefree input succeeds and offers a none-free wrapper.
+silently assume completeness. The companion package proves that every nonzero
+squarefree input succeeds and offers a none-free wrapper.
 
 # Verification
 
@@ -67,7 +59,7 @@ The Mathlib bridge supplies the semantic statements over `Polynomial ℂ`:
 existence and uniqueness inside each region, exact root count, pairwise
 separation, full coverage, and preservation under refinement.
 
-# Reference manual
+Reference material:
 
 - [SPEC](SPEC/hex-roots.md) — data model, algorithms, fuel, precision, and
   performance budgets.

--- a/HexRoots/SoftPellet.lean
+++ b/HexRoots/SoftPellet.lean
@@ -50,7 +50,9 @@ graph. -/
 constructors below always produce a nonnegative radius; keeping that fact out
 of the structure leaves proof fields out of the hot path. -/
 structure CoeffBall where
+  /-- Rounded Gaussian-dyadic centre of the enclosure. -/
   center : GaussDyadic
+  /-- Nonnegative `L¹` error radius around `center`. -/
   radius : Dyadic
   deriving DecidableEq
 
@@ -178,6 +180,7 @@ out-of-range convolution terms are exact zero balls. -/
     if k = 0 then graeffeEven bits cs 0
     else CoeffBall.sub bits (graeffeEven bits cs k) (graeffeOdd bits cs (k - 1))
 
+/-- A Graeffe step preserves the number of stored coefficients. -/
 @[simp] theorem graeffe_size (bits : Nat) (cs : Array CoeffBall) :
     (graeffe bits cs).size = cs.size := by
   simp [graeffe]
@@ -209,11 +212,17 @@ isolation-ratio constants. -/
 iteration.  All six endpoints are stored explicitly because every radius,
 not merely the base radius, must be squared after roots are squared. -/
 structure SoftRadii where
+  /-- Lower endpoint for the base-radius interval. -/
   baseLo : Dyadic
+  /-- Upper endpoint for the base-radius interval. -/
   baseHi : Dyadic
+  /-- Lower endpoint for the doubled-radius interval. -/
   twoLo : Dyadic
+  /-- Upper endpoint for the doubled-radius interval. -/
   twoHi : Dyadic
+  /-- Lower endpoint for the quadrupled-radius interval. -/
   fourLo : Dyadic
+  /-- Upper endpoint for the quadrupled-radius interval. -/
   fourHi : Dyadic
   deriving DecidableEq
 
@@ -318,7 +327,8 @@ theorem softWitnessCheck_false {p : ZPoly} {s : DyadicSquare} {k : Nat}
   have hSeed (bits : Nat) :
       (TaylorShift.compute p s.center).softSeededWitness s k bits = false := by
     apply softGraeffeLoop_false
-    simpa [seededTaylorBalls, TaylorShift.compute, taylor_size] using h
+    simpa [seededTaylorBalls, TaylorShift.compute, TaylorShift.coeffs,
+      taylor_size] using h
   simp [softWitnessCheck, TaylorShift.softWitnessCheck, softPrecisions, hAt, hSeed]
 
 /-- Any valid cached shift gives the same adaptive soft witness as the public
@@ -523,7 +533,7 @@ theorem softRefinementCandidate?_sound {p : ZPoly} {s : DyadicSquare}
   unfold softRefinementCandidate? TaylorShift.softRefinementCandidate? at h
   by_cases hprec : s.prec < 32
   · have hs : softSeededCandidate? p s ks 64 = some k := by
-      rw [if_pos hprec] at h
+      rw [_root_.ite_eq_left hprec] at h
       change softSeededCandidate? p s ks 64 = some k at h
       exact h
     have hsound := softSeededCandidate?_sound hs

--- a/HexRoots/Taylor.lean
+++ b/HexRoots/Taylor.lean
@@ -38,22 +38,27 @@ namespace GaussDyadic
   | 0 => ofInt 1
   | n + 1 => mul (pow z n) z
 
+/-- Zero is a right identity for Gaussian-dyadic addition. -/
 @[simp] theorem add_zero (z : GaussDyadic) : add z (0, 0) = z := by
   cases z
   simp [add]
 
+/-- Zero is a left identity for Gaussian-dyadic addition. -/
 @[simp] theorem zero_add (z : GaussDyadic) : add (0, 0) z = z := by
   cases z
   simp [add]
 
+/-- Gaussian-dyadic addition is associative. -/
 theorem add_assoc (x y z : GaussDyadic) : add (add x y) z = add x (add y z) := by
   cases x; cases y; cases z
   simp [add, Dyadic.add_assoc]
 
+/-- Gaussian-dyadic addition is commutative. -/
 theorem add_comm (x y : GaussDyadic) : add x y = add y x := by
   cases x; cases y
   simp [add, Dyadic.add_comm]
 
+/-- Reassociate two Gaussian-dyadic sums after exchanging their middle terms. -/
 theorem add_cross (x y z w : GaussDyadic) :
     add (add x y) (add z w) = add (add x z) (add y w) := by
   rw [add_assoc x y, ← add_assoc y z w, add_comm y z,
@@ -64,14 +69,17 @@ private theorem dyadic_sub_zero (x : Dyadic) : x - 0 = x := by
   rw [Rat.sub_eq_add_neg]
   simpa using Rat.add_zero x.toRat
 
+/-- Zero is right-absorbing for Gaussian-dyadic multiplication. -/
 @[simp] theorem mul_zero (z : GaussDyadic) : mul z (0, 0) = (0, 0) := by
   cases z
   simp [mul, dyadic_sub_zero]
 
+/-- Zero is left-absorbing for Gaussian-dyadic multiplication. -/
 @[simp] theorem zero_mul (z : GaussDyadic) : mul (0, 0) z = (0, 0) := by
   cases z
   simp [mul, dyadic_sub_zero]
 
+/-- One is a right identity for Gaussian-dyadic multiplication. -/
 @[simp] theorem mul_one (z : GaussDyadic) : mul z (ofInt 1) = z := by
   rcases z with ⟨x, y⟩
   unfold mul ofInt
@@ -79,6 +87,7 @@ private theorem dyadic_sub_zero (x : Dyadic) : x - 0 = x := by
   rw [h1]
   simp [Dyadic.mul_one, dyadic_sub_zero]
 
+/-- One is a left identity for Gaussian-dyadic multiplication. -/
 @[simp] theorem one_mul (z : GaussDyadic) : mul (ofInt 1) z = z := by
   rcases z with ⟨x, y⟩
   unfold mul ofInt
@@ -86,18 +95,21 @@ private theorem dyadic_sub_zero (x : Dyadic) : x - 0 = x := by
   rw [h1]
   simp [Dyadic.one_mul, dyadic_sub_zero]
 
+/-- Gaussian-dyadic multiplication distributes over addition on the left. -/
 theorem mul_add (x y z : GaussDyadic) : mul x (add y z) = add (mul x y) (mul x z) := by
   cases x; cases y; cases z
   apply Prod.ext <;>
     simp [mul, add, ← Dyadic.toRat_inj, Dyadic.toRat_add, Dyadic.toRat_sub,
       Dyadic.toRat_mul, Rat.sub_eq_add_neg, Rat.neg_add, Rat.mul_add] <;> ac_rfl
 
+/-- Gaussian-dyadic multiplication distributes over addition on the right. -/
 theorem add_mul (x y z : GaussDyadic) : mul (add x y) z = add (mul x z) (mul y z) := by
   cases x; cases y; cases z
   apply Prod.ext <;>
     simp [mul, add, ← Dyadic.toRat_inj, Dyadic.toRat_add, Dyadic.toRat_sub,
       Dyadic.toRat_mul, Rat.sub_eq_add_neg, Rat.neg_add, Rat.add_mul] <;> ac_rfl
 
+/-- Gaussian-dyadic multiplication is associative. -/
 theorem mul_assoc (x y z : GaussDyadic) : mul (mul x y) z = mul x (mul y z) := by
   cases x; cases y; cases z
   apply Prod.ext <;>
@@ -105,16 +117,20 @@ theorem mul_assoc (x y z : GaussDyadic) : mul (mul x y) z = mul x (mul y z) := b
       Dyadic.toRat_mul, Rat.sub_eq_add_neg, Rat.mul_add, Rat.add_mul,
       Rat.neg_add, Rat.mul_neg, Rat.neg_mul, Rat.mul_assoc] <;> ac_rfl
 
+/-- Gaussian-dyadic multiplication is commutative. -/
 theorem mul_comm (x y : GaussDyadic) : mul x y = mul y x := by
   cases x; cases y
   apply Prod.ext <;>
     simp [mul, Dyadic.mul_comm, Dyadic.add_comm]
 
+/-- The zeroth Gaussian-dyadic power is one. -/
 @[simp] theorem pow_zero (z : GaussDyadic) : pow z 0 = ofInt 1 := rfl
 
+/-- Characterization of a successor Gaussian-dyadic power. -/
 @[simp] theorem pow_succ (z : GaussDyadic) (n : Nat) :
     pow z (n + 1) = mul (pow z n) z := rfl
 
+/-- Adding natural scalars before scaling agrees with adding the scaled values. -/
 theorem nsmul_add (m n : Nat) (z : GaussDyadic) :
     nsmul (m + n) z = add (nsmul m z) (nsmul n z) := by
   have h : ofInt (m + n) = add (ofInt m) (ofInt n) := by
@@ -127,14 +143,17 @@ theorem nsmul_add (m n : Nat) (z : GaussDyadic) :
   have hi : (↑(m + n) : Int) = ↑m + ↑n := by omega
   rw [hi, h, add_mul]
 
+/-- Scaling a Gaussian dyadic by one leaves it unchanged. -/
 @[simp] theorem nsmul_one (z : GaussDyadic) : nsmul 1 z = z := by
   simp [nsmul]
 
+/-- A natural scalar can move across Gaussian-dyadic multiplication. -/
 theorem mul_nsmul (x y : GaussDyadic) (n : Nat) :
     mul x (nsmul n y) = nsmul n (mul x y) := by
   simp only [nsmul]
   rw [← mul_assoc, mul_comm x (ofInt n), mul_assoc]
 
+/-- Multiplication by `z` advances the power in a naturally scaled monomial. -/
 theorem mul_term (z a : GaussDyadic) (n r : Nat) :
     mul z (nsmul n (mul a (pow z r))) =
       nsmul n (mul a (pow z (r + 1))) := by
@@ -147,23 +166,15 @@ end GaussDyadic
 @[expose] def gaussSum (n : Nat) (f : Nat → GaussDyadic) : GaussDyadic :=
   (List.range n).foldl (fun s i => GaussDyadic.add s (f i)) (0, 0)
 
+/-- The empty Gaussian-dyadic sum is zero. -/
 @[simp] theorem gaussSum_zero (f : Nat → GaussDyadic) : gaussSum 0 f = (0, 0) := rfl
 
+/-- Split the last term from a Gaussian-dyadic sum. -/
 theorem gaussSum_succ (n : Nat) (f : Nat → GaussDyadic) :
     gaussSum (n + 1) f = GaussDyadic.add (gaussSum n f) (f n) := by
   simp [gaussSum, List.range_succ, List.foldl_append]
 
-theorem gaussSum_add (n : Nat) (f g : Nat → GaussDyadic) :
-    gaussSum n (fun i => GaussDyadic.add (f i) (g i)) =
-      GaussDyadic.add (gaussSum n f) (gaussSum n g) := by
-  induction n with
-  | zero => simp
-  | succ n ih =>
-      rw [gaussSum_succ, gaussSum_succ, gaussSum_succ, ih]
-      simp only [GaussDyadic.add_assoc]
-      rw [← GaussDyadic.add_assoc (gaussSum n g) (f n) (g n),
-        GaussDyadic.add_comm (gaussSum n g) (f n), GaussDyadic.add_assoc]
-
+/-- Left multiplication distributes over a Gaussian-dyadic sum. -/
 theorem mul_gaussSum (z : GaussDyadic) (n : Nat) (f : Nat → GaussDyadic) :
     GaussDyadic.mul z (gaussSum n f) =
       gaussSum n (fun i => GaussDyadic.mul z (f i)) := by
@@ -172,6 +183,7 @@ theorem mul_gaussSum (z : GaussDyadic) (n : Nat) (f : Nat → GaussDyadic) :
   | succ n ih =>
       rw [gaussSum_succ, GaussDyadic.mul_add, ih, gaussSum_succ]
 
+/-- Split the first term from a nonempty Gaussian-dyadic sum. -/
 theorem gaussSum_head (n : Nat) (f : Nat → GaussDyadic) :
     gaussSum (n + 1) f =
       GaussDyadic.add (f 0) (gaussSum n (fun i => f (i + 1))) := by
@@ -289,6 +301,8 @@ private theorem coeffStage_last (p : ZPoly) (z : GaussDyadic) (k : Nat)
   rw [this, taylorStage_one]
   simp
 
+/-- Loop invariant for one synthetic-division pass: entries from `k` onward
+    agree with the corresponding partial Taylor coefficients. -/
 private def AtStage (p : ZPoly) (z : GaussDyadic) (k : Nat)
     (a : Array GaussDyadic) : Prop :=
   a.size = p.size ∧
@@ -370,8 +384,9 @@ private theorem pass_atStage (p : ZPoly) (z : GaussDyadic) (k : Nat)
             have hj1new : p.size - 1 - r ≤ j + 1 := by
               dsimp [j]
               omega
-            rw [if_neg hjold, if_pos hj1new, ← coeffStage_step p z k j hj1lt]
-            rw [if_pos]
+            rw [_root_.ite_eq_right hjold, _root_.ite_eq_left hj1new,
+              ← coeffStage_step p z k j hj1lt]
+            rw [_root_.ite_eq_left]
             dsimp [j]
             omega
           · have hget : (step b r).getD i (0, 0) = b.getD i (0, 0) := by
@@ -384,15 +399,15 @@ private theorem pass_atStage (p : ZPoly) (z : GaussDyadic) (k : Nat)
               dsimp [j] at hij
               omega
             split <;> rename_i h
-            · rw [if_pos (hiff.mpr h)]
-            · rw [if_neg (fun h' => h (hiff.mp h'))]
+            · rw [_root_.ite_eq_left (hiff.mpr h)]
+            · rw [_root_.ite_eq_right (fun h' => h (hiff.mp h'))]
   unfold Taylor.pass
   have hm := hloop m (Nat.le_refl m)
   constructor
   · exact hm.1
   · intro i hki hi
     rw [hm.2 i hki hi]
-    rw [if_pos]
+    rw [_root_.ite_eq_left]
     dsimp [m]
     omega
 
@@ -421,6 +436,8 @@ private theorem pass_getD_of_lt (n : Nat) (z : GaussDyadic) (a : Array GaussDyad
   unfold Taylor.pass
   exact hloop m (Nat.le_refl m)
 
+/-- Outer-loop invariant: entries before `k` are final, while the remaining
+    entries agree with stage `k` of synthetic division. -/
 private def FullStage (p : ZPoly) (z : GaussDyadic) (k : Nat)
     (a : Array GaussDyadic) : Prop :=
   a.size = p.size ∧ ∀ i, i < p.size →
@@ -442,19 +459,19 @@ private theorem pass_fullStage (p : ZPoly) (z : GaussDyadic) (k : Nat)
     constructor
     · exact ha.1
     · intro i hki hi
-      rw [ha.2 i hi, if_neg (by omega)]
+      rw [ha.2 i hi, _root_.ite_eq_right (by omega)]
   have hadv := pass_atStage p z k a hastage
   constructor
   · exact hadv.1
   · intro i hi
     by_cases hik : i < k
-    · rw [pass_getD_of_lt p.size z a hik, ha.2 i hi, if_pos hik,
-        if_pos (by omega)]
+    · rw [pass_getD_of_lt p.size z a hik, ha.2 i hi, _root_.ite_eq_left hik,
+        _root_.ite_eq_left (by omega)]
     · rw [hadv.2 i (by omega) hi]
       by_cases hEq : i = k
       · subst i
         simp
-      · rw [if_neg (by omega)]
+      · rw [_root_.ite_eq_right (by omega)]
 
 private theorem fold_fullStage (p : ZPoly) (z : GaussDyadic) : ∀ r, r ≤ p.size →
     FullStage p z r
@@ -504,11 +521,15 @@ private theorem coeffStage_final (p : ZPoly) (z : GaussDyadic) (k : Nat) :
   -- empty (`Nat` subtraction gives `0`), a no-op.
   (List.range n).foldl (init := a₀) (Taylor.pass n z)
 
+set_option genInjectivity false in
 /-- Exact Taylor coefficients indexed by the polynomial and centre they
     represent. The equality is proof-only; compiled values contain just the
-    coefficient array. -/
+    coefficient array. Equality is characterized by the subsingleton instance
+    below, so no constructor injectivity rule is generated. -/
 structure TaylorShift (p : ZPoly) (center : GaussDyadic) where
+  /-- The cached exact coefficient array. -/
   coeffs : Array GaussDyadic
+  /-- The cache contains the exact Taylor shift at its indexed centre. -/
   valid : coeffs = taylor p center
 
 namespace TaylorShift
@@ -561,8 +582,8 @@ theorem taylor_getD (p : ZPoly) (z : GaussDyadic) (k : Nat) :
   have hfull : FullStage p z p.size (taylor p z) := by
     simpa [taylor] using fold_fullStage p z p.size (Nat.le_refl _)
   by_cases hk : k < p.size
-  · rw [hfull.2 k hk, if_pos hk, if_pos hk, coeffStage_final]
-  · rw [if_neg hk, Array.getD_eq_getD_getElem?,
+  · rw [hfull.2 k hk, _root_.ite_eq_left hk, _root_.ite_eq_left hk, coeffStage_final]
+  · rw [_root_.ite_eq_right hk, Array.getD_eq_getD_getElem?,
       Array.getElem?_eq_none (by rw [taylor_size]; omega)]
     rfl
 

--- a/libraries.yml
+++ b/libraries.yml
@@ -824,7 +824,7 @@ libraries:
   HexRoots:
     deps: [HexPolyZ]
     mathlib: false
-    done_through: 5
+    done_through: 7
     status: active
     phase4:
       comparators:
@@ -989,7 +989,7 @@ libraries:
   HexRealRoots:
     deps: [HexPolyZ]
     mathlib: false
-    done_through: 5
+    done_through: 7
     status: active
     phase4:
       comparators:


### PR DESCRIPTION
Closes #9655

## Summary

- audit and document the public HexRoots and HexRealRoots APIs, remove one unused Gaussian-sum lemma, and clear applicable linter/deprecation findings
- clarify certificate, precision, failure, and computation/proof boundaries in both manual chapters and released-repository READMEs
- advance both libraries to done_through: 7 after completing their independent exit evidence

## Verification

- lake build HexRoots HexRealRoots HexConformance HexManual
- both benchmark list/verify suites (14 HexRoots and 11 HexRealRoots cases)
- all scientific commands from both performance reports, including strategy agreement and real-root budget rungs
- fresh python-flint fixture replay for both libraries
- linter/docstring, trust-surface, DAG, phase, release-manifest, manual-split, line-count, copyright, and Mathlib-free bench checks

The exact historical HexRoots scientific sweep still reproduces stable hashes, but on the current Lean 4.34.0-rc2 toolchain the Pellet routes exceed the report-era per-call cap recorded under Lean 4.32.0-rc1. A comparison run with a 30-second cap completed all strategies with identical hashes and output; the source changes do not alter the computational path.