### PR TITLE
docs: complete HexPolyZMathlib Phase 7 correspondence

### DIFF
--- a/HexManual/Chapters/HexPolyZ.lean
+++ b/HexManual/Chapters/HexPolyZ.lean
@@ -69,6 +69,12 @@ analogue of normalizing to a monic polynomial over a field.
 
 {docstring Hex.ZPoly.Primitive}
 
+The decidable {name}`Hex.ZPoly.SquareFreeRat` predicate tests whether
+the executable rational gcd of a polynomial and its derivative has
+size at most one.
+
+{docstring Hex.ZPoly.SquareFreeRat}
+
 A related substitution, used when transferring a factor of a monic
 transform back to the original polynomial, scales the variable rather
 than the polynomial.
@@ -132,6 +138,11 @@ being coprime modulo `p`.
 {docstring Hex.ZPoly.congr}
 
 {docstring Hex.ZPoly.coprimeModP}
+
+{name}`Hex.ZPoly.modP` reduces an integer polynomial coefficientwise to
+an executable polynomial over {name}`Hex.ZMod64`.
+
+{docstring Hex.ZPoly.modP}
 
 The congruence is an equivalence relation and is compatible with the
 ring operations, so Hensel-step reasoning can rewrite under it.
@@ -299,6 +310,10 @@ changing their meaning.
 
 {docstring HexPolyZMathlib.equiv}
 
+{docstring HexPolyZMathlib.toPolynomial_zero}
+
+{docstring HexPolyZMathlib.toPolynomial_one}
+
 {docstring HexPolyZMathlib.toPolynomial_C}
 
 {docstring HexPolyZMathlib.toPolynomial_add}
@@ -309,9 +324,10 @@ changing their meaning.
 
 {docstring HexPolyZMathlib.toPolynomial_sub}
 
