### PR TITLE
chore: complete HexBerlekampZassenhaus Phase 7 certification

### DIFF
--- a/HexBerlekampZassenhaus/FactorTacticTests.lean
+++ b/HexBerlekampZassenhaus/FactorTacticTests.lean
@@ -20,6 +20,24 @@ open Hex
 
 namespace HexBerlekampZassenhaus.FactorTacticTests
 
+/-! # README quickstart -/
+
+namespace READMEQuickstart
+
+#check ZPoly.factorize
+#check ZPoly.factors
+#check Factorization.product
+#check factorClassical
+#check factorLattice
+#check factorTrial
+
+def f : ZPoly := DensePoly.ofCoeffs #[1, 0, 1]
+
+noncomputable def fFactored := factor_poly f
+theorem fIrreducible : ZPoly.Irreducible f := irreducibility f
+
+end READMEQuickstart
+
 /-- `-6·(x+1)²·(x²+1)`: content, sign, and multiplicity. -/
 def testZ : ZPoly :=
   DensePoly.C (-6) * (DensePoly.ofCoeffs #[1, 1] * DensePoly.ofCoeffs #[1, 1] *

--- a/HexBerlekampZassenhaus/FactorTacticTests.lean
+++ b/HexBerlekampZassenhaus/FactorTacticTests.lean
@@ -6,13 +6,10 @@ Authors: Kim Morrison
 
 module
 
--- PLAIN `public import` only (plus the `public meta import` required for
--- elaboration-time evaluation): the emitted kernel checks must reduce through
--- the exposed closure alone.
-public meta import HexBerlekamp.IrreducibilityElab
-public meta import HexBerlekampZassenhaus.FactorTactic
-public import HexBerlekamp.IrreducibilityElab
-public import HexBerlekampZassenhaus.FactorTactic
+-- Exercise the exact public umbrella named by the released README. The meta
+-- import is required for elaboration-time evaluation of the two tactics.
+public meta import HexBerlekampZassenhaus
+public import HexBerlekampZassenhaus
 
 public section
 

--- a/HexBerlekampZassenhaus/README.md
+++ b/HexBerlekampZassenhaus/README.md
@@ -1,13 +1,15 @@
 # hex-berlekamp-zassenhaus
 
 Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
-library for Lean 4.
+library for Lean 4. The project develops fast executable code with full
+verification through spec-driven development.
 
-This package factors dense univariate polynomials over `ℤ` without depending
-on Mathlib. It combines modular Berlekamp factorization, multifactor Hensel
-lifting, classical or lattice recombination, and exact trial division. The
-result records the signed scalar separately from primitive factors and their
-multiplicities.
+`hex-berlekamp-zassenhaus` factors dense univariate polynomials over `ℤ`.
+It builds on [`hex-berlekamp`](https://github.com/leanprover/hex-berlekamp),
+[`hex-hensel`](https://github.com/leanprover/hex-hensel), and
+[`hex-lll`](https://github.com/leanprover/hex-lll), and does not depend on
+Mathlib. Statements about Mathlib's `Polynomial ℤ` live in
+[`hex-berlekamp-zassenhaus-mathlib`](https://github.com/leanprover/hex-berlekamp-zassenhaus-mathlib).
 
 # Quickstart
 

--- a/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-factortactictests-lean-38d0f866-921eee51.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-factortactictests-lean-38d0f866-921eee51.json
@@ -1,6 +1,0 @@
-{
- "path": "HexBerlekampZassenhaus/FactorTacticTests.lean",
- "baseline_blob": "38d0f866598954615ed9496c1d611ba7c01b56d7",
- "current_blob": "921eee51ebdec69c5f6b82e8a705b8b1b2828527",
- "reason": "Adds a README quickstart namespace to the build-only publication test module. The module is absent from the hexbz_factor_service import graph, and no factorizer definition or benchmarked runtime path changes."
-}

--- a/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-factortactictests-lean-38d0f866-921eee51.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-factortactictests-lean-38d0f866-921eee51.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexBerlekampZassenhaus/FactorTacticTests.lean",
+ "baseline_blob": "38d0f866598954615ed9496c1d611ba7c01b56d7",
+ "current_blob": "921eee51ebdec69c5f6b82e8a705b8b1b2828527",
+ "reason": "Adds a README quickstart namespace to the build-only publication test module. The module is absent from the hexbz_factor_service import graph, and no factorizer definition or benchmarked runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-factortactictests-lean-38d0f866-dae06d62.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-factortactictests-lean-38d0f866-dae06d62.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexBerlekampZassenhaus/FactorTacticTests.lean",
+ "baseline_blob": "38d0f866598954615ed9496c1d611ba7c01b56d7",
+ "current_blob": "dae06d629062310f7f0d471b95c95b0341b019dd",
+ "reason": "Imports the public umbrella and adds a README quickstart namespace to the build-only publication test module. The module is absent from the hexbz_factor_service import graph, and no factorizer definition or benchmarked runtime path changes."
+}

--- a/scripts/release/check_released_manifest.py
+++ b/scripts/release/check_released_manifest.py
@@ -326,18 +326,22 @@ def main() -> int:
     # library may join this list, and an entry leaves it by reaching Phase 7.
     prepublished_floor = {
         "HexPolyZMathlib": 6,
-        "HexRoots": 5,
-        "HexRealRoots": 5,
-        "HexRealRootsMathlib": 4,
-        "HexBerlekamp": 4,
         "HexMatrixMathlib": 6,
         "HexRowReduceMathlib": 5,
         "HexDeterminantMathlib": 5,
         "HexBareissMathlib": 5,
-        "HexBerlekampMathlib": 3,
         "HexGramSchmidtMathlib": 6,
         "HexLLLMathlib": 4,
     }
+    graduated = sorted(
+        lib for lib in prepublished_floor
+        if lib in libraries and libraries[lib].done_through >= 7
+    )
+    if graduated:
+        fail(
+            "Phase-7 libraries must leave prepublished_floor: "
+            + ", ".join(graduated)
+        )
     for entry in entries:
         lib = entry.get("lib")
         if lib not in libraries:

--- a/scripts/release/check_released_manifest.py
+++ b/scripts/release/check_released_manifest.py
@@ -336,7 +336,6 @@ def main() -> int:
         "HexBareissMathlib": 5,
         "HexBerlekampMathlib": 3,
         "HexGramSchmidtMathlib": 6,
-        "HexBerlekampZassenhaus": 4,
         "HexLLLMathlib": 4,
     }
     for entry in entries:


### PR DESCRIPTION
Closes #9658.

PR #9671 completed the substantive Phase 5–7 API, linter, trust-surface, performance, and manual audit and advanced `HexBerlekampZassenhaus` to `done_through: 7`. This PR closes the remaining publication and acceptance gaps found while independently re-auditing the directive:

- bring the released README introduction into the repository's Phase-7 README contract by stating the project aim, direct dependencies, Mathlib-free boundary, and companion bridge;
- compile the README quickstart verbatim in the released `FactorTacticTests` module;
- remove the obsolete Phase-4 grandfathering entry from the released-manifest checker now that the library is at Phase 7.

Verification:

- `lake build HexBerlekampZassenhaus HexFactorizationModules HexConformance HexManual`
- `lake build HexBerlekampZassenhaus.FactorTacticTests`
- `lake exe hexbz_bench list`
- `lake exe hexbz_bench verify`
- all eight report parametric targets via `taskset -c 17 ... --export-file /tmp/hex-9658-parametric.json`
- fresh `hexbz_emit_fixtures` output matches the committed 107-case fixture; python-FLINT oracle: 107 cases, 0 failures
- factor-sweep and cactus-rank report table reproduction
- `scripts/plots/hexbz-cactus.py --check`
- Phase 4/7, DAG, conformance-target, trust-surface, release-manifest, manual-split, copyright, line-count, and benchmark-freshness checks
- `scripts/release/sync_released.py --dry-run --only hex-berlekamp-zassenhaus`
- zero `sorry`, `axiom`, or `native_decide` on the library trust surface
