### PR TITLE
chore: certify matrix bridges through phase 7

### DIFF
--- a/HexGramSchmidtMathlib/README.md
+++ b/HexGramSchmidtMathlib/README.md
@@ -42,7 +42,7 @@ open Hex
 
 # Functionality
 
-The proof-facing API splits into two parts.
+The proof-facing API splits into three parts.
 
 - The view `GramSchmidtMathlib.rowToEuclidean` from a rational dense row
   into `EuclideanSpace ℝ (Fin m)`, with its additivity, scaling, and

--- a/HexGramSchmidtMathlib/README.md
+++ b/HexGramSchmidtMathlib/README.md
@@ -9,8 +9,9 @@ with spec-driven development.
 identifies the executable dense-matrix Gram-Schmidt basis with Mathlib's
 `InnerProductSpace.gramSchmidt`, and the fraction-free integer
 coefficients with Bareiss determinants. It depends on
-[`hex-gram-schmidt`](https://github.com/leanprover/hex-gram-schmidt) and on
-Mathlib.
+[`hex-gram-schmidt`](https://github.com/leanprover/hex-gram-schmidt),
+[`hex-bareiss-mathlib`](https://github.com/leanprover/hex-bareiss-mathlib),
+and Mathlib.
 
 # Quickstart
 
@@ -97,7 +98,7 @@ theorem gramDet_eq_prod_normSq (b : Matrix Int n m)
 The executable Gram-Schmidt algorithm and its own algebraic API live in
 [`hex-gram-schmidt`](https://github.com/leanprover/hex-gram-schmidt).
 
-# Reference manual
+Reference manual:
 
 The hex reference manual covers this library and its computational base at
 <https://kim-em.github.io/hex-dev/find/?domain=Verso.Genre.Manual.section&name=hex-gram-schmidt>.

--- a/HexManual/Chapters/HexGramSchmidt.lean
+++ b/HexManual/Chapters/HexGramSchmidt.lean
@@ -243,14 +243,16 @@ Bareiss libraries and underpins `HexLLL`:
   operations ({name}`Hex.Matrix.rowAdd`, {name}`Hex.Matrix.rowSwap`) that the
   {ref "hex-gram-schmidt-updates"}[update formulas] reason about. The
   orthogonalization here is built entirely on that representation.
-* {ref "hex-row-reduce"}[HexRowReduce] supplies the row-space API used by
-  the rational kernel, while {ref "hex-determinant"}[HexDeterminant] and
+* {ref "hex-row-reduce"}[HexRowReduce] supplies
+  {name}`Hex.Matrix.IsRowReduced` and its row-echelon contracts, used by the
+  integer Bareiss-Gram invariant, while
+  {ref "hex-determinant"}[HexDeterminant] and
   {ref "hex-bareiss"}[HexBareiss] supply the determinant and fraction-free
   elimination layers used by the integer data.
-* `HexGramSchmidtMathlib` re-exports this executable theory as theorems
-  about Mathlib's {name}`LinearMap` and
-  Mathlib's {name}`_root_.Matrix` Gram-Schmidt. `HexGramSchmidt`
-  itself imports only `HexMatrix` and `Std`.
+* `HexGramSchmidtMathlib` re-expresses this executable theory as theorems
+  about Mathlib's {name}`InnerProductSpace.gramSchmidt` on
+  {name}`EuclideanSpace` and Mathlib's {name}`_root_.Matrix` determinants.
+  `HexGramSchmidt` itself is Mathlib-free.
 * `HexLLL` consumes the {ref "hex-gram-schmidt-core"}[integer data]
   (the Gram determinants and scaled coefficients) and the
   {ref "hex-gram-schmidt-updates"}[exact update formulas] to drive

--- a/HexManual/Chapters/HexGramSchmidt.lean
+++ b/HexManual/Chapters/HexGramSchmidt.lean
@@ -51,8 +51,12 @@ are `noncomputable`. The computable determinant operations
 ({name}`Hex.GramSchmidt.Int.gramDet`,
 {name}`Hex.GramSchmidt.Int.scaledCoeffs`) drive the worked examples below.
 
-`HexGramSchmidt` is Mathlib-free and depends only on `HexMatrix`. `HexLLL`
-uses it for orthogonalization and the exact-update formulas. See
+`HexGramSchmidt` is Mathlib-free and depends on
+{ref "hex-row-reduce"}[HexRowReduce],
+{ref "hex-determinant"}[HexDeterminant], and
+{ref "hex-bareiss"}[HexBareiss], which in turn build on
+{ref "hex-matrix"}[HexMatrix]. `HexLLL` uses it for orthogonalization and
+the exact-update formulas. See
 {ref "hex-gram-schmidt-cross-references"}[Cross-references].
 
 # Fundamental operations
@@ -232,12 +236,17 @@ integral.
 tag := "hex-gram-schmidt-cross-references"
 %%%
 
-`HexGramSchmidt` depends only on `HexMatrix` and underpins `HexLLL`:
+`HexGramSchmidt` builds on the matrix, row-reduction, determinant, and
+Bareiss libraries and underpins `HexLLL`:
 
 * `HexMatrix` supplies the {name}`Hex.Matrix` representation and the row
   operations ({name}`Hex.Matrix.rowAdd`, {name}`Hex.Matrix.rowSwap`) that the
   {ref "hex-gram-schmidt-updates"}[update formulas] reason about. The
   orthogonalization here is built entirely on that representation.
+* {ref "hex-row-reduce"}[HexRowReduce] supplies the row-space API used by
+  the rational kernel, while {ref "hex-determinant"}[HexDeterminant] and
+  {ref "hex-bareiss"}[HexBareiss] supply the determinant and fraction-free
+  elimination layers used by the integer data.
 * `HexGramSchmidtMathlib` re-exports this executable theory as theorems
   about Mathlib's {name}`LinearMap` and
   Mathlib's {name}`_root_.Matrix` Gram-Schmidt. `HexGramSchmidt`

--- a/HexManual/Chapters/HexMatrix.lean
+++ b/HexManual/Chapters/HexMatrix.lean
@@ -226,7 +226,7 @@ tag := "hex-matrix-mathlib"
 
 Everything above is executable and Mathlib-free. `HexMatrixMathlib`
 connects it to Mathlib: every {name}`Hex.Matrix` corresponds to a Mathlib
-Mathlib's {name}`_root_.Matrix` type with the same entries.
+{name}`_root_.Matrix` type with the same entries.
 
 {docstring HexMatrixMathlib.matrixEquiv}
 

--- a/HexManual/Chapters/HexMatrix.lean
+++ b/HexManual/Chapters/HexMatrix.lean
@@ -31,9 +31,10 @@ Mathlib correspondence in
 
 This library has the type, its arithmetic (the dot product, matrix-vector
 and matrix-matrix multiplication, transpose, the Gram matrix), and the
-elementary row and column operations. It depends on no other `hex`
-library. The determinant, row reduction, and integer determinant are
-separate libraries built on it: {ref "hex-determinant"}[HexDeterminant],
+elementary row and column operations. It depends only on
+{ref "hex-basic"}[HexBasic]. The determinant, row reduction, and integer
+determinant are separate libraries built on it:
+{ref "hex-determinant"}[HexDeterminant],
 {ref "hex-row-reduce"}[HexRowReduce], {ref "hex-bareiss"}[HexBareiss].
 
 The type and its operations are Mathlib-free. The

--- a/HexMatrixMathlib/README.md
+++ b/HexMatrixMathlib/README.md
@@ -105,7 +105,7 @@ The executable matrices and their operations live in
 reduction, and Bareiss correspondences build on this base in their own bridge
 libraries.
 
-# Reference manual
+Reference manual:
 
 The Mathlib correspondence section of the hex reference manual covers this library at
 <https://kim-em.github.io/hex-dev/find/?domain=Verso.Genre.Manual.section&name=hex-matrix-mathlib>.

--- a/libraries.yml
+++ b/libraries.yml
@@ -694,7 +694,7 @@ libraries:
   HexMatrixMathlib:
     deps: [HexMatrix]
     mathlib: true
-    done_through: 6
+    done_through: 7
     status: active
     phase4:
       input_families:
@@ -737,7 +737,7 @@ libraries:
   HexGramSchmidtMathlib:
     deps: [HexGramSchmidt, HexBareissMathlib]
     mathlib: true
-    done_through: 6
+    done_through: 7
     status: active
   HexPolyZMathlib:
     deps: [HexPolyZ, HexHensel, HexPolyMathlib, HexModArithMathlib]


### PR DESCRIPTION
## Summary

- audit the HexMatrix and HexGramSchmidt manual chapters against the Phase 7 contract
- correct README structure and dependency and cross-reference documentation found by the audit
- advance HexMatrixMathlib and HexGramSchmidtMathlib to done_through: 7

## Verification

- exact README quickstarts compiled as temporary modules
- lake build HexMatrixMathlib HexGramSchmidtMathlib HexManual
- python3 scripts/check_phase7.py
- python3 scripts/release/check_manual_split.py
- python3 scripts/release/check_released_manifest.py
- python3 scripts/check_dag.py
- CI build, manual, benches, conformance, and oracle gates

Closes #9653