-The following live example illustrates the usual proof pattern: cross
-to `Polynomial ℤ`, use the simplification rules supplied by the bridge,
-and cross back only if executable data is needed again.
+The example below illustrates the usual proof pattern. Convert to
+`Polynomial ℤ`, use the simplification rules supplied by
+`HexPolyZMathlib`, and convert back only if executable data is needed
+again.
 
 ```lean
 open HexPolyZMathlib
@@ -334,11 +350,11 @@ end HexPolyZChapterCorrespondence
 tag := "hex-poly-z-mathlib-transports"
 %%%
 
-The bridge also names the transports that do not follow from the ring
-equivalence alone. The Mathlib-free unit predicate agrees with
-`IsUnit`; variable dilation becomes composition by `C c * X`; and the
-executable content and primitive-part decomposition becomes Mathlib's
-Gauss decomposition.
+`HexPolyZMathlib` also names the transports that do not follow from the
+ring equivalence alone. The Mathlib-free unit predicate agrees with
+{name}`IsUnit`. Variable dilation becomes composition by `C c * X`.
+The executable content and primitive-part decomposition agrees with
+Mathlib's Gauss decomposition.
 
 {docstring HexPolyZMathlib.isUnit_iff_toPolynomial_isUnit}
 
@@ -350,11 +366,12 @@ Gauss decomposition.
 
 {docstring HexPolyZMathlib.isPrimitive_toPolynomial_of_primitive}
 
-Reduction modulo `p` crosses both representation boundaries: integer
-coefficients are reduced into executable `ZMod64 p` values, then
-identified with Mathlib's `ZMod p`. The coefficient theorem is the
-rewrite rule used to prove the extensional map theorem and to transport
-divisibility.
+{name}`Hex.ZPoly.modP` reduces integer coefficients into executable
+{name}`Hex.ZMod64` values. The coefficient theorem identifies them with
+the corresponding values in Mathlib's {name}`ZMod` type. It is the
+rewrite rule used to prove the extensional map theorem. Divisibility
+transports separately because {name}`Polynomial.map` preserves
+multiplication.
 
 {docstring HexPolyZMathlib.coeff_toZMod_modP_eq_coeff_map_intCast}
 
@@ -370,7 +387,7 @@ tag := "hex-poly-z-mathlib-correctness"
 The executable library computes a natural-number squared coefficient
 norm and a conservative integer bound. The companion identifies that
 norm with the square of the real `l2norm`, identifies the executable
-binomial coefficient with `Nat.choose`, and then applies Mathlib's
+binomial coefficient with {name}`Nat.choose`, and then applies Mathlib's
 Mahler-measure theory to prove Mignotte's coefficient bound for every
 factor of a nonzero integer polynomial.
 
@@ -382,12 +399,11 @@ factor of a nonzero integer polynomial.
 
 {docstring HexPolyZMathlib.mignotte_bound}
 
-The same boundary covers rational squarefreeness and the shared
-root-separation foundations. The executable gcd test is related to
-`Squarefree` after casting to `Polynomial ℚ`; discriminant,
-Hadamard, Robinson-form, and Mahler-separation theorems remain entirely
-on the Mathlib side for downstream certified factorization and root
-isolation proofs.
+`HexPolyZMathlib` also relates the executable rational squarefreeness
+test to Mathlib's {name}`Squarefree` predicate after casting to
+`Polynomial ℚ`. Its discriminant, Hadamard, Robinson-form, and
+Mahler-separation theorems remain entirely on the Mathlib side for
+downstream certified factorization and root isolation proofs.
 
 {docstring HexPolyZMathlib.squareFreeRat_iff}
 

--- a/HexManual/Chapters/HexPolyZ.lean
+++ b/HexManual/Chapters/HexPolyZ.lean
@@ -8,6 +8,7 @@ import VersoManual
 
 import HexPolyZ.Decomposition
 import HexPolyZ.Mignotte
+import HexPolyZMathlib
 
 open Verso.Genre Manual
 open Verso.Genre.Manual.InlineLean
@@ -262,6 +263,141 @@ polynomial, which the factorization driver needs to set a valid
 precision modulus.
 
 {docstring Hex.ZPoly.defaultFactorCoeffBound_pos_of_ne_zero}
+
+# The Mathlib correspondence
+%%%
+tag := "hex-poly-z-mathlib"
+%%%
+
+Everything above is executable and Mathlib-free. `HexPolyZMathlib` is
+the proof-facing companion: it identifies {name}`Hex.ZPoly` with
+Mathlib's `Polynomial ℤ`, transports the integer-polynomial operations
+used by factorization, and proves the analytic bounds that justify the
+executable estimates.
+
+## Conversion and ring operations
+%%%
+tag := "hex-poly-z-mathlib-conversion"
+%%%
+
+The two conversion functions preserve coefficients and are mutually
+inverse.
+
+{docstring HexPolyZMathlib.toPolynomial}
+
+{docstring HexPolyZMathlib.ofPolynomial}
+
+{docstring HexPolyZMathlib.coeff_toPolynomial}
+
+{docstring HexPolyZMathlib.toPolynomial_ofPolynomial}
+
+{docstring HexPolyZMathlib.ofPolynomial_toPolynomial}
+
+They are bundled as a ring equivalence, so zero, one, constants,
+addition, multiplication, negation, and subtraction transport without
+changing their meaning.
+
+{docstring HexPolyZMathlib.equiv}
+
+{docstring HexPolyZMathlib.toPolynomial_C}
+
+{docstring HexPolyZMathlib.toPolynomial_add}
+
+{docstring HexPolyZMathlib.toPolynomial_mul}
+
+{docstring HexPolyZMathlib.toPolynomial_neg}
+
+{docstring HexPolyZMathlib.toPolynomial_sub}
+
+The following live example illustrates the usual proof pattern: cross
+to `Polynomial ℤ`, use the simplification rules supplied by the bridge,
+and cross back only if executable data is needed again.
+
+```lean
+open HexPolyZMathlib
+
+namespace HexPolyZChapterCorrespondence
+
+example (f g : Hex.ZPoly) :
+    ofPolynomial (toPolynomial (f * g)) = f * g := by
+  simp
+
+example (f : Hex.ZPoly) (n : Nat) :
+    (toPolynomial f).coeff n = f.coeff n := by
+  simp
+
+end HexPolyZChapterCorrespondence
+```
+
+## Integer-specific transports
+%%%
+tag := "hex-poly-z-mathlib-transports"
+%%%
+
+The bridge also names the transports that do not follow from the ring
+equivalence alone. The Mathlib-free unit predicate agrees with
+`IsUnit`; variable dilation becomes composition by `C c * X`; and the
+executable content and primitive-part decomposition becomes Mathlib's
+Gauss decomposition.
+
+{docstring HexPolyZMathlib.isUnit_iff_toPolynomial_isUnit}
+
+{docstring HexPolyZMathlib.toPolynomial_dilate}
+
+{docstring HexPolyZMathlib.toPolynomial_content}
+
+{docstring HexPolyZMathlib.toPolynomial_eq_C_content_mul_primitivePart}
+
+{docstring HexPolyZMathlib.isPrimitive_toPolynomial_of_primitive}
+
+Reduction modulo `p` crosses both representation boundaries: integer
+coefficients are reduced into executable `ZMod64 p` values, then
+identified with Mathlib's `ZMod p`. The coefficient theorem is the
+rewrite rule used to prove the extensional map theorem and to transport
+divisibility.
+
+{docstring HexPolyZMathlib.coeff_toZMod_modP_eq_coeff_map_intCast}
+
+{docstring HexPolyZMathlib.eq_map_intCast_of_coeff_eq_toZMod_modP}
+
+{docstring HexPolyZMathlib.dvd_modP_of_dvd}
+
+## Correctness theorems and the proof boundary
+%%%
+tag := "hex-poly-z-mathlib-correctness"
+%%%
+
+The executable library computes a natural-number squared coefficient
+norm and a conservative integer bound. The companion identifies that
+norm with the square of the real `l2norm`, identifies the executable
+binomial coefficient with `Nat.choose`, and then applies Mathlib's
+Mahler-measure theory to prove Mignotte's coefficient bound for every
+factor of a nonzero integer polynomial.
+
+{docstring HexPolyZMathlib.l2norm}
+
+{docstring HexPolyZMathlib.l2norm_toPolynomial_sq_eq_coeffNormSq}
+
+{docstring HexPolyZMathlib.binom_eq_choose}
+
+{docstring HexPolyZMathlib.mignotte_bound}
+
+The same boundary covers rational squarefreeness and the shared
+root-separation foundations. The executable gcd test is related to
+`Squarefree` after casting to `Polynomial ℚ`; discriminant,
+Hadamard, Robinson-form, and Mahler-separation theorems remain entirely
+on the Mathlib side for downstream certified factorization and root
+isolation proofs.
+
+{docstring HexPolyZMathlib.squareFreeRat_iff}
+
+{docstring HexPolyZMathlib.one_le_mahlerDist}
+
+Thus callers use {name}`Hex.ZPoly` and its natural-number bounds when
+they need computation. They import `HexPolyZMathlib` only when a proof
+must interpret those results as Mathlib polynomials or invoke
+noncomputable algebraic and analytic theory. No Mathlib dependency
+flows back into `HexPolyZ`.
 
 # Cross-references
 %%%

--- a/HexPolyZMathlib/README.md
+++ b/HexPolyZMathlib/README.md
@@ -7,9 +7,9 @@ with spec-driven development.
 This package supplies Mathlib semantics and analytic bounds for its
 computational counterpart,
 [`hex-poly-z`](https://github.com/leanprover/hex-poly-z). It depends on
-`hex-hensel`, `hex-poly-mathlib`, `hex-mod-arith-mathlib`, and Mathlib. It
-identifies `Hex.ZPoly` with `Polynomial ℤ` and provides the proofs shared by
-integer factorization and certified root isolation.
+`hex-poly-z`, `hex-hensel`, `hex-poly-mathlib`, `hex-mod-arith-mathlib`, and
+Mathlib. It identifies `Hex.ZPoly` with `Polynomial ℤ` and provides the proofs
+shared by integer factorization and certified root isolation.
 
 # Quickstart
 
@@ -43,7 +43,7 @@ example (f : Hex.ZPoly) :
   squarefreeness.
 - `mignotte_bound`, `one_le_mahlerDist`, and the discriminant, Hadamard, and
   Robinson-form APIs provide the analytic results used downstream.
-- `PolyParse` supplies shared elaboration-time polynomial parsing.
+- `PolyParse.parsePoly` supplies shared elaboration-time polynomial parsing.
 
 # Verification
 

--- a/HexPolyZMathlib/README.md
+++ b/HexPolyZMathlib/README.md
@@ -4,12 +4,12 @@ Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
 library for Lean 4. The aim is fast executable code, fully verified, built
 with spec-driven development.
 
-Mathlib semantics and analytic bounds for
-[`hex-poly-z`](https://github.com/leanprover/hex-poly-z).
-
-The package identifies `Hex.ZPoly` with `Polynomial ℤ` and develops the
-square-free, discriminant, Hadamard, Mahler-separation, Mignotte, and parsing
-results shared by integer factorization and certified root isolation.
+This package supplies Mathlib semantics and analytic bounds for its
+computational counterpart,
+[`hex-poly-z`](https://github.com/leanprover/hex-poly-z). It depends on
+`hex-hensel`, `hex-poly-mathlib`, `hex-mod-arith-mathlib`, and Mathlib. It
+identifies `Hex.ZPoly` with `Polynomial ℤ` and provides the proofs shared by
+integer factorization and certified root isolation.
 
 # Quickstart
 
@@ -22,18 +22,41 @@ rev = "main"
 
 ```lean
 import HexPolyZMathlib
+
+open HexPolyZMathlib
+
+#check equiv
+
+example (f : Hex.ZPoly) :
+    ofPolynomial (toPolynomial f) = f := by
+  simp
 ```
 
 # Functionality
 
-The proof-facing API includes the `ZPoly` equivalence, square-free transport,
-polynomial parsing, and the discriminant, Hadamard, Mahler, and Mignotte bounds.
+- `equiv`, `toPolynomial`, and `ofPolynomial` identify `Hex.ZPoly` with
+  `Polynomial ℤ` and preserve coefficients and ring operations.
+- `toPolynomial_content`, `toPolynomial_dilate`, and
+  `coeff_toZMod_modP_eq_coeff_map_intCast` transport integer-specific
+  operations.
+- `squareFreeRat_iff` connects the executable rational-gcd test to Mathlib
+  squarefreeness.
+- `mignotte_bound`, `one_le_mahlerDist`, and the discriminant, Hadamard, and
+  Robinson-form APIs provide the analytic results used downstream.
+- `PolyParse` supplies shared elaboration-time polynomial parsing.
 
 # Verification
 
-The computational representation remains in the Mathlib-free package. This
-package owns theorem statements over `Polynomial ℤ`, `Polynomial ℚ`, and
-`Polynomial ℂ`. See the [SPEC](SPEC/hex-poly-z-mathlib.md) for the theorem map.
+The representation correspondence covers both conversion directions,
+coefficients, and the ring operations. Specialized theorems cover content,
+primitive parts, dilation, reduction modulo `p`, rational squarefreeness, and
+the Mignotte bound. The discriminant and Mahler developments provide the
+Mathlib-side analytic surface used by root isolation.
+
+Executable polynomial arithmetic and natural-number coefficient bounds remain
+in `hex-poly-z`; this package provides proofs over `Polynomial ℤ`,
+`Polynomial ℚ`, and `Polynomial ℂ`. See the
+[SPEC](SPEC/hex-poly-z-mathlib.md) for the theorem map.
 
 # Contributing
 

--- a/libraries.yml
+++ b/libraries.yml
@@ -742,7 +742,7 @@ libraries:
   HexPolyZMathlib:
     deps: [HexPolyZ, HexHensel, HexPolyMathlib, HexModArithMathlib]
     mathlib: true
-    done_through: 6
+    done_through: 7
     status: active
   HexPolyZGcdMathlib:
     deps: [HexPolyZGcd, HexPolyZMathlib, HexPolyMathlib]

--- a/progress/20260827T034011Z_issue9654.md
+++ b/progress/20260827T034011Z_issue9654.md
@@ -1,0 +1,24 @@
+# HexPolyZMathlib Phase 7 documentation (#9654)
+
+## Accomplished
+
+`HexPolyZMathlib.done_through` advances from 6 to 7. The shared HexPolyZ
+manual chapter now documents the conversion between `Hex.ZPoly` and
+`Polynomial ℤ`, the principal transported operations and correctness
+theorems, and the boundary between executable computation and Mathlib proofs.
+The README states the direct dependencies and includes a compiling quickstart.
+
+## Verification
+
+The complete `HexPolyZMathlib` and `HexManual` targets build successfully. The
+README quickstart compiles exactly as written. The Phase 7, manual-split,
+released-manifest, and library-DAG checks pass.
+
+An independent review checked the referenced declarations against their source.
+It identified an inaccurate explanation of divisibility transport, several
+writing-style violations, and omitted documentation for the executable
+squarefreeness and modular-reduction operations. These points were corrected.
+
+## Remaining work
+
+None for issue #9654.


### PR DESCRIPTION
Closes #9654

## Summary
- document the supported Hex.ZPoly / Polynomial ℤ correspondence and proof boundary in the manual
- add live Lean examples and canonical declaration docstrings for conversion, transport, and correctness APIs
- audit and compile the HexPolyZMathlib README quickstart
- advance HexPolyZMathlib to Phase 7 after the full checks pass

## Verification
- lake build HexPolyZMathlib HexManual
- exact README quickstart compiled as HexPolyZMathlib.READMEQuickstart
- python3 scripts/check_phase7.py
- python3 scripts/release/check_manual_split.py
- python3 scripts/release/check_released_manifest.py
- python3 scripts/check_dag.py