### PR TITLE
chore: certify row-reduction, determinant, and Bareiss through Phase 7

### DIFF
--- a/HexBareiss/Bareiss.lean
+++ b/HexBareiss/Bareiss.lean
@@ -949,7 +949,7 @@ variable {quot : R → R → R}
 
 /-- Bareiss elimination with row pivoting. If a column has no nonzero pivot,
 the elimination aborts and the determinant is zero. -/
-@[expose]
+@[expose, specialize quot]
 def pivotLoopWith (quot : R → R → R) (fuel : Nat)
     (state : BareissState R n) : BareissState R n :=
   match fuel with
@@ -1061,7 +1061,7 @@ theorem pivotLoopWith_of_regular_swap (fuel : Nat) (state : BareissState R n)
 /-- `bareissArrayStateWith` runs the matrix-level Bareiss elimination via `pivotLoopWith quot`
 and repackages the reduced result as a `BareissArrayState R`, storing the matrix
 row-by-row via `matrixToRows`. -/
-@[expose]
+@[expose, specialize quot]
 def bareissArrayStateWith (quot : R → R → R) (M : Matrix R n n) : BareissArrayState R :=
   let state := pivotLoopWith quot n
     { step := 0
@@ -1110,7 +1110,7 @@ def finish (state : BareissState R n) : BareissData R n :=
 
 /-- Bareiss elimination without pivoting. A zero pivot aborts and records the
 singular step. -/
-@[expose]
+@[expose, specialize quot]
 def noPivotLoopWith (quot : R → R → R) (fuel : Nat)
     (state : BareissState R n) : BareissState R n :=
   match fuel with
@@ -1458,7 +1458,7 @@ theorem bareissDataWith_eq_finish_pivotLoopWith (M : Matrix R n n) :
     rowsToMatrix_matrixToRows]
 
 /-- Determinant computed by the row-pivoted Bareiss algorithm. -/
-@[expose]
+@[expose, specialize quot]
 def bareissWith (quot : R → R → R) (M : Matrix R n n) : R :=
   let state := bareissArrayStateWith quot M
   bareissArrayDet state n

--- a/HexBareiss/Bareiss.lean
+++ b/HexBareiss/Bareiss.lean
@@ -1433,6 +1433,13 @@ def noPivotInitialState (M : Matrix R n n) : BareissState R n :=
 def bareissNoPivotDataWith (quot : R → R → R) (M : Matrix R n n) : BareissData R n :=
   finish <| noPivotLoopWith quot n (noPivotInitialState M)
 
+/-- Characterisation of the generic no-pivot result by its completed loop
+state. Consumers can use this theorem without unfolding the public wrapper. -/
+theorem bareissNoPivotDataWith_eq_finish (M : Matrix R n n) :
+    bareissNoPivotDataWith quot M =
+      finish (noPivotLoopWith quot n (noPivotInitialState M)) :=
+  rfl
+
 /-- Determinant computed by the no-pivot Bareiss recurrence. -/
 @[expose]
 def bareissNoPivotWith (quot : R → R → R) (M : Matrix R n n) : R :=
@@ -1540,8 +1547,9 @@ abbrev bareissArrayState (M : Matrix Int n n) : BareissArrayState Int :=
   bareissArrayStateWith exactDiv M
 
 /-- Integer specialization returning no-pivot elimination data. -/
-abbrev bareissNoPivotData (M : Matrix Int n n) : BareissData Int n :=
-  bareissNoPivotDataWith exactDiv M
+@[expose]
+def bareissNoPivotData (M : Matrix Int n n) : BareissData Int n :=
+  finish <| noPivotLoop n (noPivotInitialState M)
 
 /-- Integer specialization of the no-pivot Bareiss determinant. -/
 abbrev bareissNoPivot (M : Matrix Int n n) : Int :=
@@ -1784,10 +1792,17 @@ theorem pivotLoop_eq_noPivotLoop_of_no_singular (fuel : Nat)
   pivotLoopWith_eq_noPivotLoopWith_of_no_singular
     (quot := exactDiv) fuel state h_no_sing
 
+/-- The integer no-pivot result is the completed integer no-pivot loop state. -/
+theorem bareissNoPivotData_eq_finish (M : Matrix Int n n) :
+    bareissNoPivotData M = finish (noPivotLoop n (noPivotInitialState M)) :=
+  rfl
+
+/-- The integer row-pivoted result is the completed pivot-loop state. -/
 theorem bareissData_eq_finish_pivotLoop (M : Matrix Int n n) :
     bareissData M = finish (pivotLoop n (noPivotInitialState M)) :=
   bareissDataWith_eq_finish_pivotLoopWith (quot := exactDiv) M
 
+/-- The integer determinant entry point agrees with its packaged result. -/
 theorem bareiss_eq_bareissData_det (M : Matrix Int n n) :
     bareiss M = (bareissData M).det :=
   bareissWith_eq_bareissDataWith_det (quot := exactDiv) M

--- a/HexBareiss/Bareiss.lean
+++ b/HexBareiss/Bareiss.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexDeterminant
+public import HexBasic.ExactDiv
 public import HexArith.ExactDiv
 public import HexBareiss.BorderedMinor
 
@@ -30,14 +31,14 @@ universe u
 
 namespace Matrix
 
-variable {n : Nat}
+variable {R : Type u} {n : Nat}
 
 /-- Output of an executable Bareiss elimination pass. -/
-structure BareissData (n : Nat) where
+structure BareissData (R : Type u) (n : Nat) where
   /-- Terminal matrix produced by the Bareiss pass. When `singularStep = none`,
   `BareissData.det` reads the last diagonal entry of this matrix, with the
   row-swap sign applied; for `n = 0`, the empty diagonal contributes `1`. -/
-  matrix : Matrix Int n n
+  matrix : Matrix R n n
   /-- Number of row swaps performed by pivoting. Even parity contributes sign
   `1`; odd parity contributes sign `-1`. -/
   rowSwaps : Nat
@@ -51,11 +52,11 @@ namespace BareissData
 
 /-- The determinant sign contributed by the recorded row swaps. -/
 @[expose]
-def sign (data : BareissData n) : Int :=
+def sign [One R] [Neg R] (data : BareissData R n) : R :=
   if data.rowSwaps % 2 = 0 then 1 else -1
 
 @[expose]
-def lastDiag? (M : Matrix Int n n) : Option Int :=
+def lastDiag? (M : Matrix R n n) : Option R :=
   match n with
   | 0 => none
   | k + 1 =>
@@ -64,7 +65,7 @@ def lastDiag? (M : Matrix Int n n) : Option Int :=
 
 /-- The determinant encoded by a Bareiss elimination result. -/
 @[expose]
-def det (data : BareissData n) : Int :=
+def det [Zero R] [One R] [Neg R] [Mul R] (data : BareissData R n) : R :=
   match data.singularStep with
   | some _ => 0
   | none =>
@@ -74,7 +75,8 @@ def det (data : BareissData n) : Int :=
 
 /-- A recorded singular step encodes determinant zero. -/
 @[grind →]
-theorem det_eq_zero_of_singularStep {data : BareissData n} {k : Nat}
+theorem det_eq_zero_of_singularStep [Zero R] [One R] [Neg R] [Mul R]
+    {data : BareissData R n} {k : Nat}
     (h : data.singularStep = some k) :
     data.det = 0 := by
   unfold det
@@ -83,7 +85,8 @@ theorem det_eq_zero_of_singularStep {data : BareissData n} {k : Nat}
 /-- For a non-singular Bareiss elimination of a positive-size matrix, the
 encoded determinant is `sign * (last diagonal entry)`. -/
 @[grind =]
-theorem det_succ_eq {k : Nat} (data : BareissData (k + 1))
+theorem det_succ_eq [Zero R] [One R] [Neg R] [Mul R]
+    {k : Nat} (data : BareissData R (k + 1))
     (h : data.singularStep = none) :
     data.det = data.sign *
       data.matrix[(⟨k, Nat.lt_succ_self k⟩ : Fin (k + 1))][
@@ -95,7 +98,7 @@ theorem det_succ_eq {k : Nat} (data : BareissData (k + 1))
 /-- For a non-singular Bareiss elimination of an empty matrix, the encoded
 determinant is the sign. -/
 @[grind =]
-theorem det_zero_eq (data : BareissData 0)
+theorem det_zero_eq [Zero R] [One R] [Neg R] [Mul R] (data : BareissData R 0)
     (h : data.singularStep = none) :
     data.det = data.sign := by
   unfold det
@@ -106,16 +109,16 @@ end BareissData
 
 /-- Internal state of the no-pivot Bareiss recurrence, exposed read-only for
 the Mathlib-side determinant proof. -/
-structure BareissState (n : Nat) where
+structure BareissState (R : Type u) (n : Nat) where
   /-- Current elimination step. The next update, if any, uses this row and
   column as the pivot position. -/
   step : Nat
   /-- Current matrix carried by the Bareiss recurrence. Its terminal value is
   copied into `BareissData.matrix` by `finish`. -/
-  matrix : Matrix Int n n
+  matrix : Matrix R n n
   /-- Previous nonzero pivot used as the exact-division denominator; initially
   `1`. -/
-  prevPivot : Int
+  prevPivot : R
   /-- Number of row swaps already performed by the pivoting wrapper. Even
   parity contributes determinant sign `1`; odd parity contributes sign `-1`. -/
   rowSwaps : Nat
@@ -138,7 +141,8 @@ theorem exactDiv_eq_divExact {num denom : Int} (h : denom ∣ num) :
 
 /-- Search column `col` for a nonzero pivot at or below `start`. -/
 @[expose]
-def findPivotAux (M : Matrix Int n n) (col : Fin n) (start fuel : Nat) :
+def findPivotAux [Zero R] [DecidableEq R]
+    (M : Matrix R n n) (col : Fin n) (start fuel : Nat) :
     Option (Fin n) :=
   match fuel with
   | 0 => none
@@ -154,14 +158,16 @@ def findPivotAux (M : Matrix Int n n) (col : Fin n) (start fuel : Nat) :
 
 /-- Search column `col` for a nonzero pivot at or below `start`. -/
 @[expose]
-def findPivot? (M : Matrix Int n n) (col : Fin n) (start : Nat) :
+def findPivot? [Zero R] [DecidableEq R]
+    (M : Matrix R n n) (col : Fin n) (start : Nat) :
     Option (Fin n) :=
   findPivotAux M col start (n - start)
 
 /-- A pivot returned by `findPivotAux` is always at or below its starting row. -/
 -- @[grind]-excluded: subsumed by `findPivot?_ge_start`; tagging the fuelled
 -- helper too would duplicate grind's rule for the same fact.
-theorem findPivotAux_ge_start (M : Matrix Int n n) (col : Fin n)
+theorem findPivotAux_ge_start [Zero R] [DecidableEq R]
+    (M : Matrix R n n) (col : Fin n)
     (start fuel : Nat) {pivot : Fin n}
     (hfind : findPivotAux M col start fuel = some pivot) :
     start ≤ pivot.val := by
@@ -179,7 +185,8 @@ theorem findPivotAux_ge_start (M : Matrix Int n n) (col : Fin n)
 
 /-- A pivot returned by `findPivot?` is always at or below its starting row. -/
 @[grind →]
-theorem findPivot?_ge_start (M : Matrix Int n n) (col : Fin n)
+theorem findPivot?_ge_start [Zero R] [DecidableEq R]
+    (M : Matrix R n n) (col : Fin n)
     (start : Nat) {pivot : Fin n}
     (hfind : findPivot? M col start = some pivot) :
     start ≤ pivot.val :=
@@ -188,7 +195,8 @@ theorem findPivot?_ge_start (M : Matrix Int n n) (col : Fin n)
 /-- If bounded pivot search fails, every checked entry in the pivot column is
 zero. -/
 -- @[grind]-excluded: subsumed by `findPivot?_eq_zero_of_none`.
-theorem findPivotAux_eq_zero_of_none (M : Matrix Int n n) (col : Fin n)
+theorem findPivotAux_eq_zero_of_none [Zero R] [DecidableEq R]
+    (M : Matrix R n n) (col : Fin n)
     (start fuel : Nat) (hfind : findPivotAux M col start fuel = none)
     (i : Fin n) (hstart : start ≤ i.val) (hfuel : i.val < start + fuel) :
     M[i][col] = 0 := by
@@ -231,7 +239,8 @@ theorem findPivotAux_eq_zero_of_none (M : Matrix Int n n) (col : Fin n)
 /-- If pivot search fails, every entry in the searched suffix of the pivot
 column is zero. -/
 @[grind]
-theorem findPivot?_eq_zero_of_none (M : Matrix Int n n) (col : Fin n)
+theorem findPivot?_eq_zero_of_none [Zero R] [DecidableEq R]
+    (M : Matrix R n n) (col : Fin n)
     (start : Nat) (hfind : findPivot? M col start = none)
     (i : Fin n) (hstart : start ≤ i.val) :
     M[i][col] = 0 := by
@@ -242,7 +251,8 @@ theorem findPivot?_eq_zero_of_none (M : Matrix Int n n) (col : Fin n)
 the search fails. -/
 -- @[grind]-excluded: ∀-quantified `hzero` premise grind cannot discharge (same
 -- reason its `findPivot?` wrapper is left untagged).
-theorem findPivotAux_eq_none_of_zero (M : Matrix Int n n) (col : Fin n)
+theorem findPivotAux_eq_none_of_zero [Zero R] [DecidableEq R]
+    (M : Matrix R n n) (col : Fin n)
     (start fuel : Nat)
     (hzero : ∀ i : Fin n, start ≤ i.val → i.val < start + fuel → M[i][col] = 0) :
     findPivotAux M col start fuel = none := by
@@ -265,13 +275,14 @@ theorem findPivotAux_eq_none_of_zero (M : Matrix Int n n) (col : Fin n)
 /-- If every entry in the suffix searched by `findPivot?` is zero, pivot
 search fails. This is the converse of `findPivot?_eq_zero_of_none` and lets
 callers turn a column-zero invariant into the executable no-replacement-pivot
-condition used by `pivotLoop`. -/
+condition used by `pivotLoopWith`. -/
 -- @[grind]-excluded: its conclusion `findPivot? … = none` makes grind E-match on
 -- every `findPivot?` term and inject an existential case-split from the ∀-premise
 -- (`hzero`), derailing unrelated goals — confirmed to break `findPivot?_ge_start`
 -- closes under `grind`. Use the lemma explicitly when the column-zero converse is
 -- needed.
-theorem findPivot?_eq_none_of_zero (M : Matrix Int n n) (col : Fin n)
+theorem findPivot?_eq_none_of_zero [Zero R] [DecidableEq R]
+    (M : Matrix R n n) (col : Fin n)
     (start : Nat)
     (hzero : ∀ i : Fin n, start ≤ i.val → M[i][col] = 0) :
     findPivot? M col start = none := by
@@ -282,7 +293,8 @@ theorem findPivot?_eq_none_of_zero (M : Matrix Int n n) (col : Fin n)
 /-- A pivot returned by `findPivotAux` indexes a nonzero entry in the pivot
 column. -/
 -- @[grind]-excluded: subsumed by `findPivot?_some_ne_zero`.
-theorem findPivotAux_some_ne_zero (M : Matrix Int n n) (col : Fin n)
+theorem findPivotAux_some_ne_zero [Zero R] [DecidableEq R]
+    (M : Matrix R n n) (col : Fin n)
     (start fuel : Nat) {pivot : Fin n}
     (hfind : findPivotAux M col start fuel = some pivot) :
     M[pivot][col] ≠ 0 := by
@@ -306,7 +318,8 @@ theorem findPivotAux_some_ne_zero (M : Matrix Int n n) (col : Fin n)
 column. Lets row-pivoted Bareiss callers read off the nonzero post-swap pivot
 without unfolding the `findPivotAux` recursion. -/
 @[grind →]
-theorem findPivot?_some_ne_zero (M : Matrix Int n n) (col : Fin n)
+theorem findPivot?_some_ne_zero [Zero R] [DecidableEq R]
+    (M : Matrix R n n) (col : Fin n)
     (start : Nat) {pivot : Fin n}
     (hfind : findPivot? M col start = some pivot) :
     M[pivot][col] ≠ 0 :=
@@ -319,10 +332,11 @@ Rows at or above the pivot (`i ≤ k`) are left untouched, and only the rows bel
 the pivot are rebuilt. The pivot row is read once into `pivotRow` before the
 scatter (it is never mutated, since only rows `i > k` change). This
 `mapRowsIdx` form is the reference the entry lemmas reduce through; compiled
-code runs the per-entry in-place `stepMatrixImpl` via the `@[csimp]` below. -/
-@[expose]
-def stepMatrix (M : Matrix Int n n) (k : Nat) (pivot prevPivot : Int) :
-    Matrix Int n n :=
+code runs the per-entry in-place `stepMatrixWithImpl` via the `@[csimp]` below. -/
+@[expose, specialize quot]
+def stepMatrixWith [Zero R] [Sub R] [Mul R] (quot : R → R → R)
+    (M : Matrix R n n) (k : Nat) (pivot prevPivot : R) :
+    Matrix R n n :=
   if hk : k < n then
     let pivotRow := Matrix.getRow M ⟨k, hk⟩
     M.mapRowsIdx fun i row =>
@@ -331,7 +345,7 @@ def stepMatrix (M : Matrix Int n n) (k : Nat) (pivot prevPivot : Int) :
         Fin.foldl n (fun r j =>
           r.modify j.val fun x =>
             if k < j.val then
-              exactDiv (pivot * x - mik * pivotRow[j]) prevPivot
+              quot (pivot * x - mik * pivotRow[j]) prevPivot
             else if j.val = k then
               0
             else
@@ -341,13 +355,14 @@ def stepMatrix (M : Matrix Int n n) (k : Nat) (pivot prevPivot : Int) :
   else
     M
 
-/-- Fast in-place implementation of `stepMatrix`: each updated row is written
+/-- Fast in-place implementation of `stepMatrixWith`: each updated row is written
 through per-entry `Matrix.modifyEntries` updates of the flat backing buffer,
 with no per-row materialization or write-back. Swapped in for compiled code by
-the `@[csimp]` lemma below; `stepMatrix` stays the reference form for proofs. -/
-@[expose]
-def stepMatrixImpl (M : Matrix Int n n) (k : Nat) (pivot prevPivot : Int) :
-    Matrix Int n n :=
+the `@[csimp]` lemma below; `stepMatrixWith` stays the reference form for proofs. -/
+@[expose, specialize quot]
+def stepMatrixWithImpl [Zero R] [Sub R] [Mul R] (quot : R → R → R)
+    (M : Matrix R n n) (k : Nat) (pivot prevPivot : R) :
+    Matrix R n n :=
   if hk : k < n then
     let pivotRow := Matrix.getRow M ⟨k, hk⟩
     Fin.foldl n (fun A i =>
@@ -355,7 +370,7 @@ def stepMatrixImpl (M : Matrix Int n n) (k : Nat) (pivot prevPivot : Int) :
         let mik := A[(i, (⟨k, hk⟩ : Fin n))]
         A.modifyEntries i.val fun j x =>
           if k < j.val then
-            exactDiv (pivot * x - mik * pivotRow[j]) prevPivot
+            quot (pivot * x - mik * pivotRow[j]) prevPivot
           else if j.val = k then
             0
           else
@@ -365,16 +380,17 @@ def stepMatrixImpl (M : Matrix Int n n) (k : Nat) (pivot prevPivot : Int) :
   else
     M
 
-/-- The `stepMatrixImpl` fold leaves row `r` untouched when `r` is not among the
+/-- The `stepMatrixWithImpl` fold leaves row `r` untouched when `r` is not among the
 folded indices. -/
-private theorem stepImplFold_ne (k : Nat) (hk : k < n) (pivot prevPivot : Int)
-    (pivotRow : Vector Int n) (r c : Fin n) :
-    ∀ (xs : List (Fin n)) (A : Matrix Int n n), (∀ t ∈ xs, t ≠ r) →
+private theorem stepImplFold_ne [Zero R] [Sub R] [Mul R] (quot : R → R → R)
+    (k : Nat) (hk : k < n) (pivot prevPivot : R)
+    (pivotRow : Vector R n) (r c : Fin n) :
+    ∀ (xs : List (Fin n)) (A : Matrix R n n), (∀ t ∈ xs, t ≠ r) →
       (xs.foldl (fun A (i : Fin n) =>
         if k < i.val then
           A.modifyEntries i.val fun j x =>
             if k < j.val then
-              exactDiv (pivot * x - A[(i, (⟨k, hk⟩ : Fin n))] * pivotRow[j]) prevPivot
+              quot (pivot * x - A[(i, (⟨k, hk⟩ : Fin n))] * pivotRow[j]) prevPivot
             else if j.val = k then 0
             else x
         else A) A)[r][c] = A[r][c] := by
@@ -389,22 +405,23 @@ private theorem stepImplFold_ne (k : Nat) (hk : k < n) (pivot prevPivot : Int)
         if_neg (fun hv => hne x List.mem_cons_self ((Fin.ext hv).symm))]
     · rw [if_neg hx]
 
-/-- The `stepMatrixImpl` fold updates every member row from its original
+/-- The `stepMatrixWithImpl` fold updates every member row from its original
 entries. -/
-private theorem stepImplFold_mem (k : Nat) (hk : k < n) (pivot prevPivot : Int)
-    (pivotRow : Vector Int n) (c : Fin n) :
-    ∀ (xs : List (Fin n)), xs.Nodup → ∀ (A : Matrix Int n n) (r : Fin n), r ∈ xs →
+private theorem stepImplFold_mem [Zero R] [Sub R] [Mul R] (quot : R → R → R)
+    (k : Nat) (hk : k < n) (pivot prevPivot : R)
+    (pivotRow : Vector R n) (c : Fin n) :
+    ∀ (xs : List (Fin n)), xs.Nodup → ∀ (A : Matrix R n n) (r : Fin n), r ∈ xs →
       (xs.foldl (fun A (i : Fin n) =>
         if k < i.val then
           A.modifyEntries i.val fun j x =>
             if k < j.val then
-              exactDiv (pivot * x - A[(i, (⟨k, hk⟩ : Fin n))] * pivotRow[j]) prevPivot
+              quot (pivot * x - A[(i, (⟨k, hk⟩ : Fin n))] * pivotRow[j]) prevPivot
             else if j.val = k then 0
             else x
         else A) A)[r][c] =
       if k < r.val then
         (if k < c.val then
-          exactDiv (pivot * A[r][c] - A[(r, (⟨k, hk⟩ : Fin n))] * pivotRow[c]) prevPivot
+          quot (pivot * A[r][c] - A[(r, (⟨k, hk⟩ : Fin n))] * pivotRow[c]) prevPivot
         else if c.val = k then 0
         else A[r][c])
       else A[r][c] := by
@@ -415,7 +432,7 @@ private theorem stepImplFold_mem (k : Nat) (hk : k < n) (pivot prevPivot : Int)
     intro hnd A r hr
     rw [List.foldl_cons]
     rcases List.mem_cons.mp hr with rfl | hr'
-    · rw [stepImplFold_ne k hk pivot prevPivot pivotRow r c xs _
+    · rw [stepImplFold_ne quot k hk pivot prevPivot pivotRow r c xs _
         (fun t ht heq => (List.nodup_cons.mp hnd).1 (heq ▸ ht))]
       by_cases hx : k < r.val
       · rw [if_pos hx, if_pos hx, Matrix.getElem_modifyEntries, if_pos rfl]
@@ -425,7 +442,7 @@ private theorem stepImplFold_mem (k : Nat) (hk : k < n) (pivot prevPivot : Int)
           (if k < x.val then
             A.modifyEntries x.val fun j y =>
               if k < j.val then
-                exactDiv (pivot * y - A[(x, (⟨k, hk⟩ : Fin n))] * pivotRow[j]) prevPivot
+                quot (pivot * y - A[(x, (⟨k, hk⟩ : Fin n))] * pivotRow[j]) prevPivot
               else if j.val = k then 0
               else y
           else A)[r][cc] = A[r][cc] := by
@@ -438,7 +455,7 @@ private theorem stepImplFold_mem (k : Nat) (hk : k < n) (pivot prevPivot : Int)
       rw [show (if k < x.val then
             A.modifyEntries x.val fun j y =>
               if k < j.val then
-                exactDiv (pivot * y - A[(x, (⟨k, hk⟩ : Fin n))] * pivotRow[j]) prevPivot
+                quot (pivot * y - A[(x, (⟨k, hk⟩ : Fin n))] * pivotRow[j]) prevPivot
               else if j.val = k then 0
               else y
           else A)[(r, (⟨k, hk⟩ : Fin n))] = A[(r, (⟨k, hk⟩ : Fin n))] from by
@@ -447,16 +464,16 @@ private theorem stepImplFold_mem (k : Nat) (hk : k < n) (pivot prevPivot : Int)
         exact hrowr ⟨k, hk⟩]
       rw [hrowr c]
 
-/-- `stepMatrixImpl` agrees entrywise with the same `ofFn` form as
-`stepMatrix` (`stepMatrix_eq_ofFn`); the `@[csimp]` equality chains the two. -/
-private theorem stepMatrixImpl_eq_ofFn (M : Matrix Int n n) (k : Nat)
-    (pivot prevPivot : Int) :
-    stepMatrixImpl M k pivot prevPivot =
+/-- `stepMatrixWithImpl` agrees entrywise with the same `ofFn` form as
+`stepMatrixWith` (`stepMatrixWith_eq_ofFn`); the `@[csimp]` equality chains the two. -/
+private theorem stepMatrixImpl_eq_ofFn [Zero R] [Sub R] [Mul R]
+    (quot : R → R → R) (M : Matrix R n n) (k : Nat) (pivot prevPivot : R) :
+    stepMatrixWithImpl quot M k pivot prevPivot =
       Matrix.ofFn fun i j =>
         if hkij : k < i.val ∧ k < j.val then
           let colK : Fin n := ⟨k, Nat.lt_trans hkij.1 i.isLt⟩
           let rowK : Fin n := ⟨k, Nat.lt_trans hkij.2 j.isLt⟩
-          exactDiv (pivot * M[(i, j)] - M[(i, colK)] * M[(rowK, j)]) prevPivot
+          quot (pivot * M[(i, j)] - M[(i, colK)] * M[(rowK, j)]) prevPivot
         else if k < i.val ∧ j.val = k then
           0
         else
@@ -464,12 +481,12 @@ private theorem stepMatrixImpl_eq_ofFn (M : Matrix Int n n) (k : Nat)
   apply Matrix.ext_getElem
   intro i j
   rw [Matrix.getElem_ofFn]
-  unfold stepMatrixImpl
+  unfold stepMatrixWithImpl
   by_cases hk : k < n
   · rw [dif_pos hk]
     show (Fin.foldl n _ M)[i][j] = _
     rw [Fin.foldl_eq_finRange_foldl,
-      stepImplFold_mem k hk pivot prevPivot (Matrix.getRow M ⟨k, hk⟩) j
+      stepImplFold_mem quot k hk pivot prevPivot (Matrix.getRow M ⟨k, hk⟩) j
         (List.finRange n) (List.nodup_finRange n) M i (List.mem_finRange _)]
     simp only [Matrix.getElem_pair_eq_nested, Matrix.getElem_eq_getRow]
     rw [show (Matrix.getRow M ⟨k, hk⟩)[j] = (Matrix.getRow M ⟨k, hk⟩)[j.val] from rfl]
@@ -479,15 +496,16 @@ private theorem stepMatrixImpl_eq_ofFn (M : Matrix Int n n) (k : Nat)
     simp only [Matrix.getElem_pair_eq_nested]
     grind
 
-/-- The in-place `stepMatrix` agrees entrywise with the `ofFn` form it replaces;
+/-- The in-place `stepMatrixWith` agrees entrywise with the `ofFn` form it replaces;
 lets the existing entry lemmas reduce through the same body. -/
-theorem stepMatrix_eq_ofFn (M : Matrix Int n n) (k : Nat) (pivot prevPivot : Int) :
-    stepMatrix M k pivot prevPivot =
+theorem stepMatrixWith_eq_ofFn [Zero R] [Sub R] [Mul R] (quot : R → R → R)
+    (M : Matrix R n n) (k : Nat) (pivot prevPivot : R) :
+    stepMatrixWith quot M k pivot prevPivot =
       Matrix.ofFn fun i j =>
         if hkij : k < i.val ∧ k < j.val then
           let colK : Fin n := ⟨k, Nat.lt_trans hkij.1 i.isLt⟩
           let rowK : Fin n := ⟨k, Nat.lt_trans hkij.2 j.isLt⟩
-          exactDiv (pivot * M[(i, j)] - M[(i, colK)] * M[(rowK, j)]) prevPivot
+          quot (pivot * M[(i, j)] - M[(i, colK)] * M[(rowK, j)]) prevPivot
         else if k < i.val ∧ j.val = k then
           0
         else
@@ -495,7 +513,7 @@ theorem stepMatrix_eq_ofFn (M : Matrix Int n n) (k : Nat) (pivot prevPivot : Int
   apply Matrix.ext_getElem
   intro i j
   rw [Matrix.getElem_ofFn]
-  unfold stepMatrix
+  unfold stepMatrixWith
   by_cases hk : k < n
   · rw [dif_pos hk, Matrix.getElem_mapRowsIdx]
     by_cases hi : k < i.val
@@ -511,61 +529,66 @@ theorem stepMatrix_eq_ofFn (M : Matrix Int n n) (k : Nat) (pivot prevPivot : Int
       Fin.getElem_fin]
     grind
 
-@[csimp] theorem stepMatrix_eq_stepMatrixImpl : @stepMatrix = @stepMatrixImpl := by
-  funext n M k pivot prevPivot
-  rw [stepMatrix_eq_ofFn, stepMatrixImpl_eq_ofFn]
+@[csimp] theorem stepMatrixWith_eq_stepMatrixWithImpl : @stepMatrixWith = @stepMatrixWithImpl := by
+  funext R _ _ _ quot n M k pivot prevPivot
+  rw [stepMatrixWith_eq_ofFn, stepMatrixImpl_eq_ofFn]
 
 /-- Outside the trailing update region and pivot column below the pivot,
-`stepMatrix` leaves entries unchanged. -/
+`stepMatrixWith` leaves entries unchanged. -/
 @[grind =]
-theorem stepMatrix_eq_of_not_update
-    (M : Matrix Int n n) (k : Nat) (pivot prevPivot : Int) (i j : Fin n)
+theorem stepMatrixWith_eq_of_not_update
+    [Zero R] [Sub R] [Mul R] (quot : R → R → R)
+    (M : Matrix R n n) (k : Nat) (pivot prevPivot : R) (i j : Fin n)
     (htrail : ¬ (k < i.val ∧ k < j.val))
     (hcol : ¬ (k < i.val ∧ j.val = k)) :
-    (stepMatrix M k pivot prevPivot)[i][j] = M[i][j] := by
-  rw [stepMatrix_eq_ofFn, Matrix.getElem_ofFn]; simp [htrail, hcol]
+    (stepMatrixWith quot M k pivot prevPivot)[i][j] = M[i][j] := by
+  rw [stepMatrixWith_eq_ofFn, Matrix.getElem_ofFn]; simp [htrail, hcol]
 
-/-- `stepMatrix` preserves diagonal entries whose index is at or before the
+/-- `stepMatrixWith` preserves diagonal entries whose index is at or before the
 current pivot step. -/
 @[grind =]
-theorem stepMatrix_diag_of_le
-    (M : Matrix Int n n) (k : Nat) (pivot prevPivot : Int) (i : Fin n)
+theorem stepMatrixWith_diag_of_le
+    [Zero R] [Sub R] [Mul R] (quot : R → R → R)
+    (M : Matrix R n n) (k : Nat) (pivot prevPivot : R) (i : Fin n)
     (hi : i.val ≤ k) :
-    (stepMatrix M k pivot prevPivot)[i][i] = M[i][i] := by
-  apply stepMatrix_eq_of_not_update
+    (stepMatrixWith quot M k pivot prevPivot)[i][i] = M[i][i] := by
+  apply stepMatrixWith_eq_of_not_update
   · intro htrail
     exact Nat.not_lt_of_ge hi htrail.1
   · intro hcol
     exact Nat.not_lt_of_ge hi hcol.1
 
-/-- `stepMatrix` clears the pivot column below the current pivot. -/
+/-- `stepMatrixWith` clears the pivot column below the current pivot. -/
 @[grind =]
-theorem stepMatrix_pivot_col_below
-    (M : Matrix Int n n) (k : Nat) (pivot prevPivot : Int) (i colK : Fin n)
+theorem stepMatrixWith_pivot_col_below
+    [Zero R] [Sub R] [Mul R] (quot : R → R → R)
+    (M : Matrix R n n) (k : Nat) (pivot prevPivot : R) (i colK : Fin n)
     (hi : k < i.val) (hcolK : colK.val = k) :
-    (stepMatrix M k pivot prevPivot)[i][colK] = 0 := by
-  rw [stepMatrix_eq_ofFn, Matrix.getElem_ofFn]; simp [hi, hcolK]
+    (stepMatrixWith quot M k pivot prevPivot)[i][colK] = 0 := by
+  rw [stepMatrixWith_eq_ofFn, Matrix.getElem_ofFn]; simp [hi, hcolK]
 
 /-- Entry formula for the trailing block updated by one Bareiss step. -/
 -- @[grind]-excluded: `let`-wrapped RHS (`let colK := …; let rowK := …`) is
 -- rejected by `grind =`; left untagged like the analogous Hensel step lemmas.
-theorem stepMatrix_update_eq
-    (M : Matrix Int n n) (k : Nat) (pivot prevPivot : Int) (i j : Fin n)
+theorem stepMatrixWith_update_eq
+    [Zero R] [Sub R] [Mul R] (quot : R → R → R)
+    (M : Matrix R n n) (k : Nat) (pivot prevPivot : R) (i j : Fin n)
     (hi : k < i.val) (hj : k < j.val) :
-    (stepMatrix M k pivot prevPivot)[i][j] =
+    (stepMatrixWith quot M k pivot prevPivot)[i][j] =
       (let colK : Fin n := ⟨k, Nat.lt_trans hi i.isLt⟩
        let rowK : Fin n := ⟨k, Nat.lt_trans hj j.isLt⟩
-       exactDiv (pivot * M[i][j] - M[i][colK] * M[rowK][j]) prevPivot) := by
-  rw [stepMatrix_eq_ofFn, Matrix.getElem_ofFn]; simp [hi, hj]
+       quot (pivot * M[i][j] - M[i][colK] * M[rowK][j]) prevPivot) := by
+  rw [stepMatrixWith_eq_ofFn, Matrix.getElem_ofFn]; simp [hi, hj]
 
 /-- If the current matrix entries already match bordered minors and exact
-division evaluates to the next bordered minor, then one `stepMatrix` update
+division evaluates to the next bordered minor, then one `stepMatrixWith` update
 preserves the bordered-minor invariant at the updated entry. -/
 -- @[grind]-excluded: one-shot bordered-minor invariant-preservation lemma whose
 -- bespoke premises (`hpivot`/`hentry`/`hexact`) are not a characterising rewrite.
-theorem stepMatrix_borderedMinor_update
-    (source current : Matrix Int n n) (k : Nat) (hk : k < n) (hnext : k + 1 < n)
-    (i j : Fin n) (hi : k < i.val) (hj : k < j.val) (pivot prevPivot : Int)
+theorem stepMatrixWith_borderedMinor_update
+    [Lean.Grind.CommRing R] (quot : R → R → R)
+    (source current : Matrix R n n) (k : Nat) (hk : k < n) (hnext : k + 1 < n)
+    (i j : Fin n) (hi : k < i.val) (hj : k < j.val) (pivot prevPivot : R)
     (hpivot :
       pivot =
         det (borderedMinor source k hk
@@ -580,7 +603,7 @@ theorem stepMatrix_borderedMinor_update
       current[(⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n)][j] =
         det (borderedMinor source k hk (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n) j))
     (hexact :
-      exactDiv
+      quot
         (det (borderedMinor source k hk
             (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n)
             (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)) *
@@ -589,11 +612,11 @@ theorem stepMatrix_borderedMinor_update
           det (borderedMinor source k hk (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n) j))
         prevPivot =
           det (borderedMinor source (k + 1) hnext i j)) :
-    (stepMatrix current k pivot prevPivot)[i][j] =
+    (stepMatrixWith quot current k pivot prevPivot)[i][j] =
       det (borderedMinor source (k + 1) hnext i j) := by
-  rw [stepMatrix_update_eq current k pivot prevPivot i j hi hj]
+  rw [stepMatrixWith_update_eq quot current k pivot prevPivot i j hi hj]
   change
-    exactDiv
+    quot
       (pivot * current[i][j] -
         current[i][(⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)] *
         current[(⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n)][j])
@@ -605,10 +628,54 @@ theorem stepMatrix_borderedMinor_update
 /-- Exact-division equation for one Bareiss bordered-minor update.
 
 Once a determinant identity supplies the numerator as `nextMinor * prevPivot`,
-this lemma packages it as the `exactDiv` premise expected by
-`stepMatrix_borderedMinor_update`. -/
+this lemma packages it as the `quot` premise expected by
+`stepMatrixWith_borderedMinor_update`. -/
 -- @[grind]-excluded: proof-composition lemma gated on a determinant identity
 -- premise (`hdesnanot`); not a local rewrite.
+theorem exactQuot_borderedMinor_of_mul_eq [Lean.Grind.CommRing R]
+    (quot : R → R → R) (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (source : Matrix R n n) (k : Nat) (hk : k < n) (hnext : k + 1 < n)
+    (i j : Fin n) (hi : k < i.val) (hj : k < j.val) (prevPivot : R)
+    (hprev_ne : prevPivot ≠ 0)
+    (hdesnanot :
+      det (borderedMinor source (k + 1) hnext i j) * prevPivot =
+        det (borderedMinor source k hk
+            (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n)
+            (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)) *
+          det (borderedMinor source k hk i j) -
+          det (borderedMinor source k hk
+            i (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)) *
+          det (borderedMinor source k hk
+            (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n) j)) :
+    quot
+        (det (borderedMinor source k hk
+            (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n)
+            (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)) *
+          det (borderedMinor source k hk i j) -
+          det (borderedMinor source k hk
+            i (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)) *
+          det (borderedMinor source k hk
+            (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n) j))
+        prevPivot =
+      det (borderedMinor source (k + 1) hnext i j) := by
+  let nextMinor := det (borderedMinor source (k + 1) hnext i j)
+  let numerator :=
+    det (borderedMinor source k hk
+        (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n)
+        (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)) *
+      det (borderedMinor source k hk i j) -
+      det (borderedMinor source k hk
+        i (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)) *
+      det (borderedMinor source k hk
+        (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n) j)
+  have hnum : numerator = prevPivot * nextMinor := by
+    dsimp [numerator, nextMinor]
+    rw [← hdesnanot, Lean.Grind.CommRing.mul_comm]
+  change quot numerator prevPivot = nextMinor
+  rw [hnum, Lean.Grind.CommRing.mul_comm]
+  exact hquot nextMinor prevPivot hprev_ne
+
+/-- Integer specialization of `exactQuot_borderedMinor_of_mul_eq`. -/
 theorem bareissExactDiv_borderedMinor_of_mul_eq
     (source : Matrix Int n n) (k : Nat) (hk : k < n) (hnext : k + 1 < n)
     (i j : Fin n) (hi : k < i.val) (hj : k < j.val) (prevPivot : Int)
@@ -633,44 +700,31 @@ theorem bareissExactDiv_borderedMinor_of_mul_eq
           det (borderedMinor source k hk
             (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n) j))
         prevPivot =
-      det (borderedMinor source (k + 1) hnext i j) := by
-  let nextMinor := det (borderedMinor source (k + 1) hnext i j)
-  let numerator :=
-    det (borderedMinor source k hk
-        (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n)
-        (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)) *
-      det (borderedMinor source k hk i j) -
-      det (borderedMinor source k hk
-        i (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)) *
-      det (borderedMinor source k hk
-        (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n) j)
-  have hnum : numerator = prevPivot * nextMinor := by
-    dsimp [numerator, nextMinor]
-    rw [← hdesnanot, Lean.Grind.CommRing.mul_comm]
-  have hdvd : prevPivot ∣ numerator := ⟨nextMinor, hnum⟩
-  rw [exactDiv_eq_divExact hdvd]
-  change numerator / prevPivot = nextMinor
-  exact Int.ediv_eq_of_eq_mul_right hprev_ne hnum
+      det (borderedMinor source (k + 1) hnext i j) :=
+  exactQuot_borderedMinor_of_mul_eq exactDiv Int.mul_ediv_cancel source k hk hnext
+    i j hi hj prevPivot hprev_ne hdesnanot
 
-structure BareissArrayState where
+/-- Array-backed state used by the executable row-pivoted Bareiss loop. -/
+structure BareissArrayState (R : Type u) where
   step : Nat
-  matrix : Array (Array Int)
-  prevPivot : Int
+  matrix : Array (Array R)
+  prevPivot : R
   rowSwaps : Nat
   singularStep : Option Nat
 
-/-- Read an entry from an `Array (Array Int)` row-storage representation.
+/-- Read an entry from an `Array (Array R)` row-storage representation.
 
 Exposed so downstream Mathlib-free clients (notably the shared scaled
 Gram-Schmidt loop in `HexGramSchmidt.Int`) can speak about array storage
 without re-deriving the conversion lemmas. -/
-@[expose, inline] def getEntry (rows : Array (Array Int)) (row col : Nat) : Int :=
-  rows[row]![col]!
+@[expose, inline] def getEntry [Zero R]
+    (rows : Array (Array R)) (row col : Nat) : R :=
+  (rows.getD row #[]).getD col 0
 
-/-- Pack a `Matrix Int n n` as an `Array (Array Int)` of size `n × n`. The
+/-- Pack a `Matrix R n n` as an `Array (Array R)` of size `n × n`. The
 representation used by the executable Bareiss array pass. -/
 @[expose]
-def matrixToRows (M : Matrix Int n n) : Array (Array Int) :=
+def matrixToRows [Zero R] (M : Matrix R n n) : Array (Array R) :=
   (Array.range n).map fun row =>
     (Array.range n).map fun col =>
       if hrow : row < n then
@@ -683,23 +737,23 @@ def matrixToRows (M : Matrix Int n n) : Array (Array Int) :=
       else
         0
 
-/-- Unpack an `Array (Array Int)` row-storage representation back into a
-`Matrix Int n n`. Inverse-on-the-left of `matrixToRows`. -/
+/-- Unpack an `Array (Array R)` row-storage representation back into a
+`Matrix R n n`. Inverse-on-the-left of `matrixToRows`. -/
 @[expose]
-def rowsToMatrix (rows : Array (Array Int)) (n : Nat) : Matrix Int n n :=
+def rowsToMatrix [Zero R] (rows : Array (Array R)) (n : Nat) : Matrix R n n :=
   Matrix.ofFn fun i j => getEntry rows i.val j.val
 
 /-- Pointwise round-trip: `getEntry (matrixToRows M)` reads back the matrix
 entry at the same index. -/
 @[grind =]
-theorem getEntry_matrixToRows (M : Matrix Int n n) (i j : Fin n) :
+theorem getEntry_matrixToRows [Zero R] (M : Matrix R n n) (i j : Fin n) :
     getEntry (matrixToRows M) i.val j.val = M[i][j] := by
   simp [getEntry, matrixToRows]
 
 /-- Reading back the array storage produced by `matrixToRows` recovers the
 original matrix. -/
 @[grind =]
-theorem rowsToMatrix_matrixToRows (M : Matrix Int n n) :
+theorem rowsToMatrix_matrixToRows [Zero R] (M : Matrix R n n) :
     rowsToMatrix (matrixToRows M) n = M := by
   apply Matrix.ext_getElem
   intro i j
@@ -711,7 +765,7 @@ theorem rowsToMatrix_matrixToRows (M : Matrix Int n n) :
 in bounds, the base case for tracking entries through the array row swap. -/
 -- @[grind]-excluded: generic `Array.set!` bookkeeping; tagging would enlarge
 -- grind's global search with no Bareiss-specific gain.
-private theorem array_getElem!_set!_same {α : Type} [Inhabited α]
+private theorem array_getElem!_set!_same {α : Type u} [Inhabited α]
     (xs : Array α) {i : Nat} (hi : i < xs.size) (v : α) :
     (xs.set! i v)[i]! = v := by
   rw [Array.getElem!_eq_getD]
@@ -720,7 +774,7 @@ private theorem array_getElem!_set!_same {α : Type} [Inhabited α]
 /-- `set!`-ing index `i` leaves every other entry untouched: `(xs.set! i v)[j]!`
 equals `xs[j]!` whenever `j ≠ i`, the non-target case of the array row swap. -/
 -- @[grind]-excluded: generic `Array.set!` bookkeeping (see `_set!_same`).
-private theorem array_getElem!_set!_ne {α : Type} [Inhabited α]
+private theorem array_getElem!_set!_ne {α : Type u} [Inhabited α]
     (xs : Array α) {i j : Nat} (hij : j ≠ i) (v : α) :
     (xs.set! i v)[j]! = xs[j]! := by
   rw [Array.getElem!_eq_getD, Array.getElem!_eq_getD]
@@ -735,7 +789,7 @@ private theorem array_getElem!_set!_ne {α : Type} [Inhabited α]
 /-- The `setIfInBounds` analogue of `array_getElem!_set!_same`:
 `(xs.setIfInBounds i v)[i]!` returns `v` when `i` is in bounds. -/
 -- @[grind]-excluded: generic `Array.setIfInBounds` bookkeeping (see `_set!_same`).
-private theorem array_getElem!_setIfInBounds_same {α : Type} [Inhabited α]
+private theorem array_getElem!_setIfInBounds_same {α : Type u} [Inhabited α]
     (xs : Array α) {i : Nat} (hi : i < xs.size) (v : α) :
     (xs.setIfInBounds i v)[i]! = v := by
   rw [Array.getElem!_eq_getD]
@@ -745,7 +799,7 @@ private theorem array_getElem!_setIfInBounds_same {α : Type} [Inhabited α]
 /-- The `setIfInBounds` analogue of `array_getElem!_set!_ne`:
 `(xs.setIfInBounds i v)[j]!` equals `xs[j]!` whenever `j ≠ i`. -/
 -- @[grind]-excluded: generic `Array.setIfInBounds` bookkeeping (see `_set!_same`).
-private theorem array_getElem!_setIfInBounds_ne {α : Type} [Inhabited α]
+private theorem array_getElem!_setIfInBounds_ne {α : Type u} [Inhabited α]
     (xs : Array α) {i j : Nat} (hij : j ≠ i) (v : α) :
     (xs.setIfInBounds i v)[j]! = xs[j]! := by
   rw [Array.getElem!_eq_getD, Array.getElem!_eq_getD]
@@ -756,19 +810,32 @@ private theorem array_getElem!_setIfInBounds_ne {α : Type} [Inhabited α]
     simp [hij.symm]
   · simp [hi]
 
-/-- `swapRowsArray` exchanges rows `rowA` and `rowB` of an `Array (Array Int)`
+/-- Reading the updated index through `getD` returns the new value. -/
+private theorem array_getD_setIfInBounds_same {α : Type u}
+    (xs : Array α) {i : Nat} (hi : i < xs.size) (v d : α) :
+    (xs.setIfInBounds i v).getD i d = v := by
+  simp [Array.getD_eq_getD_getElem?, hi]
+
+/-- Reading another index through `getD` is unchanged by `setIfInBounds`. -/
+private theorem array_getD_setIfInBounds_ne {α : Type u}
+    (xs : Array α) {i j : Nat} (hij : j ≠ i) (v d : α) :
+    (xs.setIfInBounds i v).getD j d = xs.getD j d := by
+  simp only [Array.getD_eq_getD_getElem?, Array.getElem?_setIfInBounds]
+  split <;> simp_all
+
+/-- `swapRowsArray` exchanges rows `rowA` and `rowB` of an `Array (Array R)`
 via two `set!`s, returning `rows` unchanged when the indices coincide. -/
-private def swapRowsArray (rows : Array (Array Int)) (rowA rowB : Nat) :
-    Array (Array Int) :=
+private def swapRowsArray (rows : Array (Array R)) (rowA rowB : Nat) :
+    Array (Array R) :=
   if rowA = rowB then
     rows
   else
-    (rows.set! rowA rows[rowB]!).set! rowB rows[rowA]!
+    (rows.set! rowA (rows.getD rowB #[])).set! rowB (rows.getD rowA #[])
 
 /-- Entry-wise value of the abstract `rowSwap M rowA rowB` at `[i][j]`: the
 swapped rows read from the opposite source, every other row is unchanged. -/
 @[grind =]
-private theorem rowSwap_get (M : Matrix Int n n) (rowA rowB i j : Fin n) :
+private theorem rowSwap_get (M : Matrix R n n) (rowA rowB i j : Fin n) :
     (rowSwap M rowA rowB)[i][j] =
       if i = rowB then M[rowA][j] else if i = rowA then M[rowB][j] else M[i][j] :=
   getElem_rowSwap M rowA rowB i j
@@ -776,7 +843,7 @@ private theorem rowSwap_get (M : Matrix Int n n) (rowA rowB i j : Fin n) :
 /-- `swapRowsArray` applied to `matrixToRows M` matches the abstract
 `rowSwap M rowA rowB` entry by entry. -/
 @[grind =]
-private theorem getEntry_swapRowsArray_matrixToRows (M : Matrix Int n n)
+private theorem getEntry_swapRowsArray_matrixToRows [Zero R] (M : Matrix R n n)
     (rowA rowB i j : Fin n) :
     getEntry (swapRowsArray (matrixToRows M) rowA.val rowB.val) i.val j.val =
       (rowSwap M rowA rowB)[i][j] := by
@@ -799,15 +866,19 @@ private theorem getEntry_swapRowsArray_matrixToRows (M : Matrix Int n n)
         exact hsame h.symm
       have hrowB_after :
           rowB.val <
-            ((matrixToRows M).setIfInBounds rowA.val (matrixToRows M)[rowB.val]!).size := by
+            ((matrixToRows M).setIfInBounds rowA.val
+              ((matrixToRows M).getD rowB.val #[])).size := by
         simpa [Array.size_setIfInBounds] using hrowB
       calc
         getEntry (swapRowsArray (matrixToRows M) rowA.val rowB.val) rowB.val j.val =
             getEntry (matrixToRows M) rowA.val j.val := by
-              simp [swapRowsArray, hsame, getEntry, Array.set!_eq_setIfInBounds]
-              rw [array_getElem!_setIfInBounds_same
-                (xs := (matrixToRows M).setIfInBounds rowA.val (matrixToRows M)[rowB.val]!)
-                hrowB_after]
+              simp only [swapRowsArray, hsame, if_false, getEntry,
+                Array.set!_eq_setIfInBounds]
+              exact congrArg (fun row : Array R => row.getD j.val 0)
+                (array_getD_setIfInBounds_same
+                  ((matrixToRows M).setIfInBounds rowA.val
+                    ((matrixToRows M).getD rowB.val #[]))
+                  hrowB_after ((matrixToRows M).getD rowA.val #[]) (#[] : Array R))
         _ = M[rowA][j] := getEntry_matrixToRows M rowA j
         _ = (rowSwap M rowA rowB)[rowB][j] := by
               rw [rowSwap_get]
@@ -820,13 +891,16 @@ private theorem getEntry_swapRowsArray_matrixToRows (M : Matrix Int n n)
         calc
           getEntry (swapRowsArray (matrixToRows M) rowA.val rowB.val) rowA.val j.val =
               getEntry (matrixToRows M) rowB.val j.val := by
-                simp [swapRowsArray, hsame, getEntry, Array.set!_eq_setIfInBounds]
-                rw [array_getElem!_setIfInBounds_ne
-                  (xs := (matrixToRows M).setIfInBounds rowA.val
-                    (matrixToRows M)[rowB.val]!) hAB]
-                exact congrArg (fun row => row[j.val]!)
-                  (array_getElem!_setIfInBounds_same
-                    (xs := matrixToRows M) hrowA (matrixToRows M)[rowB.val]!)
+                simp only [swapRowsArray, hsame, if_false, getEntry,
+                  Array.set!_eq_setIfInBounds]
+                exact congrArg (fun row : Array R => row.getD j.val 0)
+                  ((array_getD_setIfInBounds_ne
+                    ((matrixToRows M).setIfInBounds rowA.val
+                      ((matrixToRows M).getD rowB.val #[]))
+                    hAB ((matrixToRows M).getD rowA.val #[]) (#[] : Array R)).trans
+                  (array_getD_setIfInBounds_same
+                    (matrixToRows M) hrowA ((matrixToRows M).getD rowB.val #[])
+                    (#[] : Array R)))
           _ = M[rowB][j] := getEntry_matrixToRows M rowB j
           _ = (rowSwap M rowA rowB)[rowA][j] := by
                 rw [rowSwap_get]
@@ -840,13 +914,16 @@ private theorem getEntry_swapRowsArray_matrixToRows (M : Matrix Int n n)
         calc
           getEntry (swapRowsArray (matrixToRows M) rowA.val rowB.val) i.val j.val =
               getEntry (matrixToRows M) i.val j.val := by
-                simp [swapRowsArray, hsame, getEntry, Array.set!_eq_setIfInBounds]
-                rw [array_getElem!_setIfInBounds_ne
-                  (xs := (matrixToRows M).setIfInBounds rowA.val
-                    (matrixToRows M)[rowB.val]!) hiB_val]
-                exact congrArg (fun row => row[j.val]!)
-                  (array_getElem!_setIfInBounds_ne
-                    (xs := matrixToRows M) hiA_val (matrixToRows M)[rowB.val]!)
+                simp only [swapRowsArray, hsame, if_false, getEntry,
+                  Array.set!_eq_setIfInBounds]
+                exact congrArg (fun row : Array R => row.getD j.val 0)
+                  ((array_getD_setIfInBounds_ne
+                    ((matrixToRows M).setIfInBounds rowA.val
+                      ((matrixToRows M).getD rowB.val #[]))
+                    hiB_val ((matrixToRows M).getD rowA.val #[]) (#[] : Array R)).trans
+                  (array_getD_setIfInBounds_ne
+                    (matrixToRows M) hiA_val ((matrixToRows M).getD rowB.val #[])
+                    (#[] : Array R)))
           _ = M[i][j] := getEntry_matrixToRows M i j
           _ = (rowSwap M rowA rowB)[i][j] := by
                 rw [rowSwap_get]
@@ -855,7 +932,7 @@ private theorem getEntry_swapRowsArray_matrixToRows (M : Matrix Int n n)
 /-- Round-tripping `swapRowsArray (matrixToRows M)` back through `rowsToMatrix`
 reproduces the abstract `rowSwap M rowA rowB`. -/
 @[grind =]
-private theorem rowsToMatrix_swapRowsArray_matrixToRows (M : Matrix Int n n)
+private theorem rowsToMatrix_swapRowsArray_matrixToRows [Zero R] (M : Matrix R n n)
     (rowA rowB : Fin n) :
     rowsToMatrix (swapRowsArray (matrixToRows M) rowA.val rowB.val) n =
       rowSwap M rowA rowB := by
@@ -865,10 +942,16 @@ private theorem rowsToMatrix_swapRowsArray_matrixToRows (M : Matrix Int n n)
   rw [Matrix.getElem_ofFn]
   exact getEntry_swapRowsArray_matrixToRows M rowA rowB i j
 
+section GenericBareiss
+
+variable [Zero R] [One R] [Neg R] [Sub R] [Mul R] [DecidableEq R]
+variable {quot : R → R → R}
+
 /-- Bareiss elimination with row pivoting. If a column has no nonzero pivot,
 the elimination aborts and the determinant is zero. -/
 @[expose]
-def pivotLoop (fuel : Nat) (state : BareissState n) : BareissState n :=
+def pivotLoopWith (quot : R → R → R) (fuel : Nat)
+    (state : BareissState R n) : BareissState R n :=
   match fuel with
   | 0 => state
   | fuel + 1 =>
@@ -885,35 +968,682 @@ def pivotLoop (fuel : Nat) (state : BareissState n) : BareissState n :=
         if hp : pivot = 0 then
           { state with matrix := M, rowSwaps := swaps, singularStep := some state.step }
         else
-          let next : BareissState n :=
+          let next : BareissState R n :=
             { step := state.step + 1
-              matrix := stepMatrix M state.step pivot state.prevPivot
+              matrix := stepMatrixWith quot M state.step pivot state.prevPivot
               prevPivot := pivot
               rowSwaps := swaps
               singularStep := none }
-          pivotLoop fuel next
+          pivotLoopWith quot fuel next
       else
         state
 
 /-- With zero fuel, the row-pivoted Bareiss loop returns its input state. -/
 @[grind]
-theorem pivotLoop_zero_fuel (state : BareissState n) :
-    pivotLoop 0 state = state := by
+theorem pivotLoopWith_zero_fuel (state : BareissState R n) :
+    pivotLoopWith quot 0 state = state := by
   rfl
 
 /-- If the current step is already past the last update step, the row-pivoted
 Bareiss loop returns its input state. -/
 @[grind]
-theorem pivotLoop_done (fuel : Nat) (state : BareissState n)
+theorem pivotLoopWith_done (fuel : Nat) (state : BareissState R n)
     (hDone : ¬ state.step + 1 < n) :
-    pivotLoop (fuel + 1) state = state := by
-  simp [pivotLoop, hDone]
+    pivotLoopWith quot (fuel + 1) state = state := by
+  simp [pivotLoopWith, hDone]
 
 /-- If the current row-pivoted Bareiss pivot is already nonzero, one loop
-iteration applies `stepMatrix`, advances the step, and recurses without
+iteration applies `stepMatrixWith quot`, advances the step, and recurses without
 changing the row-swap counter. -/
 @[grind]
-theorem pivotLoop_of_regular_no_swap (fuel : Nat) (state : BareissState n)
+theorem pivotLoopWith_of_regular_no_swap (fuel : Nat) (state : BareissState R n)
+    (hDone : state.step + 1 < n)
+    (hp : state.matrix[state.step][state.step] ≠ 0) :
+    pivotLoopWith quot (fuel + 1) state =
+      pivotLoopWith quot fuel
+        { step := state.step + 1
+          matrix := stepMatrixWith quot state.matrix state.step state.matrix[state.step][state.step]
+            state.prevPivot
+          prevPivot := state.matrix[state.step][state.step]
+          rowSwaps := state.rowSwaps
+          singularStep := none } := by
+  simp_all [pivotLoopWith, getRow, Fin.getElem_fin]
+
+/-- If the current pivot is zero and pivot search finds no replacement row,
+the row-pivoted Bareiss loop records a singular step. -/
+@[grind]
+theorem pivotLoopWith_of_singular_no_pivot (fuel : Nat) (state : BareissState R n)
+    (hDone : state.step + 1 < n)
+    (hp0 : state.matrix[state.step][state.step] = 0)
+    (hfind :
+      findPivot? state.matrix
+        (⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩ : Fin n)
+        (state.step + 1) = none) :
+    pivotLoopWith quot (fuel + 1) state =
+      { state with singularStep := some state.step } := by
+  simp_all [pivotLoopWith]
+
+/-- If the current pivot is zero, pivot search finds a replacement row, and
+the swapped pivot is nonzero, one loop iteration swaps rows, applies
+`stepMatrixWith quot`, advances the step, increments the row-swap counter, and recurses. -/
+@[grind]
+theorem pivotLoopWith_of_regular_swap (fuel : Nat) (state : BareissState R n)
+    (hDone : state.step + 1 < n)
+    (hp0 : state.matrix[state.step][state.step] = 0) {pivot : Fin n}
+    (hfind :
+      findPivot? state.matrix
+        (⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩ : Fin n)
+        (state.step + 1) = some pivot)
+    (hp :
+      (rowSwap state.matrix
+        (⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩ : Fin n)
+        pivot)[state.step][state.step] ≠ 0) :
+    pivotLoopWith quot (fuel + 1) state =
+      pivotLoopWith quot fuel
+        { step := state.step + 1
+          matrix := stepMatrixWith quot
+            (rowSwap state.matrix
+              (⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩ : Fin n)
+              pivot)
+            state.step
+            ((rowSwap state.matrix
+              (⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩ : Fin n)
+              pivot)[state.step][state.step])
+            state.prevPivot
+          prevPivot :=
+            (rowSwap state.matrix
+              (⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩ : Fin n)
+              pivot)[state.step][state.step]
+          rowSwaps := state.rowSwaps + 1
+          singularStep := none } := by
+  simp_all [pivotLoopWith]
+
+/-- `bareissArrayStateWith` runs the matrix-level Bareiss elimination via `pivotLoopWith quot`
+and repackages the reduced result as a `BareissArrayState R`, storing the matrix
+row-by-row via `matrixToRows`. -/
+@[expose]
+def bareissArrayStateWith (quot : R → R → R) (M : Matrix R n n) : BareissArrayState R :=
+  let state := pivotLoopWith quot n
+    { step := 0
+      matrix := M
+      prevPivot := 1
+      rowSwaps := 0
+      singularStep := none }
+  { step := state.step
+    matrix := matrixToRows state.matrix
+    prevPivot := state.prevPivot
+    rowSwaps := state.rowSwaps
+    singularStep := state.singularStep }
+
+/-- `arraySign` is the determinant sign contributed by `rowSwaps` recorded row
+swaps, `1` for an even count and `-1` for an odd count. -/
+@[expose]
+def arraySign (rowSwaps : Nat) : R :=
+  if rowSwaps % 2 = 0 then 1 else -1
+
+/-- `arrayLastDiag?` reads the last diagonal entry `(n-1, n-1)` of the reduced
+rows, returning `none` when `n = 0`. -/
+@[expose]
+def arrayLastDiag? (rows : Array (Array R)) (n : Nat) : Option R :=
+  match n with
+  | 0 => none
+  | k + 1 => some (getEntry rows k k)
+
+/-- `bareissArrayDet` assembles the determinant value from the final array
+state, returning `0` when elimination recorded a singular column and the signed
+last diagonal entry otherwise. -/
+@[expose]
+def bareissArrayDet (state : BareissArrayState R) (n : Nat) : R :=
+  match state.singularStep with
+  | some _ => 0
+  | none =>
+      match arrayLastDiag? state.matrix n with
+      | some d => arraySign state.rowSwaps * d
+      | none => arraySign state.rowSwaps
+
+/-- Package a Bareiss state as public elimination data. -/
+@[expose]
+def finish (state : BareissState R n) : BareissData R n :=
+  { matrix := state.matrix
+    rowSwaps := state.rowSwaps
+    singularStep := state.singularStep }
+
+/-- Bareiss elimination without pivoting. A zero pivot aborts and records the
+singular step. -/
+@[expose]
+def noPivotLoopWith (quot : R → R → R) (fuel : Nat)
+    (state : BareissState R n) : BareissState R n :=
+  match fuel with
+  | 0 => state
+  | fuel + 1 =>
+      if hDone : state.step + 1 < n then
+        let k : Fin n := ⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩
+        let pivot := state.matrix[(k, k)]
+        if hp : pivot = 0 then
+          { state with singularStep := some state.step }
+        else
+          let next : BareissState R n :=
+            { step := state.step + 1
+              matrix := stepMatrixWith quot state.matrix state.step pivot state.prevPivot
+              prevPivot := pivot
+              rowSwaps := state.rowSwaps
+              singularStep := none }
+          noPivotLoopWith quot fuel next
+      else
+        state
+
+/-- With zero fuel, the no-pivot Bareiss loop returns its input state. -/
+@[grind]
+theorem noPivotLoopWith_zero_fuel (state : BareissState R n) :
+    noPivotLoopWith quot 0 state = state := by
+  rfl
+
+/-- If the current step is already past the last update step, the no-pivot loop
+returns its input state. -/
+@[grind]
+theorem noPivotLoopWith_done (fuel : Nat) (state : BareissState R n)
+    (hDone : ¬ state.step + 1 < n) :
+    noPivotLoopWith quot (fuel + 1) state = state := by
+  simp [noPivotLoopWith, hDone]
+
+/-- If the no-pivot loop sees a zero pivot before completion, it records the
+current step as singular. -/
+@[grind]
+theorem noPivotLoopWith_of_singular (fuel : Nat) (state : BareissState R n)
+    (hDone : state.step + 1 < n)
+    (hp : state.matrix[state.step][state.step] = 0) :
+    noPivotLoopWith quot (fuel + 1) state = { state with singularStep := some state.step } := by
+  simp_all [noPivotLoopWith]
+
+/-- If the current no-pivot Bareiss pivot is nonzero, one loop iteration applies
+`stepMatrixWith quot`, advances the step, and recurses on the remaining fuel. -/
+@[grind]
+theorem noPivotLoopWith_of_regular (fuel : Nat) (state : BareissState R n)
+    (hDone : state.step + 1 < n)
+    (hp : state.matrix[state.step][state.step] ≠ 0) :
+    noPivotLoopWith quot (fuel + 1) state =
+      noPivotLoopWith quot fuel
+        { step := state.step + 1
+          matrix := stepMatrixWith quot state.matrix state.step state.matrix[state.step][state.step]
+            state.prevPivot
+          prevPivot := state.matrix[state.step][state.step]
+          rowSwaps := state.rowSwaps
+          singularStep := none } := by
+  simp_all [noPivotLoopWith]
+
+/-- Entries in rows already processed, or in columns strictly before the current
+step, are unchanged by subsequent no-pivot loop iterations. -/
+@[grind]
+theorem noPivotLoopWith_matrix_entry_of_row_le_or_col_lt (fuel : Nat)
+    (state : BareissState R n) (i j : Fin n)
+    (hfixed : i.val ≤ state.step ∨ j.val < state.step) :
+    (noPivotLoopWith quot fuel state).matrix[i][j] = state.matrix[i][j] := by
+  induction fuel generalizing state with
+  | zero =>
+      simp [noPivotLoopWith]
+  | succ fuel ih =>
+      by_cases hDone : state.step + 1 < n
+      · let k : Fin n :=
+          ⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩
+        by_cases hp : state.matrix[k][k] = 0
+        · simp [noPivotLoopWith_of_singular (quot := quot) fuel state hDone hp]
+        · rw [noPivotLoopWith_of_regular (quot := quot) fuel state hDone]
+          · let next : BareissState R n :=
+              { step := state.step + 1
+                matrix := stepMatrixWith quot state.matrix state.step
+                  state.matrix[state.step][state.step] state.prevPivot
+                prevPivot := state.matrix[state.step][state.step]
+                rowSwaps := state.rowSwaps
+                singularStep := none }
+            change (noPivotLoopWith quot fuel next).matrix[i][j] = state.matrix[i][j]
+            have hnext : i.val ≤ next.step ∨ j.val < next.step := by
+              cases hfixed with
+              | inl hi =>
+                  exact Or.inl (Nat.le_trans hi (Nat.le_succ state.step))
+              | inr hj =>
+                  exact Or.inr (Nat.lt_trans hj (Nat.lt_succ_self state.step))
+            rw [ih next hnext]
+            dsimp [next]
+            apply stepMatrixWith_eq_of_not_update
+            · intro htrail
+              cases hfixed with
+              | inl hi =>
+                  exact Nat.not_lt_of_ge hi htrail.1
+              | inr hj =>
+                  exact Nat.not_lt_of_ge (Nat.le_of_lt hj) htrail.2
+            · intro hcol
+              cases hfixed with
+              | inl hi =>
+                  exact Nat.not_lt_of_ge hi hcol.1
+              | inr hj =>
+                  exact Nat.ne_of_lt hj hcol.2
+          · simpa [k] using hp
+      · simp [noPivotLoopWith_done (quot := quot) fuel state hDone]
+
+/-- Diagonal entries at or before the current step are unchanged by subsequent
+no-pivot loop iterations. -/
+@[grind =]
+theorem noPivotLoopWith_diag_of_le_step (fuel : Nat) (state : BareissState R n)
+    (i : Fin n) (hi : i.val ≤ state.step) :
+    (noPivotLoopWith quot fuel state).matrix[i][i] = state.matrix[i][i] :=
+  noPivotLoopWith_matrix_entry_of_row_le_or_col_lt (quot := quot) fuel state i i (Or.inl hi)
+
+/-- The no-pivot loop never changes the row-swap counter. -/
+@[grind =]
+theorem noPivotLoopWith_rowSwaps (fuel : Nat) (state : BareissState R n) :
+    (noPivotLoopWith quot fuel state).rowSwaps = state.rowSwaps := by
+  induction fuel generalizing state with
+  | zero =>
+      simp [noPivotLoopWith]
+  | succ fuel ih =>
+      by_cases hDone : state.step + 1 < n
+      · let k : Fin n :=
+          ⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩
+        by_cases hp : state.matrix[k][k] = 0
+        · simp [noPivotLoopWith_of_singular (quot := quot) fuel state hDone hp]
+        · rw [noPivotLoopWith_of_regular (quot := quot) fuel state hDone]
+          · let next : BareissState R n :=
+              { step := state.step + 1
+                matrix := stepMatrixWith quot state.matrix state.step
+                  state.matrix[state.step][state.step] state.prevPivot
+                prevPivot := state.matrix[state.step][state.step]
+                rowSwaps := state.rowSwaps
+                singularStep := none }
+            change (noPivotLoopWith quot fuel next).rowSwaps = state.rowSwaps
+            rw [ih next]
+          · simpa [k] using hp
+      · simp [noPivotLoopWith_done (quot := quot) fuel state hDone]
+
+/-- Once a no-pivot Bareiss state is already at the terminal step boundary,
+additional fuel leaves it unchanged. -/
+-- @[grind]-excluded: structural fixed-point lemma overlapping `noPivotLoopWith_done (quot := quot)`;
+-- kept for manual fuel reasoning.
+theorem noPivotLoopWith_id_at_done
+    {n : Nat} (fuel : Nat) (state : BareissState R n)
+    (hDone : ¬ state.step + 1 < n) :
+    noPivotLoopWith quot fuel state = state := by
+  induction fuel with
+  | zero => rfl
+  | succ f _ih => exact noPivotLoopWith_done (quot := quot) f state hDone
+
+/-- Once a no-pivot Bareiss state has recorded a zero pivot at the current
+step, additional fuel leaves that singular fixed point unchanged. -/
+-- @[grind]-excluded: structural fixed-point lemma with bespoke singular-state
+-- premises; used once inside `noPivotLoopWith_add (quot := quot)`.
+theorem noPivotLoopWith_id_at_singular_fixedpoint
+    {n : Nat} (fuel : Nat) (state : BareissState R n)
+    (hDone : state.step + 1 < n)
+    (hp : state.matrix[(⟨state.step, Nat.lt_of_succ_lt hDone⟩ : Fin n)][
+        (⟨state.step, Nat.lt_of_succ_lt hDone⟩ : Fin n)] = 0)
+    (hsing : state.singularStep = some state.step) :
+    noPivotLoopWith quot fuel state = state := by
+  induction fuel with
+  | zero => rfl
+  | succ f _ih =>
+      rw [noPivotLoopWith_of_singular (quot := quot) f state hDone hp]
+      cases state
+      simp at hsing ⊢
+      exact hsing.symm
+
+/-- Fuel composition for the no-pivot Bareiss loop: running `a + b` units of
+fuel from `state` equals running `b` more units after `a` initial units. -/
+-- @[grind]-excluded: fuel-composition (associativity) lemma; as a rewrite it
+-- splits one loop into two and risks non-termination of grind's saturation.
+theorem noPivotLoopWith_add
+    {n : Nat} (a b : Nat) (state : BareissState R n) :
+    noPivotLoopWith quot (a + b) state = noPivotLoopWith quot b (noPivotLoopWith quot a state) := by
+  induction a generalizing state with
+  | zero =>
+      show noPivotLoopWith quot (0 + b) state = noPivotLoopWith quot b state
+      simp
+  | succ a' ih =>
+      by_cases hDone : state.step + 1 < n
+      · let k : Fin n :=
+          ⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩
+        by_cases hp : state.matrix[k][k] = 0
+        · have h_lhs :
+              noPivotLoopWith quot (a' + 1 + b) state =
+                {state with singularStep := some state.step} := by
+            have : a' + 1 + b = (a' + b) + 1 := by omega
+            rw [this]
+            exact noPivotLoopWith_of_singular (quot := quot) (a' + b) state hDone hp
+          have h_rhs_inner :
+              noPivotLoopWith quot (a' + 1) state =
+                {state with singularStep := some state.step} :=
+            noPivotLoopWith_of_singular (quot := quot) a' state hDone hp
+          rw [h_lhs, h_rhs_inner]
+          symm
+          let s' : BareissState R n := {state with singularStep := some state.step}
+          have hDone_s' : s'.step + 1 < n := hDone
+          have hp_s' : s'.matrix[(⟨s'.step, Nat.lt_of_succ_lt hDone_s'⟩ : Fin n)][
+              (⟨s'.step, Nat.lt_of_succ_lt hDone_s'⟩ : Fin n)] = 0 := hp
+          have hsing_s' : s'.singularStep = some s'.step := rfl
+          exact noPivotLoopWith_id_at_singular_fixedpoint (quot := quot) b s' hDone_s' hp_s' hsing_s'
+        · have h_lhs :
+              noPivotLoopWith quot (a' + 1 + b) state =
+                noPivotLoopWith quot (a' + b)
+                  { step := state.step + 1
+                    matrix := stepMatrixWith quot state.matrix state.step
+                      state.matrix[k][k] state.prevPivot
+                    prevPivot := state.matrix[k][k]
+                    rowSwaps := state.rowSwaps
+                    singularStep := none } := by
+            have : a' + 1 + b = (a' + b) + 1 := by omega
+            rw [this]
+            exact noPivotLoopWith_of_regular (quot := quot) (a' + b) state hDone hp
+          have h_rhs_inner :
+              noPivotLoopWith quot (a' + 1) state =
+                noPivotLoopWith quot a'
+                  { step := state.step + 1
+                    matrix := stepMatrixWith quot state.matrix state.step
+                      state.matrix[k][k] state.prevPivot
+                    prevPivot := state.matrix[k][k]
+                    rowSwaps := state.rowSwaps
+                    singularStep := none } :=
+            noPivotLoopWith_of_regular (quot := quot) a' state hDone hp
+          rw [h_lhs, h_rhs_inner]
+          exact ih _
+      · rw [noPivotLoopWith_id_at_done (quot := quot) (a' + 1 + b) state hDone]
+        rw [noPivotLoopWith_id_at_done (quot := quot) (a' + 1) state hDone]
+        exact (noPivotLoopWith_id_at_done (quot := quot) b state hDone).symm
+
+/-- When a no-pivot Bareiss run records no singular step and has enough room,
+the `step` field advances by exactly the amount of consumed fuel. -/
+-- @[grind]-excluded: step-count accounting lemma with arithmetic-room and
+-- no-singular premises; proof-internal, not a characterising rewrite.
+theorem noPivotLoopWith_step_eq_add_of_singularStep_none
+    {n : Nat} (fuel : Nat) (state : BareissState R n)
+    (h_init : state.singularStep = none)
+    (h_room : state.step + fuel + 1 ≤ n)
+    (h_no_sing : (noPivotLoopWith quot fuel state).singularStep = none) :
+    (noPivotLoopWith quot fuel state).step = state.step + fuel := by
+  induction fuel generalizing state with
+  | zero =>
+      show state.step = state.step + 0
+      omega
+  | succ f ih =>
+      have hDone : state.step + 1 < n := by omega
+      by_cases hp : state.matrix[state.step][state.step] = 0
+      · rw [noPivotLoopWith_of_singular (quot := quot) f state hDone hp] at h_no_sing
+        simp at h_no_sing
+      · rw [noPivotLoopWith_of_regular (quot := quot) f state hDone hp] at h_no_sing
+        rw [noPivotLoopWith_of_regular (quot := quot) f state hDone hp]
+        have h_next_room : state.step + 1 + f + 1 ≤ n := by omega
+        have h_next_step := ih
+          { step := state.step + 1
+            matrix := stepMatrixWith quot state.matrix state.step
+              state.matrix[state.step][state.step] state.prevPivot
+            prevPivot := state.matrix[state.step][state.step]
+            rowSwaps := state.rowSwaps
+            singularStep := none }
+          rfl h_next_room h_no_sing
+        rw [h_next_step]
+        show state.step + 1 + f = state.step + (f + 1)
+        omega
+
+/-- When the no-pivot Bareiss loop completes `fuel` iterations without
+recording a singular step, the row-pivoted Bareiss loop produces an
+identical state: every diagonal pivot is nonzero, so the row search and
+swap branches of `pivotLoopWith quot` are never entered and both loops apply the
+same `stepMatrixWith quot` updates. -/
+-- @[grind]-excluded: one-shot equivalence-of-two-algorithms bridge gated on a
+-- no-singular premise.
+theorem pivotLoopWith_eq_noPivotLoopWith_of_no_singular {n : Nat}
+    (fuel : Nat) (state : BareissState R n)
+    (h_no_sing : (noPivotLoopWith quot fuel state).singularStep = none) :
+    pivotLoopWith quot fuel state = noPivotLoopWith quot fuel state := by
+  induction fuel generalizing state with
+  | zero => rfl
+  | succ f ih =>
+      by_cases hDone : state.step + 1 < n
+      · by_cases hp : state.matrix[state.step][state.step] = 0
+        · -- `noPivotLoopWith quot` records `singularStep = some state.step`, contradicting
+          -- `h_no_sing`.
+          rw [noPivotLoopWith_of_singular (quot := quot) f state hDone hp] at h_no_sing
+          simp at h_no_sing
+        · -- Regular branch in both loops; recurse on the same updated state.
+          let next : BareissState R n :=
+            { step := state.step + 1
+              matrix := stepMatrixWith quot state.matrix state.step
+                state.matrix[state.step][state.step] state.prevPivot
+              prevPivot := state.matrix[state.step][state.step]
+              rowSwaps := state.rowSwaps
+              singularStep := none }
+          rw [noPivotLoopWith_of_regular (quot := quot) f state hDone hp,
+            pivotLoopWith_of_regular_no_swap (quot := quot) f state hDone hp]
+          show pivotLoopWith quot f next = noPivotLoopWith quot f next
+          apply ih
+          show (noPivotLoopWith quot f next).singularStep = none
+          rw [← noPivotLoopWith_of_regular (quot := quot) f state hDone hp]
+          exact h_no_sing
+      · rw [pivotLoopWith_done (quot := quot) f state hDone]
+        rw [noPivotLoopWith_done (quot := quot) f state hDone]
+
+/-- Initial state used by the no-pivot Bareiss recurrence. -/
+@[expose]
+def noPivotInitialState (M : Matrix R n n) : BareissState R n :=
+  { step := 0
+    matrix := M
+    prevPivot := 1
+    rowSwaps := 0
+    singularStep := none }
+
+/-- Run the no-pivot Bareiss recurrence and return the final elimination data. -/
+@[expose]
+def bareissNoPivotDataWith (quot : R → R → R) (M : Matrix R n n) : BareissData R n :=
+  finish <| noPivotLoopWith quot n (noPivotInitialState M)
+
+/-- Determinant computed by the no-pivot Bareiss recurrence. -/
+@[expose]
+def bareissNoPivotWith (quot : R → R → R) (M : Matrix R n n) : R :=
+  (bareissNoPivotDataWith quot M).det
+
+/-- Run the row-pivoted Bareiss elimination and return the final elimination
+data together with the swap/sign bookkeeping. -/
+@[expose]
+def bareissDataWith (quot : R → R → R) (M : Matrix R n n) : BareissData R n :=
+  let state := bareissArrayStateWith quot M
+  { matrix := rowsToMatrix state.matrix n
+    rowSwaps := state.rowSwaps
+    singularStep := state.singularStep }
+
+/-- The packaged row-pivoted Bareiss data is exactly the structured pivot loop
+state finished into public determinant data. This is the equality consumed by the
+Mathlib determinant proof; array storage is erased by `rowsToMatrix`. -/
+-- @[grind]-excluded: array-erasure bridge consumed by the Mathlib determinant
+-- proof; not a local rewrite.
+theorem bareissDataWith_eq_finish_pivotLoopWith (M : Matrix R n n) :
+    bareissDataWith quot M = finish (pivotLoopWith quot n (noPivotInitialState M)) := by
+  simp [bareissDataWith, bareissArrayStateWith, noPivotInitialState, finish,
+    rowsToMatrix_matrixToRows]
+
+/-- Determinant computed by the row-pivoted Bareiss algorithm. -/
+@[expose]
+def bareissWith (quot : R → R → R) (M : Matrix R n n) : R :=
+  let state := bareissArrayStateWith quot M
+  bareissArrayDet state n
+
+/-- The public row-pivoted determinant agrees with the determinant encoded by
+`bareissDataWith`. This separates executable array evaluation from the packaged
+elimination data used by correctness proofs. -/
+-- @[grind]-excluded: one-shot executable-vs-packaged determinant bridge.
+theorem bareissWith_eq_bareissDataWith_det (M : Matrix R n n) :
+    bareissWith quot M = (bareissDataWith quot M).det := by
+  cases n with
+  | zero =>
+      simp [bareissWith, bareissDataWith, bareissArrayDet, BareissData.det,
+        arrayLastDiag?, BareissData.lastDiag?, arraySign, BareissData.sign]
+      rfl
+  | succ k =>
+      simp [bareissWith, bareissDataWith, bareissArrayDet, BareissData.det,
+        arrayLastDiag?, BareissData.lastDiag?, rowsToMatrix,
+        arraySign, BareissData.sign]
+      cases (bareissArrayStateWith quot M).singularStep with
+      | some s => rfl
+      | none =>
+          exact congrArg
+            (fun x =>
+              (if (bareissArrayStateWith quot M).rowSwaps % 2 = 0 then (1 : R) else -1) * x)
+            (Matrix.getElem_ofFn
+              (fun i j => getEntry (bareissArrayStateWith quot M).matrix i.val j.val)
+              ⟨k, Nat.lt_succ_self k⟩ ⟨k, Nat.lt_succ_self k⟩).symm
+
+/-- If the no-pivot Bareiss pass reaches the final pivot without recording a
+singular step, then the public row-pivoted `bareissWith` determinant is exactly
+the no-pivot final diagonal entry. -/
+-- @[grind]-excluded: premise-heavy final-diagonal identity; one-shot.
+theorem bareissWith_eq_noPivotLoopWith_last_of_no_singular {k : Nat}
+    (M : Matrix R (k + 1) (k + 1))
+    (h_no_sing :
+      (noPivotLoopWith quot k (noPivotInitialState M)).singularStep = none)
+    (hone : ∀ x : R, 1 * x = x) :
+    bareissWith quot M =
+      (noPivotLoopWith quot k (noPivotInitialState M)).matrix[Fin.last k][Fin.last k] := by
+  let init := noPivotInitialState M
+  let stateK := noPivotLoopWith quot k init
+  have h_step : stateK.step = k := by
+    have h := noPivotLoopWith_step_eq_add_of_singularStep_none (quot := quot) k init rfl
+      (by simp [init, noPivotInitialState]) h_no_sing
+    simpa [stateK, init, noPivotInitialState] using h
+  have hDone_stateK : ¬ stateK.step + 1 < k + 1 := by omega
+  have h_full_nopivot : noPivotLoopWith quot (k + 1) init = stateK := by
+    rw [noPivotLoopWith_add (quot := quot) k 1 init]
+    exact noPivotLoopWith_id_at_done (quot := quot) 1 stateK hDone_stateK
+  have h_full_sing : (noPivotLoopWith quot (k + 1) init).singularStep = none := by
+    rw [h_full_nopivot]
+    exact h_no_sing
+  have hpivot := pivotLoopWith_eq_noPivotLoopWith_of_no_singular (quot := quot) (k + 1) init h_full_sing
+  rw [bareissWith_eq_bareissDataWith_det (quot := quot), bareissDataWith_eq_finish_pivotLoopWith (quot := quot), hpivot, h_full_nopivot]
+  have hdet := BareissData.det_succ_eq (finish stateK) h_no_sing
+  rw [hdet]
+  simp [finish, BareissData.sign, stateK, init, noPivotInitialState,
+    noPivotLoopWith_rowSwaps (quot := quot), hone,
+    getRow, Fin.getElem_fin]
+
+end GenericBareiss
+
+/-- Integer specialization of the generic Bareiss matrix update. -/
+abbrev stepMatrix (M : Matrix Int n n) (k : Nat) (pivot prevPivot : Int) :
+    Matrix Int n n :=
+  stepMatrixWith exactDiv M k pivot prevPivot
+
+/-- Integer specialization of the generic row-pivoted Bareiss loop. -/
+abbrev pivotLoop (fuel : Nat) (state : BareissState Int n) : BareissState Int n :=
+  pivotLoopWith exactDiv fuel state
+
+/-- Integer specialization of the generic no-pivot Bareiss loop. -/
+abbrev noPivotLoop (fuel : Nat) (state : BareissState Int n) : BareissState Int n :=
+  noPivotLoopWith exactDiv fuel state
+
+/-- Integer specialization returning the executable array-backed state. -/
+abbrev bareissArrayState (M : Matrix Int n n) : BareissArrayState Int :=
+  bareissArrayStateWith exactDiv M
+
+/-- Integer specialization returning no-pivot elimination data. -/
+abbrev bareissNoPivotData (M : Matrix Int n n) : BareissData Int n :=
+  bareissNoPivotDataWith exactDiv M
+
+/-- Integer specialization of the no-pivot Bareiss determinant. -/
+abbrev bareissNoPivot (M : Matrix Int n n) : Int :=
+  bareissNoPivotWith exactDiv M
+
+/-- Integer specialization returning row-pivoted elimination data. -/
+abbrev bareissData (M : Matrix Int n n) : BareissData Int n :=
+  bareissDataWith exactDiv M
+
+/-- Integer specialization of the row-pivoted Bareiss determinant. -/
+abbrev bareiss (M : Matrix Int n n) : Int :=
+  bareissWith exactDiv M
+
+/-! Integer proof-interface compatibility.  These theorems state their
+conclusions through the traditional entry points while delegating every proof
+to the generic `With` theorem. -/
+
+theorem stepMatrix_eq_ofFn (M : Matrix Int n n) (k : Nat)
+    (pivot prevPivot : Int) :
+    stepMatrix M k pivot prevPivot =
+      Matrix.ofFn fun i j =>
+        if hkij : k < i.val ∧ k < j.val then
+          let colK : Fin n := ⟨k, Nat.lt_trans hkij.1 i.isLt⟩
+          let rowK : Fin n := ⟨k, Nat.lt_trans hkij.2 j.isLt⟩
+          exactDiv (pivot * M[(i, j)] - M[(i, colK)] * M[(rowK, j)]) prevPivot
+        else if k < i.val ∧ j.val = k then
+          0
+        else
+          M[(i, j)] :=
+  stepMatrixWith_eq_ofFn exactDiv M k pivot prevPivot
+
+@[grind =]
+theorem stepMatrix_eq_of_not_update (M : Matrix Int n n) (k : Nat)
+    (pivot prevPivot : Int) (i j : Fin n)
+    (htrail : ¬ (k < i.val ∧ k < j.val))
+    (hcol : ¬ (k < i.val ∧ j.val = k)) :
+    (stepMatrix M k pivot prevPivot)[i][j] = M[i][j] :=
+  stepMatrixWith_eq_of_not_update exactDiv M k pivot prevPivot i j htrail hcol
+
+@[grind =]
+theorem stepMatrix_diag_of_le (M : Matrix Int n n) (k : Nat)
+    (pivot prevPivot : Int) (i : Fin n) (hi : i.val ≤ k) :
+    (stepMatrix M k pivot prevPivot)[i][i] = M[i][i] :=
+  stepMatrixWith_diag_of_le exactDiv M k pivot prevPivot i hi
+
+@[grind =]
+theorem stepMatrix_pivot_col_below (M : Matrix Int n n) (k : Nat)
+    (pivot prevPivot : Int) (i colK : Fin n)
+    (hi : k < i.val) (hcolK : colK.val = k) :
+    (stepMatrix M k pivot prevPivot)[i][colK] = 0 :=
+  stepMatrixWith_pivot_col_below exactDiv M k pivot prevPivot i colK hi hcolK
+
+theorem stepMatrix_update_eq (M : Matrix Int n n) (k : Nat)
+    (pivot prevPivot : Int) (i j : Fin n) (hi : k < i.val) (hj : k < j.val) :
+    (stepMatrix M k pivot prevPivot)[i][j] =
+      (let colK : Fin n := ⟨k, Nat.lt_trans hi i.isLt⟩
+       let rowK : Fin n := ⟨k, Nat.lt_trans hj j.isLt⟩
+       exactDiv (pivot * M[i][j] - M[i][colK] * M[rowK][j]) prevPivot) :=
+  stepMatrixWith_update_eq exactDiv M k pivot prevPivot i j hi hj
+
+theorem stepMatrix_borderedMinor_update
+    (source current : Matrix Int n n) (k : Nat) (hk : k < n) (hnext : k + 1 < n)
+    (i j : Fin n) (hi : k < i.val) (hj : k < j.val) (pivot prevPivot : Int)
+    (hpivot :
+      pivot =
+        det (borderedMinor source k hk
+          (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n)
+          (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)))
+    (hentry : current[i][j] = det (borderedMinor source k hk i j))
+    (hleft :
+      current[i][(⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)] =
+        det (borderedMinor source k hk i (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)))
+    (htop :
+      current[(⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n)][j] =
+        det (borderedMinor source k hk (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n) j))
+    (hexact :
+      exactDiv
+        (det (borderedMinor source k hk
+            (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n)
+            (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)) *
+          det (borderedMinor source k hk i j) -
+          det (borderedMinor source k hk i (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)) *
+          det (borderedMinor source k hk (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n) j))
+        prevPivot = det (borderedMinor source (k + 1) hnext i j)) :
+    (stepMatrix current k pivot prevPivot)[i][j] =
+      det (borderedMinor source (k + 1) hnext i j) :=
+  stepMatrixWith_borderedMinor_update exactDiv source current k hk hnext i j hi hj
+    pivot prevPivot hpivot hentry hleft htop hexact
+
+@[grind]
+theorem pivotLoop_zero_fuel (state : BareissState Int n) :
+    pivotLoop 0 state = state :=
+  pivotLoopWith_zero_fuel (quot := exactDiv) state
+
+@[grind]
+theorem pivotLoop_done (fuel : Nat) (state : BareissState Int n)
+    (hDone : ¬ state.step + 1 < n) :
+    pivotLoop (fuel + 1) state = state :=
+  pivotLoopWith_done (quot := exactDiv) fuel state hDone
+
+@[grind]
+theorem pivotLoop_of_regular_no_swap (fuel : Nat) (state : BareissState Int n)
     (hDone : state.step + 1 < n)
     (hp : state.matrix[state.step][state.step] ≠ 0) :
     pivotLoop (fuel + 1) state =
@@ -923,13 +1653,11 @@ theorem pivotLoop_of_regular_no_swap (fuel : Nat) (state : BareissState n)
             state.prevPivot
           prevPivot := state.matrix[state.step][state.step]
           rowSwaps := state.rowSwaps
-          singularStep := none } := by
-  simp_all [pivotLoop, getRow, Fin.getElem_fin]
+          singularStep := none } :=
+  pivotLoopWith_of_regular_no_swap (quot := exactDiv) fuel state hDone hp
 
-/-- If the current pivot is zero and pivot search finds no replacement row,
-the row-pivoted Bareiss loop records a singular step. -/
 @[grind]
-theorem pivotLoop_of_singular_no_pivot (fuel : Nat) (state : BareissState n)
+theorem pivotLoop_of_singular_no_pivot (fuel : Nat) (state : BareissState Int n)
     (hDone : state.step + 1 < n)
     (hp0 : state.matrix[state.step][state.step] = 0)
     (hfind :
@@ -937,14 +1665,11 @@ theorem pivotLoop_of_singular_no_pivot (fuel : Nat) (state : BareissState n)
         (⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩ : Fin n)
         (state.step + 1) = none) :
     pivotLoop (fuel + 1) state =
-      { state with singularStep := some state.step } := by
-  simp_all [pivotLoop]
+      { state with singularStep := some state.step } :=
+  pivotLoopWith_of_singular_no_pivot (quot := exactDiv) fuel state hDone hp0 hfind
 
-/-- If the current pivot is zero, pivot search finds a replacement row, and
-the swapped pivot is nonzero, one loop iteration swaps rows, applies
-`stepMatrix`, advances the step, increments the row-swap counter, and recurses. -/
 @[grind]
-theorem pivotLoop_of_regular_swap (fuel : Nat) (state : BareissState n)
+theorem pivotLoop_of_regular_swap (fuel : Nat) (state : BareissState Int n)
     (hDone : state.step + 1 < n)
     (hp0 : state.matrix[state.step][state.step] = 0) {pivot : Fin n}
     (hfind :
@@ -972,109 +1697,29 @@ theorem pivotLoop_of_regular_swap (fuel : Nat) (state : BareissState n)
               (⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩ : Fin n)
               pivot)[state.step][state.step]
           rowSwaps := state.rowSwaps + 1
-          singularStep := none } := by
-  simp_all [pivotLoop]
+          singularStep := none } :=
+  pivotLoopWith_of_regular_swap (quot := exactDiv) fuel state hDone hp0 hfind hp
 
-/-- `bareissArrayState` runs the matrix-level Bareiss elimination via `pivotLoop`
-and repackages the reduced result as a `BareissArrayState`, storing the matrix
-row-by-row via `matrixToRows`. -/
-@[expose]
-def bareissArrayState (M : Matrix Int n n) : BareissArrayState :=
-  let state := pivotLoop n
-    { step := 0
-      matrix := M
-      prevPivot := 1
-      rowSwaps := 0
-      singularStep := none }
-  { step := state.step
-    matrix := matrixToRows state.matrix
-    prevPivot := state.prevPivot
-    rowSwaps := state.rowSwaps
-    singularStep := state.singularStep }
-
-/-- `arraySign` is the determinant sign contributed by `rowSwaps` recorded row
-swaps, `1` for an even count and `-1` for an odd count. -/
-@[expose]
-def arraySign (rowSwaps : Nat) : Int :=
-  if rowSwaps % 2 = 0 then 1 else -1
-
-/-- `arrayLastDiag?` reads the last diagonal entry `(n-1, n-1)` of the reduced
-rows, returning `none` when `n = 0`. -/
-@[expose]
-def arrayLastDiag? (rows : Array (Array Int)) (n : Nat) : Option Int :=
-  match n with
-  | 0 => none
-  | k + 1 => some (getEntry rows k k)
-
-/-- `bareissArrayDet` assembles the determinant value from the final array
-state, returning `0` when elimination recorded a singular column and the signed
-last diagonal entry otherwise. -/
-@[expose]
-def bareissArrayDet (state : BareissArrayState) (n : Nat) : Int :=
-  match state.singularStep with
-  | some _ => 0
-  | none =>
-      match arrayLastDiag? state.matrix n with
-      | some d => arraySign state.rowSwaps * d
-      | none => arraySign state.rowSwaps
-
-/-- Package a Bareiss state as public elimination data. -/
-@[expose]
-def finish (state : BareissState n) : BareissData n :=
-  { matrix := state.matrix
-    rowSwaps := state.rowSwaps
-    singularStep := state.singularStep }
-
-/-- Bareiss elimination without pivoting. A zero pivot aborts and records the
-singular step. -/
-@[expose]
-def noPivotLoop (fuel : Nat) (state : BareissState n) : BareissState n :=
-  match fuel with
-  | 0 => state
-  | fuel + 1 =>
-      if hDone : state.step + 1 < n then
-        let k : Fin n := ⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩
-        let pivot := state.matrix[(k, k)]
-        if hp : pivot = 0 then
-          { state with singularStep := some state.step }
-        else
-          let next : BareissState n :=
-            { step := state.step + 1
-              matrix := stepMatrix state.matrix state.step pivot state.prevPivot
-              prevPivot := pivot
-              rowSwaps := state.rowSwaps
-              singularStep := none }
-          noPivotLoop fuel next
-      else
-        state
-
-/-- With zero fuel, the no-pivot Bareiss loop returns its input state. -/
 @[grind]
-theorem noPivotLoop_zero_fuel (state : BareissState n) :
-    noPivotLoop 0 state = state := by
-  rfl
+theorem noPivotLoop_zero_fuel (state : BareissState Int n) :
+    noPivotLoop 0 state = state :=
+  noPivotLoopWith_zero_fuel (quot := exactDiv) state
 
-/-- If the current step is already past the last update step, the no-pivot loop
-returns its input state. -/
 @[grind]
-theorem noPivotLoop_done (fuel : Nat) (state : BareissState n)
+theorem noPivotLoop_done (fuel : Nat) (state : BareissState Int n)
     (hDone : ¬ state.step + 1 < n) :
-    noPivotLoop (fuel + 1) state = state := by
-  simp [noPivotLoop, hDone]
+    noPivotLoop (fuel + 1) state = state :=
+  noPivotLoopWith_done (quot := exactDiv) fuel state hDone
 
-/-- If the no-pivot loop sees a zero pivot before completion, it records the
-current step as singular. -/
 @[grind]
-theorem noPivotLoop_of_singular (fuel : Nat) (state : BareissState n)
+theorem noPivotLoop_of_singular (fuel : Nat) (state : BareissState Int n)
     (hDone : state.step + 1 < n)
     (hp : state.matrix[state.step][state.step] = 0) :
-    noPivotLoop (fuel + 1) state = { state with singularStep := some state.step } := by
-  simp_all [noPivotLoop]
+    noPivotLoop (fuel + 1) state = { state with singularStep := some state.step } :=
+  noPivotLoopWith_of_singular (quot := exactDiv) fuel state hDone hp
 
-/-- If the current no-pivot Bareiss pivot is nonzero, one loop iteration applies
-`stepMatrix`, advances the step, and recurses on the remaining fuel. -/
 @[grind]
-theorem noPivotLoop_of_regular (fuel : Nat) (state : BareissState n)
+theorem noPivotLoop_of_regular (fuel : Nat) (state : BareissState Int n)
     (hDone : state.step + 1 < n)
     (hp : state.matrix[state.step][state.step] ≠ 0) :
     noPivotLoop (fuel + 1) state =
@@ -1084,354 +1729,77 @@ theorem noPivotLoop_of_regular (fuel : Nat) (state : BareissState n)
             state.prevPivot
           prevPivot := state.matrix[state.step][state.step]
           rowSwaps := state.rowSwaps
-          singularStep := none } := by
-  simp_all [noPivotLoop]
+          singularStep := none } :=
+  noPivotLoopWith_of_regular (quot := exactDiv) fuel state hDone hp
 
-/-- Entries in rows already processed, or in columns strictly before the current
-step, are unchanged by subsequent no-pivot loop iterations. -/
 @[grind]
 theorem noPivotLoop_matrix_entry_of_row_le_or_col_lt (fuel : Nat)
-    (state : BareissState n) (i j : Fin n)
+    (state : BareissState Int n) (i j : Fin n)
     (hfixed : i.val ≤ state.step ∨ j.val < state.step) :
-    (noPivotLoop fuel state).matrix[i][j] = state.matrix[i][j] := by
-  induction fuel generalizing state with
-  | zero =>
-      simp [noPivotLoop]
-  | succ fuel ih =>
-      by_cases hDone : state.step + 1 < n
-      · let k : Fin n :=
-          ⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩
-        by_cases hp : state.matrix[k][k] = 0
-        · simp [noPivotLoop_of_singular fuel state hDone hp]
-        · rw [noPivotLoop_of_regular fuel state hDone]
-          · let next : BareissState n :=
-              { step := state.step + 1
-                matrix := stepMatrix state.matrix state.step
-                  state.matrix[state.step][state.step] state.prevPivot
-                prevPivot := state.matrix[state.step][state.step]
-                rowSwaps := state.rowSwaps
-                singularStep := none }
-            change (noPivotLoop fuel next).matrix[i][j] = state.matrix[i][j]
-            have hnext : i.val ≤ next.step ∨ j.val < next.step := by
-              cases hfixed with
-              | inl hi =>
-                  exact Or.inl (Nat.le_trans hi (Nat.le_succ state.step))
-              | inr hj =>
-                  exact Or.inr (Nat.lt_trans hj (Nat.lt_succ_self state.step))
-            rw [ih next hnext]
-            dsimp [next]
-            apply stepMatrix_eq_of_not_update
-            · intro htrail
-              cases hfixed with
-              | inl hi =>
-                  exact Nat.not_lt_of_ge hi htrail.1
-              | inr hj =>
-                  exact Nat.not_lt_of_ge (Nat.le_of_lt hj) htrail.2
-            · intro hcol
-              cases hfixed with
-              | inl hi =>
-                  exact Nat.not_lt_of_ge hi hcol.1
-              | inr hj =>
-                  exact Nat.ne_of_lt hj hcol.2
-          · simpa [k] using hp
-      · simp [noPivotLoop_done fuel state hDone]
+    (noPivotLoop fuel state).matrix[i][j] = state.matrix[i][j] :=
+  noPivotLoopWith_matrix_entry_of_row_le_or_col_lt
+    (quot := exactDiv) fuel state i j hfixed
 
-/-- Diagonal entries at or before the current step are unchanged by subsequent
-no-pivot loop iterations. -/
 @[grind =]
-theorem noPivotLoop_diag_of_le_step (fuel : Nat) (state : BareissState n)
+theorem noPivotLoop_diag_of_le_step (fuel : Nat) (state : BareissState Int n)
     (i : Fin n) (hi : i.val ≤ state.step) :
     (noPivotLoop fuel state).matrix[i][i] = state.matrix[i][i] :=
-  noPivotLoop_matrix_entry_of_row_le_or_col_lt fuel state i i (Or.inl hi)
+  noPivotLoopWith_diag_of_le_step (quot := exactDiv) fuel state i hi
 
-/-- The no-pivot loop never changes the row-swap counter. -/
 @[grind =]
-theorem noPivotLoop_rowSwaps (fuel : Nat) (state : BareissState n) :
-    (noPivotLoop fuel state).rowSwaps = state.rowSwaps := by
-  induction fuel generalizing state with
-  | zero =>
-      simp [noPivotLoop]
-  | succ fuel ih =>
-      by_cases hDone : state.step + 1 < n
-      · let k : Fin n :=
-          ⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩
-        by_cases hp : state.matrix[k][k] = 0
-        · simp [noPivotLoop_of_singular fuel state hDone hp]
-        · rw [noPivotLoop_of_regular fuel state hDone]
-          · let next : BareissState n :=
-              { step := state.step + 1
-                matrix := stepMatrix state.matrix state.step
-                  state.matrix[state.step][state.step] state.prevPivot
-                prevPivot := state.matrix[state.step][state.step]
-                rowSwaps := state.rowSwaps
-                singularStep := none }
-            change (noPivotLoop fuel next).rowSwaps = state.rowSwaps
-            rw [ih next]
-          · simpa [k] using hp
-      · simp [noPivotLoop_done fuel state hDone]
+theorem noPivotLoop_rowSwaps (fuel : Nat) (state : BareissState Int n) :
+    (noPivotLoop fuel state).rowSwaps = state.rowSwaps :=
+  noPivotLoopWith_rowSwaps (quot := exactDiv) fuel state
 
-/-- Once a no-pivot Bareiss state is already at the terminal step boundary,
-additional fuel leaves it unchanged. -/
--- @[grind]-excluded: structural fixed-point lemma overlapping `noPivotLoop_done`;
--- kept for manual fuel reasoning.
-theorem noPivotLoop_id_at_done
-    {n : Nat} (fuel : Nat) (state : BareissState n)
+theorem noPivotLoop_id_at_done (fuel : Nat) (state : BareissState Int n)
     (hDone : ¬ state.step + 1 < n) :
-    noPivotLoop fuel state = state := by
-  induction fuel with
-  | zero => rfl
-  | succ f _ih => exact noPivotLoop_done f state hDone
+    noPivotLoop fuel state = state :=
+  noPivotLoopWith_id_at_done (quot := exactDiv) fuel state hDone
 
-/-- Once a no-pivot Bareiss state has recorded a zero pivot at the current
-step, additional fuel leaves that singular fixed point unchanged. -/
--- @[grind]-excluded: structural fixed-point lemma with bespoke singular-state
--- premises; used once inside `noPivotLoop_add`.
-theorem noPivotLoop_id_at_singular_fixedpoint
-    {n : Nat} (fuel : Nat) (state : BareissState n)
-    (hDone : state.step + 1 < n)
+theorem noPivotLoop_id_at_singular_fixedpoint (fuel : Nat)
+    (state : BareissState Int n) (hDone : state.step + 1 < n)
     (hp : state.matrix[(⟨state.step, Nat.lt_of_succ_lt hDone⟩ : Fin n)][
         (⟨state.step, Nat.lt_of_succ_lt hDone⟩ : Fin n)] = 0)
     (hsing : state.singularStep = some state.step) :
-    noPivotLoop fuel state = state := by
-  induction fuel with
-  | zero => rfl
-  | succ f _ih =>
-      rw [noPivotLoop_of_singular f state hDone hp]
-      cases state
-      simp at hsing ⊢
-      exact hsing.symm
+    noPivotLoop fuel state = state :=
+  noPivotLoopWith_id_at_singular_fixedpoint
+    (quot := exactDiv) fuel state hDone hp hsing
 
-/-- Fuel composition for the no-pivot Bareiss loop: running `a + b` units of
-fuel from `state` equals running `b` more units after `a` initial units. -/
--- @[grind]-excluded: fuel-composition (associativity) lemma; as a rewrite it
--- splits one loop into two and risks non-termination of grind's saturation.
-theorem noPivotLoop_add
-    {n : Nat} (a b : Nat) (state : BareissState n) :
-    noPivotLoop (a + b) state = noPivotLoop b (noPivotLoop a state) := by
-  induction a generalizing state with
-  | zero =>
-      show noPivotLoop (0 + b) state = noPivotLoop b state
-      simp
-  | succ a' ih =>
-      by_cases hDone : state.step + 1 < n
-      · let k : Fin n :=
-          ⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩
-        by_cases hp : state.matrix[k][k] = 0
-        · have h_lhs :
-              noPivotLoop (a' + 1 + b) state =
-                {state with singularStep := some state.step} := by
-            have : a' + 1 + b = (a' + b) + 1 := by omega
-            rw [this]
-            exact noPivotLoop_of_singular (a' + b) state hDone hp
-          have h_rhs_inner :
-              noPivotLoop (a' + 1) state =
-                {state with singularStep := some state.step} :=
-            noPivotLoop_of_singular a' state hDone hp
-          rw [h_lhs, h_rhs_inner]
-          symm
-          let s' : BareissState n := {state with singularStep := some state.step}
-          have hDone_s' : s'.step + 1 < n := hDone
-          have hp_s' : s'.matrix[(⟨s'.step, Nat.lt_of_succ_lt hDone_s'⟩ : Fin n)][
-              (⟨s'.step, Nat.lt_of_succ_lt hDone_s'⟩ : Fin n)] = 0 := hp
-          have hsing_s' : s'.singularStep = some s'.step := rfl
-          exact noPivotLoop_id_at_singular_fixedpoint b s' hDone_s' hp_s' hsing_s'
-        · have h_lhs :
-              noPivotLoop (a' + 1 + b) state =
-                noPivotLoop (a' + b)
-                  { step := state.step + 1
-                    matrix := stepMatrix state.matrix state.step
-                      state.matrix[k][k] state.prevPivot
-                    prevPivot := state.matrix[k][k]
-                    rowSwaps := state.rowSwaps
-                    singularStep := none } := by
-            have : a' + 1 + b = (a' + b) + 1 := by omega
-            rw [this]
-            exact noPivotLoop_of_regular (a' + b) state hDone hp
-          have h_rhs_inner :
-              noPivotLoop (a' + 1) state =
-                noPivotLoop a'
-                  { step := state.step + 1
-                    matrix := stepMatrix state.matrix state.step
-                      state.matrix[k][k] state.prevPivot
-                    prevPivot := state.matrix[k][k]
-                    rowSwaps := state.rowSwaps
-                    singularStep := none } :=
-            noPivotLoop_of_regular a' state hDone hp
-          rw [h_lhs, h_rhs_inner]
-          exact ih _
-      · rw [noPivotLoop_id_at_done (a' + 1 + b) state hDone]
-        rw [noPivotLoop_id_at_done (a' + 1) state hDone]
-        exact (noPivotLoop_id_at_done b state hDone).symm
+theorem noPivotLoop_add (a b : Nat) (state : BareissState Int n) :
+    noPivotLoop (a + b) state = noPivotLoop b (noPivotLoop a state) :=
+  noPivotLoopWith_add (quot := exactDiv) a b state
 
-/-- When a no-pivot Bareiss run records no singular step and has enough room,
-the `step` field advances by exactly the amount of consumed fuel. -/
--- @[grind]-excluded: step-count accounting lemma with arithmetic-room and
--- no-singular premises; proof-internal, not a characterising rewrite.
-theorem noPivotLoop_step_eq_add_of_singularStep_none
-    {n : Nat} (fuel : Nat) (state : BareissState n)
-    (h_init : state.singularStep = none)
+theorem noPivotLoop_step_eq_add_of_singularStep_none (fuel : Nat)
+    (state : BareissState Int n) (h_init : state.singularStep = none)
     (h_room : state.step + fuel + 1 ≤ n)
     (h_no_sing : (noPivotLoop fuel state).singularStep = none) :
-    (noPivotLoop fuel state).step = state.step + fuel := by
-  induction fuel generalizing state with
-  | zero =>
-      show state.step = state.step + 0
-      omega
-  | succ f ih =>
-      have hDone : state.step + 1 < n := by omega
-      by_cases hp : state.matrix[state.step][state.step] = 0
-      · rw [noPivotLoop_of_singular f state hDone hp] at h_no_sing
-        simp at h_no_sing
-      · rw [noPivotLoop_of_regular f state hDone hp] at h_no_sing
-        rw [noPivotLoop_of_regular f state hDone hp]
-        have h_next_room : state.step + 1 + f + 1 ≤ n := by omega
-        have h_next_step := ih
-          { step := state.step + 1
-            matrix := stepMatrix state.matrix state.step
-              state.matrix[state.step][state.step] state.prevPivot
-            prevPivot := state.matrix[state.step][state.step]
-            rowSwaps := state.rowSwaps
-            singularStep := none }
-          rfl h_next_room h_no_sing
-        rw [h_next_step]
-        show state.step + 1 + f = state.step + (f + 1)
-        omega
+    (noPivotLoop fuel state).step = state.step + fuel :=
+  noPivotLoopWith_step_eq_add_of_singularStep_none
+    (quot := exactDiv) fuel state h_init h_room h_no_sing
 
-/-- When the no-pivot Bareiss loop completes `fuel` iterations without
-recording a singular step, the row-pivoted Bareiss loop produces an
-identical state: every diagonal pivot is nonzero, so the row search and
-swap branches of `pivotLoop` are never entered and both loops apply the
-same `stepMatrix` updates. -/
--- @[grind]-excluded: one-shot equivalence-of-two-algorithms bridge gated on a
--- no-singular premise.
-theorem pivotLoop_eq_noPivotLoop_of_no_singular {n : Nat}
-    (fuel : Nat) (state : BareissState n)
+theorem pivotLoop_eq_noPivotLoop_of_no_singular (fuel : Nat)
+    (state : BareissState Int n)
     (h_no_sing : (noPivotLoop fuel state).singularStep = none) :
-    pivotLoop fuel state = noPivotLoop fuel state := by
-  induction fuel generalizing state with
-  | zero => rfl
-  | succ f ih =>
-      by_cases hDone : state.step + 1 < n
-      · by_cases hp : state.matrix[state.step][state.step] = 0
-        · -- `noPivotLoop` records `singularStep = some state.step`, contradicting
-          -- `h_no_sing`.
-          rw [noPivotLoop_of_singular f state hDone hp] at h_no_sing
-          simp at h_no_sing
-        · -- Regular branch in both loops; recurse on the same updated state.
-          let next : BareissState n :=
-            { step := state.step + 1
-              matrix := stepMatrix state.matrix state.step
-                state.matrix[state.step][state.step] state.prevPivot
-              prevPivot := state.matrix[state.step][state.step]
-              rowSwaps := state.rowSwaps
-              singularStep := none }
-          rw [noPivotLoop_of_regular f state hDone hp,
-            pivotLoop_of_regular_no_swap f state hDone hp]
-          show pivotLoop f next = noPivotLoop f next
-          apply ih
-          show (noPivotLoop f next).singularStep = none
-          rw [← noPivotLoop_of_regular f state hDone hp]
-          exact h_no_sing
-      · rw [pivotLoop_done f state hDone]
-        rw [noPivotLoop_done f state hDone]
+    pivotLoop fuel state = noPivotLoop fuel state :=
+  pivotLoopWith_eq_noPivotLoopWith_of_no_singular
+    (quot := exactDiv) fuel state h_no_sing
 
-/-- Initial state used by the no-pivot Bareiss recurrence. -/
-@[expose]
-def noPivotInitialState (M : Matrix Int n n) : BareissState n :=
-  { step := 0
-    matrix := M
-    prevPivot := 1
-    rowSwaps := 0
-    singularStep := none }
-
-/-- Run the no-pivot Bareiss recurrence and return the final elimination data. -/
-@[expose]
-def bareissNoPivotData (M : Matrix Int n n) : BareissData n :=
-  finish <| noPivotLoop n (noPivotInitialState M)
-
-/-- Determinant computed by the no-pivot Bareiss recurrence. -/
-@[expose]
-def bareissNoPivot (M : Matrix Int n n) : Int :=
-  (bareissNoPivotData M).det
-
-/-- Run the row-pivoted Bareiss elimination and return the final elimination
-data together with the swap/sign bookkeeping. -/
-@[expose]
-def bareissData (M : Matrix Int n n) : BareissData n :=
-  let state := bareissArrayState M
-  { matrix := rowsToMatrix state.matrix n
-    rowSwaps := state.rowSwaps
-    singularStep := state.singularStep }
-
-/-- The packaged row-pivoted Bareiss data is exactly the structured pivot loop
-state finished into public determinant data. This is the equality consumed by the
-Mathlib determinant proof; array storage is erased by `rowsToMatrix`. -/
--- @[grind]-excluded: array-erasure bridge consumed by the Mathlib determinant
--- proof; not a local rewrite.
 theorem bareissData_eq_finish_pivotLoop (M : Matrix Int n n) :
-    bareissData M = finish (pivotLoop n (noPivotInitialState M)) := by
-  simp [bareissData, bareissArrayState, noPivotInitialState, finish,
-    rowsToMatrix_matrixToRows]
+    bareissData M = finish (pivotLoop n (noPivotInitialState M)) :=
+  bareissDataWith_eq_finish_pivotLoopWith (quot := exactDiv) M
 
-/-- Determinant computed by the row-pivoted Bareiss algorithm. -/
-@[expose]
-def bareiss (M : Matrix Int n n) : Int :=
-  let state := bareissArrayState M
-  bareissArrayDet state n
-
-/-- The public row-pivoted determinant agrees with the determinant encoded by
-`bareissData`. This separates executable array evaluation from the packaged
-elimination data used by correctness proofs. -/
--- @[grind]-excluded: one-shot executable-vs-packaged determinant bridge.
 theorem bareiss_eq_bareissData_det (M : Matrix Int n n) :
-    bareiss M = (bareissData M).det := by
-  cases n with
-  | zero =>
-      simp [bareiss, bareissData, bareissArrayDet, BareissData.det,
-        arrayLastDiag?, BareissData.lastDiag?, arraySign, BareissData.sign]
-      rfl
-  | succ k =>
-      simp [bareiss, bareissData, bareissArrayDet, BareissData.det,
-        arrayLastDiag?, BareissData.lastDiag?, rowsToMatrix,
-        arraySign, BareissData.sign]
-      cases (bareissArrayState M).singularStep with
-      | some s => rfl
-      | none =>
-          exact congrArg
-            (fun x => (if (bareissArrayState M).rowSwaps % 2 = 0 then (1 : Int) else -1) * x)
-            (Matrix.getElem_ofFn
-              (fun i j => getEntry (bareissArrayState M).matrix i.val j.val)
-              ⟨k, Nat.lt_succ_self k⟩ ⟨k, Nat.lt_succ_self k⟩).symm
+    bareiss M = (bareissData M).det :=
+  bareissWith_eq_bareissDataWith_det (quot := exactDiv) M
 
-/-- If the no-pivot Bareiss pass reaches the final pivot without recording a
-singular step, then the public row-pivoted `bareiss` determinant is exactly
-the no-pivot final diagonal entry. -/
--- @[grind]-excluded: premise-heavy final-diagonal identity; one-shot.
 theorem bareiss_eq_noPivotLoop_last_of_no_singular {k : Nat}
     (M : Matrix Int (k + 1) (k + 1))
     (h_no_sing :
       (noPivotLoop k (noPivotInitialState M)).singularStep = none) :
     bareiss M =
-      (noPivotLoop k (noPivotInitialState M)).matrix[Fin.last k][Fin.last k] := by
-  let init := noPivotInitialState M
-  let stateK := noPivotLoop k init
-  have h_step : stateK.step = k := by
-    have h := noPivotLoop_step_eq_add_of_singularStep_none k init rfl
-      (by simp [init, noPivotInitialState]) h_no_sing
-    simpa [stateK, init, noPivotInitialState] using h
-  have hDone_stateK : ¬ stateK.step + 1 < k + 1 := by omega
-  have h_full_nopivot : noPivotLoop (k + 1) init = stateK := by
-    rw [noPivotLoop_add k 1 init]
-    exact noPivotLoop_id_at_done 1 stateK hDone_stateK
-  have h_full_sing : (noPivotLoop (k + 1) init).singularStep = none := by
-    rw [h_full_nopivot]
-    exact h_no_sing
-  have hpivot := pivotLoop_eq_noPivotLoop_of_no_singular (k + 1) init h_full_sing
-  rw [bareiss_eq_bareissData_det, bareissData_eq_finish_pivotLoop, hpivot, h_full_nopivot]
-  have hdet := BareissData.det_succ_eq (finish stateK) h_no_sing
-  rw [hdet]
-  simp [finish, BareissData.sign, stateK, init, noPivotInitialState, noPivotLoop_rowSwaps,
-    getRow, Fin.getElem_fin]
+      (noPivotLoop k (noPivotInitialState M)).matrix[Fin.last k][Fin.last k] :=
+  bareissWith_eq_noPivotLoopWith_last_of_no_singular
+    (quot := exactDiv) M h_no_sing Int.one_mul
 
 end Matrix
 end Hex

--- a/HexBareiss/README.md
+++ b/HexBareiss/README.md
@@ -5,7 +5,9 @@ library for Lean 4. The aim is fast executable code, fully verified, built
 with spec-driven development.
 
 `hex-bareiss` provides the executable fraction-free Bareiss determinant of a
-dense integer matrix, computed by Gaussian elimination with exact division.
+dense square matrix over a coefficient type with a caller-supplied exact
+quotient. Its retained `Int` entry points use a directly specialized,
+GMP-backed exact-division path.
 This library depends on [`hex-determinant`](https://github.com/leanprover/hex-determinant)
 and [`hex-matrix`](https://github.com/leanprover/hex-matrix). See
 [`hex-bareiss-mathlib`](https://github.com/leanprover/hex-bareiss-mathlib) for the
@@ -36,29 +38,39 @@ def M : Matrix Int 3 3 := Matrix.ofFn fun i j => (i + 2 * j : Int)
 -- bareissData also records the row-swap count alongside the determinant.
 #eval (Matrix.bareissData M).det
 #eval (Matrix.bareissData M).rowSwaps
+
+-- The same implementation accepts another coefficient type and quotient.
+def Q : Matrix Rat 2 2 := Matrix.ofFn fun i j =>
+  if i = j then (2 : Rat) else 1
+
+#eval Matrix.bareissWith Hex.exactDiv Q
 ```
 
 # Functionality
 
-- `bareiss`: the determinant of a square `Int` matrix via fraction-free
-  Gaussian elimination with row pivoting;
-- `bareissData`: the same elimination, packaged as a `BareissData` record that
+- `bareissWith` and `bareissDataWith`: coefficient-generic fraction-free
+  Gaussian elimination with row pivoting and an explicit quotient operation;
+- `bareiss` and `bareissData`: the directly specialized `Int` entry points;
+- `bareissDataWith` packages the elimination as a `BareissData` record that
   carries the terminal matrix, the row-swap count, and any singular step, with
   `.det` reading off the signed determinant;
-- `bareissNoPivot` and `bareissNoPivotData`: the recurrence without pivot
-  search, for inputs whose leading pivots are already nonzero;
+- `bareissNoPivotWith` and `bareissNoPivotDataWith`, with retained `Int`
+  specializations `bareissNoPivot` and `bareissNoPivotData`: the recurrence
+  without pivot search, for inputs whose leading pivots are already nonzero;
 - `borderedMinor`: the bordered minors that the correctness development uses to
   track the elimination invariant.
 
-The division at each step is `Int.divExact` (GMP-backed `mpz_divexact`), which
-is always exact and carries its divisibility proof.
+The generic functions make their quotient operation explicit. The `Int`
+specialization calls the GMP-backed `lean_int_div_exact` primitive directly;
+exactness is certified separately by the correspondence proof, rather than by
+passing a divisibility proof through the executable loop.
 
 # Verification
 
 The Mathlib-free layer proves the structural properties of the algorithm: the
-exactness of each division, the sign contributed by row swaps, the bordered-minor
-entry formulas, and the agreement between the public `bareiss` value and the
-determinant encoded by `bareissData`.
+sign contributed by row swaps, the bordered-minor entry formulas, and the
+agreement between the public result and its packaged determinant data. The
+Mathlib bridge proves quotient exactness implies agreement with the determinant.
 
 The public determinant agrees with the encoded data, `bareiss_eq_bareissData_det`:
 

--- a/HexBareissMathlib/Bareiss.lean
+++ b/HexBareissMathlib/Bareiss.lean
@@ -41,10 +41,10 @@ variable {hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a}
 theorem isDomain_of_quot (quot : R → R → R)
     (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
     (h1 : (1 : R) ≠ 0) : IsDomain R := by
-  letI : Div R := ⟨quot⟩
-  haveI : Hex.ExactDivLaws R := ⟨hquot⟩
-  letI : Nontrivial R := ⟨⟨1, 0, h1⟩⟩
-  letI : NoZeroDivisors R := ⟨by
+  let _ : Div R := ⟨quot⟩
+  have _ : Hex.ExactDivLaws R := ⟨hquot⟩
+  let _ : Nontrivial R := ⟨⟨1, 0, h1⟩⟩
+  let _ : NoZeroDivisors R := ⟨by
     intro a b hab
     by_cases ha : a = 0
     · exact Or.inl ha
@@ -117,7 +117,7 @@ structure BareissNoPivotInvariant
 /-- The initial Bareiss no-pivot state satisfies the bordered-minor invariant:
 the matrix is the source itself, and the previous-pivot convention is
 `det (principalSubmatrix _ 0 _) = 1`. -/
-theorem bareissNoPivotInvariant_initial {R : Type u} [CommRing R]
+theorem bareissNoPivotInvariant_initialWith {R : Type u} [CommRing R]
     (M : Hex.Matrix R n n) (h1 : (1 : R) ≠ 0) :
     BareissNoPivotInvariant M (Hex.Matrix.noPivotInitialState M) where
   singular_none := rfl
@@ -138,6 +138,11 @@ theorem bareissNoPivotInvariant_initial {R : Type u} [CommRing R]
     show M[i][j] =
         (Hex.Matrix.borderedMinor M 0 h0 i j)[(Fin.last 0)][(Fin.last 0)]
     rw [Hex.Matrix.borderedMinor_entry_last_last]
+
+/-- Integer compatibility form of `bareissNoPivotInvariant_initialWith`. -/
+theorem bareissNoPivotInvariant_initial (M : Hex.Matrix Int n n) :
+    BareissNoPivotInvariant M (Hex.Matrix.noPivotInitialState M) :=
+  bareissNoPivotInvariant_initialWith M (by omega)
 
 /-- One regular no-pivot Bareiss step preserves the bordered-minor invariant.
 Given a state satisfying the invariant with `state.step + 1 < n` and a nonzero
@@ -386,8 +391,8 @@ theorem borderedMinor_zero_column_succ_det_eq_zero_of_entries
                   (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n) j))
               hleft
       _ = 0 := by ring
-  letI : Div R := ⟨quot⟩
-  haveI : Hex.ExactDivLaws R := ⟨hquot⟩
+  let _ : Div R := ⟨quot⟩
+  have _ : Hex.ExactDivLaws R := ⟨hquot⟩
   apply Hex.ExactDivLaws.mul_right_cancel hprev
   simpa using hmul_zero
 
@@ -637,7 +642,7 @@ theorem bareissPivotInvariant_initial {R : Type u} [CommRing R]
     (M : Hex.Matrix R n n) (h1 : (1 : R) ≠ 0) :
     BareissPivotInvariant M (Hex.Matrix.noPivotInitialState M) :=
   ⟨M, by simp [bareissStateSign, Hex.Matrix.noPivotInitialState],
-    bareissNoPivotInvariant_initial M h1⟩
+    bareissNoPivotInvariant_initialWith M h1⟩
 
 /-- A regular row-pivoted Bareiss step that does not swap rows preserves the
 pivoted invariant. -/
@@ -850,7 +855,7 @@ theorem bareissNoPivotInvariant_holds
     BareissNoPivotInvariant M
       (Hex.Matrix.noPivotLoopWith quot n (Hex.Matrix.noPivotInitialState M)) :=
   noPivotLoop_invariant hquot M n (Hex.Matrix.noPivotInitialState M)
-    (bareissNoPivotInvariant_initial M h1)
+    (bareissNoPivotInvariant_initialWith M h1)
     (fun k _ => h k)
 
 /-- Immediate consequence of the bordered-minor invariant: under
@@ -880,7 +885,7 @@ non-singular outcome guarantees every visited pivot was nonzero, which is the
 hypothesis the inductive step needs.
 
 This is the no-pivot analog of `pivotLoop_invariant_of_singularStep_eq_none`. -/
-theorem noPivotLoop_invariant_of_singularStep_eq_none
+theorem noPivotLoopWith_invariant_of_singularStep_eq_none
     (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
     (source : Hex.Matrix R n n)
     (fuel : Nat) (state : Hex.Matrix.BareissState R n)
@@ -903,6 +908,17 @@ theorem noPivotLoop_invariant_of_singularStep_eq_none
           · simpa [Hex.Matrix.noPivotLoopWith_of_regular (quot := quot) fuel state hDone hp0]
               using hregular
       · simpa [Hex.Matrix.noPivotLoopWith_done (quot := quot) fuel state hDone] using hinv
+
+/-- Integer compatibility form of
+`noPivotLoopWith_invariant_of_singularStep_eq_none`. -/
+theorem noPivotLoop_invariant_of_singularStep_eq_none
+    (source : Hex.Matrix Int n n)
+    (fuel : Nat) (state : Hex.Matrix.BareissState Int n)
+    (hinv : BareissNoPivotInvariant source state)
+    (hregular : (Hex.Matrix.noPivotLoop fuel state).singularStep = none) :
+    BareissNoPivotInvariant source (Hex.Matrix.noPivotLoop fuel state) :=
+  noPivotLoopWith_invariant_of_singularStep_eq_none Int.mul_ediv_cancel
+    source fuel state hinv hregular
 
 /-- The no-pivot Bareiss loop preserves the bound `state.step + 1 ≤ n`. -/
 private theorem noPivotLoop_step_succ_le
@@ -1048,7 +1064,7 @@ private theorem bareissNoPivotWith_eq_det_of_one_ne_zero
               + 1 := by
         apply noPivotLoop_step_succ_ge hquot (k + 1)
           (Hex.Matrix.noPivotInitialState M) M
-          (bareissNoPivotInvariant_initial M h1)
+          (bareissNoPivotInvariant_initialWith M h1)
         · intro k' _
           exact h k'
         · show k + 1 ≤ 0 + (k + 1) + 1
@@ -1428,7 +1444,7 @@ theorem det_eq_zero_of_bareiss_failed_column
     (hcol : ∀ i : Fin n, k ≤ i.val →
       Hex.Matrix.det (Hex.Matrix.borderedMinor source k hk i ⟨k, hk⟩) = 0) :
     Hex.Matrix.det source = 0 := by
-  letI : IsDomain R := isDomain_of_quot quot hquot h1
+  let _ : IsDomain R := isDomain_of_quot quot hquot h1
   obtain ⟨α, hα_ne, _hα_above, hmulvec⟩ :=
     failed_bareiss_column_dependence source k hk hprev hcol
   have hdet_zero : Matrix.det (matrixEquiv source) = 0 := by
@@ -1784,7 +1800,7 @@ at `(a, c)` with `k + 1 ≤ a.val, c.val` equals the determinant of the
 `(k + 2) × (k + 2)` bordered minor of `M` with trailing row `a` and column
 `c`, provided the partial loop records no singular step.
 
-Composes `noPivotLoop_invariant_of_singularStep_eq_none` (the invariant
+Composes `noPivotLoopWith_invariant_of_singularStep_eq_none` (the invariant
 propagates through a non-singular partial pass), `BareissNoPivotInvariant`
 (the trailing-block entries equal bordered-minor determinants), and
 `noPivotLoop_step_eq_add_of_singularStep_none` (the partial pass advances
@@ -1802,8 +1818,8 @@ theorem noPivotLoop_full_eq_borderedMinor_det
       Hex.Matrix.det (Hex.Matrix.borderedMinor M (k + 1) hk a c) := by
   have hinv : BareissNoPivotInvariant M
       (Hex.Matrix.noPivotLoopWith quot (k + 1) (Hex.Matrix.noPivotInitialState M)) :=
-    noPivotLoop_invariant_of_singularStep_eq_none hquot M (k + 1)
-      (Hex.Matrix.noPivotInitialState M) (bareissNoPivotInvariant_initial M h1)
+    noPivotLoopWith_invariant_of_singularStep_eq_none hquot M (k + 1)
+      (Hex.Matrix.noPivotInitialState M) (bareissNoPivotInvariant_initialWith M h1)
       h_no_sing
   have hstep_eq :
       k + 1 =

--- a/HexBareissMathlib/Bareiss.lean
+++ b/HexBareissMathlib/Bareiss.lean
@@ -84,7 +84,7 @@ The implication on diagonal entries (`state.matrix[k][k]` agrees with the
 leading-prefix determinant of size `k + 1`) follows from `trailing_eq` taken
 at `i = j = ⟨k, _⟩` together with `borderedMinor_corner_eq_principalSubmatrix`. -/
 structure BareissNoPivotInvariant
-    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState n) : Prop where
+    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState Int n) : Prop where
   singular_none : state.singularStep = none
   step_le : state.step ≤ n
   prevPivot_eq :
@@ -126,7 +126,7 @@ Given a state satisfying the invariant with `state.step + 1 < n` and a nonzero
 diagonal pivot, the state produced by one `noPivotLoop` iteration also
 satisfies the invariant. -/
 private theorem bareissNoPivotInvariant_step
-    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState n)
+    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState Int n)
     (hinv : BareissNoPivotInvariant source state)
     (hDone : state.step + 1 < n)
     (hp : state.matrix[(⟨state.step, Nat.lt_of_succ_lt hDone⟩ : Fin n)][
@@ -239,7 +239,7 @@ When the current diagonal pivot is already nonzero, the row-pivoted loop takes
 the same regular step as the no-pivot loop, so the bordered-minor invariant is
 preserved by the existing no-pivot step proof. -/
 theorem bareissPivotInvariant_regular_no_swap
-    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState n)
+    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState Int n)
     (hinv : BareissNoPivotInvariant source state)
     (hDone : state.step + 1 < n)
     (hp : state.matrix[state.step][state.step] ≠ 0) :
@@ -255,7 +255,7 @@ theorem bareissPivotInvariant_regular_no_swap
 /-- In the pivot-search failure branch, the current pivot column is zero at
 and below the current step. -/
 theorem bareissPivotNoPivot_column_eq_zero
-    (state : Hex.Matrix.BareissState n) (hDone : state.step + 1 < n)
+    (state : Hex.Matrix.BareissState Int n) (hDone : state.step + 1 < n)
     (hp0 : state.matrix[state.step][state.step] = 0)
     (hfind :
       Hex.Matrix.findPivot? state.matrix
@@ -281,7 +281,7 @@ theorem bareissPivotNoPivot_column_eq_zero
 /-- In the pivot-search failure branch, the bordered-minor invariant identifies
 the zero current pivot with the next leading-prefix determinant. -/
 theorem bareissPivotNoPivot_principalSubmatrix_det_eq_zero
-    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState n)
+    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState Int n)
     (hinv : BareissNoPivotInvariant source state)
     (hDone : state.step + 1 < n)
     (hp0 : state.matrix[state.step][state.step] = 0)
@@ -383,7 +383,7 @@ theorem borderedMinor_zero_column_succ_det_eq_zero
       simpa using hcol i (Nat.le_of_lt hi))
 
 private theorem findPivot?_some_ne_current
-    (state : Hex.Matrix.BareissState n) (hDone : state.step + 1 < n)
+    (state : Hex.Matrix.BareissState Int n) (hDone : state.step + 1 < n)
     {pivot : Fin n}
     (hfind :
       Hex.Matrix.findPivot? state.matrix
@@ -404,7 +404,7 @@ private theorem findPivot?_some_ne_current
 flips sign. This is the determinant-side row-swap fact needed by the
 row-pivoted Bareiss invariant. -/
 theorem bareissPivotRegularSwap_det
-    (state : Hex.Matrix.BareissState n) (hDone : state.step + 1 < n)
+    (state : Hex.Matrix.BareissState Int n) (hDone : state.step + 1 < n)
     {pivot : Fin n}
     (hfind :
       Hex.Matrix.findPivot? state.matrix
@@ -511,7 +511,7 @@ match, the row-swap counter increments, and `state.step` is unchanged.
 The subsequent stepMatrix update is then handled by
 `bareissPivotInvariant_regular_no_swap` applied to the swapped source. -/
 theorem bareissPivotInvariant_regular_swap
-    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState n)
+    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState Int n)
     (hinv : BareissNoPivotInvariant source state)
     (hDone : state.step + 1 < n)
     {pivot : Fin n}
@@ -573,12 +573,12 @@ private theorem bareissSign_succ (swaps : Nat) :
   omega
 
 /-- Incrementing the row-swap counter flips the Bareiss sign. -/
-theorem bareissData_sign_succ (data : Hex.Matrix.BareissData n) :
+theorem bareissData_sign_succ (data : Hex.Matrix.BareissData Int n) :
     ({ data with rowSwaps := data.rowSwaps + 1 }).sign = -data.sign := by
   simp [Hex.Matrix.BareissData.sign, bareissSign_succ]
 
 @[expose]
-def bareissStateSign (state : Hex.Matrix.BareissState n) : Int :=
+def bareissStateSign (state : Hex.Matrix.BareissState Int n) : Int :=
   if state.rowSwaps % 2 = 0 then 1 else -1
 
 /-- Row-pivoted Bareiss invariant. The current working state is interpreted as
@@ -587,7 +587,7 @@ by the row swaps already performed; the sign field records the determinant
 relation back to the original source. -/
 @[expose]
 def BareissPivotInvariant
-    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState n) : Prop :=
+    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState Int n) : Prop :=
   ∃ logicalSource : Hex.Matrix Int n n,
     Hex.Matrix.det source = bareissStateSign state * Hex.Matrix.det logicalSource ∧
       BareissNoPivotInvariant logicalSource state
@@ -602,7 +602,7 @@ theorem bareissPivotInvariant_initial (M : Hex.Matrix Int n n) :
 /-- A regular row-pivoted Bareiss step that does not swap rows preserves the
 pivoted invariant. -/
 theorem bareissPivotInvariant_regular_no_swap_step
-    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState n)
+    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState Int n)
     (hinv : BareissPivotInvariant source state)
     (hDone : state.step + 1 < n)
     (hp : state.matrix[state.step][state.step] ≠ 0) :
@@ -618,7 +618,7 @@ theorem bareissPivotInvariant_regular_no_swap_step
     bareissPivotInvariant_regular_no_swap logicalSource state hnopiv hDone hp⟩
 
 private theorem bareissPivotInvariant_swap_source
-    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState n)
+    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState Int n)
     (hinv : BareissPivotInvariant source state)
     (hDone : state.step + 1 < n)
     {pivot : Fin n}
@@ -648,7 +648,7 @@ private theorem bareissPivotInvariant_swap_source
       bareissPivotInvariant_regular_swap logicalSource state hnopiv hDone hfind
 
 private theorem pivotLoop_swap_pivot_ne_zero
-    (state : Hex.Matrix.BareissState n)
+    (state : Hex.Matrix.BareissState Int n)
     (hDone : state.step + 1 < n)
     {pivot : Fin n}
     (hfind :
@@ -675,7 +675,7 @@ private theorem pivotLoop_swap_pivot_ne_zero
 /-- A regular row-pivoted Bareiss step that swaps rows preserves the pivoted
 invariant. -/
 theorem bareissPivotInvariant_regular_swap_step
-    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState n)
+    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState Int n)
     (hinv : BareissPivotInvariant source state)
     (hDone : state.step + 1 < n)
     {pivot : Fin n}
@@ -714,13 +714,13 @@ theorem bareissPivotInvariant_regular_swap_step
 no singular step, then the final state still satisfies the pivoted invariant. -/
 theorem pivotLoop_invariant_of_singularStep_eq_none
     (source : Hex.Matrix Int n n)
-    (fuel : Nat) (state : Hex.Matrix.BareissState n)
+    (fuel : Nat) (state : Hex.Matrix.BareissState Int n)
     (hinv : BareissPivotInvariant source state)
     (hregular : (Hex.Matrix.pivotLoop fuel state).singularStep = none) :
     BareissPivotInvariant source (Hex.Matrix.pivotLoop fuel state) := by
   induction fuel generalizing state with
   | zero =>
-      simpa [Hex.Matrix.pivotLoop] using hinv
+      simpa only [Hex.Matrix.pivotLoop_zero_fuel] using hinv
   | succ fuel ih =>
       by_cases hDone : state.step + 1 < n
       · by_cases hp0 : state.matrix[state.step][state.step] = 0
@@ -757,7 +757,7 @@ satisfies `BareissNoPivotInvariant`, if every future leading-prefix determinant
 after running `noPivotLoop` for any amount of fuel. -/
 theorem noPivotLoop_invariant
     (source : Hex.Matrix Int n n)
-    (fuel : Nat) (state : Hex.Matrix.BareissState n)
+    (fuel : Nat) (state : Hex.Matrix.BareissState Int n)
     (hinv : BareissNoPivotInvariant source state)
     (hpivots : ∀ (k : Fin n), state.step ≤ k.val →
       Hex.Matrix.det
@@ -833,13 +833,13 @@ hypothesis the inductive step needs.
 This is the no-pivot analog of `pivotLoop_invariant_of_singularStep_eq_none`. -/
 theorem noPivotLoop_invariant_of_singularStep_eq_none
     (source : Hex.Matrix Int n n)
-    (fuel : Nat) (state : Hex.Matrix.BareissState n)
+    (fuel : Nat) (state : Hex.Matrix.BareissState Int n)
     (hinv : BareissNoPivotInvariant source state)
     (hregular : (Hex.Matrix.noPivotLoop fuel state).singularStep = none) :
     BareissNoPivotInvariant source (Hex.Matrix.noPivotLoop fuel state) := by
   induction fuel generalizing state with
   | zero =>
-      simpa [Hex.Matrix.noPivotLoop] using hinv
+      simpa only [Hex.Matrix.noPivotLoop_zero_fuel] using hinv
   | succ fuel ih =>
       by_cases hDone : state.step + 1 < n
       · by_cases hp0 :
@@ -856,7 +856,7 @@ theorem noPivotLoop_invariant_of_singularStep_eq_none
 
 /-- The no-pivot Bareiss loop preserves the bound `state.step + 1 ≤ n`. -/
 private theorem noPivotLoop_step_succ_le
-    (fuel : Nat) (state : Hex.Matrix.BareissState n) (h : state.step + 1 ≤ n) :
+    (fuel : Nat) (state : Hex.Matrix.BareissState Int n) (h : state.step + 1 ≤ n) :
     (Hex.Matrix.noPivotLoop fuel state).step + 1 ≤ n := by
   induction fuel generalizing state with
   | zero =>
@@ -879,7 +879,7 @@ private theorem noPivotLoop_step_succ_le
 /-- Under `NonzeroBareissPivots`, the no-pivot Bareiss loop run with enough
 fuel reaches a final step satisfying `state.step + 1 ≥ n`. -/
 private theorem noPivotLoop_step_succ_ge
-    (fuel : Nat) (state : Hex.Matrix.BareissState n)
+    (fuel : Nat) (state : Hex.Matrix.BareissState Int n)
     (source : Hex.Matrix Int n n)
     (hinv : BareissNoPivotInvariant source state)
     (hpivots : ∀ (k : Fin n), state.step ≤ k.val →
@@ -933,7 +933,7 @@ Stated with `state` as an explicit free variable so that `state.step = k` can
 be substituted via `subst`. -/
 private theorem trailing_corner_entry_eq_det
     (k : Nat) (M : Hex.Matrix Int (k + 1) (k + 1))
-    (state : Hex.Matrix.BareissState (k + 1))
+    (state : Hex.Matrix.BareissState Int (k + 1))
     (hinv : BareissNoPivotInvariant M state)
     (hstep : state.step = k) :
     state.matrix[(⟨k, Nat.lt_succ_self k⟩ : Fin (k + 1))][
@@ -1353,7 +1353,7 @@ theorem det_eq_zero_of_bareiss_failed_column
 /-- If row-pivoted Bareiss pivot search fails in a state satisfying the
 pivoted invariant, then the original source determinant is zero. -/
 theorem bareissPivotInvariant_singular_no_pivot_det_eq_zero
-    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState n)
+    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState Int n)
     (hinv : BareissPivotInvariant source state)
     (hDone : state.step + 1 < n)
     (hp0 : state.matrix[state.step][state.step] = 0)
@@ -1396,14 +1396,15 @@ satisfying the pivoted invariant, then the original source determinant is
 zero. -/
 theorem pivotLoop_singularStep_ne_none_det_eq_zero
     (source : Hex.Matrix Int n n)
-    (fuel : Nat) (state : Hex.Matrix.BareissState n)
+    (fuel : Nat) (state : Hex.Matrix.BareissState Int n)
     (hinv : BareissPivotInvariant source state)
     (hsing : (Hex.Matrix.pivotLoop fuel state).singularStep ≠ none) :
     Hex.Matrix.det source = 0 := by
   induction fuel generalizing state with
   | zero =>
       rcases hinv with ⟨_, _, hnopiv⟩
-      simp [Hex.Matrix.pivotLoop, hnopiv.singular_none] at hsing
+      simp only [Hex.Matrix.pivotLoop_zero_fuel, hnopiv.singular_none] at hsing
+      exact (hsing rfl).elim
   | succ fuel ih =>
       by_cases hDone : state.step + 1 < n
       · by_cases hp0 : state.matrix[state.step][state.step] = 0
@@ -1433,7 +1434,7 @@ theorem pivotLoop_singularStep_ne_none_det_eq_zero
 determinant to be zero. -/
 theorem pivotLoop_singularStep_eq_some_det_eq_zero
     (source : Hex.Matrix Int n n)
-    (fuel : Nat) (state : Hex.Matrix.BareissState n)
+    (fuel : Nat) (state : Hex.Matrix.BareissState Int n)
     (hinv : BareissPivotInvariant source state) {k : Nat}
     (hsing : (Hex.Matrix.pivotLoop fuel state).singularStep = some k) :
     Hex.Matrix.det source = 0 :=
@@ -1463,7 +1464,7 @@ theorem bareissData_singularStep_ne_none_det_eq_zero
   simpa [Hex.Matrix.bareissData_eq_finish_pivotLoop, Hex.Matrix.finish] using hregular
 
 private theorem pivotLoop_step_succ_le
-    (fuel : Nat) (state : Hex.Matrix.BareissState n) (h : state.step + 1 ≤ n) :
+    (fuel : Nat) (state : Hex.Matrix.BareissState Int n) (h : state.step + 1 ≤ n) :
     (Hex.Matrix.pivotLoop fuel state).step + 1 ≤ n := by
   induction fuel generalizing state with
   | zero =>
@@ -1496,7 +1497,7 @@ private theorem pivotLoop_step_succ_le
         exact h
 
 private theorem pivotLoop_step_succ_ge_of_regular
-    (fuel : Nat) (state : Hex.Matrix.BareissState n)
+    (fuel : Nat) (state : Hex.Matrix.BareissState Int n)
     (hregular : (Hex.Matrix.pivotLoop fuel state).singularStep = none)
     (hfuel : n ≤ state.step + fuel + 1) :
     n ≤ (Hex.Matrix.pivotLoop fuel state).step + 1 := by
@@ -1636,7 +1637,7 @@ proof terms. Lets callers consume `trailing_eq` at an arbitrary numeric step
 value `s` known to equal `state.step` without manually transporting the
 inequality proofs. -/
 private theorem trailing_eq_at_step
-    {M : Hex.Matrix Int n n} {state : Hex.Matrix.BareissState n}
+    {M : Hex.Matrix Int n n} {state : Hex.Matrix.BareissState Int n}
     (hinv : BareissNoPivotInvariant M state)
     (s : Nat) (hs : s < n) (hstep : s = state.step)
     (a c : Fin n) (hsa : s ≤ a.val) (hsc : s ≤ c.val) :

--- a/HexBareissMathlib/Bareiss.lean
+++ b/HexBareissMathlib/Bareiss.lean
@@ -23,7 +23,7 @@ determinants are nonzero (`NonzeroBareissPivots`), the loop never takes the
 singular branch.
 
 The invariant proof composes the bordered-minor `stepMatrix` update lemma
-(`Hex.Matrix.stepMatrix_borderedMinor_update`) with the bordered-minor
+(`Hex.Matrix.stepMatrixWith_borderedMinor_update`) with the bordered-minor
 specialization of Desnanot-Jacobi (`desnanot_jacobi_borderedMinor` in the
 parent module) and the exact-division equation
 (`bareissExactDiv_borderedMinor_of_mul_eq`).
@@ -33,13 +33,30 @@ namespace HexMatrixMathlib
 
 universe u
 
-variable {n : Nat}
+variable {R : Type u} [CommRing R] [DecidableEq R] {n : Nat}
+variable {quot : R → R → R}
+variable {hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a}
+
+/-- An exact quotient makes a nontrivial commutative ring an integral domain. -/
+theorem isDomain_of_quot (quot : R → R → R)
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (h1 : (1 : R) ≠ 0) : IsDomain R := by
+  letI : Div R := ⟨quot⟩
+  haveI : Hex.ExactDivLaws R := ⟨hquot⟩
+  letI : Nontrivial R := ⟨⟨1, 0, h1⟩⟩
+  letI : NoZeroDivisors R := ⟨by
+    intro a b hab
+    by_cases ha : a = 0
+    · exact Or.inl ha
+    by_cases hb : b = 0
+    · exact Or.inr hb
+    exact (Hex.ExactDivLaws.mul_ne_zero ha hb hab).elim⟩
+  exact NoZeroDivisors.to_isDomain R
 
 /-- The `k`-bordered minor of `M` at the corner row/column `⟨k, hk⟩` is exactly
 the `(k + 1)`-leading prefix of `M`. This identifies the trailing-corner entry
 under the no-pivot Bareiss invariant with a leading-prefix determinant. -/
 theorem borderedMinor_corner_eq_principalSubmatrix {R : Type u}
-    [Lean.Grind.Ring R]
     (M : Hex.Matrix R n n) (k : Nat) (hk : k < n) :
     Hex.Matrix.borderedMinor M k hk ⟨k, hk⟩ ⟨k, hk⟩ =
       Hex.Matrix.principalSubmatrix M (k + 1) (Nat.succ_le_of_lt hk) := by
@@ -66,7 +83,7 @@ theorem borderedMinor_corner_eq_principalSubmatrix {R : Type u}
 /-- Hypothesis used by the no-pivot Bareiss soundness proof: every leading
 prefix determinant up to size `n` is nonzero. -/
 @[expose]
-def NonzeroBareissPivots (M : Hex.Matrix Int n n) : Prop :=
+def NonzeroBareissPivots (M : Hex.Matrix R n n) : Prop :=
   ∀ k : Fin n,
     Hex.Matrix.det
       (Hex.Matrix.principalSubmatrix M (k.val + 1) (Nat.succ_le_of_lt k.isLt)) ≠ 0
@@ -84,7 +101,7 @@ The implication on diagonal entries (`state.matrix[k][k]` agrees with the
 leading-prefix determinant of size `k + 1`) follows from `trailing_eq` taken
 at `i = j = ⟨k, _⟩` together with `borderedMinor_corner_eq_principalSubmatrix`. -/
 structure BareissNoPivotInvariant
-    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState Int n) : Prop where
+    (source : Hex.Matrix R n n) (state : Hex.Matrix.BareissState R n) : Prop where
   singular_none : state.singularStep = none
   step_le : state.step ≤ n
   prevPivot_eq :
@@ -100,16 +117,17 @@ structure BareissNoPivotInvariant
 /-- The initial Bareiss no-pivot state satisfies the bordered-minor invariant:
 the matrix is the source itself, and the previous-pivot convention is
 `det (principalSubmatrix _ 0 _) = 1`. -/
-theorem bareissNoPivotInvariant_initial (M : Hex.Matrix Int n n) :
+theorem bareissNoPivotInvariant_initial {R : Type u} [CommRing R]
+    (M : Hex.Matrix R n n) (h1 : (1 : R) ≠ 0) :
     BareissNoPivotInvariant M (Hex.Matrix.noPivotInitialState M) where
   singular_none := rfl
   step_le := Nat.zero_le _
   prevPivot_eq := by
-    show (1 : Int) = Hex.Matrix.det (Hex.Matrix.principalSubmatrix M 0 (Nat.zero_le n))
+    show (1 : R) = Hex.Matrix.det (Hex.Matrix.principalSubmatrix M 0 (Nat.zero_le n))
     simp
   prevPivot_ne := by
-    show (1 : Int) ≠ 0
-    decide
+    show (1 : R) ≠ 0
+    exact h1
   trailing_eq := by
     intro h i j _hi _hj
     have h0 : 0 < n := by omega
@@ -126,14 +144,17 @@ Given a state satisfying the invariant with `state.step + 1 < n` and a nonzero
 diagonal pivot, the state produced by one `noPivotLoop` iteration also
 satisfies the invariant. -/
 private theorem bareissNoPivotInvariant_step
-    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState Int n)
+    {R : Type u} [CommRing R]
+    (quot : R → R → R)
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (source : Hex.Matrix R n n) (state : Hex.Matrix.BareissState R n)
     (hinv : BareissNoPivotInvariant source state)
     (hDone : state.step + 1 < n)
     (hp : state.matrix[(⟨state.step, Nat.lt_of_succ_lt hDone⟩ : Fin n)][
         (⟨state.step, Nat.lt_of_succ_lt hDone⟩ : Fin n)] ≠ 0) :
     BareissNoPivotInvariant source
       { step := state.step + 1
-        matrix := Hex.Matrix.stepMatrix state.matrix state.step
+        matrix := Hex.Matrix.stepMatrixWith quot state.matrix state.step
           (state.matrix[(⟨state.step, Nat.lt_of_succ_lt hDone⟩ : Fin n)][
             (⟨state.step, Nat.lt_of_succ_lt hDone⟩ : Fin n)]) state.prevPivot
         prevPivot := state.matrix[(⟨state.step, Nat.lt_of_succ_lt hDone⟩ : Fin n)][
@@ -211,7 +232,7 @@ private theorem bareissNoPivotInvariant_step
       rw [hinv.prevPivot_eq]
       exact desnanot_jacobi_borderedMinor source state.step hk hnext i j hi' hj'
     have hexact :
-        Hex.Matrix.exactDiv
+        quot
             (Hex.Matrix.det (Hex.Matrix.borderedMinor source state.step hk
               (⟨state.step, Nat.lt_trans hj' j.isLt⟩ : Fin n)
               (⟨state.step, Nat.lt_trans hi' i.isLt⟩ : Fin n)) *
@@ -222,14 +243,14 @@ private theorem bareissNoPivotInvariant_step
                 (⟨state.step, Nat.lt_trans hj' j.isLt⟩ : Fin n) j))
             state.prevPivot =
           Hex.Matrix.det (Hex.Matrix.borderedMinor source (state.step + 1) hnext i j) :=
-      bareissExactDiv_borderedMinor_of_mul_eq source state.step hk hnext i j
+      Hex.Matrix.exactQuot_borderedMinor_of_mul_eq quot hquot source state.step hk hnext i j
         hi' hj' state.prevPivot hinv.prevPivot_ne hdesnanot
     -- Apply `stepMatrix_borderedMinor_update` to obtain the updated entry.
-    show (Hex.Matrix.stepMatrix state.matrix state.step
+    show (Hex.Matrix.stepMatrixWith quot state.matrix state.step
         (state.matrix[(⟨state.step, hk⟩ : Fin n)][(⟨state.step, hk⟩ : Fin n)])
         state.prevPivot)[i][j] =
       Hex.Matrix.det (Hex.Matrix.borderedMinor source (state.step + 1) hnext i j)
-    exact Hex.Matrix.stepMatrix_borderedMinor_update source state.matrix
+    exact Hex.Matrix.stepMatrixWith_borderedMinor_update quot source state.matrix
       state.step hk hnext i j hi' hj'
       (state.matrix[(⟨state.step, hk⟩ : Fin n)][(⟨state.step, hk⟩ : Fin n)])
       state.prevPivot hpivot_eq hentry hleft htop hexact
@@ -239,23 +260,26 @@ When the current diagonal pivot is already nonzero, the row-pivoted loop takes
 the same regular step as the no-pivot loop, so the bordered-minor invariant is
 preserved by the existing no-pivot step proof. -/
 theorem bareissPivotInvariant_regular_no_swap
-    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState Int n)
+    {R : Type u} [CommRing R]
+    (quot : R → R → R)
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (source : Hex.Matrix R n n) (state : Hex.Matrix.BareissState R n)
     (hinv : BareissNoPivotInvariant source state)
     (hDone : state.step + 1 < n)
     (hp : state.matrix[state.step][state.step] ≠ 0) :
     BareissNoPivotInvariant source
       { step := state.step + 1
-        matrix := Hex.Matrix.stepMatrix state.matrix state.step
+        matrix := Hex.Matrix.stepMatrixWith quot state.matrix state.step
           state.matrix[state.step][state.step] state.prevPivot
         prevPivot := state.matrix[state.step][state.step]
         rowSwaps := state.rowSwaps
         singularStep := none } :=
-  bareissNoPivotInvariant_step source state hinv hDone hp
+  bareissNoPivotInvariant_step quot hquot source state hinv hDone hp
 
 /-- In the pivot-search failure branch, the current pivot column is zero at
 and below the current step. -/
 theorem bareissPivotNoPivot_column_eq_zero
-    (state : Hex.Matrix.BareissState Int n) (hDone : state.step + 1 < n)
+    (state : Hex.Matrix.BareissState R n) (hDone : state.step + 1 < n)
     (hp0 : state.matrix[state.step][state.step] = 0)
     (hfind :
       Hex.Matrix.findPivot? state.matrix
@@ -281,7 +305,7 @@ theorem bareissPivotNoPivot_column_eq_zero
 /-- In the pivot-search failure branch, the bordered-minor invariant identifies
 the zero current pivot with the next leading-prefix determinant. -/
 theorem bareissPivotNoPivot_principalSubmatrix_det_eq_zero
-    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState Int n)
+    (source : Hex.Matrix R n n) (state : Hex.Matrix.BareissState R n)
     (hinv : BareissNoPivotInvariant source state)
     (hDone : state.step + 1 < n)
     (hp0 : state.matrix[state.step][state.step] = 0)
@@ -315,7 +339,10 @@ proof is the Desnanot-Jacobi recurrence: both numerator terms contain a zero
 minor from the failed pivot column, and the previous leading-prefix pivot is
 nonzero, so the next determinant must vanish. -/
 theorem borderedMinor_zero_column_succ_det_eq_zero_of_entries
-    (source : Hex.Matrix Int n n) (k : Nat) (hk : k < n) (hnext : k + 1 < n)
+    {R : Type u} [CommRing R]
+    (quot : R → R → R)
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (source : Hex.Matrix R n n) (k : Nat) (hk : k < n) (hnext : k + 1 < n)
     (hprev :
       Hex.Matrix.det (Hex.Matrix.principalSubmatrix source k (Nat.le_of_lt hk)) ≠ 0)
     (i j : Fin n) (hi : k < i.val) (hj : k < j.val)
@@ -359,14 +386,20 @@ theorem borderedMinor_zero_column_succ_det_eq_zero_of_entries
                   (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n) j))
               hleft
       _ = 0 := by ring
-  exact (Int.mul_eq_zero.mp hmul_zero).resolve_right hprev
+  letI : Div R := ⟨quot⟩
+  haveI : Hex.ExactDivLaws R := ⟨hquot⟩
+  apply Hex.ExactDivLaws.mul_right_cancel hprev
+  simpa using hmul_zero
 
-/-- Column-shaped form of `borderedMinor_zero_column_succ_det_eq_zero_of_entries`.
+/-- Column-shaped form of `borderedMinor_zero_column_succ_det_eq_zero_of_entries quot hquot`.
 This is the API used by the singular row-pivoted Bareiss branch: failed pivot
 search supplies a zero current pivot column, and the bordered-minor invariant
 transports that to this determinant column hypothesis. -/
 theorem borderedMinor_zero_column_succ_det_eq_zero
-    (source : Hex.Matrix Int n n) (k : Nat) (hk : k < n) (hnext : k + 1 < n)
+    {R : Type u} [CommRing R]
+    (quot : R → R → R)
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (source : Hex.Matrix R n n) (k : Nat) (hk : k < n) (hnext : k + 1 < n)
     (hprev :
       Hex.Matrix.det (Hex.Matrix.principalSubmatrix source k (Nat.le_of_lt hk)) ≠ 0)
     (hcol : ∀ i : Fin n, k ≤ i.val →
@@ -374,7 +407,7 @@ theorem borderedMinor_zero_column_succ_det_eq_zero
         (Hex.Matrix.borderedMinor source k hk i (⟨k, hk⟩ : Fin n)) = 0)
     (i j : Fin n) (hi : k < i.val) (hj : k < j.val) :
     Hex.Matrix.det (Hex.Matrix.borderedMinor source (k + 1) hnext i j) = 0 :=
-  borderedMinor_zero_column_succ_det_eq_zero_of_entries source k hk hnext hprev
+  borderedMinor_zero_column_succ_det_eq_zero_of_entries quot hquot source k hk hnext hprev
     i j hi hj
     (by
       simpa using
@@ -383,7 +416,7 @@ theorem borderedMinor_zero_column_succ_det_eq_zero
       simpa using hcol i (Nat.le_of_lt hi))
 
 private theorem findPivot?_some_ne_current
-    (state : Hex.Matrix.BareissState Int n) (hDone : state.step + 1 < n)
+    (state : Hex.Matrix.BareissState R n) (hDone : state.step + 1 < n)
     {pivot : Fin n}
     (hfind :
       Hex.Matrix.findPivot? state.matrix
@@ -404,7 +437,7 @@ private theorem findPivot?_some_ne_current
 flips sign. This is the determinant-side row-swap fact needed by the
 row-pivoted Bareiss invariant. -/
 theorem bareissPivotRegularSwap_det
-    (state : Hex.Matrix.BareissState Int n) (hDone : state.step + 1 < n)
+    (state : Hex.Matrix.BareissState R n) (hDone : state.step + 1 < n)
     {pivot : Fin n}
     (hfind :
       Hex.Matrix.findPivot? state.matrix
@@ -511,7 +544,7 @@ match, the row-swap counter increments, and `state.step` is unchanged.
 The subsequent stepMatrix update is then handled by
 `bareissPivotInvariant_regular_no_swap` applied to the swapped source. -/
 theorem bareissPivotInvariant_regular_swap
-    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState Int n)
+    (source : Hex.Matrix R n n) (state : Hex.Matrix.BareissState R n)
     (hinv : BareissNoPivotInvariant source state)
     (hDone : state.step + 1 < n)
     {pivot : Fin n}
@@ -567,18 +600,24 @@ theorem bareissPivotInvariant_regular_swap
       · simp only [if_neg hip, if_neg hik]
         exact hinv.trailing_eq hk i j hi hj
 
-private theorem bareissSign_succ (swaps : Nat) :
-    (if (swaps + 1) % 2 = 0 then (1 : Int) else -1) =
-      -(if swaps % 2 = 0 then (1 : Int) else -1) := by
-  omega
+private theorem bareissSign_succ {R : Type u} [CommRing R] (swaps : Nat) :
+    (if (swaps + 1) % 2 = 0 then (1 : R) else -1) =
+      -(if swaps % 2 = 0 then (1 : R) else -1) := by
+  by_cases h : swaps % 2 = 0
+  · have hs : (swaps + 1) % 2 ≠ 0 := by omega
+    simp [h, hs]
+  · have hs : (swaps + 1) % 2 = 0 := by omega
+    simp [h, hs]
 
 /-- Incrementing the row-swap counter flips the Bareiss sign. -/
-theorem bareissData_sign_succ (data : Hex.Matrix.BareissData Int n) :
+theorem bareissData_sign_succ {R : Type u} [CommRing R]
+    (data : Hex.Matrix.BareissData R n) :
     ({ data with rowSwaps := data.rowSwaps + 1 }).sign = -data.sign := by
   simp [Hex.Matrix.BareissData.sign, bareissSign_succ]
 
+/-- Sign contributed by the row swaps recorded in a Bareiss state. -/
 @[expose]
-def bareissStateSign (state : Hex.Matrix.BareissState Int n) : Int :=
+def bareissStateSign (state : Hex.Matrix.BareissState R n) : R :=
   if state.rowSwaps % 2 = 0 then 1 else -1
 
 /-- Row-pivoted Bareiss invariant. The current working state is interpreted as
@@ -587,38 +626,42 @@ by the row swaps already performed; the sign field records the determinant
 relation back to the original source. -/
 @[expose]
 def BareissPivotInvariant
-    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState Int n) : Prop :=
-  ∃ logicalSource : Hex.Matrix Int n n,
+    (source : Hex.Matrix R n n) (state : Hex.Matrix.BareissState R n) : Prop :=
+  ∃ logicalSource : Hex.Matrix R n n,
     Hex.Matrix.det source = bareissStateSign state * Hex.Matrix.det logicalSource ∧
       BareissNoPivotInvariant logicalSource state
 
 /-- The initial row-pivoted Bareiss state satisfies the pivoted invariant with
 the original matrix as its logical source. -/
-theorem bareissPivotInvariant_initial (M : Hex.Matrix Int n n) :
+theorem bareissPivotInvariant_initial {R : Type u} [CommRing R]
+    (M : Hex.Matrix R n n) (h1 : (1 : R) ≠ 0) :
     BareissPivotInvariant M (Hex.Matrix.noPivotInitialState M) :=
   ⟨M, by simp [bareissStateSign, Hex.Matrix.noPivotInitialState],
-    bareissNoPivotInvariant_initial M⟩
+    bareissNoPivotInvariant_initial M h1⟩
 
 /-- A regular row-pivoted Bareiss step that does not swap rows preserves the
 pivoted invariant. -/
 theorem bareissPivotInvariant_regular_no_swap_step
-    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState Int n)
+    {R : Type u} [CommRing R]
+    (quot : R → R → R)
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (source : Hex.Matrix R n n) (state : Hex.Matrix.BareissState R n)
     (hinv : BareissPivotInvariant source state)
     (hDone : state.step + 1 < n)
     (hp : state.matrix[state.step][state.step] ≠ 0) :
     BareissPivotInvariant source
       { step := state.step + 1
-        matrix := Hex.Matrix.stepMatrix state.matrix state.step
+        matrix := Hex.Matrix.stepMatrixWith quot state.matrix state.step
           state.matrix[state.step][state.step] state.prevPivot
         prevPivot := state.matrix[state.step][state.step]
         rowSwaps := state.rowSwaps
         singularStep := none } := by
   rcases hinv with ⟨logicalSource, hdet, hnopiv⟩
   exact ⟨logicalSource, hdet,
-    bareissPivotInvariant_regular_no_swap logicalSource state hnopiv hDone hp⟩
+    bareissPivotInvariant_regular_no_swap quot hquot logicalSource state hnopiv hDone hp⟩
 
 private theorem bareissPivotInvariant_swap_source
-    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState Int n)
+    (source : Hex.Matrix R n n) (state : Hex.Matrix.BareissState R n)
     (hinv : BareissPivotInvariant source state)
     (hDone : state.step + 1 < n)
     {pivot : Fin n}
@@ -648,7 +691,7 @@ private theorem bareissPivotInvariant_swap_source
       bareissPivotInvariant_regular_swap logicalSource state hnopiv hDone hfind
 
 private theorem pivotLoop_swap_pivot_ne_zero
-    (state : Hex.Matrix.BareissState Int n)
+    (state : Hex.Matrix.BareissState R n)
     (hDone : state.step + 1 < n)
     {pivot : Fin n}
     (hfind :
@@ -675,7 +718,8 @@ private theorem pivotLoop_swap_pivot_ne_zero
 /-- A regular row-pivoted Bareiss step that swaps rows preserves the pivoted
 invariant. -/
 theorem bareissPivotInvariant_regular_swap_step
-    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState Int n)
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (source : Hex.Matrix R n n) (state : Hex.Matrix.BareissState R n)
     (hinv : BareissPivotInvariant source state)
     (hDone : state.step + 1 < n)
     {pivot : Fin n}
@@ -685,7 +729,7 @@ theorem bareissPivotInvariant_regular_swap_step
         (state.step + 1) = some pivot) :
     BareissPivotInvariant source
       { step := state.step + 1
-        matrix := Hex.Matrix.stepMatrix
+        matrix := Hex.Matrix.stepMatrixWith quot
           (Hex.Matrix.rowSwap state.matrix
             (⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩ : Fin n)
             pivot)
@@ -702,7 +746,7 @@ theorem bareissPivotInvariant_regular_swap_step
         singularStep := none } := by
   have hswapped :=
     bareissPivotInvariant_swap_source source state hinv hDone hfind
-  exact bareissPivotInvariant_regular_no_swap_step source
+  exact bareissPivotInvariant_regular_no_swap_step quot hquot source
     { state with
         matrix := Hex.Matrix.rowSwap state.matrix
           (⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩ : Fin n)
@@ -713,14 +757,15 @@ theorem bareissPivotInvariant_regular_swap_step
 /-- Recursive row-pivoted Bareiss invariant. If a `pivotLoop` run finishes with
 no singular step, then the final state still satisfies the pivoted invariant. -/
 theorem pivotLoop_invariant_of_singularStep_eq_none
-    (source : Hex.Matrix Int n n)
-    (fuel : Nat) (state : Hex.Matrix.BareissState Int n)
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (source : Hex.Matrix R n n)
+    (fuel : Nat) (state : Hex.Matrix.BareissState R n)
     (hinv : BareissPivotInvariant source state)
-    (hregular : (Hex.Matrix.pivotLoop fuel state).singularStep = none) :
-    BareissPivotInvariant source (Hex.Matrix.pivotLoop fuel state) := by
+    (hregular : (Hex.Matrix.pivotLoopWith quot fuel state).singularStep = none) :
+    BareissPivotInvariant source (Hex.Matrix.pivotLoopWith quot fuel state) := by
   induction fuel generalizing state with
   | zero =>
-      simpa only [Hex.Matrix.pivotLoop_zero_fuel] using hinv
+      simpa only [Hex.Matrix.pivotLoopWith_zero_fuel (quot := quot)] using hinv
   | succ fuel ih =>
       by_cases hDone : state.step + 1 < n
       · by_cases hp0 : state.matrix[state.step][state.step] = 0
@@ -730,43 +775,44 @@ theorem pivotLoop_invariant_of_singularStep_eq_none
               Hex.Matrix.findPivot? state.matrix kFin (state.step + 1) with
           | none =>
               have hloop :=
-                Hex.Matrix.pivotLoop_of_singular_no_pivot fuel state hDone hp0
+                Hex.Matrix.pivotLoopWith_of_singular_no_pivot (quot := quot) fuel state hDone hp0
                   (by simpa [kFin] using hfind)
               rw [hloop] at hregular
               simp at hregular
           | some pivot =>
               have hp :=
                 pivotLoop_swap_pivot_ne_zero state hDone (by simpa [kFin] using hfind)
-              rw [Hex.Matrix.pivotLoop_of_regular_swap fuel state hDone hp0
+              rw [Hex.Matrix.pivotLoopWith_of_regular_swap (quot := quot) fuel state hDone hp0
                 (by simpa [kFin] using hfind) hp]
               apply ih
-              · exact bareissPivotInvariant_regular_swap_step source state hinv hDone
+              · exact bareissPivotInvariant_regular_swap_step hquot source state hinv hDone
                   (by simpa [kFin] using hfind)
-              · simpa [Hex.Matrix.pivotLoop_of_regular_swap fuel state hDone hp0
+              · simpa [Hex.Matrix.pivotLoopWith_of_regular_swap (quot := quot) fuel state hDone hp0
                   (by simpa [kFin] using hfind) hp] using hregular
-        · rw [Hex.Matrix.pivotLoop_of_regular_no_swap fuel state hDone hp0]
+        · rw [Hex.Matrix.pivotLoopWith_of_regular_no_swap (quot := quot) fuel state hDone hp0]
           apply ih
-          · exact bareissPivotInvariant_regular_no_swap_step source state hinv hDone hp0
-          · simpa [Hex.Matrix.pivotLoop_of_regular_no_swap fuel state hDone hp0]
+          · exact bareissPivotInvariant_regular_no_swap_step quot hquot source state hinv hDone hp0
+          · simpa [Hex.Matrix.pivotLoopWith_of_regular_no_swap (quot := quot) fuel state hDone hp0]
               using hregular
-      · simpa [Hex.Matrix.pivotLoop_done fuel state hDone] using hinv
+      · simpa [Hex.Matrix.pivotLoopWith_done (quot := quot) fuel state hDone] using hinv
 
 /-- The recursive no-pivot Bareiss invariant: starting from any state that
 satisfies `BareissNoPivotInvariant`, if every future leading-prefix determinant
 (from `state.step` up to `n`) is nonzero, then the invariant continues to hold
 after running `noPivotLoop` for any amount of fuel. -/
 theorem noPivotLoop_invariant
-    (source : Hex.Matrix Int n n)
-    (fuel : Nat) (state : Hex.Matrix.BareissState Int n)
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (source : Hex.Matrix R n n)
+    (fuel : Nat) (state : Hex.Matrix.BareissState R n)
     (hinv : BareissNoPivotInvariant source state)
     (hpivots : ∀ (k : Fin n), state.step ≤ k.val →
       Hex.Matrix.det
         (Hex.Matrix.principalSubmatrix source (k.val + 1) (Nat.succ_le_of_lt k.isLt))
           ≠ 0) :
-    BareissNoPivotInvariant source (Hex.Matrix.noPivotLoop fuel state) := by
+    BareissNoPivotInvariant source (Hex.Matrix.noPivotLoopWith quot fuel state) := by
   induction fuel generalizing state with
   | zero =>
-      simp [Hex.Matrix.noPivotLoop]
+      simp [Hex.Matrix.noPivotLoopWith]
       exact hinv
   | succ fuel ih =>
       by_cases hDone : state.step + 1 < n
@@ -786,43 +832,46 @@ theorem noPivotLoop_invariant
               (⟨state.step, hk⟩ : Fin n)] ≠ 0 := by
           rw [hpivot_idx]
           exact hpivots ⟨state.step, hk⟩ (Nat.le_refl _)
-        rw [Hex.Matrix.noPivotLoop_of_regular fuel state hDone hp_ne]
+        rw [Hex.Matrix.noPivotLoopWith_of_regular (quot := quot) fuel state hDone hp_ne]
         -- Apply IH on the next state.
         apply ih
-        · exact bareissNoPivotInvariant_step source state hinv hDone hp_ne
+        · exact bareissNoPivotInvariant_step quot hquot source state hinv hDone hp_ne
         · intro k' hk'
           change state.step + 1 ≤ k'.val at hk'
           exact hpivots k' (Nat.le_of_succ_le hk')
-      · simp [Hex.Matrix.noPivotLoop_done fuel state hDone]
+      · simp [Hex.Matrix.noPivotLoopWith_done (quot := quot) fuel state hDone]
         exact hinv
 
 /-- Under `NonzeroBareissPivots`, the no-pivot Bareiss recurrence run from the
 initial state satisfies the bordered-minor invariant. -/
 theorem bareissNoPivotInvariant_holds
-    (M : Hex.Matrix Int n n) (h : NonzeroBareissPivots M) :
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (h1 : (1 : R) ≠ 0) (M : Hex.Matrix R n n) (h : NonzeroBareissPivots M) :
     BareissNoPivotInvariant M
-      (Hex.Matrix.noPivotLoop n (Hex.Matrix.noPivotInitialState M)) :=
-  noPivotLoop_invariant M n (Hex.Matrix.noPivotInitialState M)
-    (bareissNoPivotInvariant_initial M)
+      (Hex.Matrix.noPivotLoopWith quot n (Hex.Matrix.noPivotInitialState M)) :=
+  noPivotLoop_invariant hquot M n (Hex.Matrix.noPivotInitialState M)
+    (bareissNoPivotInvariant_initial M h1)
     (fun k _ => h k)
 
 /-- Immediate consequence of the bordered-minor invariant: under
 `NonzeroBareissPivots`, the no-pivot Bareiss recurrence never takes the
 singular branch. -/
 theorem noPivotLoop_singularStep_eq_none
-    (M : Hex.Matrix Int n n) (h : NonzeroBareissPivots M) :
-    (Hex.Matrix.noPivotLoop n (Hex.Matrix.noPivotInitialState M)).singularStep =
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (h1 : (1 : R) ≠ 0) (M : Hex.Matrix R n n) (h : NonzeroBareissPivots M) :
+    (Hex.Matrix.noPivotLoopWith quot n (Hex.Matrix.noPivotInitialState M)).singularStep =
       none :=
-  (bareissNoPivotInvariant_holds M h).singular_none
+  (bareissNoPivotInvariant_holds hquot h1 M h).singular_none
 
 /-- Public corollary: under `NonzeroBareissPivots`, the executable no-pivot
 Bareiss data records no singular step. -/
 theorem bareissNoPivotData_singularStep_eq_none
-    (M : Hex.Matrix Int n n) (h : NonzeroBareissPivots M) :
-    (Hex.Matrix.bareissNoPivotData M).singularStep = none := by
-  show (Hex.Matrix.noPivotLoop n (Hex.Matrix.noPivotInitialState M)).singularStep
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (h1 : (1 : R) ≠ 0) (M : Hex.Matrix R n n) (h : NonzeroBareissPivots M) :
+    (Hex.Matrix.bareissNoPivotDataWith quot M).singularStep = none := by
+  show (Hex.Matrix.noPivotLoopWith quot n (Hex.Matrix.noPivotInitialState M)).singularStep
       = none
-  exact noPivotLoop_singularStep_eq_none M h
+  exact noPivotLoop_singularStep_eq_none hquot h1 M h
 
 /-- Outcome-driven companion of `noPivotLoop_invariant`: if the no-pivot
 Bareiss loop run from a valid invariant state does NOT record a singular step
@@ -832,32 +881,33 @@ hypothesis the inductive step needs.
 
 This is the no-pivot analog of `pivotLoop_invariant_of_singularStep_eq_none`. -/
 theorem noPivotLoop_invariant_of_singularStep_eq_none
-    (source : Hex.Matrix Int n n)
-    (fuel : Nat) (state : Hex.Matrix.BareissState Int n)
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (source : Hex.Matrix R n n)
+    (fuel : Nat) (state : Hex.Matrix.BareissState R n)
     (hinv : BareissNoPivotInvariant source state)
-    (hregular : (Hex.Matrix.noPivotLoop fuel state).singularStep = none) :
-    BareissNoPivotInvariant source (Hex.Matrix.noPivotLoop fuel state) := by
+    (hregular : (Hex.Matrix.noPivotLoopWith quot fuel state).singularStep = none) :
+    BareissNoPivotInvariant source (Hex.Matrix.noPivotLoopWith quot fuel state) := by
   induction fuel generalizing state with
   | zero =>
-      simpa only [Hex.Matrix.noPivotLoop_zero_fuel] using hinv
+      simpa only [Hex.Matrix.noPivotLoopWith_zero_fuel (quot := quot)] using hinv
   | succ fuel ih =>
       by_cases hDone : state.step + 1 < n
       · by_cases hp0 :
             state.matrix[(⟨state.step, Nat.lt_of_succ_lt hDone⟩ : Fin n)][
               (⟨state.step, Nat.lt_of_succ_lt hDone⟩ : Fin n)] = 0
-        · rw [Hex.Matrix.noPivotLoop_of_singular fuel state hDone hp0] at hregular
+        · rw [Hex.Matrix.noPivotLoopWith_of_singular (quot := quot) fuel state hDone hp0] at hregular
           simp at hregular
-        · rw [Hex.Matrix.noPivotLoop_of_regular fuel state hDone hp0]
+        · rw [Hex.Matrix.noPivotLoopWith_of_regular (quot := quot) fuel state hDone hp0]
           apply ih
-          · exact bareissNoPivotInvariant_step source state hinv hDone hp0
-          · simpa [Hex.Matrix.noPivotLoop_of_regular fuel state hDone hp0]
+          · exact bareissNoPivotInvariant_step quot hquot source state hinv hDone hp0
+          · simpa [Hex.Matrix.noPivotLoopWith_of_regular (quot := quot) fuel state hDone hp0]
               using hregular
-      · simpa [Hex.Matrix.noPivotLoop_done fuel state hDone] using hinv
+      · simpa [Hex.Matrix.noPivotLoopWith_done (quot := quot) fuel state hDone] using hinv
 
 /-- The no-pivot Bareiss loop preserves the bound `state.step + 1 ≤ n`. -/
 private theorem noPivotLoop_step_succ_le
-    (fuel : Nat) (state : Hex.Matrix.BareissState Int n) (h : state.step + 1 ≤ n) :
-    (Hex.Matrix.noPivotLoop fuel state).step + 1 ≤ n := by
+    (fuel : Nat) (state : Hex.Matrix.BareissState R n) (h : state.step + 1 ≤ n) :
+    (Hex.Matrix.noPivotLoopWith quot fuel state).step + 1 ≤ n := by
   induction fuel generalizing state with
   | zero =>
       show state.step + 1 ≤ n
@@ -867,27 +917,28 @@ private theorem noPivotLoop_step_succ_le
       · by_cases hp :
             state.matrix[(⟨state.step, Nat.lt_of_succ_lt hDone⟩ : Fin n)][
               (⟨state.step, Nat.lt_of_succ_lt hDone⟩ : Fin n)] = 0
-        · rw [Hex.Matrix.noPivotLoop_of_singular fuel state hDone hp]
+        · rw [Hex.Matrix.noPivotLoopWith_of_singular (quot := quot) fuel state hDone hp]
           exact h
-        · rw [Hex.Matrix.noPivotLoop_of_regular fuel state hDone hp]
+        · rw [Hex.Matrix.noPivotLoopWith_of_regular (quot := quot) fuel state hDone hp]
           apply ih
           show state.step + 1 + 1 ≤ n
           omega
-      · rw [Hex.Matrix.noPivotLoop_done fuel state hDone]
+      · rw [Hex.Matrix.noPivotLoopWith_done (quot := quot) fuel state hDone]
         exact h
 
 /-- Under `NonzeroBareissPivots`, the no-pivot Bareiss loop run with enough
 fuel reaches a final step satisfying `state.step + 1 ≥ n`. -/
 private theorem noPivotLoop_step_succ_ge
-    (fuel : Nat) (state : Hex.Matrix.BareissState Int n)
-    (source : Hex.Matrix Int n n)
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (fuel : Nat) (state : Hex.Matrix.BareissState R n)
+    (source : Hex.Matrix R n n)
     (hinv : BareissNoPivotInvariant source state)
     (hpivots : ∀ (k : Fin n), state.step ≤ k.val →
       Hex.Matrix.det
         (Hex.Matrix.principalSubmatrix source (k.val + 1) (Nat.succ_le_of_lt k.isLt))
           ≠ 0)
     (hfuel : n ≤ state.step + fuel + 1) :
-    n ≤ (Hex.Matrix.noPivotLoop fuel state).step + 1 := by
+    n ≤ (Hex.Matrix.noPivotLoopWith quot fuel state).step + 1 := by
   induction fuel generalizing state with
   | zero =>
       show n ≤ state.step + 1
@@ -907,20 +958,20 @@ private theorem noPivotLoop_step_succ_ge
             state.matrix[(⟨state.step, hk⟩ : Fin n)][(⟨state.step, hk⟩ : Fin n)] ≠ 0 := by
           rw [hpivot_idx]
           exact hpivots ⟨state.step, hk⟩ (Nat.le_refl _)
-        rw [Hex.Matrix.noPivotLoop_of_regular fuel state hDone hp_ne]
+        rw [Hex.Matrix.noPivotLoopWith_of_regular (quot := quot) fuel state hDone hp_ne]
         apply ih
-        · exact bareissNoPivotInvariant_step source state hinv hDone hp_ne
+        · exact bareissNoPivotInvariant_step quot hquot source state hinv hDone hp_ne
         · intro k' hk'
           change state.step + 1 ≤ k'.val at hk'
           exact hpivots k' (Nat.le_of_succ_le hk')
         · show n ≤ state.step + 1 + fuel + 1
           omega
-      · rw [Hex.Matrix.noPivotLoop_done fuel state hDone]
+      · rw [Hex.Matrix.noPivotLoopWith_done (quot := quot) fuel state hDone]
         show n ≤ state.step + 1
         omega
 
 /-- The leading prefix of size `n` of an `n × n` matrix is the matrix itself. -/
-private theorem principalSubmatrix_self {R : Type u} [Lean.Grind.Ring R]
+private theorem principalSubmatrix_self {R : Type u}
     (M : Hex.Matrix R n n) (h : n ≤ n) :
     Hex.Matrix.principalSubmatrix M n h = M := by
   apply Hex.Matrix.ext_getElem
@@ -932,8 +983,9 @@ equals `k`, the `(k, k)` entry of the working matrix equals `Hex.Matrix.det M`.
 Stated with `state` as an explicit free variable so that `state.step = k` can
 be substituted via `subst`. -/
 private theorem trailing_corner_entry_eq_det
-    (k : Nat) (M : Hex.Matrix Int (k + 1) (k + 1))
-    (state : Hex.Matrix.BareissState Int (k + 1))
+    {R : Type u} [CommRing R]
+    (k : Nat) (M : Hex.Matrix R (k + 1) (k + 1))
+    (state : Hex.Matrix.BareissState R (k + 1))
     (hinv : BareissNoPivotInvariant M state)
     (hstep : state.step = k) :
     state.matrix[(⟨k, Nat.lt_succ_self k⟩ : Fin (k + 1))][
@@ -957,67 +1009,90 @@ private theorem trailing_corner_entry_eq_det
 
 /-- Under `NonzeroBareissPivots`, the no-pivot Bareiss recurrence
 computes the Mathlib determinant of the source matrix. -/
-theorem bareissNoPivot_eq_det
-    (M : Hex.Matrix Int n n) (h : NonzeroBareissPivots M) :
-    Hex.Matrix.bareissNoPivot M = Matrix.det (matrixEquiv M) := by
+private theorem bareissNoPivotWith_eq_det_of_one_ne_zero
+    (quot : R → R → R)
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (h1 : (1 : R) ≠ 0) (M : Hex.Matrix R n n) (h : NonzeroBareissPivots M) :
+    Hex.Matrix.bareissNoPivotWith quot M = Matrix.det (matrixEquiv M) := by
   -- The no-pivot Bareiss data has `singularStep = none` (no zero pivot) and
   -- `rowSwaps = 0` (the no-pivot loop never swaps rows), giving sign `1`.
-  have hdata_sing : (Hex.Matrix.bareissNoPivotData M).singularStep = none :=
-    bareissNoPivotData_singularStep_eq_none M h
-  have hdata_swaps : (Hex.Matrix.bareissNoPivotData M).rowSwaps = 0 := by
-    show (Hex.Matrix.noPivotLoop n (Hex.Matrix.noPivotInitialState M)).rowSwaps = 0
-    rw [Hex.Matrix.noPivotLoop_rowSwaps]
+  have hdata_sing : (Hex.Matrix.bareissNoPivotDataWith quot M).singularStep = none :=
+    bareissNoPivotData_singularStep_eq_none hquot h1 M h
+  have hdata_swaps : (Hex.Matrix.bareissNoPivotDataWith quot M).rowSwaps = 0 := by
+    show (Hex.Matrix.noPivotLoopWith quot n (Hex.Matrix.noPivotInitialState M)).rowSwaps = 0
+    rw [Hex.Matrix.noPivotLoopWith_rowSwaps (quot := quot)]
     rfl
-  have hdata_sign : (Hex.Matrix.bareissNoPivotData M).sign = 1 := by
+  have hdata_sign : (Hex.Matrix.bareissNoPivotDataWith quot M).sign = 1 := by
     unfold Hex.Matrix.BareissData.sign
     rw [hdata_swaps]
-    decide
+    rfl
   match n, M, h with
   | 0, M, _ =>
       -- Empty matrix: Hex side is `sign = 1` by `det_zero_eq`,
       -- Mathlib side is `1` by `Matrix.det_isEmpty`.
-      show (Hex.Matrix.bareissNoPivotData M).det = Matrix.det (matrixEquiv M)
+      show (Hex.Matrix.bareissNoPivotDataWith quot M).det = Matrix.det (matrixEquiv M)
       rw [Hex.Matrix.BareissData.det_zero_eq _ hdata_sing, hdata_sign,
         Matrix.det_isEmpty]
   | k + 1, M, h =>
-      have hinv := bareissNoPivotInvariant_holds M h
+      have hinv := bareissNoPivotInvariant_holds hquot h1 M h
       have hk : k < k + 1 := Nat.lt_succ_self k
       -- The final step equals `k = (k + 1) - 1`.
       have hstep_le :
-          (Hex.Matrix.noPivotLoop (k + 1) (Hex.Matrix.noPivotInitialState M)).step + 1 ≤
+          (Hex.Matrix.noPivotLoopWith quot (k + 1) (Hex.Matrix.noPivotInitialState M)).step + 1 ≤
             k + 1 :=
         noPivotLoop_step_succ_le (k + 1) (Hex.Matrix.noPivotInitialState M)
           (by show 0 + 1 ≤ k + 1; omega)
       have hstep_ge :
           k + 1 ≤
-            (Hex.Matrix.noPivotLoop (k + 1) (Hex.Matrix.noPivotInitialState M)).step
+            (Hex.Matrix.noPivotLoopWith quot (k + 1) (Hex.Matrix.noPivotInitialState M)).step
               + 1 := by
-        apply noPivotLoop_step_succ_ge (k + 1)
+        apply noPivotLoop_step_succ_ge hquot (k + 1)
           (Hex.Matrix.noPivotInitialState M) M
-          (bareissNoPivotInvariant_initial M)
+          (bareissNoPivotInvariant_initial M h1)
         · intro k' _
           exact h k'
         · show k + 1 ≤ 0 + (k + 1) + 1
           omega
       have hstep_eq :
-          (Hex.Matrix.noPivotLoop (k + 1) (Hex.Matrix.noPivotInitialState M)).step
+          (Hex.Matrix.noPivotLoopWith quot (k + 1) (Hex.Matrix.noPivotInitialState M)).step
             = k := by
         omega
       -- The (k, k) entry of the final matrix equals `det M`.
       have hentry :
-          (Hex.Matrix.noPivotLoop (k + 1)
+          (Hex.Matrix.noPivotLoopWith quot (k + 1)
               (Hex.Matrix.noPivotInitialState M)).matrix[(⟨k, hk⟩ : Fin (k + 1))][
                 (⟨k, hk⟩ : Fin (k + 1))] =
             Hex.Matrix.det M :=
         trailing_corner_entry_eq_det k M
-          (Hex.Matrix.noPivotLoop (k + 1) (Hex.Matrix.noPivotInitialState M))
+          (Hex.Matrix.noPivotLoopWith quot (k + 1) (Hex.Matrix.noPivotInitialState M))
           hinv hstep_eq
       -- Combine: BareissData.det = sign * (k, k) entry = 1 * det M = det M.
-      show (Hex.Matrix.bareissNoPivotData M).det = Matrix.det (matrixEquiv M)
+      show (Hex.Matrix.bareissNoPivotDataWith quot M).det = Matrix.det (matrixEquiv M)
       rw [Hex.Matrix.BareissData.det_succ_eq _ hdata_sing, hdata_sign, one_mul,
-        show (Hex.Matrix.bareissNoPivotData M).matrix[(⟨k, hk⟩ : Fin (k + 1))][
+        show (Hex.Matrix.bareissNoPivotDataWith quot M).matrix[(⟨k, hk⟩ : Fin (k + 1))][
             (⟨k, hk⟩ : Fin (k + 1))] = Hex.Matrix.det M from hentry]
       exact det_eq M
+
+/-- A no-pivot Bareiss computation over any commutative ring with an exact
+quotient agrees with Mathlib's determinant when its leading pivots are
+nonzero. No separate nontriviality or domain assumption is required. -/
+theorem bareissNoPivotWith_eq_det
+    (quot : R → R → R)
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (M : Hex.Matrix R n n) (h : NonzeroBareissPivots M) :
+    Hex.Matrix.bareissNoPivotWith quot M = Matrix.det (matrixEquiv M) := by
+  by_cases h1 : (1 : R) = 0
+  · have hz : ∀ x : R, x = 0 := by
+      intro x
+      rw [← one_mul x, h1, zero_mul]
+    exact (hz _).trans (hz _).symm
+  · exact bareissNoPivotWith_eq_det_of_one_ne_zero quot hquot h1 M h
+
+/-- Integer compatibility specialization of `bareissNoPivotWith_eq_det`. -/
+theorem bareissNoPivot_eq_det
+    (M : Hex.Matrix Int n n) (h : NonzeroBareissPivots M) :
+    Hex.Matrix.bareissNoPivot M = Matrix.det (matrixEquiv M) :=
+  bareissNoPivotWith_eq_det Hex.Matrix.exactDiv Int.mul_ediv_cancel M h
 
 /-! # Failed Bareiss column dependence
 
@@ -1035,8 +1110,8 @@ dependence: leading `k` rows of `source`, restricted to columns `0..k-1`
 followed by column `k`. -/
 @[expose]
 def failedBareissTopBlock
-    (source : Hex.Matrix Int n n) (k : Nat) (hk : k < n) :
-    Matrix (Fin k) (Fin (k + 1)) Int :=
+    (source : Hex.Matrix R n n) (k : Nat) (hk : k < n) :
+    Matrix (Fin k) (Fin (k + 1)) R :=
   fun s c =>
     if hc : c.val < k then
       matrixEquiv source (⟨s.val, Nat.lt_trans s.isLt hk⟩ : Fin n)
@@ -1050,8 +1125,8 @@ def failedBareissTopBlock
 `det (principalSubmatrix source k _)`; see `failedBareissColumn_at_pivot`. -/
 @[expose]
 noncomputable def failedBareissColumn
-    (source : Hex.Matrix Int n n) (k : Nat) (hk : k < n) :
-    Fin n → Int :=
+    (source : Hex.Matrix R n n) (k : Nat) (hk : k < n) :
+    Fin n → R :=
   fun c =>
     if hc : c.val ≤ k then
       (-1) ^ (k + c.val) *
@@ -1061,14 +1136,16 @@ noncomputable def failedBareissColumn
     else 0
 
 theorem failedBareissColumn_above_pivot
-    (source : Hex.Matrix Int n n) (k : Nat) (hk : k < n)
+    {R : Type u} [CommRing R]
+    (source : Hex.Matrix R n n) (k : Nat) (hk : k < n)
     (c : Fin n) (hc : k < c.val) :
     failedBareissColumn source k hk c = 0 := by
-  show (if h : c.val ≤ k then _ else (0 : Int)) = 0
+  show (if h : c.val ≤ k then _ else (0 : R)) = 0
   rw [dif_neg (Nat.not_le_of_lt hc)]
 
 private theorem failedBareissTopBlock_apply_lt
-    (source : Hex.Matrix Int n n) (k : Nat) (hk : k < n)
+    {R : Type u}
+    (source : Hex.Matrix R n n) (k : Nat) (hk : k < n)
     (s : Fin k) (c : Fin (k + 1)) (hc : c.val < k) :
     failedBareissTopBlock source k hk s c =
       matrixEquiv source (⟨s.val, Nat.lt_trans s.isLt hk⟩ : Fin n)
@@ -1077,7 +1154,8 @@ private theorem failedBareissTopBlock_apply_lt
   rw [dif_pos hc]
 
 private theorem failedBareissTopBlock_apply_last
-    (source : Hex.Matrix Int n n) (k : Nat) (hk : k < n)
+    {R : Type u}
+    (source : Hex.Matrix R n n) (k : Nat) (hk : k < n)
     (s : Fin k) :
     failedBareissTopBlock source k hk s (Fin.last k) =
       matrixEquiv source (⟨s.val, Nat.lt_trans s.isLt hk⟩ : Fin n) ⟨k, hk⟩ := by
@@ -1086,7 +1164,8 @@ private theorem failedBareissTopBlock_apply_last
   rw [dif_neg (Nat.lt_irrefl k)]
 
 private theorem failedBareissTopBlock_succAbove_last
-    (source : Hex.Matrix Int n n) (k : Nat) (hk : k < n) :
+    {R : Type u}
+    (source : Hex.Matrix R n n) (k : Nat) (hk : k < n) :
     (failedBareissTopBlock source k hk).submatrix id (Fin.last k).succAbove =
       matrixEquiv (Hex.Matrix.principalSubmatrix source k (Nat.le_of_lt hk)) := by
   ext s t
@@ -1100,7 +1179,8 @@ private theorem failedBareissTopBlock_succAbove_last
   rfl
 
 theorem failedBareissColumn_at_pivot
-    (source : Hex.Matrix Int n n) (k : Nat) (hk : k < n) :
+    {R : Type u} [CommRing R]
+    (source : Hex.Matrix R n n) (k : Nat) (hk : k < n) :
     failedBareissColumn source k hk ⟨k, hk⟩ =
       Hex.Matrix.det (Hex.Matrix.principalSubmatrix source k (Nat.le_of_lt hk)) := by
   show (if hc : (⟨k, hk⟩ : Fin n).val ≤ k then
@@ -1109,19 +1189,19 @@ theorem failedBareissColumn_at_pivot
           (⟨(⟨k, hk⟩ : Fin n).val, Nat.lt_succ_of_le hc⟩ : Fin (k + 1)).succAbove)
       else 0) = _
   rw [dif_pos (le_refl k)]
-  have hsign : (-1 : Int) ^ (k + k) = 1 := by
+  have hsign : (-1 : R) ^ (k + k) = 1 := by
     rw [← Nat.two_mul, pow_mul]; norm_num
-  show (-1 : Int) ^ (k + k) *
+  show (-1 : R) ^ (k + k) *
       Matrix.det ((failedBareissTopBlock source k hk).submatrix id
         (Fin.last k).succAbove) = _
   rw [hsign, one_mul, failedBareissTopBlock_succAbove_last, ← det_eq]
-  rfl
 
 /-- The bordered minor's `(Fin.last k, c')` entry equals
 `matrixEquiv source r ⟨c'.val, _⟩` (independent of which subcase of `c'.val < k`
 vs `c'.val = k` we are in). -/
 private theorem matrixEquiv_borderedMinor_apply_last
-    (source : Hex.Matrix Int n n) (k : Nat) (hk : k < n) (r : Fin n)
+    {R : Type u}
+    (source : Hex.Matrix R n n) (k : Nat) (hk : k < n) (r : Fin n)
     (c' : Fin (k + 1)) :
     ((matrixEquiv source).submatrix
         (fun r' : Fin (k + 1) =>
@@ -1152,7 +1232,8 @@ private theorem matrixEquiv_borderedMinor_apply_last
 /-- The cofactor minor of the bordered minor (with the last row removed) equals
 the corresponding submatrix of the top block. -/
 private theorem submatrix_borderedMinor_succAbove_last_eq_topBlock
-    (source : Hex.Matrix Int n n) (k : Nat) (hk : k < n) (r : Fin n)
+    {R : Type u}
+    (source : Hex.Matrix R n n) (k : Nat) (hk : k < n) (r : Fin n)
     (c' : Fin (k + 1)) :
     ((matrixEquiv source).submatrix
         (fun r' : Fin (k + 1) =>
@@ -1190,7 +1271,8 @@ private theorem submatrix_borderedMinor_succAbove_last_eq_topBlock
 trailing row `r` and trailing column `⟨k, _⟩`. This is the cofactor expansion
 of the bordered minor along its last row. -/
 private theorem failedBareissColumn_dot_row_eq_borderedMinor_det
-    (source : Hex.Matrix Int n n) (k : Nat) (hk : k < n) (r : Fin n) :
+    {R : Type u} [CommRing R]
+    (source : Hex.Matrix R n n) (k : Nat) (hk : k < n) (r : Fin n) :
     ∑ c : Fin n, failedBareissColumn source k hk c * matrixEquiv source r c =
       Matrix.det
         (matrixEquiv (Hex.Matrix.borderedMinor source k hk r ⟨k, hk⟩)) := by
@@ -1237,28 +1319,29 @@ private theorem failedBareissColumn_dot_row_eq_borderedMinor_det
         (-1) ^ (k + c'.val) *
           Matrix.det
             ((failedBareissTopBlock source k hk).submatrix id c'.succAbove) := by
-    show (if hc : (φ c').val ≤ k then _ else (0 : Int)) = _
+    show (if hc : (φ c').val ≤ k then _ else (0 : R)) = _
     rw [dif_pos hφc'_le, hφc'_eq_c', hφ_apply]
   rw [hα_eq, matrixEquiv_borderedMinor_apply_last source k hk r c',
       submatrix_borderedMinor_succAbove_last_eq_topBlock source k hk r c']
   -- Now reduce both sides to a normal form.
-  show (-1 : Int) ^ (k + c'.val) *
+  show (-1 : R) ^ (k + c'.val) *
       Matrix.det ((failedBareissTopBlock source k hk).submatrix id c'.succAbove) *
       matrixEquiv source r (φ c') =
-    (-1 : Int) ^ ((Fin.last k : Fin (k + 1)).val + c'.val) *
+    (-1 : R) ^ ((Fin.last k : Fin (k + 1)).val + c'.val) *
       matrixEquiv source r
         (⟨c'.val, Nat.lt_of_le_of_lt (Nat.le_of_lt_succ c'.isLt) hk⟩ : Fin n) *
       Matrix.det ((failedBareissTopBlock source k hk).submatrix id c'.succAbove)
   simp only [Fin.val_last]
-  show (-1 : Int) ^ (k + c'.val) * _ * matrixEquiv source r (φ c') =
-    (-1 : Int) ^ (k + c'.val) * matrixEquiv source r (φ c') * _
+  show (-1 : R) ^ (k + c'.val) * _ * matrixEquiv source r (φ c') =
+    (-1 : R) ^ (k + c'.val) * matrixEquiv source r (φ c') * _
   ring
 
 /-- For row `r` with `r.val < k`, the bordered minor at level `k` with trailing
 row `r` has two equal rows (the `r.val`-th leading row and the trailing row),
 so its determinant is zero. -/
 private theorem matrixEquiv_borderedMinor_det_eq_zero_of_row_lt
-    (source : Hex.Matrix Int n n) (k : Nat) (hk : k < n) (r : Fin n) (hr : r.val < k) :
+    {R : Type u} [CommRing R]
+    (source : Hex.Matrix R n n) (k : Nat) (hk : k < n) (r : Fin n) (hr : r.val < k) :
     Matrix.det
       (matrixEquiv (Hex.Matrix.borderedMinor source k hk r ⟨k, hk⟩)) = 0 := by
   rw [matrixEquiv_borderedMinor source k hk r ⟨k, hk⟩]
@@ -1291,14 +1374,15 @@ The construction is the standard cofactor/adjugate trick: cofactor expansion
 along the last row of the `(k+1)`-bordered minors yields the coefficient
 function `failedBareissColumn`. -/
 theorem failed_bareiss_column_dependence
-    (source : Hex.Matrix Int n n) (k : Nat) (hk : k < n)
+    {R : Type u} [CommRing R]
+    (source : Hex.Matrix R n n) (k : Nat) (hk : k < n)
     (hprev :
       Hex.Matrix.det (Hex.Matrix.principalSubmatrix source k (Nat.le_of_lt hk)) ≠ 0)
     (hcol :
       ∀ i : Fin n, k ≤ i.val →
         Hex.Matrix.det
           (Hex.Matrix.borderedMinor source k hk i (⟨k, hk⟩ : Fin n)) = 0) :
-    ∃ α : Fin n → Int,
+    ∃ α : Fin n → R,
       α ⟨k, hk⟩ ≠ 0 ∧
         (∀ c : Fin n, k < c.val → α c = 0) ∧
         (matrixEquiv source).mulVec α = 0 := by
@@ -1335,12 +1419,16 @@ hypothesis here. The proof obtains a nonzero kernel vector for
 `matrixEquiv source` from `failed_bareiss_column_dependence`, then closes the
 determinant via `Matrix.exists_mulVec_eq_zero_iff`. -/
 theorem det_eq_zero_of_bareiss_failed_column
-    (source : Hex.Matrix Int n n) (k : Nat) (hk : k < n)
+    (quot : R → R → R)
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (h1 : (1 : R) ≠ 0)
+    (source : Hex.Matrix R n n) (k : Nat) (hk : k < n)
     (hprev :
       Hex.Matrix.det (Hex.Matrix.principalSubmatrix source k (Nat.le_of_lt hk)) ≠ 0)
     (hcol : ∀ i : Fin n, k ≤ i.val →
       Hex.Matrix.det (Hex.Matrix.borderedMinor source k hk i ⟨k, hk⟩) = 0) :
     Hex.Matrix.det source = 0 := by
+  letI : IsDomain R := isDomain_of_quot quot hquot h1
   obtain ⟨α, hα_ne, _hα_above, hmulvec⟩ :=
     failed_bareiss_column_dependence source k hk hprev hcol
   have hdet_zero : Matrix.det (matrixEquiv source) = 0 := by
@@ -1353,7 +1441,9 @@ theorem det_eq_zero_of_bareiss_failed_column
 /-- If row-pivoted Bareiss pivot search fails in a state satisfying the
 pivoted invariant, then the original source determinant is zero. -/
 theorem bareissPivotInvariant_singular_no_pivot_det_eq_zero
-    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState Int n)
+    (quot : R → R → R)
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (source : Hex.Matrix R n n) (state : Hex.Matrix.BareissState R n)
     (hinv : BareissPivotInvariant source state)
     (hDone : state.step + 1 < n)
     (hp0 : state.matrix[state.step][state.step] = 0)
@@ -1387,7 +1477,8 @@ theorem bareissPivotInvariant_singular_no_pivot_det_eq_zero
     exact hentry
   have hlogical_zero :
       Hex.Matrix.det logicalSource = 0 :=
-    det_eq_zero_of_bareiss_failed_column logicalSource state.step hk hprev hcol
+    det_eq_zero_of_bareiss_failed_column quot hquot
+      (Hex.one_ne_zero_of_nonzero hprev) logicalSource state.step hk hprev hcol
   rw [hlogical_zero, mul_zero] at hdet
   exact hdet
 
@@ -1395,15 +1486,16 @@ theorem bareissPivotInvariant_singular_no_pivot_det_eq_zero
 satisfying the pivoted invariant, then the original source determinant is
 zero. -/
 theorem pivotLoop_singularStep_ne_none_det_eq_zero
-    (source : Hex.Matrix Int n n)
-    (fuel : Nat) (state : Hex.Matrix.BareissState Int n)
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (source : Hex.Matrix R n n)
+    (fuel : Nat) (state : Hex.Matrix.BareissState R n)
     (hinv : BareissPivotInvariant source state)
-    (hsing : (Hex.Matrix.pivotLoop fuel state).singularStep ≠ none) :
+    (hsing : (Hex.Matrix.pivotLoopWith quot fuel state).singularStep ≠ none) :
     Hex.Matrix.det source = 0 := by
   induction fuel generalizing state with
   | zero =>
       rcases hinv with ⟨_, _, hnopiv⟩
-      simp only [Hex.Matrix.pivotLoop_zero_fuel, hnopiv.singular_none] at hsing
+      simp only [Hex.Matrix.pivotLoopWith_zero_fuel (quot := quot), hnopiv.singular_none] at hsing
       exact (hsing rfl).elim
   | succ fuel ih =>
       by_cases hDone : state.step + 1 < n
@@ -1413,59 +1505,64 @@ theorem pivotLoop_singularStep_ne_none_det_eq_zero
           cases hfind :
               Hex.Matrix.findPivot? state.matrix kFin (state.step + 1) with
           | none =>
-              exact bareissPivotInvariant_singular_no_pivot_det_eq_zero source state hinv
+              exact bareissPivotInvariant_singular_no_pivot_det_eq_zero quot hquot source state hinv
                 hDone hp0 (by simpa [kFin] using hfind)
           | some pivot =>
               have hp :=
                 pivotLoop_swap_pivot_ne_zero state hDone (by simpa [kFin] using hfind)
               apply ih
-              · exact bareissPivotInvariant_regular_swap_step source state hinv hDone
+              · exact bareissPivotInvariant_regular_swap_step hquot source state hinv hDone
                   (by simpa [kFin] using hfind)
-              · simpa [Hex.Matrix.pivotLoop_of_regular_swap fuel state hDone hp0
+              · simpa [Hex.Matrix.pivotLoopWith_of_regular_swap (quot := quot) fuel state hDone hp0
                   (by simpa [kFin] using hfind) hp] using hsing
         · apply ih
-          · exact bareissPivotInvariant_regular_no_swap_step source state hinv hDone hp0
-          · simpa [Hex.Matrix.pivotLoop_of_regular_no_swap fuel state hDone hp0]
+          · exact bareissPivotInvariant_regular_no_swap_step quot hquot source state hinv hDone hp0
+          · simpa [Hex.Matrix.pivotLoopWith_of_regular_no_swap (quot := quot) fuel state hDone hp0]
               using hsing
       · rcases hinv with ⟨_, _, hnopiv⟩
-        simp [Hex.Matrix.pivotLoop_done fuel state hDone, hnopiv.singular_none] at hsing
+        simp [Hex.Matrix.pivotLoopWith_done (quot := quot) fuel state hDone, hnopiv.singular_none] at hsing
 
 /-- Some specific singular step recorded by `pivotLoop` forces the source
 determinant to be zero. -/
 theorem pivotLoop_singularStep_eq_some_det_eq_zero
-    (source : Hex.Matrix Int n n)
-    (fuel : Nat) (state : Hex.Matrix.BareissState Int n)
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (source : Hex.Matrix R n n)
+    (fuel : Nat) (state : Hex.Matrix.BareissState R n)
     (hinv : BareissPivotInvariant source state) {k : Nat}
-    (hsing : (Hex.Matrix.pivotLoop fuel state).singularStep = some k) :
+    (hsing : (Hex.Matrix.pivotLoopWith quot fuel state).singularStep = some k) :
     Hex.Matrix.det source = 0 :=
-  pivotLoop_singularStep_ne_none_det_eq_zero source fuel state hinv (by
+  pivotLoop_singularStep_ne_none_det_eq_zero hquot source fuel state hinv (by
     rw [hsing]
     simp)
 
 /-- The public row-pivoted Bareiss loop, started from the initial state,
 records a singular step only when the input determinant is zero. -/
 theorem pivotLoop_initial_singularStep_ne_none_det_eq_zero
-    (M : Hex.Matrix Int n n)
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (h1 : (1 : R) ≠ 0)
+    (M : Hex.Matrix R n n)
     (hsing :
-      (Hex.Matrix.pivotLoop n (Hex.Matrix.noPivotInitialState M)).singularStep ≠ none) :
+      (Hex.Matrix.pivotLoopWith quot n (Hex.Matrix.noPivotInitialState M)).singularStep ≠ none) :
     Hex.Matrix.det M = 0 :=
-  pivotLoop_singularStep_ne_none_det_eq_zero M n (Hex.Matrix.noPivotInitialState M)
-    (bareissPivotInvariant_initial M) hsing
+  pivotLoop_singularStep_ne_none_det_eq_zero hquot M n (Hex.Matrix.noPivotInitialState M)
+    (bareissPivotInvariant_initial M h1) hsing
 
 /-- If the row-pivoted Bareiss result records a singular step, the Mathlib
 determinant of the input is zero. -/
 theorem bareissData_singularStep_ne_none_det_eq_zero
-    (M : Hex.Matrix Int n n)
-    (hsing : (Hex.Matrix.bareissData M).singularStep ≠ none) :
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (h1 : (1 : R) ≠ 0)
+    (M : Hex.Matrix R n n)
+    (hsing : (Hex.Matrix.bareissDataWith quot M).singularStep ≠ none) :
     Hex.Matrix.det M = 0 := by
-  apply pivotLoop_initial_singularStep_ne_none_det_eq_zero M
+  apply pivotLoop_initial_singularStep_ne_none_det_eq_zero hquot h1 M
   intro hregular
   apply hsing
-  simpa [Hex.Matrix.bareissData_eq_finish_pivotLoop, Hex.Matrix.finish] using hregular
+  simpa [Hex.Matrix.bareissDataWith_eq_finish_pivotLoopWith (quot := quot), Hex.Matrix.finish] using hregular
 
 private theorem pivotLoop_step_succ_le
-    (fuel : Nat) (state : Hex.Matrix.BareissState Int n) (h : state.step + 1 ≤ n) :
-    (Hex.Matrix.pivotLoop fuel state).step + 1 ≤ n := by
+    (fuel : Nat) (state : Hex.Matrix.BareissState R n) (h : state.step + 1 ≤ n) :
+    (Hex.Matrix.pivotLoopWith quot fuel state).step + 1 ≤ n := by
   induction fuel generalizing state with
   | zero =>
       show state.step + 1 ≤ n
@@ -1478,29 +1575,29 @@ private theorem pivotLoop_step_succ_le
           cases hfind :
               Hex.Matrix.findPivot? state.matrix kFin (state.step + 1) with
           | none =>
-              rw [Hex.Matrix.pivotLoop_of_singular_no_pivot fuel state hDone hp0
+              rw [Hex.Matrix.pivotLoopWith_of_singular_no_pivot (quot := quot) fuel state hDone hp0
                 (by simpa [kFin] using hfind)]
               exact h
           | some pivot =>
               have hp :=
                 pivotLoop_swap_pivot_ne_zero state hDone (by simpa [kFin] using hfind)
-              rw [Hex.Matrix.pivotLoop_of_regular_swap fuel state hDone hp0
+              rw [Hex.Matrix.pivotLoopWith_of_regular_swap (quot := quot) fuel state hDone hp0
                 (by simpa [kFin] using hfind) hp]
               apply ih
               show state.step + 1 + 1 ≤ n
               omega
-        · rw [Hex.Matrix.pivotLoop_of_regular_no_swap fuel state hDone hp0]
+        · rw [Hex.Matrix.pivotLoopWith_of_regular_no_swap (quot := quot) fuel state hDone hp0]
           apply ih
           show state.step + 1 + 1 ≤ n
           omega
-      · rw [Hex.Matrix.pivotLoop_done fuel state hDone]
+      · rw [Hex.Matrix.pivotLoopWith_done (quot := quot) fuel state hDone]
         exact h
 
 private theorem pivotLoop_step_succ_ge_of_regular
-    (fuel : Nat) (state : Hex.Matrix.BareissState Int n)
-    (hregular : (Hex.Matrix.pivotLoop fuel state).singularStep = none)
+    (fuel : Nat) (state : Hex.Matrix.BareissState R n)
+    (hregular : (Hex.Matrix.pivotLoopWith quot fuel state).singularStep = none)
     (hfuel : n ≤ state.step + fuel + 1) :
-    n ≤ (Hex.Matrix.pivotLoop fuel state).step + 1 := by
+    n ≤ (Hex.Matrix.pivotLoopWith quot fuel state).step + 1 := by
   induction fuel generalizing state with
   | zero =>
       show n ≤ state.step + 1
@@ -1514,44 +1611,44 @@ private theorem pivotLoop_step_succ_ge_of_regular
               Hex.Matrix.findPivot? state.matrix kFin (state.step + 1) with
           | none =>
               have hloop :=
-                Hex.Matrix.pivotLoop_of_singular_no_pivot fuel state hDone hp0
+                Hex.Matrix.pivotLoopWith_of_singular_no_pivot (quot := quot) fuel state hDone hp0
                   (by simpa [kFin] using hfind)
               rw [hloop] at hregular
               simp at hregular
           | some pivot =>
               have hp :=
                 pivotLoop_swap_pivot_ne_zero state hDone (by simpa [kFin] using hfind)
-              rw [Hex.Matrix.pivotLoop_of_regular_swap fuel state hDone hp0
+              rw [Hex.Matrix.pivotLoopWith_of_regular_swap (quot := quot) fuel state hDone hp0
                 (by simpa [kFin] using hfind) hp]
               apply ih
-              · simpa [Hex.Matrix.pivotLoop_of_regular_swap fuel state hDone hp0
+              · simpa [Hex.Matrix.pivotLoopWith_of_regular_swap (quot := quot) fuel state hDone hp0
                   (by simpa [kFin] using hfind) hp] using hregular
               · show n ≤ state.step + 1 + fuel + 1
                 omega
-        · rw [Hex.Matrix.pivotLoop_of_regular_no_swap fuel state hDone hp0]
+        · rw [Hex.Matrix.pivotLoopWith_of_regular_no_swap (quot := quot) fuel state hDone hp0]
           apply ih
-          · simpa [Hex.Matrix.pivotLoop_of_regular_no_swap fuel state hDone hp0]
+          · simpa [Hex.Matrix.pivotLoopWith_of_regular_no_swap (quot := quot) fuel state hDone hp0]
               using hregular
           · show n ≤ state.step + 1 + fuel + 1
             omega
-      · rw [Hex.Matrix.pivotLoop_done fuel state hDone]
+      · rw [Hex.Matrix.pivotLoopWith_done (quot := quot) fuel state hDone]
         show n ≤ state.step + 1
         omega
 
 private theorem pivotLoop_initial_regular_step_eq_pred
-    (M : Hex.Matrix Int (k + 1) (k + 1))
+    (M : Hex.Matrix R (k + 1) (k + 1))
     (hregular :
-      (Hex.Matrix.pivotLoop (k + 1) (Hex.Matrix.noPivotInitialState M)).singularStep =
+      (Hex.Matrix.pivotLoopWith quot (k + 1) (Hex.Matrix.noPivotInitialState M)).singularStep =
         none) :
-    (Hex.Matrix.pivotLoop (k + 1) (Hex.Matrix.noPivotInitialState M)).step = k := by
+    (Hex.Matrix.pivotLoopWith quot (k + 1) (Hex.Matrix.noPivotInitialState M)).step = k := by
   have hle :
-      (Hex.Matrix.pivotLoop (k + 1) (Hex.Matrix.noPivotInitialState M)).step + 1 ≤
+      (Hex.Matrix.pivotLoopWith quot (k + 1) (Hex.Matrix.noPivotInitialState M)).step + 1 ≤
         k + 1 :=
     pivotLoop_step_succ_le (k + 1) (Hex.Matrix.noPivotInitialState M)
       (by show 0 + 1 ≤ k + 1; omega)
   have hge :
       k + 1 ≤
-        (Hex.Matrix.pivotLoop (k + 1) (Hex.Matrix.noPivotInitialState M)).step + 1 :=
+        (Hex.Matrix.pivotLoopWith quot (k + 1) (Hex.Matrix.noPivotInitialState M)).step + 1 :=
     pivotLoop_step_succ_ge_of_regular (k + 1) (Hex.Matrix.noPivotInitialState M)
       hregular (by show k + 1 ≤ 0 + (k + 1) + 1; omega)
   omega
@@ -1560,76 +1657,110 @@ private theorem pivotLoop_initial_regular_step_eq_pred
 data: its `.det` field equals Mathlib's determinant of the corresponding
 matrix. Proven directly here by combining the row-pivot invariant with the
 singular-branch determinant-zero theorem above. -/
-theorem bareissData_eq_mathlib_det (M : Hex.Matrix Int n n) :
-    (Hex.Matrix.bareissData M).det = Matrix.det (matrixEquiv M) := by
-  by_cases hregular : (Hex.Matrix.bareissData M).singularStep = none
+private theorem bareissDataWith_eq_mathlib_det_of_one_ne_zero
+    (quot : R → R → R)
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (h1 : (1 : R) ≠ 0) (M : Hex.Matrix R n n) :
+    (Hex.Matrix.bareissDataWith quot M).det = Matrix.det (matrixEquiv M) := by
+  by_cases hregular : (Hex.Matrix.bareissDataWith quot M).singularStep = none
   · have hpiv :
         BareissPivotInvariant M
-          (Hex.Matrix.pivotLoop n (Hex.Matrix.noPivotInitialState M)) := by
-      apply pivotLoop_invariant_of_singularStep_eq_none M n
-        (Hex.Matrix.noPivotInitialState M) (bareissPivotInvariant_initial M)
-      simpa [Hex.Matrix.bareissData_eq_finish_pivotLoop, Hex.Matrix.finish] using hregular
+          (Hex.Matrix.pivotLoopWith quot n (Hex.Matrix.noPivotInitialState M)) := by
+      apply pivotLoop_invariant_of_singularStep_eq_none hquot M n
+        (Hex.Matrix.noPivotInitialState M) (bareissPivotInvariant_initial M h1)
+      simpa [Hex.Matrix.bareissDataWith_eq_finish_pivotLoopWith (quot := quot), Hex.Matrix.finish] using hregular
     rcases hpiv with ⟨logicalSource, hdet, hnopiv⟩
     match n, M, logicalSource, hdet, hnopiv, hregular with
     | 0, M, logicalSource, hdet, hnopiv, hregular =>
-        have hdata_sign : (Hex.Matrix.bareissData M).sign =
-            bareissStateSign (Hex.Matrix.pivotLoop 0 (Hex.Matrix.noPivotInitialState M)) := by
-          simp [Hex.Matrix.bareissData_eq_finish_pivotLoop, Hex.Matrix.finish,
+        have hdata_sign : (Hex.Matrix.bareissDataWith quot M).sign =
+            bareissStateSign (Hex.Matrix.pivotLoopWith quot 0 (Hex.Matrix.noPivotInitialState M)) := by
+          simp [Hex.Matrix.bareissDataWith_eq_finish_pivotLoopWith (quot := quot), Hex.Matrix.finish,
             Hex.Matrix.BareissData.sign, bareissStateSign]
         have hlogical_det : Hex.Matrix.det logicalSource = 1 := by
           exact (det_eq logicalSource).trans (by rw [Matrix.det_isEmpty])
-        have hsource_det : Hex.Matrix.det M = (Hex.Matrix.bareissData M).sign := by
+        have hsource_det : Hex.Matrix.det M = (Hex.Matrix.bareissDataWith quot M).sign := by
           rw [hdet, hlogical_det, mul_one]
           exact hdata_sign.symm
         rw [Hex.Matrix.BareissData.det_zero_eq _ hregular, ← hsource_det]
         exact det_eq M
     | k + 1, M, logicalSource, hdet, hnopiv, hregular =>
         have hloop_regular :
-            (Hex.Matrix.pivotLoop (k + 1) (Hex.Matrix.noPivotInitialState M)).singularStep =
+            (Hex.Matrix.pivotLoopWith quot (k + 1) (Hex.Matrix.noPivotInitialState M)).singularStep =
               none := by
-          simpa [Hex.Matrix.bareissData_eq_finish_pivotLoop, Hex.Matrix.finish] using hregular
+          simpa [Hex.Matrix.bareissDataWith_eq_finish_pivotLoopWith (quot := quot), Hex.Matrix.finish] using hregular
         have hstep :
-            (Hex.Matrix.pivotLoop (k + 1) (Hex.Matrix.noPivotInitialState M)).step = k :=
+            (Hex.Matrix.pivotLoopWith quot (k + 1) (Hex.Matrix.noPivotInitialState M)).step = k :=
           pivotLoop_initial_regular_step_eq_pred M hloop_regular
         have hentry :
-            (Hex.Matrix.pivotLoop (k + 1)
+            (Hex.Matrix.pivotLoopWith quot (k + 1)
                 (Hex.Matrix.noPivotInitialState M)).matrix[
                   (⟨k, Nat.lt_succ_self k⟩ : Fin (k + 1))][
                   (⟨k, Nat.lt_succ_self k⟩ : Fin (k + 1))] =
               Hex.Matrix.det logicalSource :=
           trailing_corner_entry_eq_det k logicalSource
-            (Hex.Matrix.pivotLoop (k + 1) (Hex.Matrix.noPivotInitialState M))
+            (Hex.Matrix.pivotLoopWith quot (k + 1) (Hex.Matrix.noPivotInitialState M))
             hnopiv hstep
         have hsign :
-            (Hex.Matrix.bareissData M).sign =
+            (Hex.Matrix.bareissDataWith quot M).sign =
               bareissStateSign
-                (Hex.Matrix.pivotLoop (k + 1) (Hex.Matrix.noPivotInitialState M)) := by
-          simp [Hex.Matrix.bareissData_eq_finish_pivotLoop, Hex.Matrix.finish,
+                (Hex.Matrix.pivotLoopWith quot (k + 1) (Hex.Matrix.noPivotInitialState M)) := by
+          simp [Hex.Matrix.bareissDataWith_eq_finish_pivotLoopWith (quot := quot), Hex.Matrix.finish,
             Hex.Matrix.BareissData.sign, bareissStateSign]
         have hdata_entry :
-            (Hex.Matrix.bareissData M).matrix[
+            (Hex.Matrix.bareissDataWith quot M).matrix[
                   (⟨k, Nat.lt_succ_self k⟩ : Fin (k + 1))][
                   (⟨k, Nat.lt_succ_self k⟩ : Fin (k + 1))] =
               Hex.Matrix.det logicalSource := by
-          simpa [Hex.Matrix.bareissData_eq_finish_pivotLoop, Hex.Matrix.finish] using hentry
+          simpa [Hex.Matrix.bareissDataWith_eq_finish_pivotLoopWith (quot := quot), Hex.Matrix.finish] using hentry
         rw [Hex.Matrix.BareissData.det_succ_eq _ hregular, hdata_entry, hsign, ← hdet]
         exact det_eq M
-  · have hdata_zero : (Hex.Matrix.bareissData M).det = 0 := by
+  · have hdata_zero : (Hex.Matrix.bareissDataWith quot M).det = 0 := by
       unfold Hex.Matrix.BareissData.det
       split
       · rfl
       · contradiction
     have hhex_zero : Hex.Matrix.det M = 0 :=
-      bareissData_singularStep_ne_none_det_eq_zero M hregular
+      bareissData_singularStep_ne_none_det_eq_zero hquot h1 M hregular
     rw [hdata_zero, ← hhex_zero]
     exact det_eq M
 
 /-- Row-pivoted Bareiss determinant soundness, exposed against Mathlib's
 determinant for downstream Mathlib-side callers. -/
+private theorem bareissWith_eq_mathlib_det_of_one_ne_zero
+    (quot : R → R → R)
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (h1 : (1 : R) ≠ 0) (M : Hex.Matrix R n n) :
+    Hex.Matrix.bareissWith quot M = Matrix.det (matrixEquiv M) := by
+  rw [Hex.Matrix.bareissWith_eq_bareissDataWith_det (quot := quot) M]
+  exact bareissDataWith_eq_mathlib_det_of_one_ne_zero quot hquot h1 M
+
+/-- Row-pivoted Bareiss over any commutative ring with an exact quotient
+agrees with Mathlib's determinant. -/
+theorem bareissWith_eq_mathlib_det
+    (quot : R → R → R)
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (M : Hex.Matrix R n n) :
+    Hex.Matrix.bareissWith quot M = Matrix.det (matrixEquiv M) := by
+  by_cases h1 : (1 : R) = 0
+  · have hz : ∀ x : R, x = 0 := by
+      intro x
+      rw [← one_mul x, h1, zero_mul]
+    exact (hz _).trans (hz _).symm
+  · exact bareissWith_eq_mathlib_det_of_one_ne_zero quot hquot h1 M
+
+/-- Row-pivoted Bareiss over an exact-division commutative ring agrees with
+Hex's executable determinant. -/
+theorem bareissWith_eq_det
+    (quot : R → R → R)
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (M : Hex.Matrix R n n) :
+    Hex.Matrix.bareissWith quot M = Hex.Matrix.det M :=
+  (bareissWith_eq_mathlib_det quot hquot M).trans (det_eq M).symm
+
+/-- Integer compatibility specialization of `bareissWith_eq_mathlib_det`. -/
 theorem bareiss_eq_mathlib_det (M : Hex.Matrix Int n n) :
-    Hex.Matrix.bareiss M = Matrix.det (matrixEquiv M) := by
-  rw [Hex.Matrix.bareiss_eq_bareissData_det M]
-  exact bareissData_eq_mathlib_det M
+    Hex.Matrix.bareiss M = Matrix.det (matrixEquiv M) :=
+  bareissWith_eq_mathlib_det Hex.Matrix.exactDiv Int.mul_ediv_cancel M
 
 /-- Restatement of `BareissNoPivotInvariant.trailing_eq` packaged so the step
 field is given by an external equation rather than appearing inside dependent
@@ -1637,7 +1768,8 @@ proof terms. Lets callers consume `trailing_eq` at an arbitrary numeric step
 value `s` known to equal `state.step` without manually transporting the
 inequality proofs. -/
 private theorem trailing_eq_at_step
-    {M : Hex.Matrix Int n n} {state : Hex.Matrix.BareissState Int n}
+    {R : Type u} [CommRing R]
+    {M : Hex.Matrix R n n} {state : Hex.Matrix.BareissState R n}
     (hinv : BareissNoPivotInvariant M state)
     (s : Nat) (hs : s < n) (hstep : s = state.step)
     (a c : Fin n) (hsa : s ≤ a.val) (hsc : s ≤ c.val) :
@@ -1658,26 +1790,28 @@ propagates through a non-singular partial pass), `BareissNoPivotInvariant`
 `noPivotLoop_step_eq_add_of_singularStep_none` (the partial pass advances
 `step` by exactly the fuel consumed). -/
 theorem noPivotLoop_full_eq_borderedMinor_det
-    (M : Hex.Matrix Int n n) (k : Nat) (hk : k + 1 < n)
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (h1 : (1 : R) ≠ 0)
+    (M : Hex.Matrix R n n) (k : Nat) (hk : k + 1 < n)
     (a c : Fin n) (hak : k + 1 ≤ a.val) (hck : k + 1 ≤ c.val)
     (h_no_sing :
-      (Hex.Matrix.noPivotLoop (k + 1)
+      (Hex.Matrix.noPivotLoopWith quot (k + 1)
           (Hex.Matrix.noPivotInitialState M)).singularStep = none) :
-    (Hex.Matrix.noPivotLoop (k + 1)
+    (Hex.Matrix.noPivotLoopWith quot (k + 1)
         (Hex.Matrix.noPivotInitialState M)).matrix[a][c] =
       Hex.Matrix.det (Hex.Matrix.borderedMinor M (k + 1) hk a c) := by
   have hinv : BareissNoPivotInvariant M
-      (Hex.Matrix.noPivotLoop (k + 1) (Hex.Matrix.noPivotInitialState M)) :=
-    noPivotLoop_invariant_of_singularStep_eq_none M (k + 1)
-      (Hex.Matrix.noPivotInitialState M) (bareissNoPivotInvariant_initial M)
+      (Hex.Matrix.noPivotLoopWith quot (k + 1) (Hex.Matrix.noPivotInitialState M)) :=
+    noPivotLoop_invariant_of_singularStep_eq_none hquot M (k + 1)
+      (Hex.Matrix.noPivotInitialState M) (bareissNoPivotInvariant_initial M h1)
       h_no_sing
   have hstep_eq :
       k + 1 =
-        (Hex.Matrix.noPivotLoop (k + 1) (Hex.Matrix.noPivotInitialState M)).step := by
+        (Hex.Matrix.noPivotLoopWith quot (k + 1) (Hex.Matrix.noPivotInitialState M)).step := by
     have h_room : (Hex.Matrix.noPivotInitialState M).step + (k + 1) + 1 ≤ n := by
       change 0 + (k + 1) + 1 ≤ n
       omega
-    have h := Hex.Matrix.noPivotLoop_step_eq_add_of_singularStep_none (k + 1)
+    have h := Hex.Matrix.noPivotLoopWith_step_eq_add_of_singularStep_none (quot := quot) (k + 1)
       (Hex.Matrix.noPivotInitialState M) rfl h_room h_no_sing
     rw [h]
     show k + 1 = 0 + (k + 1)

--- a/HexBareissMathlib/README.md
+++ b/HexBareissMathlib/README.md
@@ -40,7 +40,14 @@ open HexMatrixMathlib
 -- The same correspondence is available over any commutative ring equipped
 -- with an exact quotient satisfying the cancellation law.
 #check @bareissWith_eq_det
+-- @bareissWith_eq_det : ∀ {R n} [CommRing R] [DecidableEq R]
+--   (quot : R → R → R), (∀ a b, b ≠ 0 → quot (a * b) b = a) →
+--   ∀ M : Hex.Matrix R n n, Matrix.bareissWith quot M = Matrix.det M
 #check @bareissWith_eq_mathlib_det
+-- @bareissWith_eq_mathlib_det : ∀ {R n} [CommRing R] [DecidableEq R]
+--   (quot : R → R → R), (∀ a b, b ≠ 0 → quot (a * b) b = a) →
+--   ∀ M : Hex.Matrix R n n,
+--     Matrix.bareissWith quot M = (matrixEquiv M).det
 ```
 
 # Functionality

--- a/HexBareissMathlib/README.md
+++ b/HexBareissMathlib/README.md
@@ -36,6 +36,11 @@ open HexMatrixMathlib
 -- ... and equals Mathlib's determinant of the corresponding matrix.
 #check @bareissDet_eq_det
 -- @bareissDet_eq_det : ∀ {n : ℕ} (M : Hex.Matrix ℤ n n), M.bareiss = (matrixEquiv M).det
+
+-- The same correspondence is available over any commutative ring equipped
+-- with an exact quotient satisfying the cancellation law.
+#check @bareissWith_eq_det
+#check @bareissWith_eq_mathlib_det
 ```
 
 # Functionality
@@ -46,13 +51,16 @@ open HexMatrixMathlib
   `Matrix.det` of the corresponding matrix `matrixEquiv M`;
 - `bareissNoPivot_eq_det` and the bordered-minor invariant
   (`BareissNoPivotInvariant`, `NonzeroBareissPivots`): the Desnanot-Jacobi
-  argument that drives the no-pivot correctness proof.
+  argument that drives the no-pivot correctness proof;
+- `bareissWith_eq_det` and `bareissWith_eq_mathlib_det`: the generic
+  coefficient-ring correspondence for a supplied exact quotient.
 
 # Verification
 
-The correspondence is fully proven on integer square matrices. The two
-headline theorems are the preferred surface for Mathlib-side callers; both
-hold outright, with no hypothesis to discharge.
+The correspondence is fully proven over any commutative ring with decidable
+equality and a quotient satisfying exact right cancellation. No public domain
+or nontriviality hypothesis is required. The original integer theorems remain
+the preferred compatibility surface and hold outright.
 
 The executable Bareiss determinant equals the Leibniz determinant,
 `bareiss_eq_det`:

--- a/HexDeterminantMathlib/CorePlucker.lean
+++ b/HexDeterminantMathlib/CorePlucker.lean
@@ -101,7 +101,7 @@ resulting permutation is the product of two disjoint cycles
 -/
 
 private theorem matrixEquiv_double_setRow_eq_submatrix_nMatrix
-    {R : Type u} [CommRing R] {n : Nat}
+    {R : Type u} {n : Nat}
     (B : Hex.Matrix R (n + 3) (n + 1)) (p1 p2 p3 q : Fin (n + 3))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val) (h3q : p3.val < q.val) :
     let h1q : p1.val < q.val := Nat.lt_trans h12 (Nat.lt_trans h23 h3q)
@@ -962,6 +962,37 @@ The remaining Mathlib-side recurrence proof can supply `hdesnanot` from the
 Desnanot-Jacobi identity; this lemma packages the resulting product identity
 as the `hexact` premise expected by `Hex.Matrix.stepMatrix_borderedMinor_update`.
 -/
+theorem exactQuot_borderedMinor_of_mul_eq [CommRing R]
+    (quot : R → R → R)
+    (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (source : Hex.Matrix R n n) (k : Nat) (hk : k < n) (hnext : k + 1 < n)
+    (i j : Fin n) (hi : k < i.val) (hj : k < j.val) (prevPivot : R)
+    (hprev_ne : prevPivot ≠ 0)
+    (hdesnanot :
+      Hex.Matrix.det (Hex.Matrix.borderedMinor source (k + 1) hnext i j) * prevPivot =
+        Hex.Matrix.det (Hex.Matrix.borderedMinor source k hk
+            (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n)
+            (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)) *
+          Hex.Matrix.det (Hex.Matrix.borderedMinor source k hk i j) -
+          Hex.Matrix.det (Hex.Matrix.borderedMinor source k hk
+            i (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)) *
+          Hex.Matrix.det (Hex.Matrix.borderedMinor source k hk
+            (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n) j)) :
+    quot
+        (Hex.Matrix.det (Hex.Matrix.borderedMinor source k hk
+            (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n)
+            (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)) *
+          Hex.Matrix.det (Hex.Matrix.borderedMinor source k hk i j) -
+          Hex.Matrix.det (Hex.Matrix.borderedMinor source k hk
+            i (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)) *
+          Hex.Matrix.det (Hex.Matrix.borderedMinor source k hk
+            (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n) j))
+        prevPivot =
+      Hex.Matrix.det (Hex.Matrix.borderedMinor source (k + 1) hnext i j) := by
+  exact Hex.Matrix.exactQuot_borderedMinor_of_mul_eq quot hquot
+    source k hk hnext i j hi hj prevPivot hprev_ne hdesnanot
+
+/-- Integer compatibility specialization of `exactQuot_borderedMinor_of_mul_eq`. -/
 theorem bareissExactDiv_borderedMinor_of_mul_eq
     (source : Hex.Matrix Int n n) (k : Nat) (hk : k < n) (hnext : k + 1 < n)
     (i j : Fin n) (hi : k < i.val) (hj : k < j.val) (prevPivot : Int)
@@ -986,8 +1017,8 @@ theorem bareissExactDiv_borderedMinor_of_mul_eq
           Hex.Matrix.det (Hex.Matrix.borderedMinor source k hk
             (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n) j))
         prevPivot =
-      Hex.Matrix.det (Hex.Matrix.borderedMinor source (k + 1) hnext i j) := by
-  exact Hex.Matrix.bareissExactDiv_borderedMinor_of_mul_eq
+      Hex.Matrix.det (Hex.Matrix.borderedMinor source (k + 1) hnext i j) :=
+  exactQuot_borderedMinor_of_mul_eq Hex.Matrix.exactDiv Int.mul_ediv_cancel
     source k hk hnext i j hi hj prevPivot hprev_ne hdesnanot
 
 /-- Cyclic shift on `Fin (k + 1)` mapping `0 ↦ k`, `r ↦ r - 1` for `r ≥ 1`.
@@ -1083,7 +1114,7 @@ private theorem bareissDesnanotIndex_castSucc_pos (k : Nat) (s : Fin (k + 1))
 
 /-- Source-row index returned by `bareissDesnanotIndex k r.succ` from `r : Fin (k+1)`:
 `r.val` for interior `r.val < k`, `i` when `r.val = k`. -/
-private theorem source_row_of_succ [CommRing R]
+private theorem source_row_of_succ
     (source : Hex.Matrix R n n) (k : Nat) (hnext : k + 1 < n) (i j : Fin n)
     (r : Fin (k + 1)) :
     ∀ (c : Fin (k + 1)),
@@ -1120,7 +1151,7 @@ private theorem source_row_of_succ [CommRing R]
     rw [Hex.Matrix.borderedMinor_entry_last_last]
     simp [hr, hc]
 
-private theorem source_row_of_borderedMinor [CommRing R]
+private theorem source_row_of_borderedMinor
     (source : Hex.Matrix R n n) (k : Nat) (hk : k < n) (i j : Fin n)
     (r c : Fin (k + 1)) :
     matrixEquiv (Hex.Matrix.borderedMinor source k hk i j) r c =
@@ -1137,7 +1168,7 @@ private theorem source_row_of_borderedMinor [CommRing R]
 the entry at `bareissDesnanotIndex k r.castSucc` lands in the interior of the
 `(k+2)` bordered minor: source row `k` for `r = 0`, source row `r.val - 1` for
 `r.val ≥ 1`. Same for columns. -/
-private theorem source_row_of_castSucc [CommRing R]
+private theorem source_row_of_castSucc
     (source : Hex.Matrix R n n) (k : Nat) (hnext : k + 1 < n) (i j : Fin n)
     (r c : Fin (k + 1)) :
     matrixEquiv (Hex.Matrix.borderedMinor source (k + 1) hnext i j)
@@ -1184,7 +1215,7 @@ private theorem source_row_of_castSucc [CommRing R]
     simp [hr, hc]
 
 /-- Mixed `succ`/`castSucc` source-row helper used for `M_1k`. -/
-private theorem source_row_of_succ_castSucc [CommRing R]
+private theorem source_row_of_succ_castSucc
     (source : Hex.Matrix R n n) (k : Nat) (hnext : k + 1 < n) (i j : Fin n)
     (r c : Fin (k + 1)) :
     matrixEquiv (Hex.Matrix.borderedMinor source (k + 1) hnext i j)
@@ -1229,7 +1260,7 @@ private theorem source_row_of_succ_castSucc [CommRing R]
     simp [hr, hc]
 
 /-- Mixed `castSucc`/`succ` source-row helper used for `M_k1`. -/
-private theorem source_row_of_castSucc_succ [CommRing R]
+private theorem source_row_of_castSucc_succ
     (source : Hex.Matrix R n n) (k : Nat) (hnext : k + 1 < n) (i j : Fin n)
     (r c : Fin (k + 1)) :
     matrixEquiv (Hex.Matrix.borderedMinor source (k + 1) hnext i j)
@@ -1302,7 +1333,7 @@ private theorem fin_n_cyclicShift_eq_castSucc_index (k : Nat) (hk : k < n)
 column yields the natural `(k+1)` bordered minor of `source` with the original
 pivot row/column position `⟨k, _⟩` (i.e. the leading prefix of `source` of size
 `k+1`), reindexed by the cyclic shift `bareissCyclicShift k`. -/
-private theorem M_kk_eq_matrixEquiv_borderedMinor_submatrix [CommRing R]
+private theorem M_kk_eq_matrixEquiv_borderedMinor_submatrix
     (source : Hex.Matrix R n n) (k : Nat) (hk : k < n) (hnext : k + 1 < n)
     (i j : Fin n) :
     (((matrixEquiv (Hex.Matrix.borderedMinor source (k + 1) hnext i j)).submatrix
@@ -1329,7 +1360,7 @@ private theorem M_kk_eq_matrixEquiv_borderedMinor_submatrix [CommRing R]
 column yields the natural `(k+1)` bordered minor with trailing row `i` and
 trailing column position `⟨k, _⟩`, with columns reindexed by
 `bareissCyclicShift k`. -/
-private theorem M_1k_eq_matrixEquiv_borderedMinor_submatrix [CommRing R]
+private theorem M_1k_eq_matrixEquiv_borderedMinor_submatrix
     (source : Hex.Matrix R n n) (k : Nat) (hk : k < n) (hnext : k + 1 < n)
     (i j : Fin n) :
     (((matrixEquiv (Hex.Matrix.borderedMinor source (k + 1) hnext i j)).submatrix
@@ -1354,7 +1385,7 @@ private theorem M_1k_eq_matrixEquiv_borderedMinor_submatrix [CommRing R]
 column 0 yields the natural `(k+1)` bordered minor with trailing row position
 `⟨k, _⟩` and trailing column `j`, with rows reindexed by
 `bareissCyclicShift k`. -/
-private theorem M_k1_eq_matrixEquiv_borderedMinor_submatrix [CommRing R]
+private theorem M_k1_eq_matrixEquiv_borderedMinor_submatrix
     (source : Hex.Matrix R n n) (k : Nat) (hk : k < n) (hnext : k + 1 < n)
     (i j : Fin n) :
     (((matrixEquiv (Hex.Matrix.borderedMinor source (k + 1) hnext i j)).submatrix
@@ -1378,7 +1409,7 @@ private theorem M_k1_eq_matrixEquiv_borderedMinor_submatrix [CommRing R]
 /-- The interior `(k × k)` submatrix of the reindexed Bareiss bordered minor:
 deleting both row 0 and the last row (and similarly columns) leaves exactly
 `matrixEquiv (principalSubmatrix source k _)`. -/
-private theorem M_interior_eq_matrixEquiv_principalSubmatrix [CommRing R]
+private theorem M_interior_eq_matrixEquiv_principalSubmatrix
     (source : Hex.Matrix R n n) (k : Nat) (hk : k < n) (hnext : k + 1 < n)
     (i j : Fin n) :
     (((matrixEquiv (Hex.Matrix.borderedMinor source (k + 1) hnext i j)).submatrix
@@ -1415,7 +1446,7 @@ private theorem M_interior_eq_matrixEquiv_principalSubmatrix [CommRing R]
 /-- After reindexing the `(k+2)` bordered minor by `bareissDesnanotIndex k`,
 deleting row 0 and column 0 yields exactly `matrixEquiv` of the natural
 `(k+1)` bordered minor with the same trailing row `i` and column `j`. -/
-private theorem M11_eq_matrixEquiv_borderedMinor [CommRing R]
+private theorem M11_eq_matrixEquiv_borderedMinor
     (source : Hex.Matrix R n n) (k : Nat) (hk : k < n) (hnext : k + 1 < n)
     (i j : Fin n) :
     (((matrixEquiv (Hex.Matrix.borderedMinor source (k + 1) hnext i j)).submatrix

--- a/HexDeterminantMathlib/CoreTransport.lean
+++ b/HexDeterminantMathlib/CoreTransport.lean
@@ -1091,7 +1091,7 @@ private theorem cycleBehind_val_in (a m : Nat) (hm : a + m < n + 1)
 end OrderedFourShift
 
 private theorem matrixEquiv_setRow_p1_eq_submatrix_nMatrix
-    {R : Type u} [CommRing R] {n : Nat}
+    {R : Type u} {n : Nat}
     (B : Hex.Matrix R (n + 3) (n + 1)) (p1 p_t q : Fin (n + 3))
     (h1t : p1.val < p_t.val) (htq : p_t.val < q.val) :
     let h1q : p1.val < q.val := Nat.lt_trans h1t htq
@@ -1296,7 +1296,7 @@ theorem ordered_four_cofactorRowPairing_p3_p1_eq_pow_mul_nDet
   exact det_setRow_p1 B p1 p3 q (Nat.lt_trans h12 h23) h3qq
 
 private theorem matrixEquiv_nMatrix_p1_pt_eq_submatrix_setRow_q
-    {R : Type u} [CommRing R] {n : Nat}
+    {R : Type u} {n : Nat}
     (B : Hex.Matrix R (n + 3) (n + 1)) (p1 p_t q : Fin (n + 3))
     (h1t : p1.val < p_t.val) (htq : p_t.val < q.val) :
     let h1q : p1.val < q.val := Nat.lt_trans h1t htq

--- a/HexDeterminantMathlib/README.md
+++ b/HexDeterminantMathlib/README.md
@@ -55,7 +55,10 @@ The proof-facing API connects the executable determinant to Mathlib:
   under an arbitrary row/column reindexing as
   `desnanot_jacobi_matrixEquiv_reindex`, in Hex minor terms as
   `desnanot_jacobi_deleteRowCol_endpoints`, and in the bordered-minor form
-  `desnanot_jacobi_borderedMinor` used by the Bareiss correctness proof.
+  `desnanot_jacobi_borderedMinor` used by the Bareiss correctness proof;
+- `exactQuot_borderedMinor_of_mul_eq`: cancellation of a known nonzero
+  bordered-minor factor through a caller-supplied exact quotient, with the
+  retained integer corollary `bareissExactDiv_borderedMinor_of_mul_eq`.
 
 Sylvester's determinant identity, the general statement that an `m × m` matrix
 of bordered minors has determinant `det A₀ ^ (m - 1) * det A`, is **not** proved

--- a/HexDeterminantMathlib/SPEC/hex-determinant-mathlib.md
+++ b/HexDeterminantMathlib/SPEC/hex-determinant-mathlib.md
@@ -127,11 +127,14 @@ determinant-preserving, and `desnanot_jacobi_borderedMinor_reindex` is the
 intermediate statement in reindexed Mathlib coordinates.
 
 Consumers: `HexBareissMathlib/Bareiss.lean` (twice) and
-`HexGramSchmidtMathlib/Int/Augmented.lean`. `bareissExactDiv_borderedMinor_of_mul_eq`
-packages the resulting product identity as the `hexact` premise of
-`Hex.Matrix.stepMatrix_borderedMinor_update`; it takes the identity as the
-hypothesis `hdesnanot` and additionally requires `prevPivot ≠ 0`, the only
-nondegeneracy hypothesis anywhere in this surface.
+`HexGramSchmidtMathlib/Int/Augmented.lean`.
+`exactQuot_borderedMinor_of_mul_eq` packages the resulting product identity as
+the `hexact` premise of `Hex.Matrix.stepMatrixWith_borderedMinor_update` for an
+arbitrary coefficient type equipped with an exact quotient operation; it takes
+the identity as the hypothesis `hdesnanot` and additionally requires
+`prevPivot ≠ 0`, the only nondegeneracy hypothesis anywhere in this surface.
+`bareissExactDiv_borderedMinor_of_mul_eq` is the retained `Int` corollary used
+by the integer-only Gram–Schmidt consumer.
 
 ## Two-row replacement and Grassmann-Plücker
 

--- a/HexGramSchmidt/Int/Canonical.lean
+++ b/HexGramSchmidt/Int/Canonical.lean
@@ -22,7 +22,7 @@ coefficient vector `coeff i` such that the represented row is
 each matrix entry in that trailing row is its inner product against the
 corresponding original row. -/
 structure BareissGramRowInvariant (b : Matrix Int n m)
-    (state : Matrix.BareissState n) where
+    (state : Matrix.BareissState Int n) where
   coeff : Fin n → Vector Int n
   coeff_supp : ∀ i k : Fin n, state.step ≤ i.val → i.val < k.val →
     (coeff i)[k] = 0
@@ -190,13 +190,13 @@ private theorem dot_vecMul_exactDiv_eq_of_eq_mul_right
 
 /-- Project the explicit coefficient witness for the row at index `i`. -/
 private def bareissGramRowInvariantCoeff
-    {b : Matrix Int n m} {state : Matrix.BareissState n}
+    {b : Matrix Int n m} {state : Matrix.BareissState Int n}
     (hinv : BareissGramRowInvariant b state) (i : Fin n) : Vector Int n :=
   hinv.coeff i
 
 /-- `bareissGramRowInvariantCoeff_support` exposes the support vanishing condition for the projected Gram-row coefficient witness. -/
 private theorem bareissGramRowInvariantCoeff_support
-    {b : Matrix Int n m} {state : Matrix.BareissState n}
+    {b : Matrix Int n m} {state : Matrix.BareissState Int n}
     (hinv : BareissGramRowInvariant b state) (i : Fin n)
     (hi : state.step ≤ i.val) :
     ∀ k : Fin n, i.val < k.val →
@@ -205,7 +205,7 @@ private theorem bareissGramRowInvariantCoeff_support
 
 /-- `bareissGramRowInvariantCoeff_row` identifies the projected Gram-row coefficient witness with the invariant's stored coefficient row. -/
 private theorem bareissGramRowInvariantCoeff_row
-    {b : Matrix Int n m} {state : Matrix.BareissState n}
+    {b : Matrix Int n m} {state : Matrix.BareissState Int n}
     (hinv : BareissGramRowInvariant b state) (i : Fin n) :
     Matrix.vecMul (bareissGramRowInvariantCoeff hinv i) b =
       Matrix.vecMul (hinv.coeff i) b := rfl
@@ -214,7 +214,7 @@ private theorem bareissGramRowInvariantCoeff_row
 index `i`.  The functional shape mirrors the row update on the matrix side. -/
 @[expose]
 def bareissGramRowInvariantStepCoeff
-    {b : Matrix Int n m} {state : Matrix.BareissState n}
+    {b : Matrix Int n m} {state : Matrix.BareissState Int n}
     (hinv : BareissGramRowInvariant b state)
     (hnext : state.step + 1 < n) (i : Fin n) (_hi : state.step + 1 ≤ i.val) :
     Vector Int n :=
@@ -231,7 +231,7 @@ Bareiss step.  The quotient vector is kept separate from
 integer divisibility witness before projecting back to the existing exact-div
 coefficient API. -/
 structure BareissGramRegularStepQuotient
-    {b : Matrix Int n m} {state : Matrix.BareissState n}
+    {b : Matrix Int n m} {state : Matrix.BareissState Int n}
     (hinv : BareissGramRowInvariant b state)
     (hnext : state.step + 1 < n) (i : Fin n) (_hi : state.step + 1 ≤ i.val) where
   q : Fin n → Int
@@ -243,7 +243,7 @@ structure BareissGramRegularStepQuotient
           q a * state.prevPivot
 
 private theorem bareissGramRegularStepQuotient_stepCoeff_get
-    {b : Matrix Int n m} {state : Matrix.BareissState n}
+    {b : Matrix Int n m} {state : Matrix.BareissState Int n}
     {hinv : BareissGramRowInvariant b state}
     {hnext : state.step + 1 < n} {i : Fin n} {hi : state.step + 1 ≤ i.val}
     (hprev : state.prevPivot ≠ 0)
@@ -254,7 +254,7 @@ private theorem bareissGramRegularStepQuotient_stepCoeff_get
   exact exactDiv_eq_of_eq_mul_right hprev (hq.coeff_num_eq_mul a)
 
 private theorem bareissGramRegularStepQuotient_stepCoeff_eq
-    {b : Matrix Int n m} {state : Matrix.BareissState n}
+    {b : Matrix Int n m} {state : Matrix.BareissState Int n}
     {hinv : BareissGramRowInvariant b state}
     {hnext : state.step + 1 < n} {i : Fin n} {hi : state.step + 1 ≤ i.val}
     (hprev : state.prevPivot ≠ 0)
@@ -268,7 +268,7 @@ private theorem bareissGramRegularStepQuotient_stepCoeff_eq
       (hinv := hinv) (hnext := hnext) (i := i) (hi := hi) hprev hq af
 
 private theorem vecMul_bareissGramRegularStepQuotient
-    {b : Matrix Int n m} {state : Matrix.BareissState n}
+    {b : Matrix Int n m} {state : Matrix.BareissState Int n}
     {hinv : BareissGramRowInvariant b state}
     {hnext : state.step + 1 < n} {i : Fin n} {hi : state.step + 1 ≤ i.val}
     (hprev : state.prevPivot ≠ 0)
@@ -278,7 +278,7 @@ private theorem vecMul_bareissGramRegularStepQuotient
   rw [bareissGramRegularStepQuotient_stepCoeff_eq hprev hq]
 
 theorem bareissGramRowInvariantStepCoeff_support
-    {b : Matrix Int n m} {state : Matrix.BareissState n}
+    {b : Matrix Int n m} {state : Matrix.BareissState Int n}
     (hinv : BareissGramRowInvariant b state)
     (hnext : state.step + 1 < n) (i : Fin n) (hi : state.step + 1 ≤ i.val) :
     ∀ a : Fin n, i.val < a.val →
@@ -463,7 +463,7 @@ not depend on the state index, so transport is the identity at that
 projection. Used to discharge canonicity proofs after transporting an explicit
 intermediate state back to the `noPivotLoop fuel initial` form. -/
 theorem bareissGramRowInvariant_coeff_transport
-    {b : Matrix Int n m} {st1 st2 : Matrix.BareissState n}
+    {b : Matrix Int n m} {st1 st2 : Matrix.BareissState Int n}
     (h : st1 = st2) (x : BareissGramRowInvariant b st2) (i : Fin n) :
     (h ▸ x).coeff i = x.coeff i := by
   cases h
@@ -501,7 +501,7 @@ column, both sides zero), `j.val = state.step` (pivot column below the pivot,
 both sides zero), and `state.step < j.val` (trailing block, `exactDiv` of the
 Bareiss numerator). -/
 private theorem bareissGramRegularStep_entry_eq_dot
-    {b : Matrix Int n m} {state : Matrix.BareissState n}
+    {b : Matrix Int n m} {state : Matrix.BareissState Int n}
     {hinv : BareissGramRowInvariant b state}
     {hnext : state.step + 1 < n} {i : Fin n} {hi : state.step + 1 ≤ i.val}
     (hprev : state.prevPivot ≠ 0)
@@ -606,7 +606,7 @@ invariant, provided the later loop proof supplies the exact-division entry
 relation for the fraction-free updated row combinations. -/
 @[expose]
 def bareissGramRowInvariant_regular_step
-    {b : Matrix Int n m} {state : Matrix.BareissState n}
+    {b : Matrix Int n m} {state : Matrix.BareissState Int n}
     (hnext : state.step + 1 < n)
     (_hp : state.matrix[state.step][state.step] ≠ 0)
     (hinv : BareissGramRowInvariant b state)
@@ -776,7 +776,7 @@ the initial step and the final step is zero below the pivot in the final
 matrix. Each such column was processed by a regular Bareiss step that cleared
 its sub-diagonal entries, and no later iteration touches them. -/
 private theorem noPivotLoop_matrix_processed_col_eq_zero {n : Nat} (fuel : Nat) :
-    ∀ (state : Matrix.BareissState n),
+    ∀ (state : Matrix.BareissState Int n),
       (Matrix.noPivotLoop fuel state).singularStep = none →
       ∀ (k : Nat), state.step ≤ k →
         k < (Matrix.noPivotLoop fuel state).step →
@@ -796,7 +796,7 @@ private theorem noPivotLoop_matrix_processed_col_eq_zero {n : Nat} (fuel : Nat) 
           rw [Matrix.noPivotLoop_of_singular f state hDone hp] at h_result_none
           simp at h_result_none
         · -- Regular branch.
-          let next : Matrix.BareissState n :=
+          let next : Matrix.BareissState Int n :=
             { step := state.step + 1
               matrix := Matrix.stepMatrix state.matrix state.step
                 state.matrix[state.step][state.step] state.prevPivot
@@ -988,7 +988,7 @@ succ-singular equation at the singular fixed-point without rewriting through
 dependent matrix-access proofs. -/
 private theorem bareissGramCanonicalCoeff_succ_singular_of_state_eq
     {n m : Nat} (b : Matrix Int n m) (fuel : Nat) (i : Fin n)
-    {s : Matrix.BareissState n}
+    {s : Matrix.BareissState Int n}
     (h_state : Matrix.noPivotLoop fuel
         (Matrix.noPivotInitialState (Matrix.gramMatrix b)) = s)
     (hDone : s.step + 1 < n)

--- a/HexGramSchmidt/Int/Combination.lean
+++ b/HexGramSchmidt/Int/Combination.lean
@@ -826,9 +826,9 @@ private theorem scaledCoeffRows_diag_eq_noPivotLoop_gramMatrix_of_no_singular
     getArrayEntry (scaledCoeffRows b) j.val j.val =
       (Matrix.noPivotLoop j.val
         (Matrix.noPivotInitialState (Matrix.gramMatrix b))).matrix[j][j] := by
-  let init : Matrix.BareissState n :=
+  let init : Matrix.BareissState Int n :=
     Matrix.noPivotInitialState (Matrix.gramMatrix b)
-  let prefAtJ : Matrix.BareissState n := Matrix.noPivotLoop j.val init
+  let prefAtJ : Matrix.BareissState Int n := Matrix.noPivotLoop j.val init
   have h_step_j : prefAtJ.step = j.val := by
     have h_room : init.step + j.val + 1 ≤ n := by
       have := j.isLt
@@ -930,7 +930,7 @@ private theorem scaledCoeffRows_diag_eq_zero_of_singularStep_lt
       (Matrix.noPivotLoop j.val
           (Matrix.noPivotInitialState (Matrix.gramMatrix b))).singularStep = some s) :
     getArrayEntry (scaledCoeffRows b) j.val j.val = 0 := by
-  let init : Matrix.BareissState n :=
+  let init : Matrix.BareissState Int n :=
     Matrix.noPivotInitialState (Matrix.gramMatrix b)
   -- Lift singularity from prefix `j` to full `n` via `prefix_singular`.
   have h_persist_split :
@@ -996,7 +996,7 @@ private theorem noPivotLoop_initial_gram_diag_ne_zero
       (⟨q, Nat.lt_trans hq hpn⟩ : Fin n)] ≠ 0 := by
   intro h_zero
   -- The (q+1)-prefix is also non-singular: split p = (q+1) + (p - q - 1).
-  let state₀ : Matrix.BareissState n := Matrix.noPivotInitialState (Matrix.gramMatrix b)
+  let state₀ : Matrix.BareissState Int n := Matrix.noPivotInitialState (Matrix.gramMatrix b)
   have h_split : p = (q + 1) + (p - q - 1) := by omega
   have h_prefix_succ_none :
       (Matrix.noPivotLoop (q + 1) state₀).singularStep = none := by
@@ -1184,7 +1184,7 @@ private theorem schurSigma_foldl_eq
   | succ q' ih =>
     -- Extend the fold by one iteration; rewrite the body via correspondence,
     -- apply the IH, then close via `schurSigma_noPivotCorrection_succ`.
-    let state₀ : Matrix.BareissState n :=
+    let state₀ : Matrix.BareissState Int n :=
       Matrix.noPivotInitialState (Matrix.gramMatrix b)
     have h_init_none : state₀.singularStep = none := by
       simp [state₀, Matrix.noPivotInitialState]

--- a/HexGramSchmidt/Int/Core.lean
+++ b/HexGramSchmidt/Int/Core.lean
@@ -125,7 +125,7 @@ noncomputable def gramSchmidtNormProduct (b : Matrix Int n m) (k : Nat) (hk : k 
 /-- Read a diagonal entry from a Bareiss elimination matrix as a natural
 determinant value. -/
 @[expose]
-def bareissDiagNat (data : Matrix.BareissData n) (r : Nat) (hr : r < n) : Nat :=
+def bareissDiagNat (data : Matrix.BareissData Int n) (r : Nat) (hr : r < n) : Nat :=
   let i : Fin n := ⟨r, hr⟩
   (data.matrix[(i, i)]).toNat
 
@@ -134,7 +134,7 @@ elimination pass over the full Gram matrix. This helper is only used for Gram
 matrices: once a leading row prefix is singular, every larger leading prefix is
 also singular, so all later leading determinants are zero. -/
 @[expose]
-def gramDetVecEntry (data : Matrix.BareissData n) (k : Fin (n + 1)) : Nat :=
+def gramDetVecEntry (data : Matrix.BareissData Int n) (k : Fin (n + 1)) : Nat :=
   match hk : k.val with
   | 0 => 1
   | r + 1 =>
@@ -149,7 +149,7 @@ def gramDetVecEntry (data : Matrix.BareissData n) (k : Fin (n + 1)) : Nat :=
 /-- After a no-pivot Bareiss pass records a singular step, every later
 `gramDetVecEntry` slot is the encoded zero tail rather than a diagonal read. -/
 private theorem gramDetVecEntry_eq_zero_of_singularStep_lt
-    (data : Matrix.BareissData n) (s r : Nat) (hr : r < n)
+    (data : Matrix.BareissData Int n) (s r : Nat) (hr : r < n)
     (hsing : data.singularStep = some s) (hs : s < r + 1) :
     gramDetVecEntry data ⟨r + 1, Nat.succ_lt_succ hr⟩ = 0 := by
   simp [gramDetVecEntry, hsing, hs]

--- a/HexGramSchmidt/Int/Correspondence.lean
+++ b/HexGramSchmidt/Int/Correspondence.lean
@@ -105,7 +105,7 @@ private theorem getArrayEntry_scaledCoeffRows_col_zero
 then the scaled-coefficient array loop records at `(i,j)` the matrix entry from
 the pre-elimination state at that target column. -/
 private theorem scaledCoeffArrayLoop_lower_matches_target_column
-    {state_array : ScaledCoeffArrayState} {state_matrix : Matrix.BareissState n}
+    {state_array : ScaledCoeffArrayState} {state_matrix : Matrix.BareissState Int n}
     (h_step_eq : state_array.step = state_matrix.step)
     (h_matrix_eq : rowsToMatrix state_array.matrix n = state_matrix.matrix)
     (h_prev_eq : state_array.prevPivot = state_matrix.prevPivot)
@@ -165,7 +165,7 @@ private theorem scaledCoeffArrayLoop_lower_matches_target_column
                 state_array.prevPivot
               coeffs := writeScaledColumn state_array.coeffs state_array.matrix n state_array.step
               prevPivot := getArrayEntry state_array.matrix state_array.step state_array.step }
-          let new_matrix : Matrix.BareissState n :=
+          let new_matrix : Matrix.BareissState Int n :=
             { step := state_matrix.step + 1
               matrix := Matrix.stepMatrix state_matrix.matrix state_matrix.step
                 state_matrix.matrix[kFin][kFin]
@@ -228,7 +228,7 @@ private theorem scaledCoeffArrayLoop_lower_matches_target_column
 in columns strictly after the current step are still unwritten before the
 singular branch, writing the current column preserves that zero tail. -/
 private theorem scaledCoeffArrayLoop_lower_singular_after_step
-    {state_array : ScaledCoeffArrayState} {state_matrix : Matrix.BareissState n}
+    {state_array : ScaledCoeffArrayState} {state_matrix : Matrix.BareissState Int n}
     (h_step_eq : state_array.step = state_matrix.step)
     (h_matrix_eq : rowsToMatrix state_array.matrix n = state_matrix.matrix)
     (h_coeffs_unwritten : ∀ r c : Fin n,
@@ -261,7 +261,7 @@ When the matrix-side `noPivotLoop` records a singular step strictly before
 reaching column `j`, the array loop halts at the singular column and the
 target column is left at its initial (unwritten) zero value. -/
 private theorem scaledCoeffArrayLoop_lower_zero
-    {state_array : ScaledCoeffArrayState} {state_matrix : Matrix.BareissState n}
+    {state_array : ScaledCoeffArrayState} {state_matrix : Matrix.BareissState Int n}
     (h_step_eq : state_array.step = state_matrix.step)
     (h_matrix_eq : rowsToMatrix state_array.matrix n = state_matrix.matrix)
     (h_prev_eq : state_array.prevPivot = state_matrix.prevPivot)
@@ -322,7 +322,7 @@ private theorem scaledCoeffArrayLoop_lower_zero
               coeffs := writeScaledColumn state_array.coeffs state_array.matrix n
                 state_array.step
               prevPivot := getArrayEntry state_array.matrix state_array.step state_array.step }
-          let new_matrix : Matrix.BareissState n :=
+          let new_matrix : Matrix.BareissState Int n :=
             { step := state_matrix.step + 1
               matrix := Matrix.stepMatrix state_matrix.matrix state_matrix.step
                 state_matrix.matrix[kFin][kFin]
@@ -405,7 +405,7 @@ diagonal of `noPivotLoop` (when no singular step has been hit at or before
 the loop-level interpretation of `gramDetVecEntry` against the executable
 array trajectory. -/
 private theorem scaledCoeffArrayLoop_diag_matches
-    {state_array : ScaledCoeffArrayState} {state_matrix : Matrix.BareissState n}
+    {state_array : ScaledCoeffArrayState} {state_matrix : Matrix.BareissState Int n}
     (h_step_eq : state_array.step = state_matrix.step)
     (h_matrix_eq : rowsToMatrix state_array.matrix n = state_matrix.matrix)
     (h_prev_eq : state_array.prevPivot = state_matrix.prevPivot)
@@ -513,7 +513,7 @@ private theorem scaledCoeffArrayLoop_diag_matches
                 state_array.prevPivot
               coeffs := writeScaledColumn state_array.coeffs state_array.matrix n state_array.step
               prevPivot := getArrayEntry state_array.matrix state_array.step state_array.step }
-          let new_matrix : Matrix.BareissState n :=
+          let new_matrix : Matrix.BareissState Int n :=
             { step := state_matrix.step + 1
               matrix := Matrix.stepMatrix state_matrix.matrix state_matrix.step
                 state_matrix.matrix[kFin][kFin]

--- a/HexGramSchmidt/Int/Invariant.lean
+++ b/HexGramSchmidt/Int/Invariant.lean
@@ -89,7 +89,7 @@ private def bareissGramRowInvariant_noPivotLoop_initialAux
                      state.matrix[state.step][state.step] state.prevPivot
                    prevPivot := state.matrix[state.step][state.step]
                    rowSwaps := state.rowSwaps
-                   singularStep := none } : Matrix.BareissState n) := by
+                   singularStep := none } : Matrix.BareissState Int n) := by
             rw [noPivotLoop_add elapsed 1
               (Matrix.noPivotInitialState (Matrix.gramMatrix b))]
             rw [Matrix.noPivotLoop_of_regular 0 state hDone hp]
@@ -631,7 +631,7 @@ private theorem matrix_diag_at_fin_eq {n : Nat} (M : Matrix Int n n)
 /-- If the `a`-fueled no-pivot Bareiss prefix already recorded a singular step,
 that step persists into any longer pass. -/
 private theorem noPivotLoop_extends_singularStep
-    {n : Nat} (state : Matrix.BareissState n) (a b : Nat) (k : Fin n)
+    {n : Nat} (state : Matrix.BareissState Int n) (a b : Nat) (k : Fin n)
     (h_sing_a : (Matrix.noPivotLoop a state).singularStep = some k.val)
     (h_step_a : (Matrix.noPivotLoop a state).step = k.val)
     (h_zero_a : (Matrix.noPivotLoop a state).matrix[k][k] = 0)
@@ -752,8 +752,8 @@ explicitly as `result` to keep Fin-index proof terms uniform across the
 induction. -/
 private theorem pivotLoop_singularStep_some
     {n : Nat} :
-    ∀ (a : Nat) (fuel : Nat) (state : Matrix.BareissState n)
-      (result : Matrix.BareissState n)
+    ∀ (a : Nat) (fuel : Nat) (state : Matrix.BareissState Int n)
+      (result : Matrix.BareissState Int n)
       (_h_partial : Matrix.noPivotLoop a state = result),
       state.singularStep = none →
       a + 1 ≤ fuel →
@@ -824,7 +824,7 @@ private theorem pivotLoop_singularStep_some
                    state.matrix[state.step][state.step] state.prevPivot
                  prevPivot := state.matrix[state.step][state.step]
                  rowSwaps := state.rowSwaps
-                 singularStep := none } : Matrix.BareissState n) = result := by
+                 singularStep := none } : Matrix.BareissState Int n) = result := by
           rw [← h_unfold_noPiv]; exact h_partial
         exact ih fuel'
           { step := state.step + 1

--- a/HexGramSchmidt/Int/Scaled.lean
+++ b/HexGramSchmidt/Int/Scaled.lean
@@ -1464,8 +1464,8 @@ theorem bareissNoPivotData_diag_eq_principalSubmatrix_bareiss_of_prefix_nonsingu
     (Matrix.bareissNoPivotData (Matrix.gramMatrix b)).matrix[
         (⟨r, hr⟩ : Fin n)][(⟨r, hr⟩ : Fin n)] =
         fullAtR.matrix[(⟨r, hr⟩ : Fin n)][(⟨r, hr⟩ : Fin n)] := by
-          simpa [Matrix.bareissNoPivotData, Matrix.finish, GM, init, fullAtR] using
-            h_final_diag
+          rw [Matrix.bareissNoPivotData_eq_finish]
+          simpa [Matrix.finish, GM, init, fullAtR] using h_final_diag
     _ =
         (Matrix.noPivotLoop r (Matrix.noPivotInitialState LP)).matrix[
           (⟨r, Nat.lt_succ_self r⟩ : Fin (r + 1))][

--- a/HexGramSchmidt/Int/Scaled.lean
+++ b/HexGramSchmidt/Int/Scaled.lean
@@ -668,7 +668,7 @@ to the bordered minor, matches the bordered-minor state's matrix. -/
 private theorem noPivotLoop_sync_borderedMinor_aux
     {n : Nat} (k : Nat) (hk : k < n) (row col : Fin n)
     (hrow : k ≤ row.val) (hcol : k ≤ col.val) (fuel : Nat) :
-    ∀ (state_full : Matrix.BareissState n) (state_bm : Matrix.BareissState (k + 1)),
+    ∀ (state_full : Matrix.BareissState Int n) (state_bm : Matrix.BareissState Int (k + 1)),
       state_full.step = state_bm.step →
       state_full.prevPivot = state_bm.prevPivot →
       state_full.rowSwaps = state_bm.rowSwaps →
@@ -792,7 +792,7 @@ theorem noPivotLoop_full_eq_borderedMinor_at_trailing
 the resulting step between the starting step and the starting step plus the
 fuel. -/
 private theorem noPivotLoop_step_le_add
-    {n : Nat} (fuel : Nat) (state : Matrix.BareissState n) :
+    {n : Nat} (fuel : Nat) (state : Matrix.BareissState Int n) :
     (Matrix.noPivotLoop fuel state).step ≤ state.step + fuel := by
   induction fuel generalizing state with
   | zero =>
@@ -826,7 +826,7 @@ update commutes through symmetry because the trailing block remains symmetric
 after each `stepMatrix` application. -/
 private theorem noPivotLoop_matrix_symm_preserve
     {n : Nat} (fuel : Nat) :
-    ∀ (state : Matrix.BareissState n),
+    ∀ (state : Matrix.BareissState Int n),
       (∀ a b : Fin n, state.step ≤ a.val → state.step ≤ b.val →
         state.matrix[a][b] = state.matrix[b][a]) →
       ∀ (a b : Fin n),
@@ -950,7 +950,7 @@ their bookkeeping fields agree and the full state's matrix, restricted
 to the leading prefix, matches the prefix state's matrix. -/
 private theorem noPivotLoop_sync_principalSubmatrix_aux
     {n K : Nat} (hK : K ≤ n) (fuel : Nat) :
-    ∀ (state_full : Matrix.BareissState n) (state_pref : Matrix.BareissState K),
+    ∀ (state_full : Matrix.BareissState Int n) (state_pref : Matrix.BareissState Int K),
       state_full.step = state_pref.step →
       state_full.prevPivot = state_pref.prevPivot →
       state_full.rowSwaps = state_pref.rowSwaps →
@@ -1044,7 +1044,7 @@ private theorem noPivotLoop_sync_principalSubmatrix_aux
 /-- Once the no-pivot Bareiss loop has reached the boundary
 (`state.step + 1 ≥ n`), any further fuel is a no-op. -/
 private theorem noPivotLoop_id_at_done
-    {n : Nat} (fuel : Nat) (state : Matrix.BareissState n)
+    {n : Nat} (fuel : Nat) (state : Matrix.BareissState Int n)
     (hDone : ¬ state.step + 1 < n) :
     Matrix.noPivotLoop fuel state = state := by
   induction fuel with
@@ -1055,7 +1055,7 @@ private theorem noPivotLoop_id_at_done
 (`state.singularStep = some state.step` with a zero pivot at that step),
 any further fuel is a no-op. -/
 theorem noPivotLoop_id_at_singular_fixedpoint
-    {n : Nat} (fuel : Nat) (state : Matrix.BareissState n)
+    {n : Nat} (fuel : Nat) (state : Matrix.BareissState Int n)
     (hDone : state.step + 1 < n)
     (hp : state.matrix[(⟨state.step, Nat.lt_of_succ_lt hDone⟩ : Fin n)][(⟨state.step, Nat.lt_of_succ_lt hDone⟩ : Fin n)] = 0)
     (hsing : state.singularStep = some state.step) :
@@ -1074,7 +1074,7 @@ theorem noPivotLoop_id_at_singular_fixedpoint
 /-- Fuel composition for the no-pivot Bareiss loop: running `a + b` units of
 fuel from `state` equals running `b` more units after `a` initial units. -/
 theorem noPivotLoop_add
-    {n : Nat} (a b : Nat) (state : Matrix.BareissState n) :
+    {n : Nat} (a b : Nat) (state : Matrix.BareissState Int n) :
     Matrix.noPivotLoop (a + b) state =
       Matrix.noPivotLoop b (Matrix.noPivotLoop a state) := by
   induction a generalizing state with
@@ -1100,7 +1100,7 @@ theorem noPivotLoop_add
           rw [h_lhs, h_rhs_inner]
           symm
           -- Now show: noPivotLoop b {state with singularStep := some state.step} = that.
-          let s' : Matrix.BareissState n :=
+          let s' : Matrix.BareissState Int n :=
             {state with singularStep := some state.step}
           have hDone_s' : s'.step + 1 < n := hDone
           have hp_s' : s'.matrix[(⟨s'.step, Nat.lt_of_succ_lt hDone_s'⟩ : Fin n)][(⟨s'.step, Nat.lt_of_succ_lt hDone_s'⟩ : Fin n)] = 0 := hp
@@ -1141,7 +1141,7 @@ step, the result has either no singular step, or it has a singular step
 that matches the current `step` field together with a zero pivot at that
 position. -/
 theorem noPivotLoop_singular_inv
-    {n : Nat} (fuel : Nat) (state : Matrix.BareissState n)
+    {n : Nat} (fuel : Nat) (state : Matrix.BareissState Int n)
     (h_init : state.singularStep = none) :
     (Matrix.noPivotLoop fuel state).singularStep = none ∨
     ∃ k : Fin n,
@@ -1180,7 +1180,7 @@ advances by at most one per regular iteration; with `fuel` iterations available
 and at least one used for the singular trigger, the recorded index is `< start
 + fuel`. -/
 theorem noPivotLoop_singularStep_lt
-    {n : Nat} (fuel : Nat) (state : Matrix.BareissState n)
+    {n : Nat} (fuel : Nat) (state : Matrix.BareissState Int n)
     (h_init : state.singularStep = none)
     (s : Nat)
     (h_sing : (Matrix.noPivotLoop fuel state).singularStep = some s) :
@@ -1216,7 +1216,7 @@ no recorded singular step, if the result also has no recorded singular step
 and the loop had at least `fuel + 1` steps of room from its starting step,
 then the result's step is the starting step plus `fuel`. -/
 private theorem noPivotLoop_step_eq_add_of_singularStep_none
-    {n : Nat} (fuel : Nat) (state : Matrix.BareissState n)
+    {n : Nat} (fuel : Nat) (state : Matrix.BareissState Int n)
     (h_init : state.singularStep = none)
     (h_room : state.step + fuel + 1 ≤ n)
     (h_no_sing : (Matrix.noPivotLoop fuel state).singularStep = none) :
@@ -1250,7 +1250,7 @@ nonzero status of the previous pivot. Regular branches replace `prevPivot` by
 the current nonzero pivot; singular branches contradict the final
 `singularStep = none` hypothesis. -/
 private theorem noPivotLoop_prevPivot_ne_zero
-    {n : Nat} (fuel : Nat) (state : Matrix.BareissState n)
+    {n : Nat} (fuel : Nat) (state : Matrix.BareissState Int n)
     (hprev : state.prevPivot ≠ 0)
     (h_no_sing : (Matrix.noPivotLoop fuel state).singularStep = none) :
     (Matrix.noPivotLoop fuel state).prevPivot ≠ 0 := by
@@ -1278,7 +1278,7 @@ private theorem noPivotLoop_prevPivot_ne_zero
 /-- The `step` field of a no-pivot Bareiss state never decreases under further
 loop iterations. -/
 theorem noPivotLoop_step_monotone
-    {n : Nat} (fuel : Nat) (state : Matrix.BareissState n) :
+    {n : Nat} (fuel : Nat) (state : Matrix.BareissState Int n) :
     state.step ≤ (Matrix.noPivotLoop fuel state).step := by
   induction fuel generalizing state with
   | zero =>
@@ -1309,7 +1309,7 @@ theorem noPivotLoop_step_monotone
 /-- A singular step recorded by an initial no-pivot prefix remains the recorded
 singular step after any further no-pivot iterations. -/
 private theorem noPivotLoop_singularStep
-    {n : Nat} (a b : Nat) (state : Matrix.BareissState n)
+    {n : Nat} (a b : Nat) (state : Matrix.BareissState Int n)
     (h_init : state.singularStep = none) {s : Nat}
     (h_prefix : (Matrix.noPivotLoop a state).singularStep = some s) :
     (Matrix.noPivotLoop (a + b) state).singularStep = some s := by
@@ -1349,7 +1349,7 @@ private theorem noPivotLoop_singularStep
 /-- If a full no-pivot run has no singular step, every initial prefix run also
 has no singular step. -/
 private theorem noPivotLoop_prefix_none_of_final_none
-    {n : Nat} (a b : Nat) (state : Matrix.BareissState n)
+    {n : Nat} (a b : Nat) (state : Matrix.BareissState Int n)
     (h_init : state.singularStep = none)
     (h_final : (Matrix.noPivotLoop (a + b) state).singularStep = none) :
     (Matrix.noPivotLoop a state).singularStep = none := by
@@ -1364,7 +1364,7 @@ private theorem noPivotLoop_prefix_none_of_final_none
 /-- If the full run records its first singular step after `a`, then the prefix
 of length `a` is non-singular. -/
 private theorem noPivotLoop_prefix_none_of_final_singular_after
-    {n : Nat} (a b : Nat) (state : Matrix.BareissState n)
+    {n : Nat} (a b : Nat) (state : Matrix.BareissState Int n)
     (h_init : state.singularStep = none) {s : Nat}
     (h_final : (Matrix.noPivotLoop (a + b) state).singularStep = some s)
     (hs_after : state.step + a ≤ s) :

--- a/HexGramSchmidtMathlib/Int/Augmented.lean
+++ b/HexGramSchmidtMathlib/Int/Augmented.lean
@@ -215,7 +215,7 @@ private theorem matrix_diag_at_fin_eq {n : Nat} (M : Matrix Int n n)
 that step persists into any longer pass. The longer pass's recorded singular
 index therefore matches the earlier one. -/
 private theorem noPivotLoop_extends_singularStep
-    {n : Nat} (state : Matrix.BareissState n) (a b : Nat) (k : Fin n)
+    {n : Nat} (state : Matrix.BareissState Int n) (a b : Nat) (k : Fin n)
     (h_sing_a : (Matrix.noPivotLoop a state).singularStep = some k.val)
     (h_step_a : (Matrix.noPivotLoop a state).step = k.val)
     (h_zero_a :
@@ -314,7 +314,7 @@ re-state `BareissNoPivotInvariant.trailing_eq` with the step value supplied
 externally so the dependent bordered-minor type matches the desired
 `s = state.step` substitution cleanly. -/
 theorem trailing_eq_at_step_local
-    {n' : Nat} {M : Hex.Matrix Int n' n'} {state : Matrix.BareissState n'}
+    {n' : Nat} {M : Hex.Matrix Int n' n'} {state : Matrix.BareissState Int n'}
     (hinv : HexMatrixMathlib.BareissNoPivotInvariant M state)
     (s : Nat) (hs : s < n') (hstep : s = state.step)
     (a c : Fin n') (hsa : s ≤ a.val) (hsc : s ≤ c.val) :
@@ -845,7 +845,7 @@ theorem noPivotLoop_initial_step_eq_and_fuel_succ_le
 so the dependent `principalSubmatrix` type matches the desired `s = state.step`
 substitution cleanly. -/
 theorem prevPivot_eq_at_step_local
-    {n' : Nat} {M : Hex.Matrix Int n' n'} {state : Matrix.BareissState n'}
+    {n' : Nat} {M : Hex.Matrix Int n' n'} {state : Matrix.BareissState Int n'}
     (hinv : HexMatrixMathlib.BareissNoPivotInvariant M state)
     (s : Nat) (hs : s ≤ n') (hstep : s = state.step) :
     state.prevPivot = Hex.Matrix.det (Hex.Matrix.principalSubmatrix M s hs) := by

--- a/HexGramSchmidtMathlib/Int/RowAdd.lean
+++ b/HexGramSchmidtMathlib/Int/RowAdd.lean
@@ -767,7 +767,7 @@ its `(k, k)` matrix entry equals the determinant of the `(k + 1)`-leading
 prefix of the source matrix. Stated with `k` as a free variable so that
 `subst` can replace the let-bound projection with a fresh name. -/
 private theorem bareissNoPivotInvariant_diag_eq
-    {n : Nat} (M : Matrix Int n n) (state : Matrix.BareissState n) (k : Nat)
+    {n : Nat} (M : Matrix Int n n) (state : Matrix.BareissState Int n) (k : Nat)
     (hinv : HexMatrixMathlib.BareissNoPivotInvariant M state)
     (hsk : k = state.step) (hk : k < n) :
     state.matrix[(⟨k, hk⟩ : Fin n)][(⟨k, hk⟩ : Fin n)] =

--- a/HexManual/Chapters/HexBareiss.lean
+++ b/HexManual/Chapters/HexBareiss.lean
@@ -152,10 +152,21 @@ tag := "hex-bareiss-mathlib"
 %%%
 
 Everything above is executable and Mathlib-free. `HexBareissMathlib`
-connects it to Mathlib. Its headline theorem is that the fraction-free
-Bareiss determinant equals the Leibniz {ref "hex-determinant"}[determinant]
-on integer square matrices, so the cubic-time route and the
-specification agree outright.
+connects it to Mathlib. The final public umbrella exposes the correspondence
+over any commutative coefficient ring supplied with an exact quotient. The
+single law says that quotient cancels a known nonzero right factor; no public
+domain or nontriviality hypothesis is added.
+
+{docstring HexMatrixMathlib.bareissWith_eq_det}
+
+The matching theorem against Mathlib's determinant is available directly,
+without unfolding the generic loop or relying on definitional equality.
+
+{docstring HexMatrixMathlib.bareissWith_eq_mathlib_det}
+
+For integer matrices, {name}`Hex.Matrix.bareiss` remains the specialization
+using the native exact-division primitive. Its original theorem names and
+premise-free statements remain the convenient compatibility surface.
 
 {docstring HexMatrixMathlib.bareiss_eq_det}
 

--- a/HexManual/Chapters/HexBareiss.lean
+++ b/HexManual/Chapters/HexBareiss.lean
@@ -13,7 +13,7 @@ open Verso.Genre.Manual.InlineLean
 
 set_option pp.rawOnError true
 
-#doc (Manual) "HexBareiss: the fraction-free integer determinant" =>
+#doc (Manual) "HexBareiss: the fraction-free determinant" =>
 %%%
 tag := "hex-bareiss"
 %%%
@@ -27,11 +27,12 @@ Released as [hex-bareiss](https://github.com/leanprover/hex-bareiss), with
 the Mathlib correspondence in
 [hex-bareiss-mathlib](https://github.com/leanprover/hex-bareiss-mathlib).
 
-`HexBareiss` is the executable fraction-free Bareiss determinant of a
-dense integer matrix: a Gaussian elimination in which every intermediate
-entry stays an exact integer because each update divides *exactly* by
-the previous pivot. It runs in cubic time and never leaves the integers,
-so it avoids both the factorial blow-up of the Leibniz
+`HexBareiss` is an executable fraction-free Bareiss determinant over a
+coefficient type with a caller-supplied exact quotient. Its retained integer
+entry point specializes that one implementation to a direct GMP-backed exact
+division call. On integer matrices every intermediate entry stays integral
+because each update divides exactly by the previous pivot. The algorithm runs
+in cubic time and avoids both the factorial blow-up of the Leibniz
 {ref "hex-determinant"}[determinant] and the denominators of ordinary
 Gaussian elimination. It builds on {ref "hex-matrix"}[HexMatrix] and the
 {ref "hex-determinant"}[HexDeterminant] Leibniz determinant (the
@@ -68,11 +69,18 @@ matrix with the swap sign applied.
 tag := "hex-bareiss-entry"
 %%%
 
-The public entry points run the row-pivoting elimination.
+The generic public entry points {name}`Hex.Matrix.bareissDataWith` and
+{name}`Hex.Matrix.bareissWith` run the row-pivoting elimination with an explicit
+quotient operation. The traditional integer entry points specialize them to
+the native exact quotient.
 {name}`Hex.Matrix.bareissData` returns the full record.
 {name}`Hex.Matrix.bareiss` returns just the integer determinant. The
 no-pivot variants skip the pivot search, for inputs whose leading pivots
 are already nonzero.
+
+{docstring Hex.Matrix.bareissDataWith}
+
+{docstring Hex.Matrix.bareissWith}
 
 {docstring Hex.Matrix.bareissData}
 
@@ -82,10 +90,11 @@ are already nonzero.
 
 {docstring Hex.Matrix.bareissNoPivot}
 
-The division at each step is `Int.divExact` (a GMP-backed
-`mpz_divexact`), which is always exact and carries its divisibility
-proof. The bordered minors are the intermediate determinants the
-correctness proof uses as its elimination invariant.
+For integers, the quotient specializes to the GMP-backed
+`lean_int_div_exact` primitive. The executable loop does not carry a
+divisibility proof; the Mathlib correspondence proves exactness from the
+quotient cancellation law. The bordered minors are the intermediate
+determinants used as the elimination invariant.
 
 {docstring Hex.Matrix.borderedMinor}
 

--- a/HexManual/Chapters/HexDeterminant.lean
+++ b/HexManual/Chapters/HexDeterminant.lean
@@ -205,6 +205,12 @@ So a fact about Mathlib's {name _root_.Matrix.det}`Matrix.det` can be discharged
 executable determinant, and a fact about the executable determinant can
 be proved with Mathlib's determinant theory.
 
+The same public umbrella re-exports the bordered-minor form of
+Desnanot--Jacobi used by fraction-free elimination. It is stated over an
+arbitrary commutative ring and remains separate from the executable layer.
+
+{docstring HexMatrixMathlib.desnanot_jacobi_borderedMinor}
+
 # Cross-references
 %%%
 tag := "hex-determinant-cross-references"

--- a/HexManual/Chapters/HexRowReduce.lean
+++ b/HexManual/Chapters/HexRowReduce.lean
@@ -112,6 +112,33 @@ has a completeness theorem.
 
 {docstring Hex.Matrix.nullspace_complete}
 
+# The Mathlib correspondence
+%%%
+tag := "hex-row-reduce-mathlib"
+%%%
+
+`HexRowReduce` computes with the length-indexed {name}`Hex.Matrix` type and
+stays Mathlib-free. The public `HexRowReduceMathlib` umbrella transports its
+certified output through {name}`HexMatrixMathlib.matrixEquiv` and
+{name}`HexMatrixMathlib.vectorEquiv`; users reason with the named theorems
+below and need not unfold either equivalence or the elimination loop.
+
+The computed rank is exactly Mathlib's matrix rank.
+
+{docstring HexMatrixMathlib.rank_eq}
+
+The Boolean span test characterizes membership in the Mathlib span of the
+original rows, while the computed nullspace spans precisely the kernel of
+Mathlib's `mulVec` linear map.
+
+{docstring HexMatrixMathlib.spanContains_iff_mem_span}
+
+{docstring HexMatrixMathlib.nullspace_span_eq_ker}
+
+These results consume {name}`Hex.Matrix.IsRowReduced`, the certificate returned
+by the executable driver. They do not depend on accidental definitional
+equality between Hex and Mathlib matrices.
+
 # Recipes
 %%%
 tag := "hex-row-reduce-recipes"

--- a/HexRowReduceMathlib/README.md
+++ b/HexRowReduceMathlib/README.md
@@ -44,7 +44,7 @@ The library transports the executable row-reduction data of an
 `Hex.Matrix R n m` to Mathlib's function-based matrix `matrixEquiv M`, then
 states the correspondence theorems:
 
-- `vectorEquiv_rowCombination`: an executable row combination transports to
+- `vectorEquiv_vecMul`: an executable row combination transports to
   Mathlib's `Fintype.linearCombination` over the rows of `matrixEquiv M`;
 - `spanCoeffs_eq_linearCombination` and `spanContains_iff_mem_span`: the
   executable span witnesses and the decidable span-membership test agree with

--- a/HexRowReduceMathlib/RankSpanNullspace.lean
+++ b/HexRowReduceMathlib/RankSpanNullspace.lean
@@ -120,7 +120,7 @@ theorem spanContains_iff_mem_span [Field R] [DecidableEq R]
 /-- Every row of the computed echelon form lies in the row span of the original
 matrix `M`: row reduction does not enlarge the span. One inclusion of the
 "echelon rows span the same subspace as `M`" equivalence. -/
-theorem rowReduce_echelon_row_mem_span [Field R] [DecidableEq R]
+theorem rowReduce_echelon_row_mem_span [Field R]
     {M : Hex.Matrix R n m} {D : Hex.Matrix.RowEchelonData R n m}
     (E : Hex.Matrix.IsRowReduced M D) (i : Fin n) :
     vectorEquiv (Hex.Matrix.row D.echelon i) ∈

--- a/bench/HexBareiss/Bench.lean
+++ b/bench/HexBareiss/Bench.lean
@@ -79,6 +79,13 @@ def runBareissDet (input : DetInput) : Int :=
   let M : Hex.Matrix Int input.n input.n := matrixOfFlat input.n input.entries
   Hex.Matrix.bareiss M
 
+/-- Internal quotient-path comparison: run the same generic Bareiss algorithm
+through the guarded, `Div`-derived exact quotient. This is not an external
+comparator and does not replace the `Int` benchmark above. -/
+def runBareissGenericDet (input : DetInput) : Int :=
+  let M : Hex.Matrix Int input.n input.n := matrixOfFlat input.n input.entries
+  Hex.Matrix.bareissWith Hex.exactDiv M
+
 /-- Encode a row-major `n × n` integer matrix fixture as the JSON 2D
 array shape FLINT's `fmpz_mat` family accepts (`rows: [[…], …]`). -/
 def flatToFlintRows (n : Nat) (entries : Array Int) : Lean.Json :=
@@ -106,6 +113,8 @@ prepared input so wall-times are comparable in the same harness. -/
 
 def runBareissDetAt (n : Nat) : Unit → IO Int := fun _ =>
   return runBareissDet (prepDetInput n)
+def runBareissGenericDetAt (n : Nat) : Unit → IO Int := fun _ =>
+  return runBareissGenericDet (prepDetInput n)
 def runFlintBareissDetAt (n : Nat) : Unit → IO Int := fun _ =>
   runFlintBareissDet (prepDetInput n)
 
@@ -135,10 +144,12 @@ def runFlintBareissDet128 : Unit → IO Int := runFlintBareissDetAt 128
 def runBareissDet192 : Unit → IO Int := runBareissDetAt 192
 def runFlintBareissDet192 : Unit → IO Int := runFlintBareissDetAt 192
 def runBareissDet256 : Unit → IO Int := runBareissDetAt 256
+def runBareissGenericDet256 : Unit → IO Int := runBareissGenericDetAt 256
 def runFlintBareissDet256 : Unit → IO Int := runFlintBareissDetAt 256
 def runBareissDet320 : Unit → IO Int := runBareissDetAt 320
 def runFlintBareissDet320 : Unit → IO Int := runFlintBareissDetAt 320
 def runBareissDet384 : Unit → IO Int := runBareissDetAt 384
+def runBareissGenericDet384 : Unit → IO Int := runBareissGenericDetAt 384
 def runFlintBareissDet384 : Unit → IO Int := runFlintBareissDetAt 384
 def runBareissDet512 : Unit → IO Int := runBareissDetAt 512
 def runFlintBareissDet512 : Unit → IO Int := runFlintBareissDetAt 512
@@ -184,10 +195,12 @@ setup_fixed_benchmark runFlintBareissDet128 where { repeats := 5, maxSecondsPerC
 setup_fixed_benchmark runBareissDet192 where { repeats := 5, maxSecondsPerCall := 6.0 }
 setup_fixed_benchmark runFlintBareissDet192 where { repeats := 5, maxSecondsPerCall := 6.0 }
 setup_fixed_benchmark runBareissDet256 where { repeats := 5, maxSecondsPerCall := 6.0 }
+setup_fixed_benchmark runBareissGenericDet256 where { repeats := 5, maxSecondsPerCall := 6.0 }
 setup_fixed_benchmark runFlintBareissDet256 where { repeats := 5, maxSecondsPerCall := 6.0 }
 setup_fixed_benchmark runBareissDet320 where { repeats := 5, maxSecondsPerCall := 8.0 }
 setup_fixed_benchmark runFlintBareissDet320 where { repeats := 5, maxSecondsPerCall := 8.0 }
 setup_fixed_benchmark runBareissDet384 where { repeats := 5, maxSecondsPerCall := 12.0 }
+setup_fixed_benchmark runBareissGenericDet384 where { repeats := 5, maxSecondsPerCall := 12.0 }
 setup_fixed_benchmark runFlintBareissDet384 where { repeats := 5, maxSecondsPerCall := 12.0 }
 setup_fixed_benchmark runBareissDet512 where { repeats := 5, maxSecondsPerCall := 25.0 }
 setup_fixed_benchmark runFlintBareissDet512 where { repeats := 5, maxSecondsPerCall := 25.0 }

--- a/conformance/HexBareiss/Conformance.lean
+++ b/conformance/HexBareiss/Conformance.lean
@@ -73,6 +73,25 @@ shape `Matrix.bareiss M = Matrix.det M`. -/
 #guard (Matrix.bareissData singularInt).det = 0
 #guard (Matrix.bareissData pivotInt).rowSwaps = 1
 
+/- The generic coefficient path agrees with the retained integer surface and
+also runs over a non-integer exact-division carrier. -/
+
+#guard Matrix.bareissWith Matrix.exactDiv baseInt = Matrix.bareiss baseInt
+#guard (Matrix.bareissDataWith Matrix.exactDiv pivotInt).det =
+  (Matrix.bareissData pivotInt).det
+#guard (Matrix.bareissDataWith Matrix.exactDiv pivotInt).rowSwaps =
+  (Matrix.bareissData pivotInt).rowSwaps
+
+private def baseRat : Matrix Rat 2 2 :=
+  Matrix.ofFn fun i j =>
+    match i.val, j.val with
+    | 0, 0 => 1 / 2
+    | 0, _ => 2 / 3
+    | 1, 0 => 3 / 4
+    | _, _ => 5 / 6
+
+#guard Matrix.bareissWith (fun a b : Rat => a / b) baseRat = Matrix.det baseRat
+
 /-!
 6×6 fixtures matching the SPEC `core` matrix-dimension band:
 

--- a/conformance/HexBareiss/Conformance.lean
+++ b/conformance/HexBareiss/Conformance.lean
@@ -76,11 +76,13 @@ shape `Matrix.bareiss M = Matrix.det M`. -/
 /- The generic coefficient path agrees with the retained integer surface and
 also runs over a non-integer exact-division carrier. -/
 
-#guard Matrix.bareissWith Matrix.exactDiv baseInt = Matrix.bareiss baseInt
-#guard (Matrix.bareissDataWith Matrix.exactDiv pivotInt).det =
+#guard Matrix.bareissWith Hex.exactDiv baseInt = Matrix.bareiss baseInt
+#guard (Matrix.bareissDataWith Hex.exactDiv pivotInt).det =
   (Matrix.bareissData pivotInt).det
-#guard (Matrix.bareissDataWith Matrix.exactDiv pivotInt).rowSwaps =
+#guard (Matrix.bareissDataWith Hex.exactDiv pivotInt).rowSwaps =
   (Matrix.bareissData pivotInt).rowSwaps
+
+#synth Hex.ExactDivLaws Rat
 
 private def baseRat : Matrix Rat 2 2 :=
   Matrix.ofFn fun i j =>
@@ -90,7 +92,32 @@ private def baseRat : Matrix Rat 2 2 :=
     | 1, 0 => 3 / 4
     | _, _ => 5 / 6
 
-#guard Matrix.bareissWith (fun a b : Rat => a / b) baseRat = Matrix.det baseRat
+private def pivotRat : Matrix Rat 2 2 :=
+  Matrix.ofFn fun i j =>
+    match i.val, j.val with
+    | 0, 0 => 0
+    | 0, _ => 2 / 3
+    | 1, 0 => 3 / 4
+    | _, _ => 5 / 6
+
+private def singularRat : Matrix Rat 2 2 :=
+  Matrix.ofFn fun i j =>
+    match i.val, j.val with
+    | 0, 0 => 1 / 2
+    | 0, _ => 2 / 3
+    | 1, 0 => 1
+    | _, _ => 4 / 3
+
+private def emptyRat : Matrix Rat 0 0 := 0
+
+private def singletonRat : Matrix Rat 1 1 :=
+  Matrix.ofFn fun _ _ => 7 / 3
+
+#guard Matrix.bareissWith Hex.exactDiv baseRat = Matrix.det baseRat
+#guard Matrix.bareissWith Hex.exactDiv pivotRat = Matrix.det pivotRat
+#guard Matrix.bareissWith Hex.exactDiv singularRat = Matrix.det singularRat
+#guard Matrix.bareissWith Hex.exactDiv emptyRat = Matrix.det emptyRat
+#guard Matrix.bareissWith Hex.exactDiv singletonRat = Matrix.det singletonRat
 
 /-!
 6×6 fixtures matching the SPEC `core` matrix-dimension band:

--- a/libraries.yml
+++ b/libraries.yml
@@ -707,12 +707,12 @@ libraries:
   HexRowReduceMathlib:
     deps: [HexMatrixMathlib, HexRowReduce]
     mathlib: true
-    done_through: 6
+    done_through: 7
     status: active
   HexDeterminantMathlib:
     deps: [HexBareiss, HexDeterminant, HexMatrixMathlib]
     mathlib: true
-    done_through: 6
+    done_through: 7
     status: active
   HexCharPolyMathlib:
     deps: [HexCharPoly, HexMatrixMathlib, HexPolyMathlib, HexDeterminantMathlib]
@@ -727,7 +727,7 @@ libraries:
   HexBareissMathlib:
     deps: [HexDeterminantMathlib]
     mathlib: true
-    done_through: 6
+    done_through: 7
     status: active
   HexModArithMathlib:
     deps: [HexModArith]

--- a/libraries.yml
+++ b/libraries.yml
@@ -707,12 +707,12 @@ libraries:
   HexRowReduceMathlib:
     deps: [HexMatrixMathlib, HexRowReduce]
     mathlib: true
-    done_through: 5
+    done_through: 6
     status: active
   HexDeterminantMathlib:
     deps: [HexBareiss, HexDeterminant, HexMatrixMathlib]
     mathlib: true
-    done_through: 5
+    done_through: 6
     status: active
   HexCharPolyMathlib:
     deps: [HexCharPoly, HexMatrixMathlib, HexPolyMathlib, HexDeterminantMathlib]
@@ -727,7 +727,7 @@ libraries:
   HexBareissMathlib:
     deps: [HexDeterminantMathlib]
     mathlib: true
-    done_through: 5
+    done_through: 6
     status: active
   HexModArithMathlib:
     deps: [HexModArith]

--- a/progress/20260827T062603Z_issue9656.md
+++ b/progress/20260827T062603Z_issue9656.md
@@ -1,0 +1,61 @@
+# Row-reduction, determinant, and Bareiss Mathlib Phases 6–7 (#9656)
+
+## Accomplished
+
+`HexRowReduceMathlib`, `HexDeterminantMathlib`, and `HexBareissMathlib` advance
+from `done_through: 5` to `done_through: 7` through separate Phase 6 and Phase 7
+commits.
+
+- Phase 6: audited public correspondence declarations, hypotheses, namespace
+  placement, docstrings, imports, and downstream uses. Removed unnecessary
+  typeclass hypotheses, retained the established short integer theorem surface,
+  and replaced a Gram–Schmidt definitional-unfolding dependency with the named
+  `bareissNoPivotData_eq_finish` characterisation theorem.
+- The executable Bareiss coefficient API is generic in its coefficient type and
+  exact quotient operation. The Mathlib proof now establishes
+  `bareissWith_eq_det` and `bareissWith_eq_mathlib_det` over any commutative ring
+  with decidable equality and the exact right-cancellation law. The original
+  integer declarations are compatibility specialisations of that one
+  implementation.
+- Phase 7: added the exact `# The Mathlib correspondence` section to the
+  row-reduction chapter with substantive rank, row-span, and nullspace content;
+  re-audited the determinant and Bareiss sections against their public
+  umbrellas; and compiled the three README quickstarts verbatim as temporary
+  Lake modules.
+
+## Integer performance gate
+
+The generic implementation preserves direct integer exact division. Generated
+C for `Hex.BareissBench.runBareissDet` calls `lean_int_div_exact` at the inner
+update site rather than applying a quotient closure.
+
+Five-repeat medians on the deterministic `structured-bareiss-determinant`
+fixture passed the required branch/base ceiling of `1.02` at both fixed rungs:
+
+| n | `origin/main` (`32ac5850a`) | branch | branch/base |
+|---:|---:|---:|---:|
+| 256 | 263.939 ms | 148.041 ms | 0.561x |
+| 384 | 825.551 ms | 512.178 ms | 0.620x |
+
+The result hashes matched at both rungs. Conformance additionally checks that
+the retained `Int` entry points agree with the generic `Matrix.exactDiv` path
+and that the same implementation computes a rational determinant.
+
+## Verification
+
+- `lake build HexRowReduceMathlib HexDeterminantMathlib HexBareissMathlib HexManual`
+- `lake build HexBareiss.Conformance hexbareiss_bench`
+- `lake exe runLinter --no-build HexRowReduceMathlib HexDeterminantMathlib HexBareissMathlib`
+- all three README quickstarts compiled exactly as written
+- Matrix, determinant, and all Lean-side Bareiss benchmark verification targets
+- DAG, Phase 4, Phase 7, Mathlib-free bench import, manual-split, released
+  manifest, and published trust-surface checks
+
+The complete Bareiss benchmark registry also contains external FLINT targets.
+Those require `python-flint`, which is absent from this worker; the applicable
+Lean-side checks and the branch/base regression evidence above passed, while CI
+provides the configured external dependency.
+
+## Remaining work
+
+None for issue #9656.

--- a/progress/20260827T062603Z_issue9656.md
+++ b/progress/20260827T062603Z_issue9656.md
@@ -41,6 +41,12 @@ The result hashes matched at both rungs. Conformance additionally checks that
 the retained `Int` entry points agree with the generic `Matrix.exactDiv` path
 and that the same implementation computes a rational determinant.
 
+Because `HexBareiss/Bareiss.lean` is also on the public integer-factorization
+runtime path, the clean-commit `hex-factor` sweep was refreshed across all 392
+corpus instances. On the 383 rows solved by both records, the median paired
+new/old ratio was `1.0027x` (p10 `0.9749x`, p90 `1.0351x`), providing a
+whole-consumer cross-check in addition to the dedicated Bareiss gate.
+
 ## Verification
 
 - `lake build HexRowReduceMathlib HexDeterminantMathlib HexBareissMathlib HexManual`
@@ -48,6 +54,7 @@ and that the same implementation computes a rational determinant.
 - `lake exe runLinter --no-build HexRowReduceMathlib HexDeterminantMathlib HexBareissMathlib`
 - all three README quickstarts compiled exactly as written
 - Matrix, determinant, and all Lean-side Bareiss benchmark verification targets
+- refreshed clean-commit Hex factorization sweep and all 25 generated figures
 - DAG, Phase 4, Phase 7, Mathlib-free bench import, manual-split, released
   manifest, and published trust-surface checks
 

--- a/reports/bench-results/hexbz-factor-sweep-62d17719-chungus2.json
+++ b/reports/bench-results/hexbz-factor-sweep-62d17719-chungus2.json
@@ -10,7 +10,7 @@
     "hostname": "chungus2",
     "exe_name": "factor_sweep",
     "lean_bench_version": null,
-    "git_commit": "7bcb3861c5ae5ee03e917f6cb420e94df508ff8b",
+    "git_commit": "62d17719af332c3e6721befd0a6bfe67d920ccf1",
     "git_dirty": false,
     "timestamp_unix_ms": 1787813535849,
     "timestamp_iso": "2026-08-27T06:52:15Z"

--- a/reports/bench-results/hexbz-factor-sweep-7bcb3861-chungus2.json
+++ b/reports/bench-results/hexbz-factor-sweep-7bcb3861-chungus2.json
@@ -1,0 +1,6037 @@
+{
+  "env": {
+    "lean_version": null,
+    "lean_toolchain": "leanprover/lean4:v4.34.0-rc2",
+    "platform_target": null,
+    "os": "linux",
+    "arch": "x86_64",
+    "cpu_model": null,
+    "cpu_cores": 96,
+    "hostname": "chungus2",
+    "exe_name": "factor_sweep",
+    "lean_bench_version": null,
+    "git_commit": "7bcb3861c5ae5ee03e917f6cb420e94df508ff8b",
+    "git_dirty": false,
+    "timestamp_unix_ms": 1787813535849,
+    "timestamp_iso": "2026-08-27T06:52:15Z"
+  },
+  "config": {
+    "cutoff_seconds": 10.0,
+    "repeats_policy": "median-of-5 when first call < 1s, else single call",
+    "overhead_repeats": 21,
+    "corpus_path": "bench/corpus/hexbz-factor-corpus.jsonl",
+    "corpus_sha256": "619913904240834c912489e6cc23ba136e8cc5ebf0ea95f83397e0682387284d",
+    "early_terminate_run": 3,
+    "early_terminate_families": [
+      "conway",
+      "hoeij-zimmermann",
+      "sd-products",
+      "swinnerton-dyer"
+    ],
+    "systems": [
+      "hex-factor"
+    ],
+    "system_versions": {
+      "hex-factor": "leanprover/lean4:v4.34.0-rc2"
+    },
+    "per_system_overhead_nanos": {
+      "hex-factor": 21933
+    }
+  },
+  "results": [
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi5",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 37054,
+      "min_nanos": 36334,
+      "max_nanos": 48702,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi7",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 43584,
+      "min_nanos": 42674,
+      "max_nanos": 54180,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi15",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 102932,
+      "min_nanos": 98406,
+      "max_nanos": 131205,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi11",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 100269,
+      "min_nanos": 90775,
+      "max_nanos": 111846,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi13",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 220608,
+      "min_nanos": 207939,
+      "max_nanos": 246055,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi17",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 103214,
+      "min_nanos": 98395,
+      "max_nanos": 108241,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi19",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 116442,
+      "min_nanos": 113869,
+      "max_nanos": 120108,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi25",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 129342,
+      "min_nanos": 125206,
+      "max_nanos": 131956,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi23",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 254468,
+      "min_nanos": 243982,
+      "max_nanos": 274056,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi35",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 353134,
+      "min_nanos": 345292,
+      "max_nanos": 390850,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi29",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 205145,
+      "min_nanos": 202190,
+      "max_nanos": 208440,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi64",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 342819,
+      "min_nanos": 333335,
+      "max_nanos": 371932,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi37",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 660881,
+      "min_nanos": 635944,
+      "max_nanos": 698477,
+      "factor_count": 1,
+      "factor_degrees": [
+        36
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi41",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 2041079,
+      "min_nanos": 1978436,
+      "max_nanos": 2128159,
+      "factor_count": 1,
+      "factor_degrees": [
+        40
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi49",
+      "degree": 42,
+      "status": "ok",
+      "median_nanos": 381827,
+      "min_nanos": 380765,
+      "max_nanos": 397340,
+      "factor_count": 1,
+      "factor_degrees": [
+        42
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi105",
+      "degree": 48,
+      "status": "ok",
+      "median_nanos": 5215320,
+      "min_nanos": 5163743,
+      "max_nanos": 5253697,
+      "factor_count": 1,
+      "factor_degrees": [
+        48
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi53",
+      "degree": 52,
+      "status": "ok",
+      "median_nanos": 541453,
+      "min_nanos": 528844,
+      "max_nanos": 572990,
+      "factor_count": 1,
+      "factor_degrees": [
+        52
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi81",
+      "degree": 54,
+      "status": "ok",
+      "median_nanos": 665748,
+      "min_nanos": 660730,
+      "max_nanos": 673770,
+      "factor_count": 1,
+      "factor_degrees": [
+        54
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi61",
+      "degree": 60,
+      "status": "ok",
+      "median_nanos": 6419858,
+      "min_nanos": 6385226,
+      "max_nanos": 6487818,
+      "factor_count": 1,
+      "factor_degrees": [
+        60
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi128",
+      "degree": 64,
+      "status": "ok",
+      "median_nanos": 982097,
+      "min_nanos": 980345,
+      "max_nanos": 1017610,
+      "factor_count": 1,
+      "factor_degrees": [
+        64
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi165",
+      "degree": 80,
+      "status": "ok",
+      "median_nanos": 7852273,
+      "min_nanos": 7808528,
+      "max_nanos": 8037408,
+      "factor_count": 1,
+      "factor_degrees": [
+        80
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi89",
+      "degree": 88,
+      "status": "ok",
+      "median_nanos": 1379807,
+      "min_nanos": 1358726,
+      "max_nanos": 1537432,
+      "factor_count": 1,
+      "factor_degrees": [
+        88
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi121",
+      "degree": 110,
+      "status": "ok",
+      "median_nanos": 42996368,
+      "min_nanos": 42294647,
+      "max_nanos": 43743136,
+      "factor_count": 1,
+      "factor_degrees": [
+        110
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi256",
+      "degree": 128,
+      "status": "ok",
+      "median_nanos": 3773300,
+      "min_nanos": 3714923,
+      "max_nanos": 3904985,
+      "factor_count": 1,
+      "factor_degrees": [
+        128
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi151",
+      "degree": 150,
+      "status": "ok",
+      "median_nanos": 29786494,
+      "min_nanos": 29385910,
+      "max_nanos": 30023285,
+      "factor_count": 1,
+      "factor_degrees": [
+        150
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi243",
+      "degree": 162,
+      "status": "ok",
+      "median_nanos": 5086929,
+      "min_nanos": 5045047,
+      "max_nanos": 5127569,
+      "factor_count": 1,
+      "factor_degrees": [
+        162
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi179",
+      "degree": 178,
+      "status": "ok",
+      "median_nanos": 32842540,
+      "min_nanos": 32685586,
+      "max_nanos": 33797606,
+      "factor_count": 1,
+      "factor_degrees": [
+        178
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi275",
+      "degree": 200,
+      "status": "ok",
+      "median_nanos": 636988937,
+      "min_nanos": 629635627,
+      "max_nanos": 638044466,
+      "factor_count": 1,
+      "factor_degrees": [
+        200
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi385",
+      "degree": 240,
+      "status": "ok",
+      "median_nanos": 110806139,
+      "min_nanos": 110396401,
+      "max_nanos": 111586377,
+      "factor_count": 1,
+      "factor_degrees": [
+        240
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi257",
+      "degree": 256,
+      "status": "ok",
+      "median_nanos": 9823708,
+      "min_nanos": 9750189,
+      "max_nanos": 9866492,
+      "factor_count": 1,
+      "factor_degrees": [
+        256
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi331",
+      "degree": 330,
+      "status": "ok",
+      "median_nanos": 16381851,
+      "min_nanos": 16350254,
+      "max_nanos": 16529039,
+      "factor_count": 1,
+      "factor_degrees": [
+        330
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi625",
+      "degree": 500,
+      "status": "ok",
+      "median_nanos": 41307662,
+      "min_nanos": 40938063,
+      "max_nanos": 41311718,
+      "factor_count": 1,
+      "factor_degrees": [
+        500
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi509",
+      "degree": 508,
+      "status": "ok",
+      "median_nanos": 38383883,
+      "min_nanos": 37617585,
+      "max_nanos": 40261338,
+      "factor_count": 1,
+      "factor_degrees": [
+        508
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi1031",
+      "degree": 1030,
+      "status": "ok",
+      "median_nanos": 2585239774,
+      "min_nanos": 2585239774,
+      "max_nanos": 2585239774,
+      "factor_count": 1,
+      "factor_degrees": [
+        1030
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow6_minus1",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 103664,
+      "min_nanos": 96473,
+      "max_nanos": 228299,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow12_minus1",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 233958,
+      "min_nanos": 226716,
+      "max_nanos": 251623,
+      "factor_count": 6,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow15_minus1",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 280246,
+      "min_nanos": 273926,
+      "max_nanos": 313154,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        2,
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi12_x_phi13",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 379784,
+      "min_nanos": 363249,
+      "max_nanos": 404420,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi7_x_phi11",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 249800,
+      "min_nanos": 245815,
+      "max_nanos": 267668,
+      "factor_count": 2,
+      "factor_degrees": [
+        6,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow20_minus1",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 454495,
+      "min_nanos": 437049,
+      "max_nanos": 490338,
+      "factor_count": 6,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        4,
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi15_x_phi17",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 614402,
+      "min_nanos": 600171,
+      "max_nanos": 668883,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow24_minus1",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 2295927,
+      "min_nanos": 2262287,
+      "max_nanos": 2429716,
+      "factor_count": 8,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow30_minus1",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 1689428,
+      "min_nanos": 1680213,
+      "max_nanos": 1750668,
+      "factor_count": 8,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        4,
+        4,
+        8,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi24_x_phi35",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 6594927,
+      "min_nanos": 6410704,
+      "max_nanos": 7019397,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow36_minus1",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 2664905,
+      "min_nanos": 2625035,
+      "max_nanos": 2666958,
+      "factor_count": 9,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        6,
+        6,
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi32_x_phi45",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 2389396,
+      "min_nanos": 2377538,
+      "max_nanos": 2500881,
+      "factor_count": 2,
+      "factor_degrees": [
+        16,
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow48_minus1",
+      "degree": 48,
+      "status": "ok",
+      "median_nanos": 10428787,
+      "min_nanos": 10369178,
+      "max_nanos": 10675553,
+      "factor_count": 10,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        8,
+        8,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow60_minus1",
+      "degree": 60,
+      "status": "ok",
+      "median_nanos": 5567713,
+      "min_nanos": 5549426,
+      "max_nanos": 5802000,
+      "factor_count": 12,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        4,
+        8,
+        8,
+        8,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi64_x_phi105",
+      "degree": 80,
+      "status": "ok",
+      "median_nanos": 16090538,
+      "min_nanos": 16044280,
+      "max_nanos": 16656759,
+      "factor_count": 2,
+      "factor_degrees": [
+        32,
+        48
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow105_minus1",
+      "degree": 105,
+      "status": "ok",
+      "median_nanos": 45791565,
+      "min_nanos": 45005058,
+      "max_nanos": 46339248,
+      "factor_count": 8,
+      "factor_degrees": [
+        1,
+        2,
+        4,
+        6,
+        8,
+        12,
+        24,
+        48
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi105_x_phi128",
+      "degree": 112,
+      "status": "ok",
+      "median_nanos": 28804376,
+      "min_nanos": 28744277,
+      "max_nanos": 29111912,
+      "factor_count": 2,
+      "factor_degrees": [
+        48,
+        64
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow120_minus1",
+      "degree": 120,
+      "status": "ok",
+      "median_nanos": 144746046,
+      "min_nanos": 144041810,
+      "max_nanos": 145940378,
+      "factor_count": 16,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        4,
+        4,
+        8,
+        8,
+        8,
+        8,
+        16,
+        16,
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi128_x_phi165",
+      "degree": 144,
+      "status": "ok",
+      "median_nanos": 61194193,
+      "min_nanos": 61074616,
+      "max_nanos": 66924386,
+      "factor_count": 2,
+      "factor_degrees": [
+        64,
+        80
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd2",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 50435,
+      "min_nanos": 47380,
+      "max_nanos": 84545,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd2_shift1",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 49903,
+      "min_nanos": 48492,
+      "max_nanos": 54260,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd3",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 163012,
+      "min_nanos": 159356,
+      "max_nanos": 194439,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd3_shift1",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 161230,
+      "min_nanos": 159647,
+      "max_nanos": 176241,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd3_shift2",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 160588,
+      "min_nanos": 157834,
+      "max_nanos": 166918,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd4",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 845425,
+      "min_nanos": 825265,
+      "max_nanos": 868930,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd4_shift1",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 761490,
+      "min_nanos": 754520,
+      "max_nanos": 787389,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd4_shift3",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 835269,
+      "min_nanos": 825505,
+      "max_nanos": 858604,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd5",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 6964566,
+      "min_nanos": 6944225,
+      "max_nanos": 6977524,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd5_shift1",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 7374915,
+      "min_nanos": 7360182,
+      "max_nanos": 7407483,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd5_shift2",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 8991383,
+      "min_nanos": 8985314,
+      "max_nanos": 9012414,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd6",
+      "degree": 64,
+      "status": "ok",
+      "median_nanos": 27686327,
+      "min_nanos": 27609463,
+      "max_nanos": 27962767,
+      "factor_count": 1,
+      "factor_degrees": [
+        64
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd6_shift1",
+      "degree": 64,
+      "status": "ok",
+      "median_nanos": 31961932,
+      "min_nanos": 31922112,
+      "max_nanos": 32026719,
+      "factor_count": 1,
+      "factor_degrees": [
+        64
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd6_shift5",
+      "degree": 64,
+      "status": "ok",
+      "median_nanos": 30978773,
+      "min_nanos": 30856151,
+      "max_nanos": 31056227,
+      "factor_count": 1,
+      "factor_degrees": [
+        64
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd7",
+      "degree": 128,
+      "status": "ok",
+      "median_nanos": 196351838,
+      "min_nanos": 192150193,
+      "max_nanos": 198977725,
+      "factor_count": 1,
+      "factor_degrees": [
+        128
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd2_x_phi12",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 141631,
+      "min_nanos": 127750,
+      "max_nanos": 236621,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd2_x_sd2shift1",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 136773,
+      "min_nanos": 131205,
+      "max_nanos": 147789,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd3_x_phi15",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 489326,
+      "min_nanos": 478500,
+      "max_nanos": 529356,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd3_x_phi24",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 567542,
+      "min_nanos": 552069,
+      "max_nanos": 592199,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd3_x_sd3shift1",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 868068,
+      "min_nanos": 844584,
+      "max_nanos": 889660,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd4_x_phi17",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 2700417,
+      "min_nanos": 2667548,
+      "max_nanos": 2735700,
+      "factor_count": 2,
+      "factor_degrees": [
+        16,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd4_x_sd4shift1",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 14238430,
+      "min_nanos": 14037562,
+      "max_nanos": 14617793,
+      "factor_count": 2,
+      "factor_degrees": [
+        16,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd4_x_phi35",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 17175329,
+      "min_nanos": 16971035,
+      "max_nanos": 17464838,
+      "factor_count": 2,
+      "factor_degrees": [
+        16,
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd5_x_phi11",
+      "degree": 42,
+      "status": "ok",
+      "median_nanos": 111454890,
+      "min_nanos": 111065692,
+      "max_nanos": 111813091,
+      "factor_count": 2,
+      "factor_degrees": [
+        10,
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd5_x_phi45",
+      "degree": 56,
+      "status": "ok",
+      "median_nanos": 253350383,
+      "min_nanos": 251963265,
+      "max_nanos": 256989444,
+      "factor_count": 2,
+      "factor_degrees": [
+        24,
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd5_x_sd5shift1",
+      "degree": 64,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd6_x_phi13",
+      "degree": 76,
+      "status": "ok",
+      "median_nanos": 2936578075,
+      "min_nanos": 2936578075,
+      "max_nanos": 2936578075,
+      "factor_count": 2,
+      "factor_degrees": [
+        12,
+        64
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd6_x_phi105",
+      "degree": 112,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd6_x_sd6shift1",
+      "degree": 128,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 38027,
+      "min_nanos": 32128,
+      "max_nanos": 20343919,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 28352,
+      "min_nanos": 27711,
+      "max_nanos": 30165,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 35834,
+      "min_nanos": 34652,
+      "max_nanos": 44936,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 58337,
+      "min_nanos": 52638,
+      "max_nanos": 117805,
+      "factor_count": 2,
+      "factor_degrees": [
+        2,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 36214,
+      "min_nanos": 35102,
+      "max_nanos": 39909,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 63705,
+      "min_nanos": 61652,
+      "max_nanos": 74060,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 91386,
+      "min_nanos": 88140,
+      "max_nanos": 102612,
+      "factor_count": 2,
+      "factor_degrees": [
+        2,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 68361,
+      "min_nanos": 66809,
+      "max_nanos": 77155,
+      "factor_count": 2,
+      "factor_degrees": [
+        3,
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 67901,
+      "min_nanos": 63364,
+      "max_nanos": 71376,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 63024,
+      "min_nanos": 57966,
+      "max_nanos": 68722,
+      "factor_count": 3,
+      "factor_degrees": [
+        1,
+        2,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 53369,
+      "min_nanos": 52107,
+      "max_nanos": 59328,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 133609,
+      "min_nanos": 130684,
+      "max_nanos": 153018,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        1,
+        3,
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 88422,
+      "min_nanos": 84215,
+      "max_nanos": 95682,
+      "factor_count": 3,
+      "factor_degrees": [
+        1,
+        2,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 104606,
+      "min_nanos": 99618,
+      "max_nanos": 115692,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        2,
+        2,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 147779,
+      "min_nanos": 140258,
+      "max_nanos": 164915,
+      "factor_count": 2,
+      "factor_degrees": [
+        2,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 110234,
+      "min_nanos": 108501,
+      "max_nanos": 122011,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 156923,
+      "min_nanos": 152096,
+      "max_nanos": 176642,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 179697,
+      "min_nanos": 176452,
+      "max_nanos": 192876,
+      "factor_count": 2,
+      "factor_degrees": [
+        6,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 278874,
+      "min_nanos": 271293,
+      "max_nanos": 297441,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        2,
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 199877,
+      "min_nanos": 196401,
+      "max_nanos": 213697,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        2,
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 129913,
+      "min_nanos": 127269,
+      "max_nanos": 140529,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 226026,
+      "min_nanos": 218685,
+      "max_nanos": 265304,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 481214,
+      "min_nanos": 460303,
+      "max_nanos": 518610,
+      "factor_count": 3,
+      "factor_degrees": [
+        2,
+        4,
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 264844,
+      "min_nanos": 259865,
+      "max_nanos": 296019,
+      "factor_count": 2,
+      "factor_degrees": [
+        9,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 519060,
+      "min_nanos": 499171,
+      "max_nanos": 552870,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 694981,
+      "min_nanos": 674241,
+      "max_nanos": 729142,
+      "factor_count": 6,
+      "factor_degrees": [
+        1,
+        1,
+        3,
+        3,
+        6,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 413043,
+      "min_nanos": 408887,
+      "max_nanos": 436848,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 573261,
+      "min_nanos": 550827,
+      "max_nanos": 602875,
+      "factor_count": 4,
+      "factor_degrees": [
+        2,
+        2,
+        10,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 39318,
+      "min_nanos": 37276,
+      "max_nanos": 49834,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 39408,
+      "min_nanos": 38587,
+      "max_nanos": 44546,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 68481,
+      "min_nanos": 65978,
+      "max_nanos": 73820,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 96012,
+      "min_nanos": 93169,
+      "max_nanos": 107039,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 79909,
+      "min_nanos": 77455,
+      "max_nanos": 83844,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 162992,
+      "min_nanos": 158435,
+      "max_nanos": 176712,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 177653,
+      "min_nanos": 171635,
+      "max_nanos": 191685,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 287537,
+      "min_nanos": 280426,
+      "max_nanos": 306354,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 232455,
+      "min_nanos": 221970,
+      "max_nanos": 243251,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 620431,
+      "min_nanos": 603846,
+      "max_nanos": 645248,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 529355,
+      "min_nanos": 520923,
+      "max_nanos": 557998,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 1232989,
+      "min_nanos": 1220381,
+      "max_nanos": 1275172,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 1774483,
+      "min_nanos": 1756366,
+      "max_nanos": 1837356,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 969559,
+      "min_nanos": 952884,
+      "max_nanos": 994315,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 1684449,
+      "min_nanos": 1677510,
+      "max_nanos": 1724930,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P26",
+      "degree": 26,
+      "status": "ok",
+      "median_nanos": 6838018,
+      "min_nanos": 6833441,
+      "max_nanos": 6890996,
+      "factor_count": 1,
+      "factor_degrees": [
+        26
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 1814432,
+      "min_nanos": 1798549,
+      "max_nanos": 1845749,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P30",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 8193659,
+      "min_nanos": 8170695,
+      "max_nanos": 8210694,
+      "factor_count": 1,
+      "factor_degrees": [
+        30
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P34",
+      "degree": 34,
+      "status": "ok",
+      "median_nanos": 2915837,
+      "min_nanos": 2903018,
+      "max_nanos": 2965881,
+      "factor_count": 1,
+      "factor_degrees": [
+        34
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P38",
+      "degree": 38,
+      "status": "ok",
+      "median_nanos": 3603888,
+      "min_nanos": 3587313,
+      "max_nanos": 3670506,
+      "factor_count": 1,
+      "factor_degrees": [
+        38
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 34792,
+      "min_nanos": 33790,
+      "max_nanos": 51787,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 63124,
+      "min_nanos": 59048,
+      "max_nanos": 72377,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 87640,
+      "min_nanos": 85497,
+      "max_nanos": 100019,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 103504,
+      "min_nanos": 98887,
+      "max_nanos": 110844,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 149372,
+      "min_nanos": 143623,
+      "max_nanos": 160328,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 118826,
+      "min_nanos": 116833,
+      "max_nanos": 128511,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 121030,
+      "min_nanos": 116923,
+      "max_nanos": 124545,
+      "factor_count": 1,
+      "factor_degrees": [
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 230351,
+      "min_nanos": 222620,
+      "max_nanos": 246606,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L11",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 169291,
+      "min_nanos": 166878,
+      "max_nanos": 175421,
+      "factor_count": 1,
+      "factor_degrees": [
+        11
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 360284,
+      "min_nanos": 356008,
+      "max_nanos": 406103,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L13",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 387075,
+      "min_nanos": 380815,
+      "max_nanos": 404901,
+      "factor_count": 1,
+      "factor_degrees": [
+        13
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 548834,
+      "min_nanos": 546350,
+      "max_nanos": 573270,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 691115,
+      "min_nanos": 681401,
+      "max_nanos": 715592,
+      "factor_count": 1,
+      "factor_degrees": [
+        15
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 918974,
+      "min_nanos": 908669,
+      "max_nanos": 949119,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 1024661,
+      "min_nanos": 1001156,
+      "max_nanos": 1039793,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 1667635,
+      "min_nanos": 1649047,
+      "max_nanos": 1686212,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 938112,
+      "min_nanos": 933745,
+      "max_nanos": 952183,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 1647935,
+      "min_nanos": 1619884,
+      "max_nanos": 1676118,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 2546428,
+      "min_nanos": 2512719,
+      "max_nanos": 2579739,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L32",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 4985287,
+      "min_nanos": 4936336,
+      "max_nanos": 5087229,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 83434,
+      "min_nanos": 78466,
+      "max_nanos": 110845,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 137204,
+      "min_nanos": 132437,
+      "max_nanos": 144375,
+      "factor_count": 6,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 201319,
+      "min_nanos": 198234,
+      "max_nanos": 211113,
+      "factor_count": 8,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 444059,
+      "min_nanos": 438691,
+      "max_nanos": 470108,
+      "factor_count": 10,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 599119,
+      "min_nanos": 590406,
+      "max_nanos": 619809,
+      "factor_count": 12,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 846877,
+      "min_nanos": 837292,
+      "max_nanos": 885344,
+      "factor_count": 14,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 1148094,
+      "min_nanos": 1131489,
+      "max_nanos": 1179771,
+      "factor_count": 16,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 1666183,
+      "min_nanos": 1651922,
+      "max_nanos": 1697580,
+      "factor_count": 18,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 2199715,
+      "min_nanos": 2192253,
+      "max_nanos": 2225833,
+      "factor_count": 20,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 3452774,
+      "min_nanos": 3425503,
+      "max_nanos": 3490059,
+      "factor_count": 24,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 5237061,
+      "min_nanos": 5220407,
+      "max_nanos": 5249870,
+      "factor_count": 28,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_32",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 6602858,
+      "min_nanos": 6601957,
+      "max_nanos": 6644941,
+      "factor_count": 32,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_40",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 9108978,
+      "min_nanos": 9091261,
+      "max_nanos": 9131521,
+      "factor_count": 40,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_48",
+      "degree": 48,
+      "status": "ok",
+      "median_nanos": 15814338,
+      "min_nanos": 15753026,
+      "max_nanos": 15945422,
+      "factor_count": 48,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_56",
+      "degree": 56,
+      "status": "ok",
+      "median_nanos": 20716722,
+      "min_nanos": 20634340,
+      "max_nanos": 20849129,
+      "factor_count": 56,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_26",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 104646,
+      "min_nanos": 100609,
+      "max_nanos": 146547,
+      "factor_count": 2,
+      "factor_degrees": [
+        3,
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_22",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 206306,
+      "min_nanos": 201298,
+      "max_nanos": 224282,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_23",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 175230,
+      "min_nanos": 171164,
+      "max_nanos": 189240,
+      "factor_count": 2,
+      "factor_degrees": [
+        3,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_25",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 176162,
+      "min_nanos": 171945,
+      "max_nanos": 186065,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_07",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 151024,
+      "min_nanos": 149743,
+      "max_nanos": 168059,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_13",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 210613,
+      "min_nanos": 206266,
+      "max_nanos": 240387,
+      "factor_count": 3,
+      "factor_degrees": [
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_09",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 300335,
+      "min_nanos": 293075,
+      "max_nanos": 328187,
+      "factor_count": 3,
+      "factor_degrees": [
+        3,
+        4,
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_14",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 210593,
+      "min_nanos": 202962,
+      "max_nanos": 228739,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_04",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 343180,
+      "min_nanos": 332112,
+      "max_nanos": 353074,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_08",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 350470,
+      "min_nanos": 346383,
+      "max_nanos": 369419,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_16",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 224463,
+      "min_nanos": 220767,
+      "max_nanos": 241068,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_20",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 312023,
+      "min_nanos": 310161,
+      "max_nanos": 326485,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_28",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 556676,
+      "min_nanos": 548664,
+      "max_nanos": 636505,
+      "factor_count": 5,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_29",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 321417,
+      "min_nanos": 313215,
+      "max_nanos": 349869,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_06",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 360585,
+      "min_nanos": 356489,
+      "max_nanos": 384751,
+      "factor_count": 3,
+      "factor_degrees": [
+        4,
+        4,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_17",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 248869,
+      "min_nanos": 243862,
+      "max_nanos": 273055,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_01",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 273175,
+      "min_nanos": 270692,
+      "max_nanos": 312564,
+      "factor_count": 2,
+      "factor_degrees": [
+        6,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_05",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 326495,
+      "min_nanos": 316179,
+      "max_nanos": 356589,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_19",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 245755,
+      "min_nanos": 241749,
+      "max_nanos": 314086,
+      "factor_count": 2,
+      "factor_degrees": [
+        7,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_27",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 429277,
+      "min_nanos": 424300,
+      "max_nanos": 456537,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        2,
+        4,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_11",
+      "degree": 17,
+      "status": "ok",
+      "median_nanos": 385171,
+      "min_nanos": 376699,
+      "max_nanos": 413764,
+      "factor_count": 3,
+      "factor_degrees": [
+        1,
+        7,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_00",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 792787,
+      "min_nanos": 788510,
+      "max_nanos": 834508,
+      "factor_count": 3,
+      "factor_degrees": [
+        5,
+        5,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_03",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 727099,
+      "min_nanos": 711026,
+      "max_nanos": 760028,
+      "factor_count": 4,
+      "factor_degrees": [
+        2,
+        2,
+        4,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_12",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 424240,
+      "min_nanos": 413955,
+      "max_nanos": 458110,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        3,
+        7,
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_24",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 474955,
+      "min_nanos": 461925,
+      "max_nanos": 508585,
+      "factor_count": 3,
+      "factor_degrees": [
+        3,
+        5,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_02",
+      "degree": 19,
+      "status": "ok",
+      "median_nanos": 754830,
+      "min_nanos": 741440,
+      "max_nanos": 783453,
+      "factor_count": 2,
+      "factor_degrees": [
+        9,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_10",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 587291,
+      "min_nanos": 574121,
+      "max_nanos": 630185,
+      "factor_count": 2,
+      "factor_degrees": [
+        10,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_15",
+      "degree": 21,
+      "status": "ok",
+      "median_nanos": 666329,
+      "min_nanos": 653460,
+      "max_nanos": 705957,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        5,
+        7,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_18",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 974616,
+      "min_nanos": 957490,
+      "max_nanos": 1008217,
+      "factor_count": 3,
+      "factor_degrees": [
+        6,
+        6,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_21",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 1341000,
+      "min_nanos": 1328421,
+      "max_nanos": 1372818,
+      "factor_count": 3,
+      "factor_degrees": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_S7",
+      "degree": 128,
+      "status": "ok",
+      "median_nanos": 195229760,
+      "min_nanos": 190188709,
+      "max_nanos": 272691909,
+      "factor_count": 1,
+      "factor_degrees": [
+        128
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_M12_f132",
+      "degree": 132,
+      "status": "ok",
+      "median_nanos": 986848212,
+      "min_nanos": 980779992,
+      "max_nanos": 988230110,
+      "factor_count": 1,
+      "factor_degrees": [
+        132
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_F190",
+      "degree": 190,
+      "status": "ok",
+      "median_nanos": 2966415531,
+      "min_nanos": 2966415531,
+      "max_nanos": 2966415531,
+      "factor_count": 3,
+      "factor_degrees": [
+        10,
+        90,
+        90
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_F192",
+      "degree": 192,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_F256",
+      "degree": 256,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_S8",
+      "degree": 256,
+      "status": "ok",
+      "median_nanos": 3814568234,
+      "min_nanos": 3814568234,
+      "max_nanos": 3814568234,
+      "factor_count": 1,
+      "factor_degrees": [
+        256
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_F351",
+      "degree": 351,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_P7",
+      "degree": 384,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_S9",
+      "degree": 512,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_F630",
+      "degree": 630,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "early_terminated": true,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 28933,
+      "min_nanos": 21782,
+      "max_nanos": 20038234,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 22553,
+      "min_nanos": 21402,
+      "max_nanos": 24827,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 21242,
+      "min_nanos": 21071,
+      "max_nanos": 22393,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 22433,
+      "min_nanos": 21392,
+      "max_nanos": 28181,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 22443,
+      "min_nanos": 21502,
+      "max_nanos": 25688,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 20640,
+      "min_nanos": 20330,
+      "max_nanos": 21492,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p65537_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 21612,
+      "min_nanos": 21162,
+      "max_nanos": 22634,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 20791,
+      "min_nanos": 20751,
+      "max_nanos": 21232,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 20991,
+      "min_nanos": 20810,
+      "max_nanos": 21432,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 28352,
+      "min_nanos": 27912,
+      "max_nanos": 36454,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 39088,
+      "min_nanos": 36324,
+      "max_nanos": 59819,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 28242,
+      "min_nanos": 27431,
+      "max_nanos": 30646,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 27470,
+      "min_nanos": 27280,
+      "max_nanos": 28162,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 37276,
+      "min_nanos": 36274,
+      "max_nanos": 39899,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 28061,
+      "min_nanos": 25648,
+      "max_nanos": 29454,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p65537_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 40550,
+      "min_nanos": 35983,
+      "max_nanos": 45778,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 33169,
+      "min_nanos": 32017,
+      "max_nanos": 35353,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 34581,
+      "min_nanos": 33990,
+      "max_nanos": 39659,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 43134,
+      "min_nanos": 41261,
+      "max_nanos": 50956,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 27901,
+      "min_nanos": 24516,
+      "max_nanos": 30195,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 40760,
+      "min_nanos": 37085,
+      "max_nanos": 85767,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 25889,
+      "min_nanos": 25388,
+      "max_nanos": 27000,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 40870,
+      "min_nanos": 38177,
+      "max_nanos": 42373,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 27961,
+      "min_nanos": 27692,
+      "max_nanos": 30775,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p65537_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 28762,
+      "min_nanos": 28392,
+      "max_nanos": 29233,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 39989,
+      "min_nanos": 38477,
+      "max_nanos": 43575,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 29043,
+      "min_nanos": 28823,
+      "max_nanos": 30706,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 56223,
+      "min_nanos": 54190,
+      "max_nanos": 64376,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 58988,
+      "min_nanos": 56814,
+      "max_nanos": 63675,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 44336,
+      "min_nanos": 41522,
+      "max_nanos": 46569,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 32918,
+      "min_nanos": 32028,
+      "max_nanos": 35092,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 35903,
+      "min_nanos": 34822,
+      "max_nanos": 37676,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 51847,
+      "min_nanos": 47731,
+      "max_nanos": 52769,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p65537_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 71957,
+      "min_nanos": 65287,
+      "max_nanos": 83284,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 47341,
+      "min_nanos": 45718,
+      "max_nanos": 52798,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 32068,
+      "min_nanos": 31717,
+      "max_nanos": 34832,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 42282,
+      "min_nanos": 41642,
+      "max_nanos": 46229,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 37235,
+      "min_nanos": 36233,
+      "max_nanos": 40200,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 49173,
+      "min_nanos": 48031,
+      "max_nanos": 55382,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 35202,
+      "min_nanos": 34771,
+      "max_nanos": 40510,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 54631,
+      "min_nanos": 53599,
+      "max_nanos": 58467,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 76223,
+      "min_nanos": 64445,
+      "max_nanos": 123933,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 63865,
+      "min_nanos": 61931,
+      "max_nanos": 67150,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 51547,
+      "min_nanos": 49924,
+      "max_nanos": 59058,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 42072,
+      "min_nanos": 41832,
+      "max_nanos": 53519,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 61782,
+      "min_nanos": 61211,
+      "max_nanos": 67680,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 43365,
+      "min_nanos": 42884,
+      "max_nanos": 44616,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 45047,
+      "min_nanos": 43264,
+      "max_nanos": 50655,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 81581,
+      "min_nanos": 78406,
+      "max_nanos": 90054,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 53679,
+      "min_nanos": 50756,
+      "max_nanos": 54070,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 71236,
+      "min_nanos": 68291,
+      "max_nanos": 73429,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 43865,
+      "min_nanos": 42152,
+      "max_nanos": 48102,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 77214,
+      "min_nanos": 75583,
+      "max_nanos": 83574,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 63033,
+      "min_nanos": 60309,
+      "max_nanos": 72788,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 61822,
+      "min_nanos": 61181,
+      "max_nanos": 67870,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 46369,
+      "min_nanos": 44757,
+      "max_nanos": 49133,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 68732,
+      "min_nanos": 68711,
+      "max_nanos": 72587,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 53650,
+      "min_nanos": 51386,
+      "max_nanos": 56594,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 61921,
+      "min_nanos": 60059,
+      "max_nanos": 67230,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 68782,
+      "min_nanos": 66279,
+      "max_nanos": 75442,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 95352,
+      "min_nanos": 93258,
+      "max_nanos": 109512,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 69593,
+      "min_nanos": 66479,
+      "max_nanos": 74220,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 99578,
+      "min_nanos": 96643,
+      "max_nanos": 110724,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 55983,
+      "min_nanos": 54872,
+      "max_nanos": 60400,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 97815,
+      "min_nanos": 96053,
+      "max_nanos": 113028,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 80239,
+      "min_nanos": 76884,
+      "max_nanos": 86368,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 73599,
+      "min_nanos": 71947,
+      "max_nanos": 81371,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 82442,
+      "min_nanos": 81050,
+      "max_nanos": 89793,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 85016,
+      "min_nanos": 79648,
+      "max_nanos": 87299,
+      "factor_count": 1,
+      "factor_degrees": [
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 59418,
+      "min_nanos": 58066,
+      "max_nanos": 63504,
+      "factor_count": 1,
+      "factor_degrees": [
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 96352,
+      "min_nanos": 89773,
+      "max_nanos": 106067,
+      "factor_count": 1,
+      "factor_degrees": [
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 101291,
+      "min_nanos": 97405,
+      "max_nanos": 108832,
+      "factor_count": 1,
+      "factor_degrees": [
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 105827,
+      "min_nanos": 105727,
+      "max_nanos": 111706,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 73119,
+      "min_nanos": 70675,
+      "max_nanos": 76794,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 67490,
+      "min_nanos": 66599,
+      "max_nanos": 70294,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 157584,
+      "min_nanos": 150714,
+      "max_nanos": 174729,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n11",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 120569,
+      "min_nanos": 116082,
+      "max_nanos": 131344,
+      "factor_count": 1,
+      "factor_degrees": [
+        11
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n11",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 67621,
+      "min_nanos": 64315,
+      "max_nanos": 70054,
+      "factor_count": 1,
+      "factor_degrees": [
+        11
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n11",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 77194,
+      "min_nanos": 74370,
+      "max_nanos": 88351,
+      "factor_count": 1,
+      "factor_degrees": [
+        11
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n11",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 162782,
+      "min_nanos": 147840,
+      "max_nanos": 227898,
+      "factor_count": 1,
+      "factor_degrees": [
+        11
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 129252,
+      "min_nanos": 124535,
+      "max_nanos": 148350,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 90504,
+      "min_nanos": 85638,
+      "max_nanos": 97104,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 206347,
+      "min_nanos": 195790,
+      "max_nanos": 229651,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 173347,
+      "min_nanos": 170443,
+      "max_nanos": 180028,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n13",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 91486,
+      "min_nanos": 90254,
+      "max_nanos": 97375,
+      "factor_count": 1,
+      "factor_degrees": [
+        13
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n13",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 78988,
+      "min_nanos": 75643,
+      "max_nanos": 81691,
+      "factor_count": 1,
+      "factor_degrees": [
+        13
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n13",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 100039,
+      "min_nanos": 98616,
+      "max_nanos": 103093,
+      "factor_count": 1,
+      "factor_degrees": [
+        13
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n13",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 215340,
+      "min_nanos": 207588,
+      "max_nanos": 243681,
+      "factor_count": 1,
+      "factor_degrees": [
+        13
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 154879,
+      "min_nanos": 151675,
+      "max_nanos": 175691,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 114710,
+      "min_nanos": 112257,
+      "max_nanos": 119388,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 136182,
+      "min_nanos": 131415,
+      "max_nanos": 137414,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 157824,
+      "min_nanos": 156763,
+      "max_nanos": 164544,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 216882,
+      "min_nanos": 208699,
+      "max_nanos": 247898,
+      "factor_count": 1,
+      "factor_degrees": [
+        15
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 113018,
+      "min_nanos": 111645,
+      "max_nanos": 118265,
+      "factor_count": 1,
+      "factor_degrees": [
+        15
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 145055,
+      "min_nanos": 141961,
+      "max_nanos": 156722,
+      "factor_count": 1,
+      "factor_degrees": [
+        15
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 188299,
+      "min_nanos": 184724,
+      "max_nanos": 196782,
+      "factor_count": 1,
+      "factor_degrees": [
+        15
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 118246,
+      "min_nanos": 117595,
+      "max_nanos": 120649,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 127619,
+      "min_nanos": 123404,
+      "max_nanos": 133318,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 287126,
+      "min_nanos": 281177,
+      "max_nanos": 311682,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 280256,
+      "min_nanos": 270051,
+      "max_nanos": 298182,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n17",
+      "degree": 17,
+      "status": "ok",
+      "median_nanos": 275158,
+      "min_nanos": 258503,
+      "max_nanos": 305223,
+      "factor_count": 1,
+      "factor_degrees": [
+        17
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n17",
+      "degree": 17,
+      "status": "ok",
+      "median_nanos": 109021,
+      "min_nanos": 107729,
+      "max_nanos": 124745,
+      "factor_count": 1,
+      "factor_degrees": [
+        17
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n17",
+      "degree": 17,
+      "status": "ok",
+      "median_nanos": 435816,
+      "min_nanos": 409207,
+      "max_nanos": 465281,
+      "factor_count": 1,
+      "factor_degrees": [
+        17
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n17",
+      "degree": 17,
+      "status": "ok",
+      "median_nanos": 294457,
+      "min_nanos": 287266,
+      "max_nanos": 332112,
+      "factor_count": 1,
+      "factor_degrees": [
+        17
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 326605,
+      "min_nanos": 320786,
+      "max_nanos": 350370,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 150563,
+      "min_nanos": 149111,
+      "max_nanos": 155701,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 231524,
+      "min_nanos": 224263,
+      "max_nanos": 247407,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 285093,
+      "min_nanos": 277181,
+      "max_nanos": 309679,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n19",
+      "degree": 19,
+      "status": "ok",
+      "median_nanos": 261788,
+      "min_nanos": 259795,
+      "max_nanos": 281098,
+      "factor_count": 1,
+      "factor_degrees": [
+        19
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n19",
+      "degree": 19,
+      "status": "ok",
+      "median_nanos": 125035,
+      "min_nanos": 123994,
+      "max_nanos": 127810,
+      "factor_count": 1,
+      "factor_degrees": [
+        19
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n19",
+      "degree": 19,
+      "status": "ok",
+      "median_nanos": 343250,
+      "min_nanos": 336609,
+      "max_nanos": 381396,
+      "factor_count": 1,
+      "factor_degrees": [
+        19
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n19",
+      "degree": 19,
+      "status": "ok",
+      "median_nanos": 129052,
+      "min_nanos": 126517,
+      "max_nanos": 150223,
+      "factor_count": 1,
+      "factor_degrees": [
+        19
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 337431,
+      "min_nanos": 321047,
+      "max_nanos": 379033,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 190713,
+      "min_nanos": 186316,
+      "max_nanos": 209791,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 275529,
+      "min_nanos": 261228,
+      "max_nanos": 314647,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 242019,
+      "min_nanos": 238063,
+      "max_nanos": 264182,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n21",
+      "degree": 21,
+      "status": "ok",
+      "median_nanos": 281037,
+      "min_nanos": 267386,
+      "max_nanos": 294508,
+      "factor_count": 1,
+      "factor_degrees": [
+        21
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n21",
+      "degree": 21,
+      "status": "ok",
+      "median_nanos": 183492,
+      "min_nanos": 182271,
+      "max_nanos": 192976,
+      "factor_count": 1,
+      "factor_degrees": [
+        21
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n21",
+      "degree": 21,
+      "status": "ok",
+      "median_nanos": 284112,
+      "min_nanos": 275129,
+      "max_nanos": 318142,
+      "factor_count": 1,
+      "factor_degrees": [
+        21
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n21",
+      "degree": 21,
+      "status": "ok",
+      "median_nanos": 264382,
+      "min_nanos": 253367,
+      "max_nanos": 289910,
+      "factor_count": 1,
+      "factor_degrees": [
+        21
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 468585,
+      "min_nanos": 454394,
+      "max_nanos": 508004,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 204233,
+      "min_nanos": 198604,
+      "max_nanos": 204714,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 379904,
+      "min_nanos": 372383,
+      "max_nanos": 416618,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 418621,
+      "min_nanos": 408426,
+      "max_nanos": 448165,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n23",
+      "degree": 23,
+      "status": "ok",
+      "median_nanos": 460973,
+      "min_nanos": 443659,
+      "max_nanos": 550297,
+      "factor_count": 1,
+      "factor_degrees": [
+        23
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n23",
+      "degree": 23,
+      "status": "ok",
+      "median_nanos": 171905,
+      "min_nanos": 170814,
+      "max_nanos": 179977,
+      "factor_count": 1,
+      "factor_degrees": [
+        23
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n23",
+      "degree": 23,
+      "status": "ok",
+      "median_nanos": 197323,
+      "min_nanos": 196262,
+      "max_nanos": 202040,
+      "factor_count": 1,
+      "factor_degrees": [
+        23
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n23",
+      "degree": 23,
+      "status": "ok",
+      "median_nanos": 287056,
+      "min_nanos": 282769,
+      "max_nanos": 322748,
+      "factor_count": 1,
+      "factor_degrees": [
+        23
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 368126,
+      "min_nanos": 362739,
+      "max_nanos": 397550,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 226857,
+      "min_nanos": 225594,
+      "max_nanos": 230852,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 458741,
+      "min_nanos": 442487,
+      "max_nanos": 498089,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 434334,
+      "min_nanos": 425672,
+      "max_nanos": 460103,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n25",
+      "degree": 25,
+      "status": "ok",
+      "median_nanos": 570046,
+      "min_nanos": 553211,
+      "max_nanos": 609144,
+      "factor_count": 1,
+      "factor_degrees": [
+        25
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n25",
+      "degree": 25,
+      "status": "ok",
+      "median_nanos": 211374,
+      "min_nanos": 209481,
+      "max_nanos": 221438,
+      "factor_count": 1,
+      "factor_degrees": [
+        25
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n25",
+      "degree": 25,
+      "status": "ok",
+      "median_nanos": 524458,
+      "min_nanos": 497408,
+      "max_nanos": 537998,
+      "factor_count": 1,
+      "factor_degrees": [
+        25
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n25",
+      "degree": 25,
+      "status": "ok",
+      "median_nanos": 438150,
+      "min_nanos": 424490,
+      "max_nanos": 470268,
+      "factor_count": 1,
+      "factor_degrees": [
+        25
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n26",
+      "degree": 26,
+      "status": "ok",
+      "median_nanos": 493513,
+      "min_nanos": 475886,
+      "max_nanos": 522506,
+      "factor_count": 1,
+      "factor_degrees": [
+        26
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n26",
+      "degree": 26,
+      "status": "ok",
+      "median_nanos": 265283,
+      "min_nanos": 262029,
+      "max_nanos": 287476,
+      "factor_count": 1,
+      "factor_degrees": [
+        26
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n26",
+      "degree": 26,
+      "status": "ok",
+      "median_nanos": 487383,
+      "min_nanos": 474044,
+      "max_nanos": 536446,
+      "factor_count": 1,
+      "factor_degrees": [
+        26
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n26",
+      "degree": 26,
+      "status": "ok",
+      "median_nanos": 517518,
+      "min_nanos": 497759,
+      "max_nanos": 550146,
+      "factor_count": 1,
+      "factor_degrees": [
+        26
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n27",
+      "degree": 27,
+      "status": "ok",
+      "median_nanos": 548975,
+      "min_nanos": 530947,
+      "max_nanos": 611587,
+      "factor_count": 1,
+      "factor_degrees": [
+        27
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n27",
+      "degree": 27,
+      "status": "ok",
+      "median_nanos": 203282,
+      "min_nanos": 202561,
+      "max_nanos": 215329,
+      "factor_count": 1,
+      "factor_degrees": [
+        27
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n27",
+      "degree": 27,
+      "status": "ok",
+      "median_nanos": 340154,
+      "min_nanos": 338002,
+      "max_nanos": 348406,
+      "factor_count": 1,
+      "factor_degrees": [
+        27
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n27",
+      "degree": 27,
+      "status": "ok",
+      "median_nanos": 588243,
+      "min_nanos": 566281,
+      "max_nanos": 617637,
+      "factor_count": 1,
+      "factor_degrees": [
+        27
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 275428,
+      "min_nanos": 271813,
+      "max_nanos": 283000,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 295279,
+      "min_nanos": 294877,
+      "max_nanos": 299013,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 818935,
+      "min_nanos": 803552,
+      "max_nanos": 850703,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 650285,
+      "min_nanos": 634051,
+      "max_nanos": 688471,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n29",
+      "degree": 29,
+      "status": "ok",
+      "median_nanos": 380084,
+      "min_nanos": 370159,
+      "max_nanos": 408356,
+      "factor_count": 1,
+      "factor_degrees": [
+        29
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n29",
+      "degree": 29,
+      "status": "ok",
+      "median_nanos": 227077,
+      "min_nanos": 225655,
+      "max_nanos": 239185,
+      "factor_count": 1,
+      "factor_degrees": [
+        29
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n29",
+      "degree": 29,
+      "status": "ok",
+      "median_nanos": 313515,
+      "min_nanos": 312474,
+      "max_nanos": 320465,
+      "factor_count": 1,
+      "factor_degrees": [
+        29
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n29",
+      "degree": 29,
+      "status": "ok",
+      "median_nanos": 337370,
+      "min_nanos": 326384,
+      "max_nanos": 390209,
+      "factor_count": 1,
+      "factor_degrees": [
+        29
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n30",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 666989,
+      "min_nanos": 655213,
+      "max_nanos": 706018,
+      "factor_count": 1,
+      "factor_degrees": [
+        30
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n30",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 356699,
+      "min_nanos": 352653,
+      "max_nanos": 368577,
+      "factor_count": 1,
+      "factor_degrees": [
+        30
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n30",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 879726,
+      "min_nanos": 862410,
+      "max_nanos": 903872,
+      "factor_count": 1,
+      "factor_degrees": [
+        30
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n30",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 919945,
+      "min_nanos": 908868,
+      "max_nanos": 948478,
+      "factor_count": 1,
+      "factor_degrees": [
+        30
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n31",
+      "degree": 31,
+      "status": "ok",
+      "median_nanos": 737595,
+      "min_nanos": 713799,
+      "max_nanos": 752968,
+      "factor_count": 1,
+      "factor_degrees": [
+        31
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n31",
+      "degree": 31,
+      "status": "ok",
+      "median_nanos": 272945,
+      "min_nanos": 267047,
+      "max_nanos": 274317,
+      "factor_count": 1,
+      "factor_degrees": [
+        31
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n31",
+      "degree": 31,
+      "status": "ok",
+      "median_nanos": 288578,
+      "min_nanos": 287306,
+      "max_nanos": 293435,
+      "factor_count": 1,
+      "factor_degrees": [
+        31
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n31",
+      "degree": 31,
+      "status": "ok",
+      "median_nanos": 668071,
+      "min_nanos": 639940,
+      "max_nanos": 692046,
+      "factor_count": 1,
+      "factor_degrees": [
+        31
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n32",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 577186,
+      "min_nanos": 551047,
+      "max_nanos": 621402,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n32",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 347546,
+      "min_nanos": 344671,
+      "max_nanos": 358712,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n33",
+      "degree": 33,
+      "status": "ok",
+      "median_nanos": 1127643,
+      "min_nanos": 1099652,
+      "max_nanos": 1169695,
+      "factor_count": 1,
+      "factor_degrees": [
+        33
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n33",
+      "degree": 33,
+      "status": "ok",
+      "median_nanos": 366083,
+      "min_nanos": 362908,
+      "max_nanos": 370129,
+      "factor_count": 1,
+      "factor_degrees": [
+        33
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n33",
+      "degree": 33,
+      "status": "ok",
+      "median_nanos": 502415,
+      "min_nanos": 499000,
+      "max_nanos": 504409,
+      "factor_count": 1,
+      "factor_degrees": [
+        33
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n34",
+      "degree": 34,
+      "status": "ok",
+      "median_nanos": 868228,
+      "min_nanos": 845244,
+      "max_nanos": 941638,
+      "factor_count": 1,
+      "factor_degrees": [
+        34
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n34",
+      "degree": 34,
+      "status": "ok",
+      "median_nanos": 425081,
+      "min_nanos": 422637,
+      "max_nanos": 429047,
+      "factor_count": 1,
+      "factor_degrees": [
+        34
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n35",
+      "degree": 35,
+      "status": "ok",
+      "median_nanos": 937822,
+      "min_nanos": 922258,
+      "max_nanos": 961928,
+      "factor_count": 1,
+      "factor_degrees": [
+        35
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n35",
+      "degree": 35,
+      "status": "ok",
+      "median_nanos": 384651,
+      "min_nanos": 383208,
+      "max_nanos": 393344,
+      "factor_count": 1,
+      "factor_degrees": [
+        35
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n35",
+      "degree": 35,
+      "status": "ok",
+      "median_nanos": 530026,
+      "min_nanos": 527502,
+      "max_nanos": 531599,
+      "factor_count": 1,
+      "factor_degrees": [
+        35
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n35",
+      "degree": 35,
+      "status": "ok",
+      "median_nanos": 1421799,
+      "min_nanos": 1411765,
+      "max_nanos": 1450652,
+      "factor_count": 1,
+      "factor_degrees": [
+        35
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n36",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 916210,
+      "min_nanos": 905234,
+      "max_nanos": 944020,
+      "factor_count": 1,
+      "factor_degrees": [
+        36
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n36",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 485991,
+      "min_nanos": 481545,
+      "max_nanos": 493271,
+      "factor_count": 1,
+      "factor_degrees": [
+        36
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n36",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 961366,
+      "min_nanos": 951011,
+      "max_nanos": 981457,
+      "factor_count": 1,
+      "factor_degrees": [
+        36
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n36",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 1324044,
+      "min_nanos": 1315012,
+      "max_nanos": 1349342,
+      "factor_count": 1,
+      "factor_degrees": [
+        36
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n37",
+      "degree": 37,
+      "status": "ok",
+      "median_nanos": 1238227,
+      "min_nanos": 1226120,
+      "max_nanos": 1254171,
+      "factor_count": 1,
+      "factor_degrees": [
+        37
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n37",
+      "degree": 37,
+      "status": "ok",
+      "median_nanos": 370550,
+      "min_nanos": 367055,
+      "max_nanos": 380335,
+      "factor_count": 1,
+      "factor_degrees": [
+        37
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n37",
+      "degree": 37,
+      "status": "ok",
+      "median_nanos": 426593,
+      "min_nanos": 424950,
+      "max_nanos": 434434,
+      "factor_count": 1,
+      "factor_degrees": [
+        37
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n37",
+      "degree": 37,
+      "status": "ok",
+      "median_nanos": 905593,
+      "min_nanos": 895409,
+      "max_nanos": 929790,
+      "factor_count": 1,
+      "factor_degrees": [
+        37
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n38",
+      "degree": 38,
+      "status": "ok",
+      "median_nanos": 1547547,
+      "min_nanos": 1536840,
+      "max_nanos": 1571783,
+      "factor_count": 1,
+      "factor_degrees": [
+        38
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n38",
+      "degree": 38,
+      "status": "ok",
+      "median_nanos": 530336,
+      "min_nanos": 522065,
+      "max_nanos": 572690,
+      "factor_count": 1,
+      "factor_degrees": [
+        38
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n39",
+      "degree": 39,
+      "status": "ok",
+      "median_nanos": 492191,
+      "min_nanos": 490488,
+      "max_nanos": 494013,
+      "factor_count": 1,
+      "factor_degrees": [
+        39
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n39",
+      "degree": 39,
+      "status": "ok",
+      "median_nanos": 468015,
+      "min_nanos": 465020,
+      "max_nanos": 468515,
+      "factor_count": 1,
+      "factor_degrees": [
+        39
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n39",
+      "degree": 39,
+      "status": "ok",
+      "median_nanos": 1210906,
+      "min_nanos": 1204808,
+      "max_nanos": 1238848,
+      "factor_count": 1,
+      "factor_degrees": [
+        39
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n40",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 1357715,
+      "min_nanos": 1320900,
+      "max_nanos": 1627696,
+      "factor_count": 1,
+      "factor_degrees": [
+        40
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n40",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 572319,
+      "min_nanos": 566190,
+      "max_nanos": 586751,
+      "factor_count": 1,
+      "factor_degrees": [
+        40
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "certificate-boundary",
+      "name": "quartic_a4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 50745,
+      "min_nanos": 48512,
+      "max_nanos": 64496,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    }
+  ],
+  "cross_check": {
+    "mismatches": [],
+    "ok": true
+  }
+}

--- a/reports/figures/hexbz-cactus-certificate-boundary.svg
+++ b/reports/figures/hexbz-cactus-certificate-boundary.svg
@@ -1037,7 +1037,7 @@ z
     </g>
    </g>
    <g id="line2d_31">
-    <path d="M 290.301172 195.319787
+    <path d="M 290.301172 194.738277
 " clip-path="url(#p2299177b78)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1053,7 +1053,7 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p2299177b78)">
-     <use xlink:href="#md73ba6276e" x="290.301172" y="195.319787" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="290.301172" y="194.738277" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_32">
@@ -1791,7 +1791,7 @@ L 96.202344 96.641875
    </g>
   </g>
   <g id="text_21">
-   <!-- cutoff 10.0s; source newest-per-system across 60 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 61 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -1891,7 +1891,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-19" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-13" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-chebyshev.svg
+++ b/reports/figures/hexbz-cactus-chebyshev.svg
@@ -1407,34 +1407,34 @@ z
     </g>
    </g>
    <g id="line2d_125">
-    <path d="M 86.724055 280.222701
-L 101.569768 264.557254
-L 116.41548 256.09375
-L 131.261192 249.653457
-L 146.106905 243.529409
-L 160.952617 238.789438
-L 175.798329 234.491927
-L 190.644042 230.883008
-L 205.489754 227.829656
-L 220.335466 225.104859
-L 235.181179 222.145914
-L 250.026891 219.397626
-L 264.872603 216.772131
-L 279.718316 214.219141
-L 294.564028 211.670647
-L 309.40974 209.292416
-L 324.255453 207.096213
-L 339.101165 204.830411
-L 353.946877 202.695415
-L 368.79259 200.557927
-L 383.638302 198.417507
-L 398.484014 196.155999
-L 413.329727 193.974828
-L 428.175439 191.215948
-L 443.021151 188.300525
-L 457.866864 185.705343
-L 472.712576 183.218008
-L 487.558288 180.55849
+    <path d="M 86.724055 279.865871
+L 101.569768 264.444594
+L 116.41548 256.001036
+L 131.261192 249.939237
+L 146.106905 243.784803
+L 160.952617 238.772755
+L 175.798329 234.531662
+L 190.644042 231.036779
+L 205.489754 227.910153
+L 220.335466 225.2117
+L 235.181179 222.211092
+L 250.026891 219.541839
+L 264.872603 216.888274
+L 279.718316 214.444844
+L 294.564028 211.920436
+L 309.40974 209.634541
+L 324.255453 207.391993
+L 339.101165 205.270544
+L 353.946877 203.102234
+L 368.79259 200.951182
+L 383.638302 198.781809
+L 398.484014 196.52144
+L 413.329727 194.401926
+L 428.175439 191.644202
+L 443.021151 188.869383
+L 457.866864 186.273023
+L 472.712576 183.767902
+L 487.558288 181.118735
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1450,34 +1450,34 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="280.222701" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="101.569768" y="264.557254" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="116.41548" y="256.09375" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="131.261192" y="249.653457" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="146.106905" y="243.529409" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="160.952617" y="238.789438" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="175.798329" y="234.491927" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="190.644042" y="230.883008" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="205.489754" y="227.829656" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="225.104859" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="235.181179" y="222.145914" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="250.026891" y="219.397626" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.872603" y="216.772131" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="279.718316" y="214.219141" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="294.564028" y="211.670647" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="309.40974" y="209.292416" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="324.255453" y="207.096213" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="339.101165" y="204.830411" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="202.695415" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="368.79259" y="200.557927" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="383.638302" y="198.417507" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="398.484014" y="196.155999" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="413.329727" y="193.974828" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="428.175439" y="191.215948" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="443.021151" y="188.300525" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="457.866864" y="185.705343" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="472.712576" y="183.218008" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="180.55849" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="279.865871" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="101.569768" y="264.444594" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="116.41548" y="256.001036" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="131.261192" y="249.939237" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="146.106905" y="243.784803" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="160.952617" y="238.772755" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="175.798329" y="234.531662" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="190.644042" y="231.036779" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="205.489754" y="227.910153" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="225.2117" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="235.181179" y="222.211092" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="250.026891" y="219.541839" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.872603" y="216.888274" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="279.718316" y="214.444844" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="294.564028" y="211.920436" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="309.40974" y="209.634541" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="324.255453" y="207.391993" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="339.101165" y="205.270544" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="203.102234" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="368.79259" y="200.951182" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="383.638302" y="198.781809" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="398.484014" y="196.52144" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="413.329727" y="194.401926" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="428.175439" y="191.644202" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="443.021151" y="188.869383" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="457.866864" y="186.273023" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="472.712576" y="183.767902" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="181.118735" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -2530,7 +2530,7 @@ z
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 60 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 61 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2667,7 +2667,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-19" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-13" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-combined.svg
+++ b/reports/figures/hexbz-cactus-combined.svg
@@ -1656,64 +1656,58 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <path d="M 86.724055 275.139765
-L 89.260981 263.282807
-L 91.797906 255.417321
-L 94.334832 249.886881
-L 96.871757 245.723618
-L 99.408683 242.249046
-L 101.945609 239.220865
-L 104.482534 236.655341
-L 107.01946 234.399703
-L 109.556385 232.40741
-L 112.093311 230.272866
-L 114.630236 228.33988
-L 119.704087 224.92937
-L 124.777938 221.747789
-L 132.388715 217.349135
-L 142.536417 211.794837
-L 147.610268 209.303287
-L 152.684119 207.10431
-L 167.905672 201.162402
-L 178.053374 197.537489
-L 185.664151 195.096004
-L 198.348778 191.410143
-L 223.718034 184.433841
-L 236.402661 181.165102
-L 256.698066 175.952303
-L 269.382693 172.752534
-L 289.678097 167.822316
-L 312.510427 162.853884
-L 335.342757 157.972364
-L 345.490459 155.43091
-L 353.101236 153.245844
-L 363.248938 150.432886
-L 370.859714 147.914039
-L 375.933565 146.117388
-L 378.470491 145.172864
-L 391.155118 139.16061
-L 403.839746 133.501597
-L 406.376672 132.251003
-L 413.987448 127.599505
-L 416.524374 126.169428
-L 419.061299 124.56136
-L 424.13515 120.873967
-L 429.209001 117.630882
-L 431.745927 116.096298
-L 436.819778 112.704402
-L 439.356703 110.629436
-L 441.893629 107.399175
-L 444.430554 104.647539
-L 446.96748 101.71256
-L 449.504405 98.45839
-L 452.041331 95.718293
-L 454.578257 92.65206
-L 457.115182 84.303229
-L 459.652108 72.434464
-L 462.189033 64.802512
-L 464.725959 59.538282
-L 467.262884 54.573432
-L 467.262884 54.573432
+    <path d="M 86.724055 274.7999
+L 89.260981 263.154876
+L 91.797906 255.279132
+L 94.334832 249.806828
+L 96.871757 245.64996
+L 99.408683 242.252282
+L 101.945609 239.413259
+L 104.482534 236.940865
+L 107.01946 234.718356
+L 109.556385 232.7522
+L 112.093311 230.553727
+L 114.630236 228.591008
+L 119.704087 225.147143
+L 129.851789 218.993535
+L 137.462566 214.689971
+L 142.536417 212.032245
+L 150.147194 208.340597
+L 155.221045 206.21031
+L 175.516449 198.424275
+L 183.127225 195.837814
+L 190.738002 193.479824
+L 218.644183 185.627979
+L 284.604246 168.928559
+L 294.751948 166.672552
+L 340.416608 156.65956
+L 348.027384 154.591948
+L 355.638161 152.493674
+L 363.248938 150.36971
+L 378.470491 145.121508
+L 393.692044 137.901214
+L 398.765895 135.70397
+L 406.376672 132.038767
+L 413.987448 127.41519
+L 416.524374 125.974976
+L 419.061299 124.387966
+L 424.13515 120.639709
+L 429.209001 117.314532
+L 431.745927 115.810368
+L 436.819778 112.373104
+L 439.356703 110.320762
+L 441.893629 107.14422
+L 444.430554 104.460581
+L 446.96748 101.514955
+L 449.504405 98.218314
+L 452.041331 95.450318
+L 454.578257 92.444701
+L 457.115182 84.159668
+L 459.652108 72.363103
+L 462.189033 64.761598
+L 464.725959 59.506306
+L 467.262884 54.525254
+L 467.262884 54.525254
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1729,157 +1723,157 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="275.139765" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="89.260981" y="263.282807" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="91.797906" y="255.417321" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="94.334832" y="249.886881" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="96.871757" y="245.723618" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.408683" y="242.249046" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="101.945609" y="239.220865" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="104.482534" y="236.655341" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.01946" y="234.399703" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="109.556385" y="232.40741" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="112.093311" y="230.272866" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="114.630236" y="228.33988" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.167162" y="226.599841" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="119.704087" y="224.92937" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="122.241013" y="223.299603" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="124.777938" y="221.747789" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.314864" y="220.260371" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="129.851789" y="218.832759" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="132.388715" y="217.349135" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="134.92564" y="215.935205" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="137.462566" y="214.488277" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="139.999491" y="213.121055" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="142.536417" y="211.794837" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="145.073342" y="210.516849" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="147.610268" y="209.303287" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="150.147194" y="208.167802" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="152.684119" y="207.10431" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="155.221045" y="206.101531" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="157.75797" y="205.138151" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="160.294896" y="204.117137" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="162.831821" y="203.141812" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="165.368747" y="202.147836" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="167.905672" y="201.162402" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="170.442598" y="200.230838" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="172.979523" y="199.333018" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="175.516449" y="198.415826" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="178.053374" y="197.537489" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="180.5903" y="196.695673" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="183.127225" y="195.87837" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="185.664151" y="195.096004" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="188.201076" y="194.340687" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="190.738002" y="193.600634" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="193.274927" y="192.852633" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="195.811853" y="192.117745" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="198.348778" y="191.410143" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="200.885704" y="190.702989" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="203.42263" y="189.953157" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="205.959555" y="189.226783" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="208.496481" y="188.495785" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="211.033406" y="187.769373" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="213.570332" y="187.056251" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="216.107257" y="186.370118" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="218.644183" y="185.710242" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="221.181108" y="185.060506" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="223.718034" y="184.433841" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="226.254959" y="183.802156" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="228.791885" y="183.148418" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="231.32881" y="182.502454" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="233.865736" y="181.825828" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="236.402661" y="181.165102" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="238.939587" y="180.526419" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="241.476512" y="179.866292" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="244.013438" y="179.199607" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="246.550363" y="178.528875" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="249.087289" y="177.870328" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.624215" y="177.229863" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="254.16114" y="176.595041" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="256.698066" y="175.952303" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="259.234991" y="175.292983" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="261.771917" y="174.65207" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.308842" y="174.013049" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="266.845768" y="173.391289" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="269.382693" y="172.752534" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.919619" y="172.123454" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="274.456544" y="171.469142" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="276.99347" y="170.832692" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="279.530395" y="170.197275" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="282.067321" y="169.583177" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="284.604246" y="168.986307" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="168.399164" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="289.678097" y="167.822316" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.215023" y="167.259296" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="294.751948" y="166.705311" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="297.288874" y="166.167286" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="299.8258" y="165.596978" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.362725" y="165.044385" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="304.899651" y="164.494186" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="307.436576" y="163.945885" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="309.973502" y="163.39815" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.510427" y="162.853884" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="315.047353" y="162.316764" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="317.584278" y="161.766778" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="320.121204" y="161.223129" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="322.658129" y="160.689447" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="325.195055" y="160.16959" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="327.73198" y="159.642421" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="330.268906" y="159.09042" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="332.805831" y="158.537905" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="335.342757" y="157.972364" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="337.879682" y="157.359725" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="340.416608" y="156.712378" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="342.953533" y="156.066592" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="345.490459" y="155.43091" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="348.027384" y="154.675925" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="350.56431" y="153.948914" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.101236" y="153.245844" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="355.638161" y="152.561982" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="358.175087" y="151.881913" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="360.712012" y="151.207542" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="363.248938" y="150.432886" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="365.785863" y="149.557681" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="368.322789" y="148.721651" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="370.859714" y="147.914039" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="373.39664" y="147.063567" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="375.933565" y="146.117388" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="378.470491" y="145.172864" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="381.007416" y="143.949698" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="383.544342" y="142.770313" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="386.081267" y="141.6009" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="388.618193" y="140.357903" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="391.155118" y="139.16061" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="393.692044" y="138.038594" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="396.228969" y="136.93259" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="398.765895" y="135.885598" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="401.302821" y="134.687799" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="403.839746" y="133.501597" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="406.376672" y="132.251003" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="408.913597" y="130.681678" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="411.450523" y="129.082801" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="413.987448" y="127.599505" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="416.524374" y="126.169428" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="419.061299" y="124.56136" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="421.598225" y="122.724853" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="424.13515" y="120.873967" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="426.672076" y="119.201622" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="429.209001" y="117.630882" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="431.745927" y="116.096298" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="434.282852" y="114.393198" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="436.819778" y="112.704402" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="439.356703" y="110.629436" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="441.893629" y="107.399175" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="444.430554" y="104.647539" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.96748" y="101.71256" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="449.504405" y="98.45839" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="452.041331" y="95.718293" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="454.578257" y="92.65206" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="457.115182" y="84.303229" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="459.652108" y="72.434464" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="462.189033" y="64.802512" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="464.725959" y="59.538282" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="467.262884" y="54.573432" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="274.7999" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="89.260981" y="263.154876" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="91.797906" y="255.279132" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="94.334832" y="249.806828" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="96.871757" y="245.64996" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.408683" y="242.252282" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="101.945609" y="239.413259" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="104.482534" y="236.940865" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.01946" y="234.718356" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="109.556385" y="232.7522" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="112.093311" y="230.553727" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="114.630236" y="228.591008" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.167162" y="226.824047" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="119.704087" y="225.147143" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="122.241013" y="223.588496" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="124.777938" y="221.95367" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.314864" y="220.462221" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="129.851789" y="218.993535" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="132.388715" y="217.534772" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="134.92564" y="216.082715" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="137.462566" y="214.689971" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="139.999491" y="213.330338" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="142.536417" y="212.032245" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="145.073342" y="210.768795" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="147.610268" y="209.512403" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="150.147194" y="208.340597" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="152.684119" y="207.24244" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="155.221045" y="206.21031" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="157.75797" y="205.229145" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="160.294896" y="204.254193" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="162.831821" y="203.263141" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="165.368747" y="202.247107" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="167.905672" y="201.235776" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="170.442598" y="200.27911" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="172.979523" y="199.345731" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="175.516449" y="198.424275" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="178.053374" y="197.541696" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="180.5903" y="196.69425" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="183.127225" y="195.837814" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="185.664151" y="195.019857" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="188.201076" y="194.232648" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="190.738002" y="193.479824" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="193.274927" y="192.759291" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="195.811853" y="192.042423" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="198.348778" y="191.331361" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="200.885704" y="190.632222" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="203.42263" y="189.887376" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="205.959555" y="189.169203" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="208.496481" y="188.428477" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="211.033406" y="187.694858" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="213.570332" y="186.987226" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="216.107257" y="186.295548" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="218.644183" y="185.627979" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="221.181108" y="184.983462" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="223.718034" y="184.358883" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="226.254959" y="183.716753" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="228.791885" y="183.062923" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="231.32881" y="182.432573" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="233.865736" y="181.77404" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="236.402661" y="181.123681" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="238.939587" y="180.487108" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="241.476512" y="179.821469" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="244.013438" y="179.1492" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="246.550363" y="178.484488" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="249.087289" y="177.831914" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.624215" y="177.171016" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="254.16114" y="176.531846" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="256.698066" y="175.90786" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="259.234991" y="175.249641" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="261.771917" y="174.608929" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.308842" y="173.970969" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="266.845768" y="173.342237" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="269.382693" y="172.695055" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.919619" y="172.067748" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="274.456544" y="171.414572" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="276.99347" y="170.771811" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="279.530395" y="170.144519" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="282.067321" y="169.531385" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="284.604246" y="168.928559" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="168.344148" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="289.678097" y="167.777223" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.215023" y="167.227967" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="294.751948" y="166.672552" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="297.288874" y="166.12147" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="299.8258" y="165.548259" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.362725" y="164.989519" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="304.899651" y="164.447422" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="307.436576" y="163.904494" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="309.973502" y="163.375714" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.510427" y="162.819694" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="315.047353" y="162.276863" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="317.584278" y="161.729809" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="320.121204" y="161.172133" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="322.658129" y="160.625967" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="325.195055" y="160.09615" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="327.73198" y="159.569924" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="330.268906" y="159.019226" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="332.805831" y="158.461466" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="335.342757" y="157.898673" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="337.879682" y="157.289758" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="340.416608" y="156.65956" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="342.953533" y="156.000039" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="345.490459" y="155.34749" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="348.027384" y="154.591948" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="350.56431" y="153.868396" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.101236" y="153.167953" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="355.638161" y="152.493674" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="358.175087" y="151.813505" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="360.712012" y="151.145449" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="363.248938" y="150.36971" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="365.785863" y="149.514382" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="368.322789" y="148.663689" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="370.859714" y="147.843583" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="373.39664" y="147.000929" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="375.933565" y="146.054994" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="378.470491" y="145.121508" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="381.007416" y="143.910375" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="383.544342" y="142.725849" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="386.081267" y="141.552113" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="388.618193" y="140.2605" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="391.155118" y="139.05998" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="393.692044" y="137.901214" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="396.228969" y="136.798021" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="398.765895" y="135.70397" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="401.302821" y="134.460076" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="403.839746" y="133.287558" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="406.376672" y="132.038767" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="408.913597" y="130.471434" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="411.450523" y="128.886918" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="413.987448" y="127.41519" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="416.524374" y="125.974976" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="419.061299" y="124.387966" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="421.598225" y="122.477575" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="424.13515" y="120.639709" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="426.672076" y="118.920668" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="429.209001" y="117.314532" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="431.745927" y="115.810368" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="434.282852" y="114.092142" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="436.819778" y="112.373104" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="439.356703" y="110.320762" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="441.893629" y="107.14422" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="444.430554" y="104.460581" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.96748" y="101.514955" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="449.504405" y="98.218314" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="452.041331" y="95.450318" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="454.578257" y="92.444701" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="457.115182" y="84.159668" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="459.652108" y="72.363103" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="462.189033" y="64.761598" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="464.725959" y="59.506306" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="467.262884" y="54.525254" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_152">
@@ -3741,7 +3735,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_26">
-   <!-- cutoff 10.0s; source newest-per-system across 60 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 61 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -3865,7 +3859,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-19" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-13" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-conway.svg
+++ b/reports/figures/hexbz-cactus-conway.svg
@@ -1637,42 +1637,42 @@ z
     </g>
    </g>
    <g id="line2d_157">
-    <path d="M 86.724055 276.057419
-L 88.890727 265.012357
-L 91.057398 258.530468
-L 93.22407 253.949388
-L 95.390742 250.38687
-L 97.557413 247.407184
-L 99.724085 244.899249
-L 104.057428 240.472316
-L 106.224099 238.485573
-L 108.390771 236.681247
-L 110.557442 235.032395
-L 114.890785 232.148169
-L 119.224128 229.672564
-L 125.724143 226.404607
-L 130.057486 224.355772
-L 134.390829 222.489066
-L 140.890844 219.972787
-L 149.55753 216.97943
-L 160.390887 213.632821
-L 171.224245 210.681402
-L 184.224274 207.365339
-L 195.057632 204.728007
-L 205.89099 202.289243
-L 216.724347 200.070407
-L 238.391062 195.996728
-L 290.391179 186.586812
-L 309.891223 182.888462
-L 327.224595 179.699908
-L 351.057982 175.464645
-L 377.05804 171.295275
-L 398.724756 167.975581
-L 424.724814 164.100797
-L 455.058215 159.729488
-L 474.558259 156.239771
-L 487.558288 153.468315
-L 487.558288 153.468315
+    <path d="M 86.724055 276.293062
+L 88.890727 265.314072
+L 91.057398 258.855734
+L 93.22407 254.240845
+L 95.390742 250.620407
+L 97.557413 247.576775
+L 99.724085 245.025921
+L 104.057428 240.620223
+L 106.224099 238.578901
+L 108.390771 236.745205
+L 110.557442 235.099485
+L 114.890785 232.230595
+L 119.224128 229.772125
+L 125.724143 226.539039
+L 130.057486 224.527772
+L 136.557501 221.765169
+L 143.057515 219.252849
+L 149.55753 216.949976
+L 158.224216 214.225936
+L 166.890902 211.798653
+L 182.057603 207.837183
+L 195.057632 204.727706
+L 208.057661 201.867053
+L 218.891019 199.654375
+L 234.057719 196.772654
+L 305.55788 183.621224
+L 322.891252 180.393433
+L 355.391325 174.630876
+L 394.391413 168.588016
+L 413.891456 165.629769
+L 444.224858 161.313996
+L 452.891544 160.036463
+L 461.55823 158.534744
+L 478.891602 155.323343
+L 487.558288 153.442341
+L 487.558288 153.442341
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1688,192 +1688,192 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="276.057419" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="88.890727" y="265.012357" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="91.057398" y="258.530468" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="93.22407" y="253.949388" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="95.390742" y="250.38687" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.557413" y="247.407184" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.724085" y="244.899249" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="101.890756" y="242.698073" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="104.057428" y="240.472316" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="106.224099" y="238.485573" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="108.390771" y="236.681247" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="110.557442" y="235.032395" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="112.724114" y="233.528678" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="114.890785" y="232.148169" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.057457" y="230.872904" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="119.224128" y="229.672564" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="121.3908" y="228.547233" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="123.557471" y="227.487944" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="125.724143" y="226.404607" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.890814" y="225.352645" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="130.057486" y="224.355772" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="132.224158" y="223.403062" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="134.390829" y="222.489066" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="136.557501" y="221.623769" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.724172" y="220.782519" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="140.890844" y="219.972787" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.057515" y="219.195714" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="145.224187" y="218.443689" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="147.390858" y="217.695658" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="149.55753" y="216.97943" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="151.724201" y="216.29179" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="153.890873" y="215.591795" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="156.057544" y="214.915834" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.224216" y="214.265301" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="160.390887" y="213.632821" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="162.557559" y="213.023101" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="164.72423" y="212.429455" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="166.890902" y="211.853403" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="169.057574" y="211.271978" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="171.224245" y="210.681402" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="173.390917" y="210.111935" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="175.557588" y="209.555472" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="177.72426" y="209.005805" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.890931" y="208.460935" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="182.057603" y="207.932984" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="184.224274" y="207.365339" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="186.390946" y="206.816693" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="188.557617" y="206.283269" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="190.724289" y="205.766532" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="192.89096" y="205.244226" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="195.057632" y="204.728007" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="197.224303" y="204.218155" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.390975" y="203.720998" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="201.557646" y="203.236157" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="203.724318" y="202.759035" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="205.89099" y="202.289243" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="208.057661" y="201.829318" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.224333" y="201.377178" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="212.391004" y="200.934322" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="214.557676" y="200.500022" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="216.724347" y="200.070407" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="218.891019" y="199.652012" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="221.05769" y="199.241508" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="223.224362" y="198.824623" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="225.391033" y="198.409699" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="227.557705" y="198.00314" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="229.724376" y="197.592253" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="231.891048" y="197.186607" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="234.057719" y="196.782046" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="236.224391" y="196.386894" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="238.391062" y="195.996728" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.557734" y="195.609142" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.724406" y="195.216559" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="244.891077" y="194.823569" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="247.057749" y="194.431582" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="249.22442" y="194.019739" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.391092" y="193.613078" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="253.557763" y="193.216022" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="255.724435" y="192.825933" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="257.891106" y="192.442319" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="260.057778" y="192.058308" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="262.224449" y="191.678205" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.391121" y="191.285944" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="266.557792" y="190.895524" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="268.724464" y="190.506714" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="270.891135" y="190.122144" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="273.057807" y="189.730066" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="275.224478" y="189.344013" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="277.39115" y="188.964525" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="279.557822" y="188.59332" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="281.724493" y="188.210378" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="283.891165" y="187.805721" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="286.057836" y="187.394326" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="288.224508" y="186.99031" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="290.391179" y="186.586812" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.557851" y="186.187765" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="294.724522" y="185.795" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="296.891194" y="185.380222" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="299.057865" y="184.971967" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="301.224537" y="184.549296" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="303.391208" y="184.134669" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="305.55788" y="183.728463" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="307.724551" y="183.309799" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="309.891223" y="182.888462" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.057894" y="182.476871" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="314.224566" y="182.072877" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="316.391238" y="181.666786" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="318.557909" y="181.270566" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="320.724581" y="180.877094" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="322.891252" y="180.47639" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="325.057924" y="180.085557" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="327.224595" y="179.699908" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="329.391267" y="179.306591" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="331.557938" y="178.899251" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.72461" y="178.489463" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="335.891281" y="178.086594" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="338.057953" y="177.691779" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="340.224624" y="177.306015" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="342.391296" y="176.928842" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="344.557967" y="176.560147" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="346.724639" y="176.18915" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="348.89131" y="175.823358" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="351.057982" y="175.464645" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.224654" y="175.108721" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="355.391325" y="174.758386" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="357.557997" y="174.406648" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="359.724668" y="174.061228" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="361.89134" y="173.722413" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.058011" y="173.384422" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="366.224683" y="173.037644" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="368.391354" y="172.686883" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="370.558026" y="172.338359" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="372.724697" y="171.992462" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.891369" y="171.642989" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="377.05804" y="171.295275" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="379.224712" y="170.952422" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="381.391383" y="170.615414" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="383.558055" y="170.277596" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="385.724726" y="169.946519" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="387.891398" y="169.616641" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="390.05807" y="169.288099" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="392.224741" y="168.964945" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="394.391413" y="168.647413" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="396.558084" y="168.311549" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="398.724756" y="167.975581" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="400.891427" y="167.645295" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="403.058099" y="167.316417" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="405.22477" y="166.991575" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="407.391442" y="166.661127" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="409.558113" y="166.326899" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="411.724785" y="165.998248" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="413.891456" y="165.67524" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="416.058128" y="165.356618" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="418.224799" y="165.038409" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="420.391471" y="164.722492" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="422.558142" y="164.411626" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="424.724814" y="164.100797" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="426.891486" y="163.79475" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="429.058157" y="163.491669" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="431.224829" y="163.184025" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="433.3915" y="162.879727" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="435.558172" y="162.580027" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="437.724843" y="162.281665" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="439.891515" y="161.970912" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="442.058186" y="161.660982" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="444.224858" y="161.355846" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.391529" y="161.049367" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="448.558201" y="160.718813" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="450.724872" y="160.394695" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="452.891544" y="160.07317" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="455.058215" y="159.729488" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="457.224887" y="159.348112" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="459.391558" y="158.959513" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="461.55823" y="158.574969" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="463.724902" y="158.179593" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="465.891573" y="157.793117" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="468.058245" y="157.41494" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="470.224916" y="157.03777" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="472.391588" y="156.663511" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="474.558259" y="156.239771" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="476.724931" y="155.785972" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="478.891602" y="155.341499" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="481.058274" y="154.884975" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="483.224945" y="154.432641" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="485.391617" y="153.963081" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="153.468315" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="276.293062" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="88.890727" y="265.314072" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="91.057398" y="258.855734" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="93.22407" y="254.240845" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="95.390742" y="250.620407" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.557413" y="247.576775" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.724085" y="245.025921" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="101.890756" y="242.82103" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="104.057428" y="240.620223" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="106.224099" y="238.578901" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="108.390771" y="236.745205" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="110.557442" y="235.099485" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="112.724114" y="233.604434" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="114.890785" y="232.230595" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.057457" y="230.962268" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="119.224128" y="229.772125" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="121.3908" y="228.659248" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="123.557471" y="227.615991" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="125.724143" y="226.539039" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.890814" y="225.50515" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="130.057486" y="224.527772" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="132.224158" y="223.569488" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="134.390829" y="222.650402" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="136.557501" y="221.765169" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.724172" y="220.896783" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="140.890844" y="220.072884" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.057515" y="219.252849" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="145.224187" y="218.45587" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="147.390858" y="217.686883" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="149.55753" y="216.949976" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="151.724201" y="216.244141" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="153.890873" y="215.549138" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="156.057544" y="214.880248" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.224216" y="214.225936" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="160.390887" y="213.594417" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="162.557559" y="212.980372" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="164.72423" y="212.383135" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="166.890902" y="211.798653" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="169.057574" y="211.21884" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="171.224245" y="210.648095" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="173.390917" y="210.076372" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="175.557588" y="209.498517" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="177.72426" y="208.937919" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.890931" y="208.378089" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="182.057603" y="207.837183" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="184.224274" y="207.305111" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="186.390946" y="206.777894" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="188.557617" y="206.265597" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="190.724289" y="205.745431" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="192.89096" y="205.238278" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="195.057632" y="204.727706" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="197.224303" y="204.232845" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.390975" y="203.752298" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="201.557646" y="203.277724" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="203.724318" y="202.811036" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="205.89099" y="202.332434" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="208.057661" y="201.867053" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.224333" y="201.407705" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="212.391004" y="200.961049" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="214.557676" y="200.521657" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="216.724347" y="200.084233" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="218.891019" y="199.654375" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="221.05769" y="199.229268" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="223.224362" y="198.812647" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="225.391033" y="198.39248" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="227.557705" y="197.978081" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="229.724376" y="197.574198" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="231.891048" y="197.171478" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="234.057719" y="196.772654" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="236.224391" y="196.377251" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="238.391062" y="195.987508" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.557734" y="195.595445" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.724406" y="195.188522" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="244.891077" y="194.787596" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="247.057749" y="194.380308" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="249.22442" y="193.979172" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.391092" y="193.582131" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="253.557763" y="193.187955" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="255.724435" y="192.801641" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="257.891106" y="192.419911" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="260.057778" y="192.030724" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="262.224449" y="191.639598" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.391121" y="191.244127" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="266.557792" y="190.852636" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="268.724464" y="190.459007" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="270.891135" y="190.067521" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="273.057807" y="189.671553" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="275.224478" y="189.27741" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="277.39115" y="188.888621" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="279.557822" y="188.508613" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="281.724493" y="188.117906" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="283.891165" y="187.712129" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="286.057836" y="187.301713" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="288.224508" y="186.890399" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="290.391179" y="186.482638" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.557851" y="186.084566" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="294.724522" y="185.684261" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="296.891194" y="185.272279" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="299.057865" y="184.86747" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="301.224537" y="184.450007" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="303.391208" y="184.032806" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="305.55788" y="183.621224" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="307.724551" y="183.2064" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="309.891223" y="182.790171" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.057894" y="182.382782" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="314.224566" y="181.981603" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="316.391238" y="181.580975" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="318.557909" y="181.183042" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="320.724581" y="180.792167" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="322.891252" y="180.393433" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="325.057924" y="180.004168" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="327.224595" y="179.61694" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="329.391267" y="179.222081" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="331.557938" y="178.805823" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.72461" y="178.396313" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="335.891281" y="177.995834" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="338.057953" y="177.594145" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="340.224624" y="177.199306" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="342.391296" y="176.813747" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="344.557967" y="176.437261" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="346.724639" y="176.063327" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="348.89131" y="175.697056" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="351.057982" y="175.335235" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.224654" y="174.980328" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="355.391325" y="174.630876" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="357.557997" y="174.288924" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="359.724668" y="173.952561" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="361.89134" y="173.616591" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.058011" y="173.286727" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="366.224683" y="172.943889" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="368.391354" y="172.594496" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="370.558026" y="172.241542" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="372.724697" y="171.89626" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.891369" y="171.555686" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="377.05804" y="171.219315" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="379.224712" y="170.885897" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="381.391383" y="170.55088" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="383.558055" y="170.214299" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="385.724726" y="169.882939" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="387.891398" y="169.556289" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="390.05807" y="169.228278" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="392.224741" y="168.906807" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="394.391413" y="168.588016" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="396.558084" y="168.248247" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="398.724756" y="167.910573" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="400.891427" y="167.57882" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="403.058099" y="167.248074" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="405.22477" y="166.923035" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="407.391442" y="166.602877" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="409.558113" y="166.274501" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="411.724785" y="165.951281" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="413.891456" y="165.629769" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="416.058128" y="165.314306" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="418.224799" y="164.993663" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="420.391471" y="164.678524" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="422.558142" y="164.366548" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="424.724814" y="164.059814" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="426.891486" y="163.753564" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="429.058157" y="163.44421" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="431.224829" y="163.136784" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="433.3915" y="162.832071" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="435.558172" y="162.532966" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="437.724843" y="162.229216" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="439.891515" y="161.919884" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="442.058186" y="161.61531" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="444.224858" y="161.313996" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.391529" y="161.012725" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="448.558201" y="160.68625" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="450.724872" y="160.35827" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="452.891544" y="160.036463" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="455.058215" y="159.688638" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="457.224887" y="159.311243" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="459.391558" y="158.920765" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="461.55823" y="158.534744" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="463.724902" y="158.147012" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="465.891573" y="157.76421" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="468.058245" y="157.388982" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="470.224916" y="157.015444" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="472.391588" y="156.641504" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="474.558259" y="156.213907" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="476.724931" y="155.767301" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="478.891602" y="155.323343" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="481.058274" y="154.862061" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="483.224945" y="154.402668" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="485.391617" y="153.935531" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="153.442341" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_158">
@@ -3789,7 +3789,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_26">
-   <!-- cutoff 10.0s; source newest-per-system across 60 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 61 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -3896,7 +3896,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-19" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-13" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-cyclotomic-products.svg
+++ b/reports/figures/hexbz-cactus-cyclotomic-products.svg
@@ -1423,25 +1423,25 @@ z
     </g>
    </g>
    <g id="line2d_123">
-    <path d="M 86.724055 273.271394
-L 108.992624 249.063183
-L 131.261192 237.948752
-L 153.529761 230.14903
-L 175.798329 222.889605
-L 198.066898 216.600314
-L 220.335466 210.390191
-L 242.604035 199.114424
-L 264.872603 189.961518
-L 287.141172 183.364454
-L 309.40974 177.984158
-L 331.678309 169.85051
-L 353.946877 163.359889
-L 376.215446 155.870676
-L 398.484014 147.922366
-L 420.752583 138.846807
-L 443.021151 129.701074
-L 465.28972 121.494682
-L 487.558288 109.788802
+    <path d="M 86.724055 272.776304
+L 108.992624 248.868178
+L 131.261192 237.654569
+L 153.529761 229.756567
+L 175.798329 222.405592
+L 198.066898 216.115187
+L 220.335466 209.8744
+L 242.604035 198.78372
+L 264.872603 189.609762
+L 287.141172 183.100486
+L 309.40974 177.685248
+L 331.678309 169.606966
+L 353.946877 162.943846
+L 376.215446 155.512477
+L 398.484014 147.65693
+L 420.752583 138.450866
+L 443.021151 129.178746
+L 465.28972 121.090907
+L 487.558288 109.427949
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1457,25 +1457,25 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="273.271394" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="108.992624" y="249.063183" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="131.261192" y="237.948752" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="153.529761" y="230.14903" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="175.798329" y="222.889605" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="198.066898" y="216.600314" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="210.390191" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="199.114424" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.872603" y="189.961518" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="183.364454" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="309.40974" y="177.984158" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="331.678309" y="169.85051" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="163.359889" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="376.215446" y="155.870676" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="398.484014" y="147.922366" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="420.752583" y="138.846807" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="443.021151" y="129.701074" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="465.28972" y="121.494682" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="109.788802" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="272.776304" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="108.992624" y="248.868178" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="131.261192" y="237.654569" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="153.529761" y="229.756567" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="175.798329" y="222.405592" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="198.066898" y="216.115187" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="209.8744" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="198.78372" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.872603" y="189.609762" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="183.100486" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="309.40974" y="177.685248" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="331.678309" y="169.606966" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="162.943846" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="376.215446" y="155.512477" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="398.484014" y="147.65693" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="420.752583" y="138.450866" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="443.021151" y="129.178746" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="465.28972" y="121.090907" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="109.427949" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_124">
@@ -2411,7 +2411,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 60 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 61 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2541,7 +2541,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-19" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-13" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-cyclotomic.svg
+++ b/reports/figures/hexbz-cactus-cyclotomic.svg
@@ -1503,40 +1503,40 @@ z
     </g>
    </g>
    <g id="line2d_133">
-    <path d="M 86.724055 274.794413
-L 98.870547 260.044395
-L 111.017039 244.661729
-L 123.163531 236.29428
-L 135.310023 230.537503
-L 147.456515 225.608713
-L 159.603007 221.365731
-L 171.749499 216.165231
-L 183.895991 211.89975
-L 196.042483 207.953581
-L 208.188974 203.77522
-L 220.335466 200.086328
-L 232.481958 196.834027
-L 244.62845 193.035617
-L 256.774942 189.239956
-L 268.921434 186.068344
-L 281.067926 182.227282
-L 293.214418 178.051696
-L 305.36091 173.161821
-L 317.507402 166.464653
-L 329.653894 160.134481
-L 341.800385 155.271184
-L 353.946877 150.636386
-L 366.093369 146.185609
-L 378.239861 141.830384
-L 390.386353 136.270592
-L 402.532845 129.068339
-L 414.679337 123.396474
-L 426.825829 118.548628
-L 438.972321 114.446417
-L 451.118813 110.951062
-L 463.265305 104.03633
-L 475.411796 85.131421
-L 487.558288 61.366004
+    <path d="M 86.724055 273.459028
+L 98.870547 259.088466
+L 111.017039 244.155729
+L 123.163531 235.831526
+L 135.310023 230.09962
+L 147.456515 225.238942
+L 159.603007 221.013506
+L 171.749499 215.824395
+L 183.895991 211.505494
+L 196.042483 207.524341
+L 208.188974 203.23731
+L 220.335466 199.664751
+L 232.481958 196.449065
+L 244.62845 192.67639
+L 256.774942 188.92014
+L 268.921434 185.778768
+L 281.067926 181.944
+L 293.214418 177.624956
+L 305.36091 172.658892
+L 317.507402 165.976286
+L 329.653894 159.6386
+L 341.800385 154.823449
+L 353.946877 150.227415
+L 366.093369 145.820273
+L 378.239861 141.469568
+L 390.386353 135.926257
+L 402.532845 128.791311
+L 414.679337 123.202208
+L 426.825829 118.282401
+L 438.972321 114.135976
+L 451.118813 110.625507
+L 463.265305 103.811778
+L 475.411796 84.964832
+L 487.558288 61.319004
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1552,40 +1552,40 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="274.794413" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="98.870547" y="260.044395" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="111.017039" y="244.661729" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="123.163531" y="236.29428" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="135.310023" y="230.537503" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="147.456515" y="225.608713" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="159.603007" y="221.365731" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="171.749499" y="216.165231" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="183.895991" y="211.89975" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="196.042483" y="207.953581" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="208.188974" y="203.77522" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="200.086328" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="232.481958" y="196.834027" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="244.62845" y="193.035617" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="256.774942" y="189.239956" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="268.921434" y="186.068344" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="281.067926" y="182.227282" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="293.214418" y="178.051696" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="305.36091" y="173.161821" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="317.507402" y="166.464653" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="329.653894" y="160.134481" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="341.800385" y="155.271184" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="150.636386" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="366.093369" y="146.185609" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="378.239861" y="141.830384" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="390.386353" y="136.270592" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="402.532845" y="129.068339" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="414.679337" y="123.396474" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="426.825829" y="118.548628" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="438.972321" y="114.446417" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="451.118813" y="110.951062" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="463.265305" y="104.03633" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="475.411796" y="85.131421" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="61.366004" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="273.459028" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="98.870547" y="259.088466" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="111.017039" y="244.155729" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="123.163531" y="235.831526" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="135.310023" y="230.09962" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="147.456515" y="225.238942" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="159.603007" y="221.013506" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="171.749499" y="215.824395" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="183.895991" y="211.505494" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="196.042483" y="207.524341" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="208.188974" y="203.23731" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="199.664751" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="232.481958" y="196.449065" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="244.62845" y="192.67639" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="256.774942" y="188.92014" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="268.921434" y="185.778768" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="281.067926" y="181.944" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="293.214418" y="177.624956" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="305.36091" y="172.658892" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="317.507402" y="165.976286" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="329.653894" y="159.6386" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="341.800385" y="154.823449" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="150.227415" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="366.093369" y="145.820273" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="378.239861" y="141.469568" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="390.386353" y="135.926257" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="402.532845" y="128.791311" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="414.679337" y="123.202208" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="426.825829" y="118.282401" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="438.972321" y="114.135976" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="451.118813" y="110.625507" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="463.265305" y="103.811778" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="475.411796" y="84.964832" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="61.319004" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -2643,7 +2643,7 @@ z
    </g>
   </g>
   <g id="text_25">
-   <!-- cutoff 10.0s; source newest-per-system across 60 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 61 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2780,7 +2780,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-19" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-13" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-hoeij-zimmermann.svg
+++ b/reports/figures/hexbz-cactus-hoeij-zimmermann.svg
@@ -791,8 +791,8 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_19">
-      <path d="M 66.682344 277.147947
-L 507.6 277.147947
+      <path d="M 66.682344 277.15512
+L 507.6 277.15512
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
@@ -802,12 +802,12 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="277.147947" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="277.15512" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 10ms -->
-      <g transform="translate(32.007344 280.946775) scale(0.1 -0.1)">
+      <g transform="translate(32.007344 280.953948) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-13" d="M 2034 4250
 Q 1547 4250 1301 3770
@@ -840,18 +840,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_21">
-      <path d="M 66.682344 194.932215
-L 507.6 194.932215
+      <path d="M 66.682344 194.982355
+L 507.6 194.982355
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="194.932215" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="194.982355" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 100ms -->
-      <g transform="translate(25.644844 198.731044) scale(0.1 -0.1)">
+      <g transform="translate(25.644844 198.781183) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
@@ -862,18 +862,18 @@ L 507.6 194.932215
     </g>
     <g id="ytick_3">
      <g id="line2d_23">
-      <path d="M 66.682344 112.716484
-L 507.6 112.716484
+      <path d="M 66.682344 112.80959
+L 507.6 112.80959
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="112.716484" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="112.80959" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1s -->
-      <g transform="translate(48.110469 116.515312) scale(0.1 -0.1)">
+      <g transform="translate(48.110469 116.608418) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(63.625 0)"/>
       </g>
@@ -881,18 +881,18 @@ L 507.6 112.716484
     </g>
     <g id="ytick_4">
      <g id="line2d_25">
-      <path d="M 66.682344 30.500752
-L 507.6 30.500752
+      <path d="M 66.682344 30.636825
+L 507.6 30.636825
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="30.500752" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="30.636825" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 10s -->
-      <g transform="translate(41.747969 34.29958) scale(0.1 -0.1)">
+      <g transform="translate(41.747969 34.435653) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(127.25 0)"/>
@@ -901,8 +901,8 @@ L 507.6 30.500752
     </g>
     <g id="ytick_5">
      <g id="line2d_27">
-      <path d="M 66.682344 301.897349
-L 507.6 301.897349
+      <path d="M 66.682344 301.891587
+L 507.6 301.891587
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
@@ -912,343 +912,343 @@ L -2 0
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="301.897349" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="301.891587" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_29">
-      <path d="M 66.682344 295.387405
-L 507.6 295.387405
+      <path d="M 66.682344 295.385045
+L 507.6 295.385045
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="295.387405" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="295.385045" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_31">
-      <path d="M 66.682344 289.883325
-L 507.6 289.883325
+      <path d="M 66.682344 289.883842
+L 507.6 289.883842
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.883325" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.883842" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_33">
-      <path d="M 66.682344 285.115475
-L 507.6 285.115475
+      <path d="M 66.682344 285.118483
+L 507.6 285.118483
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="285.115475" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="285.118483" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_35">
-      <path d="M 66.682344 280.909933
-L 507.6 280.909933
+      <path d="M 66.682344 280.915139
+L 507.6 280.915139
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="280.909933" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="280.915139" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_37">
-      <path d="M 66.682344 252.398546
-L 507.6 252.398546
+      <path d="M 66.682344 252.418653
+L 507.6 252.418653
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="252.398546" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="252.418653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_39">
-      <path d="M 66.682344 237.921074
-L 507.6 237.921074
+      <path d="M 66.682344 237.948747
+L 507.6 237.948747
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="237.921074" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="237.948747" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_41">
-      <path d="M 66.682344 227.649144
-L 507.6 227.649144
+      <path d="M 66.682344 227.682186
+L 507.6 227.682186
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="227.649144" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="227.682186" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_43">
-      <path d="M 66.682344 219.681617
-L 507.6 219.681617
+      <path d="M 66.682344 219.718822
+L 507.6 219.718822
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="219.681617" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="219.718822" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_45">
-      <path d="M 66.682344 213.171673
-L 507.6 213.171673
+      <path d="M 66.682344 213.21228
+L 507.6 213.21228
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="213.171673" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="213.21228" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_47">
-      <path d="M 66.682344 207.667593
-L 507.6 207.667593
+      <path d="M 66.682344 207.711077
+L 507.6 207.711077
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="207.667593" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="207.711077" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_49">
-      <path d="M 66.682344 202.899743
-L 507.6 202.899743
+      <path d="M 66.682344 202.945719
+L 507.6 202.945719
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="202.899743" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="202.945719" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_51">
-      <path d="M 66.682344 198.694201
-L 507.6 198.694201
+      <path d="M 66.682344 198.742374
+L 507.6 198.742374
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="198.694201" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="198.742374" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_53">
-      <path d="M 66.682344 170.182814
-L 507.6 170.182814
+      <path d="M 66.682344 170.245888
+L 507.6 170.245888
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="170.182814" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="170.245888" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_55">
-      <path d="M 66.682344 155.705342
-L 507.6 155.705342
+      <path d="M 66.682344 155.775982
+L 507.6 155.775982
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="155.705342" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="155.775982" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_57">
-      <path d="M 66.682344 145.433413
-L 507.6 145.433413
+      <path d="M 66.682344 145.509421
+L 507.6 145.509421
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="145.433413" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="145.509421" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_59">
-      <path d="M 66.682344 137.465885
-L 507.6 137.465885
+      <path d="M 66.682344 137.546057
+L 507.6 137.546057
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="137.465885" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="137.546057" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_61">
-      <path d="M 66.682344 130.955941
-L 507.6 130.955941
+      <path d="M 66.682344 131.039515
+L 507.6 131.039515
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="130.955941" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="131.039515" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_63">
-      <path d="M 66.682344 125.451862
-L 507.6 125.451862
+      <path d="M 66.682344 125.538312
+L 507.6 125.538312
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="125.451862" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="125.538312" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_65">
-      <path d="M 66.682344 120.684011
-L 507.6 120.684011
+      <path d="M 66.682344 120.772954
+L 507.6 120.772954
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="120.684011" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="120.772954" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_67">
-      <path d="M 66.682344 116.478469
-L 507.6 116.478469
+      <path d="M 66.682344 116.569609
+L 507.6 116.569609
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="116.478469" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="116.569609" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_69">
-      <path d="M 66.682344 87.967082
-L 507.6 87.967082
+      <path d="M 66.682344 88.073123
+L 507.6 88.073123
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="87.967082" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="88.073123" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_71">
-      <path d="M 66.682344 73.489611
-L 507.6 73.489611
+      <path d="M 66.682344 73.603217
+L 507.6 73.603217
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="73.489611" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="73.603217" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_73">
-      <path d="M 66.682344 63.217681
-L 507.6 63.217681
+      <path d="M 66.682344 63.336656
+L 507.6 63.336656
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="63.217681" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="63.336656" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_75">
-      <path d="M 66.682344 55.250153
-L 507.6 55.250153
+      <path d="M 66.682344 55.373292
+L 507.6 55.373292
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_76">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="55.250153" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="55.373292" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_77">
-      <path d="M 66.682344 48.740209
-L 507.6 48.740209
+      <path d="M 66.682344 48.86675
+L 507.6 48.86675
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_78">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="48.740209" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="48.86675" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_79">
-      <path d="M 66.682344 43.23613
-L 507.6 43.23613
+      <path d="M 66.682344 43.365547
+L 507.6 43.365547
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_80">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="43.23613" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="43.365547" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_81">
-      <path d="M 66.682344 38.46828
-L 507.6 38.46828
+      <path d="M 66.682344 38.600189
+L 507.6 38.600189
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_82">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="38.46828" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="38.600189" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_83">
-      <path d="M 66.682344 34.262737
-L 507.6 34.262737
+      <path d="M 66.682344 34.396844
+L 507.6 34.396844
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_84">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="34.262737" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="34.396844" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1326,9 +1326,9 @@ z
     </g>
    </g>
    <g id="line2d_85">
-    <path d="M 86.724055 171.744019
-L 136.828335 106.93745
-L 186.932614 61.983051
+    <path d="M 86.724055 171.107385
+L 136.828335 106.840057
+L 186.932614 62.035826
 L 237.036893 38.765348
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
@@ -1345,22 +1345,22 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="171.744019" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="136.828335" y="106.93745" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="186.932614" y="61.983051" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="171.107385" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="136.828335" y="106.840057" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="186.932614" y="62.035826" style="fill: #1f77b4; stroke: #1f77b4"/>
      <use xlink:href="#md73ba6276e" x="237.036893" y="38.765348" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_86">
     <path d="M 86.724055 290.872308
-L 136.828335 244.648501
-L 186.932614 212.372705
-L 237.036893 174.541973
-L 287.141172 154.438444
-L 337.245451 124.234213
-L 387.34973 106.325047
-L 437.454009 89.289928
-L 487.558288 71.536483
+L 136.828335 244.672658
+L 186.932614 212.41373
+L 237.036893 174.602769
+L 287.141172 154.509746
+L 337.245451 124.321299
+L 387.34973 106.421493
+L 437.454009 89.395277
+L 487.558288 71.65111
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #9467bd; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="meef3cfac8d" d="M 0 -2
@@ -1371,26 +1371,26 @@ z
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
      <use xlink:href="#meef3cfac8d" x="86.724055" y="290.872308" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="136.828335" y="244.648501" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="186.932614" y="212.372705" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="237.036893" y="174.541973" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="287.141172" y="154.438444" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="337.245451" y="124.234213" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="387.34973" y="106.325047" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="437.454009" y="89.289928" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="487.558288" y="71.536483" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="136.828335" y="244.672658" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="186.932614" y="212.41373" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="237.036893" y="174.602769" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="287.141172" y="154.509746" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="337.245451" y="124.321299" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="387.34973" y="106.421493" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="437.454009" y="89.395277" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="487.558288" y="71.65111" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_87">
-    <path d="M 86.724055 257.188808
-L 136.828335 217.794606
-L 186.932614 181.021002
-L 237.036893 158.035523
-L 287.141172 132.841131
-L 337.245451 116.771139
-L 387.34973 95.699778
-L 437.454009 78.312934
-L 487.558288 63.88681
+    <path d="M 86.724055 257.206412
+L 136.828335 217.832797
+L 186.932614 181.078411
+L 237.036893 158.104945
+L 287.141172 132.92372
+L 337.245451 116.862126
+L 387.34973 95.801777
+L 437.454009 78.42402
+L 487.558288 64.005435
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #8c564b; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="m975a81c4ea" d="M -0 2
@@ -1400,27 +1400,27 @@ z
 " style="stroke: #8c564b; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#m975a81c4ea" x="86.724055" y="257.188808" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="136.828335" y="217.794606" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="186.932614" y="181.021002" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="237.036893" y="158.035523" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="287.141172" y="132.841131" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="337.245451" y="116.771139" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="387.34973" y="95.699778" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="437.454009" y="78.312934" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="487.558288" y="63.88681" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="86.724055" y="257.206412" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="136.828335" y="217.832797" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="186.932614" y="181.078411" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="237.036893" y="158.104945" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="287.141172" y="132.92372" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="337.245451" y="116.862126" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="387.34973" y="95.801777" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="437.454009" y="78.42402" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="487.558288" y="64.005435" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_88">
-    <path d="M 86.724055 257.56764
-L 136.828335 223.744866
-L 186.932614 199.256172
-L 237.036893 163.149181
-L 287.141172 144.152011
-L 337.245451 129.830699
-L 387.34973 109.282098
-L 437.454009 95.18155
-L 487.558288 78.669
+    <path d="M 86.724055 257.585045
+L 136.828335 223.779948
+L 186.932614 199.304051
+L 237.036893 163.21593
+L 287.141172 144.228689
+L 337.245451 129.914862
+L 387.34973 109.376999
+L 437.454009 95.283821
+L 487.558288 78.7799
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #e377c2; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="mbe61f33afa" d="M -0.666667 2
@@ -1439,15 +1439,15 @@ z
 " style="stroke: #e377c2; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#mbe61f33afa" x="86.724055" y="257.56764" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="136.828335" y="223.744866" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="186.932614" y="199.256172" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="237.036893" y="163.149181" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="287.141172" y="144.152011" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="337.245451" y="129.830699" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="387.34973" y="109.282098" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="437.454009" y="95.18155" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="487.558288" y="78.669" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="86.724055" y="257.585045" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="136.828335" y="223.779948" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="186.932614" y="199.304051" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="237.036893" y="163.21593" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="287.141172" y="144.228689" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="337.245451" y="129.914862" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="387.34973" y="109.376999" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="437.454009" y="95.283821" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="487.558288" y="78.7799" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
@@ -1931,7 +1931,7 @@ z
    </g>
   </g>
   <g id="text_21">
-   <!-- cutoff 10.0s; source newest-per-system across 60 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 61 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2055,7 +2055,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-19" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-13" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-laguerre.svg
+++ b/reports/figures/hexbz-cactus-laguerre.svg
@@ -1489,26 +1489,26 @@ z
     </g>
    </g>
    <g id="line2d_131">
-    <path d="M 86.724055 274.530405
-L 107.820594 257.151036
-L 128.917133 245.374623
-L 150.013671 237.25948
-L 171.11021 230.834458
-L 192.206748 226.027077
-L 213.303287 221.340507
-L 234.399825 217.151821
-L 255.496364 212.545247
-L 276.592903 207.081929
-L 297.689441 202.490611
-L 318.78598 197.478894
-L 339.882518 192.677779
-L 360.979057 187.733477
-L 382.075595 183.792576
-L 403.172134 180.254062
-L 424.268673 175.664098
-L 445.365211 171.944715
-L 466.46175 167.308092
-L 487.558288 160.679547
+    <path d="M 86.724055 277.170496
+L 107.820594 257.688073
+L 128.917133 245.651922
+L 150.013671 237.305606
+L 171.11021 230.821898
+L 192.206748 225.929426
+L 213.303287 221.245945
+L 234.399825 217.050695
+L 255.496364 212.52403
+L 276.592903 207.094611
+L 297.689441 202.607062
+L 318.78598 197.657203
+L 339.882518 192.846539
+L 360.979057 187.909398
+L 382.075595 183.928246
+L 403.172134 180.367682
+L 424.268673 175.762285
+L 445.365211 172.024793
+L 466.46175 167.45168
+L 487.558288 160.82066
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1524,26 +1524,26 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="274.530405" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.820594" y="257.151036" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="128.917133" y="245.374623" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="150.013671" y="237.25948" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="171.11021" y="230.834458" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="192.206748" y="226.027077" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="213.303287" y="221.340507" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="234.399825" y="217.151821" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="255.496364" y="212.545247" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="276.592903" y="207.081929" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="297.689441" y="202.490611" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="318.78598" y="197.478894" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="339.882518" y="192.677779" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="360.979057" y="187.733477" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="382.075595" y="183.792576" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="403.172134" y="180.254062" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="424.268673" y="175.664098" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="445.365211" y="171.944715" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="466.46175" y="167.308092" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="160.679547" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="277.170496" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.820594" y="257.688073" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="128.917133" y="245.651922" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="150.013671" y="237.305606" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="171.11021" y="230.821898" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="192.206748" y="225.929426" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="213.303287" y="221.245945" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="234.399825" y="217.050695" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="255.496364" y="212.52403" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="276.592903" y="207.094611" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="297.689441" y="202.607062" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="318.78598" y="197.657203" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="339.882518" y="192.846539" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="360.979057" y="187.909398" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="382.075595" y="183.928246" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="403.172134" y="180.367682" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="424.268673" y="175.762285" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="445.365211" y="172.024793" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="466.46175" y="167.45168" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="160.82066" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_132">
@@ -2477,7 +2477,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_25">
-   <!-- cutoff 10.0s; source newest-per-system across 60 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 61 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2624,7 +2624,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-19" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-13" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-legendre.svg
+++ b/reports/figures/hexbz-cactus-legendre.svg
@@ -1477,26 +1477,26 @@ z
     </g>
    </g>
    <g id="line2d_129">
-    <path d="M 86.724055 273.095491
-L 107.820594 259.449367
-L 128.917133 247.750759
-L 150.013671 239.446953
-L 171.11021 232.414353
-L 192.206748 224.124257
-L 213.303287 218.140612
-L 234.399825 212.501242
-L 255.496364 207.02522
-L 276.592903 199.926888
-L 297.689441 193.980304
-L 318.78598 187.243086
-L 339.882518 180.97915
-L 360.979057 174.825978
-L 382.075595 170.011954
-L 403.172134 166.043508
-L 424.268673 160.993545
-L 445.365211 156.139932
-L 466.46175 149.30929
-L 487.558288 143.416106
+    <path d="M 86.724055 273.429175
+L 107.820594 259.937821
+L 128.917133 247.776087
+L 150.013671 239.350029
+L 171.11021 232.498602
+L 192.206748 224.562503
+L 213.303287 218.509781
+L 234.399825 212.675281
+L 255.496364 207.268167
+L 276.592903 200.085843
+L 297.689441 194.079949
+L 318.78598 187.327903
+L 339.882518 181.164066
+L 360.979057 175.027672
+L 382.075595 170.151014
+L 403.172134 166.176672
+L 424.268673 161.11964
+L 445.365211 156.274076
+L 466.46175 149.477138
+L 487.558288 143.592728
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1512,26 +1512,26 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="273.095491" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.820594" y="259.449367" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="128.917133" y="247.750759" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="150.013671" y="239.446953" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="171.11021" y="232.414353" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="192.206748" y="224.124257" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="213.303287" y="218.140612" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="234.399825" y="212.501242" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="255.496364" y="207.02522" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="276.592903" y="199.926888" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="297.689441" y="193.980304" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="318.78598" y="187.243086" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="339.882518" y="180.97915" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="360.979057" y="174.825978" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="382.075595" y="170.011954" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="403.172134" y="166.043508" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="424.268673" y="160.993545" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="445.365211" y="156.139932" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="466.46175" y="149.30929" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="143.416106" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="273.429175" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.820594" y="259.937821" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="128.917133" y="247.776087" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="150.013671" y="239.350029" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="171.11021" y="232.498602" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="192.206748" y="224.562503" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="213.303287" y="218.509781" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="234.399825" y="212.675281" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="255.496364" y="207.268167" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="276.592903" y="200.085843" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="297.689441" y="194.079949" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="318.78598" y="187.327903" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="339.882518" y="181.164066" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="360.979057" y="175.027672" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="382.075595" y="170.151014" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="403.172134" y="166.176672" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="424.268673" y="161.11964" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="445.365211" y="156.274076" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="466.46175" y="149.477138" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="143.592728" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_130">
@@ -2480,7 +2480,7 @@ z
    </g>
   </g>
   <g id="text_25">
-   <!-- cutoff 10.0s; source newest-per-system across 60 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 61 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2627,7 +2627,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-19" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-13" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-random-products.svg
+++ b/reports/figures/hexbz-cactus-random-products.svg
@@ -1439,36 +1439,36 @@ z
     </g>
    </g>
    <g id="line2d_125">
-    <path d="M 86.724055 267.304535
-L 100.545925 249.444715
-L 114.367796 239.328803
-L 128.189666 232.671164
-L 142.011536 226.937952
-L 155.833406 222.498442
-L 169.655276 218.739421
-L 183.477146 215.497591
-L 197.299016 212.418463
-L 211.120886 209.725172
-L 224.942756 207.135947
-L 238.764627 204.662305
-L 252.586497 202.353946
-L 266.408367 200.275345
-L 280.230237 198.365489
-L 294.052107 196.540989
-L 307.873977 194.822216
-L 321.695847 193.185438
-L 335.517717 191.574661
-L 349.339587 189.954553
-L 363.161457 188.44299
-L 376.983328 186.890523
-L 390.805198 185.219666
-L 404.627068 183.600513
-L 418.448938 181.884314
-L 432.270808 180.193364
-L 446.092678 178.584713
-L 459.914548 177.015646
-L 473.736418 175.256535
-L 487.558288 173.06414
+    <path d="M 86.724055 267.062685
+L 100.545925 249.549487
+L 114.367796 239.315923
+L 128.189666 232.596226
+L 142.011536 226.860741
+L 155.833406 222.346697
+L 169.655276 218.679637
+L 183.477146 215.404616
+L 197.299016 212.35278
+L 211.120886 209.68137
+L 224.942756 207.115537
+L 238.764627 204.635142
+L 252.586497 202.352738
+L 266.408367 200.250201
+L 280.230237 198.3229
+L 294.052107 196.482635
+L 307.873977 194.766169
+L 321.695847 193.144246
+L 335.517717 191.548227
+L 349.339587 189.928742
+L 363.161457 188.415796
+L 376.983328 186.867595
+L 390.805198 185.196129
+L 404.627068 183.574752
+L 418.448938 181.884212
+L 432.270808 180.191973
+L 446.092678 178.577239
+L 459.914548 177.013339
+L 473.736418 175.247412
+L 487.558288 173.051543
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1484,36 +1484,36 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="267.304535" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="100.545925" y="249.444715" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="114.367796" y="239.328803" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="128.189666" y="232.671164" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="142.011536" y="226.937952" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="155.833406" y="222.498442" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="169.655276" y="218.739421" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="183.477146" y="215.497591" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="197.299016" y="212.418463" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="211.120886" y="209.725172" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="224.942756" y="207.135947" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="238.764627" y="204.662305" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="252.586497" y="202.353946" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="266.408367" y="200.275345" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="280.230237" y="198.365489" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="294.052107" y="196.540989" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="307.873977" y="194.822216" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="321.695847" y="193.185438" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="335.517717" y="191.574661" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="349.339587" y="189.954553" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="363.161457" y="188.44299" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="376.983328" y="186.890523" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="390.805198" y="185.219666" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="404.627068" y="183.600513" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="418.448938" y="181.884314" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="432.270808" y="180.193364" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.092678" y="178.584713" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="459.914548" y="177.015646" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="473.736418" y="175.256535" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="173.06414" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="267.062685" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="100.545925" y="249.549487" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="114.367796" y="239.315923" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="128.189666" y="232.596226" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="142.011536" y="226.860741" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="155.833406" y="222.346697" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="169.655276" y="218.679637" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="183.477146" y="215.404616" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="197.299016" y="212.35278" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="211.120886" y="209.68137" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="224.942756" y="207.115537" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="238.764627" y="204.635142" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="252.586497" y="202.352738" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="266.408367" y="200.250201" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="280.230237" y="198.3229" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="294.052107" y="196.482635" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="307.873977" y="194.766169" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="321.695847" y="193.144246" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="335.517717" y="191.548227" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="349.339587" y="189.928742" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="363.161457" y="188.415796" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="376.983328" y="186.867595" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="390.805198" y="185.196129" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="404.627068" y="183.574752" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="418.448938" y="181.884212" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="432.270808" y="180.191973" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.092678" y="178.577239" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="459.914548" y="177.013339" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="473.736418" y="175.247412" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="173.051543" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -2526,7 +2526,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 60 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 61 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2680,7 +2680,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-19" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-13" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-sd-products.svg
+++ b/reports/figures/hexbz-cactus-sd-products.svg
@@ -674,8 +674,8 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_15">
-      <path d="M 66.682344 277.464182
-L 507.6 277.464182
+      <path d="M 66.682344 277.462606
+L 507.6 277.462606
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
@@ -685,12 +685,12 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="277.464182" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="277.462606" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 100us -->
-      <g transform="translate(29.047969 281.26301) scale(0.1 -0.1)">
+      <g transform="translate(29.047969 281.261434) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
@@ -701,18 +701,18 @@ L -3.5 0
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
-      <path d="M 66.682344 224.701504
-L 507.6 224.701504
+      <path d="M 66.682344 224.693725
+L 507.6 224.693725
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="224.701504" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="224.693725" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 1ms -->
-      <g transform="translate(38.369844 228.500332) scale(0.1 -0.1)">
+      <g transform="translate(38.369844 228.492553) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-50" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(161.03125 0)"/>
@@ -721,18 +721,18 @@ L 507.6 224.701504
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
-      <path d="M 66.682344 171.938826
-L 507.6 171.938826
+      <path d="M 66.682344 171.924844
+L 507.6 171.924844
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="171.938826" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="171.924844" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 10ms -->
-      <g transform="translate(32.007344 175.737654) scale(0.1 -0.1)">
+      <g transform="translate(32.007344 175.723672) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-50" transform="translate(127.25 0)"/>
@@ -742,18 +742,18 @@ L 507.6 171.938826
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
-      <path d="M 66.682344 119.176148
-L 507.6 119.176148
+      <path d="M 66.682344 119.155963
+L 507.6 119.155963
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="119.176148" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="119.155963" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 100ms -->
-      <g transform="translate(25.644844 122.974976) scale(0.1 -0.1)">
+      <g transform="translate(25.644844 122.954791) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
@@ -764,18 +764,18 @@ L 507.6 119.176148
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
-      <path d="M 66.682344 66.41347
-L 507.6 66.41347
+      <path d="M 66.682344 66.387082
+L 507.6 66.387082
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="66.41347" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="66.387082" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1s -->
-      <g transform="translate(48.110469 70.212298) scale(0.1 -0.1)">
+      <g transform="translate(48.110469 70.18591) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(63.625 0)"/>
       </g>
@@ -783,8 +783,8 @@ L 507.6 66.41347
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
-      <path d="M 66.682344 298.460562
-L 507.6 298.460562
+      <path d="M 66.682344 298.461455
+L 507.6 298.461455
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
@@ -794,499 +794,499 @@ L -2 0
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="298.460562" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="298.461455" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
-      <path d="M 66.682344 293.347331
-L 507.6 293.347331
+      <path d="M 66.682344 293.347622
+L 507.6 293.347622
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="293.347331" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="293.347622" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
-      <path d="M 66.682344 289.169516
-L 507.6 289.169516
+      <path d="M 66.682344 289.169316
+L 507.6 289.169316
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.169516" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.169316" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_31">
-      <path d="M 66.682344 285.637224
-L 507.6 285.637224
+      <path d="M 66.682344 285.636609
+L 507.6 285.636609
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="285.637224" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="285.636609" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_33">
-      <path d="M 66.682344 282.577414
-L 507.6 282.577414
+      <path d="M 66.682344 282.576439
+L 507.6 282.576439
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="282.577414" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="282.576439" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_35">
-      <path d="M 66.682344 279.87847
-L 507.6 279.87847
+      <path d="M 66.682344 279.877177
+L 507.6 279.877177
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="279.87847" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="279.877177" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
-      <path d="M 66.682344 261.581033
-L 507.6 261.581033
+      <path d="M 66.682344 261.57759
+L 507.6 261.57759
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="261.581033" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="261.57759" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_39">
-      <path d="M 66.682344 252.289987
-L 507.6 252.289987
+      <path d="M 66.682344 252.285451
+L 507.6 252.285451
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="252.289987" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="252.285451" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_41">
-      <path d="M 66.682344 245.697884
-L 507.6 245.697884
+      <path d="M 66.682344 245.692574
+L 507.6 245.692574
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="245.697884" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="245.692574" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_43">
-      <path d="M 66.682344 240.584653
-L 507.6 240.584653
+      <path d="M 66.682344 240.578741
+L 507.6 240.578741
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="240.584653" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="240.578741" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_45">
-      <path d="M 66.682344 236.406838
-L 507.6 236.406838
+      <path d="M 66.682344 236.400435
+L 507.6 236.400435
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="236.406838" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="236.400435" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_47">
-      <path d="M 66.682344 232.874546
-L 507.6 232.874546
+      <path d="M 66.682344 232.867728
+L 507.6 232.867728
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="232.874546" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="232.867728" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_49">
-      <path d="M 66.682344 229.814736
-L 507.6 229.814736
+      <path d="M 66.682344 229.807558
+L 507.6 229.807558
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="229.814736" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="229.807558" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_51">
-      <path d="M 66.682344 227.115792
-L 507.6 227.115792
+      <path d="M 66.682344 227.108296
+L 507.6 227.108296
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="227.115792" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="227.108296" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_53">
-      <path d="M 66.682344 208.818355
-L 507.6 208.818355
+      <path d="M 66.682344 208.808709
+L 507.6 208.808709
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="208.818355" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="208.808709" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_55">
-      <path d="M 66.682344 199.527309
-L 507.6 199.527309
+      <path d="M 66.682344 199.51657
+L 507.6 199.51657
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="199.527309" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="199.51657" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_57">
-      <path d="M 66.682344 192.935206
-L 507.6 192.935206
+      <path d="M 66.682344 192.923693
+L 507.6 192.923693
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="192.935206" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="192.923693" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_59">
-      <path d="M 66.682344 187.821975
-L 507.6 187.821975
+      <path d="M 66.682344 187.80986
+L 507.6 187.80986
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="187.821975" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="187.80986" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_61">
-      <path d="M 66.682344 183.64416
-L 507.6 183.64416
+      <path d="M 66.682344 183.631554
+L 507.6 183.631554
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="183.64416" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="183.631554" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_63">
-      <path d="M 66.682344 180.111868
-L 507.6 180.111868
+      <path d="M 66.682344 180.098847
+L 507.6 180.098847
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="180.111868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="180.098847" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_65">
-      <path d="M 66.682344 177.052058
-L 507.6 177.052058
+      <path d="M 66.682344 177.038677
+L 507.6 177.038677
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="177.052058" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="177.038677" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_67">
-      <path d="M 66.682344 174.353114
-L 507.6 174.353114
+      <path d="M 66.682344 174.339415
+L 507.6 174.339415
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="174.353114" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="174.339415" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_69">
-      <path d="M 66.682344 156.055677
-L 507.6 156.055677
+      <path d="M 66.682344 156.039828
+L 507.6 156.039828
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="156.055677" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="156.039828" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_71">
-      <path d="M 66.682344 146.764631
-L 507.6 146.764631
+      <path d="M 66.682344 146.747689
+L 507.6 146.747689
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="146.764631" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="146.747689" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_73">
-      <path d="M 66.682344 140.172528
-L 507.6 140.172528
+      <path d="M 66.682344 140.154812
+L 507.6 140.154812
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="140.172528" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="140.154812" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_75">
-      <path d="M 66.682344 135.059296
-L 507.6 135.059296
+      <path d="M 66.682344 135.040979
+L 507.6 135.040979
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_76">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="135.059296" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="135.040979" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_77">
-      <path d="M 66.682344 130.881482
-L 507.6 130.881482
+      <path d="M 66.682344 130.862673
+L 507.6 130.862673
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_78">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="130.881482" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="130.862673" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_79">
-      <path d="M 66.682344 127.34919
-L 507.6 127.34919
+      <path d="M 66.682344 127.329966
+L 507.6 127.329966
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_80">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="127.34919" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="127.329966" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_34">
      <g id="line2d_81">
-      <path d="M 66.682344 124.28938
-L 507.6 124.28938
+      <path d="M 66.682344 124.269796
+L 507.6 124.269796
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_82">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="124.28938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="124.269796" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_35">
      <g id="line2d_83">
-      <path d="M 66.682344 121.590435
-L 507.6 121.590435
+      <path d="M 66.682344 121.570535
+L 507.6 121.570535
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_84">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="121.590435" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="121.570535" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_36">
      <g id="line2d_85">
-      <path d="M 66.682344 103.292999
-L 507.6 103.292999
+      <path d="M 66.682344 103.270947
+L 507.6 103.270947
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_86">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="103.292999" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="103.270947" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_37">
      <g id="line2d_87">
-      <path d="M 66.682344 94.001953
-L 507.6 94.001953
+      <path d="M 66.682344 93.978808
+L 507.6 93.978808
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_88">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="94.001953" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="93.978808" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_38">
      <g id="line2d_89">
-      <path d="M 66.682344 87.40985
-L 507.6 87.40985
+      <path d="M 66.682344 87.385931
+L 507.6 87.385931
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_90">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="87.40985" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="87.385931" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_39">
      <g id="line2d_91">
-      <path d="M 66.682344 82.296618
-L 507.6 82.296618
+      <path d="M 66.682344 82.272098
+L 507.6 82.272098
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_92">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="82.296618" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="82.272098" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_40">
      <g id="line2d_93">
-      <path d="M 66.682344 78.118804
-L 507.6 78.118804
+      <path d="M 66.682344 78.093792
+L 507.6 78.093792
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_94">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="78.118804" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="78.093792" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_41">
      <g id="line2d_95">
-      <path d="M 66.682344 74.586512
-L 507.6 74.586512
+      <path d="M 66.682344 74.561085
+L 507.6 74.561085
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_96">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="74.586512" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="74.561085" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_42">
      <g id="line2d_97">
-      <path d="M 66.682344 71.526702
-L 507.6 71.526702
+      <path d="M 66.682344 71.500915
+L 507.6 71.500915
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_98">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="71.526702" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="71.500915" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_43">
      <g id="line2d_99">
-      <path d="M 66.682344 68.827757
-L 507.6 68.827757
+      <path d="M 66.682344 68.801654
+L 507.6 68.801654
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_100">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="68.827757" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="68.801654" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_44">
      <g id="line2d_101">
-      <path d="M 66.682344 50.530321
-L 507.6 50.530321
+      <path d="M 66.682344 50.502066
+L 507.6 50.502066
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_102">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="50.530321" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="50.502066" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_45">
      <g id="line2d_103">
-      <path d="M 66.682344 41.239275
-L 507.6 41.239275
+      <path d="M 66.682344 41.209927
+L 507.6 41.209927
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_104">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="41.239275" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="41.209927" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_46">
      <g id="line2d_105">
-      <path d="M 66.682344 34.647172
-L 507.6 34.647172
+      <path d="M 66.682344 34.61705
+L 507.6 34.61705
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_106">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="34.647172" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="34.61705" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_47">
      <g id="line2d_107">
-      <path d="M 66.682344 29.53394
-L 507.6 29.53394
+      <path d="M 66.682344 29.503217
+L 507.6 29.503217
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_108">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="29.53394" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="29.503217" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1364,16 +1364,16 @@ z
     </g>
    </g>
    <g id="line2d_109">
-    <path d="M 86.724055 270.764976
-L 117.557458 254.666963
-L 148.39086 231.337063
-L 179.224263 218.64306
-L 210.057666 207.37309
-L 240.891068 188.8564
-L 271.724471 157.403884
-L 302.557873 142.765802
-L 333.391276 110.114202
-L 364.224678 87.219252
+    <path d="M 86.724055 270.286018
+L 117.557458 253.997579
+L 148.39086 230.751143
+L 179.224263 218.06755
+L 210.057666 206.589697
+L 240.891068 188.255285
+L 271.724471 157.044465
+L 302.557873 142.368142
+L 333.391276 110.206712
+L 364.224678 87.321693
 L 395.058081 38.765348
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
@@ -1390,34 +1390,34 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="270.764976" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="254.666963" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="231.337063" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="218.64306" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="207.37309" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="188.8564" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="157.403884" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="142.765802" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.391276" y="110.114202" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="87.219252" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="270.286018" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="253.997579" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="230.751143" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="218.06755" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="206.589697" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="188.255285" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="157.044465" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="142.368142" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.391276" y="110.206712" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="87.321693" style="fill: #1f77b4; stroke: #1f77b4"/>
      <use xlink:href="#md73ba6276e" x="395.058081" y="38.765348" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_110">
     <path d="M 86.724055 290.872308
-L 117.557458 273.997519
-L 148.39086 258.922556
-L 179.224263 248.05337
-L 210.057666 238.438024
-L 240.891068 224.677822
-L 271.724471 211.679645
-L 302.557873 201.567686
-L 333.391276 192.941572
-L 364.224678 184.765512
-L 395.058081 170.133452
-L 425.891483 161.038402
-L 456.724886 152.635188
-L 487.558288 128.422223
+L 117.557458 273.995536
+L 148.39086 258.9188
+L 179.224263 248.048336
+L 210.057666 238.43186
+L 240.891068 224.670041
+L 271.724471 211.670335
+L 302.557873 201.557187
+L 333.391276 192.930059
+L 364.224678 184.753038
+L 395.058081 170.119258
+L 425.891483 161.023139
+L 456.724886 152.618937
+L 487.558288 128.403125
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #9467bd; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="meef3cfac8d" d="M 0 -2
@@ -1428,36 +1428,36 @@ z
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
      <use xlink:href="#meef3cfac8d" x="86.724055" y="290.872308" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="117.557458" y="273.997519" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="148.39086" y="258.922556" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="179.224263" y="248.05337" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="210.057666" y="238.438024" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="240.891068" y="224.677822" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="271.724471" y="211.679645" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="302.557873" y="201.567686" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="333.391276" y="192.941572" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="364.224678" y="184.765512" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="395.058081" y="170.133452" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="425.891483" y="161.038402" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="456.724886" y="152.635188" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="487.558288" y="128.422223" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="117.557458" y="273.995536" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="148.39086" y="258.9188" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="179.224263" y="248.048336" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="210.057666" y="238.43186" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="240.891068" y="224.670041" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="271.724471" y="211.670335" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="302.557873" y="201.557187" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="333.391276" y="192.930059" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="364.224678" y="184.753038" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="395.058081" y="170.119258" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="425.891483" y="161.023139" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="456.724886" y="152.618937" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="487.558288" y="128.403125" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_111">
-    <path d="M 86.724055 261.829393
-L 117.557458 244.515864
-L 148.39086 228.641721
-L 179.224263 218.870172
-L 210.057666 211.538625
-L 240.891068 199.781769
-L 271.724471 189.647522
-L 302.557873 179.46751
-L 333.391276 170.602851
-L 364.224678 163.315379
-L 395.058081 149.902969
-L 425.891483 140.597176
-L 456.724886 131.868457
-L 487.558288 110.622126
+    <path d="M 86.724055 261.825979
+L 117.557458 244.510414
+L 148.39086 228.634405
+L 179.224263 218.861707
+L 210.057666 211.529299
+L 240.891068 199.771061
+L 271.724471 189.635622
+L 302.557873 179.454413
+L 333.391276 170.588712
+L 364.224678 163.300383
+L 395.058081 149.886397
+L 425.891483 140.579509
+L 456.724886 131.849764
+L 487.558288 110.600935
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #8c564b; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="m975a81c4ea" d="M -0 2
@@ -1467,37 +1467,37 @@ z
 " style="stroke: #8c564b; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#m975a81c4ea" x="86.724055" y="261.829393" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="117.557458" y="244.515864" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="148.39086" y="228.641721" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="179.224263" y="218.870172" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="210.057666" y="211.538625" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="240.891068" y="199.781769" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="271.724471" y="189.647522" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="302.557873" y="179.46751" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="333.391276" y="170.602851" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="364.224678" y="163.315379" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="395.058081" y="149.902969" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="425.891483" y="140.597176" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="456.724886" y="131.868457" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="487.558288" y="110.622126" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="86.724055" y="261.825979" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="117.557458" y="244.510414" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="148.39086" y="228.634405" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="179.224263" y="218.861707" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="210.057666" y="211.529299" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="240.891068" y="199.771061" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="271.724471" y="189.635622" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="302.557873" y="179.454413" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="333.391276" y="170.588712" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="364.224678" y="163.300383" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="395.058081" y="149.886397" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="425.891483" y="140.579509" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="456.724886" y="131.849764" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="487.558288" y="110.600935" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_112">
-    <path d="M 86.724055 283.857941
-L 117.557458 266.746455
-L 148.39086 251.106751
-L 179.224263 241.714954
-L 210.057666 234.845695
-L 240.891068 219.4336
-L 271.724471 206.921749
-L 302.557873 198.600465
-L 333.391276 188.115368
-L 364.224678 177.916597
-L 395.058081 166.222342
-L 425.891483 156.59528
-L 456.724886 145.865673
-L 487.558288 127.422513
+    <path d="M 86.724055 283.857117
+L 117.557458 266.743619
+L 148.39086 251.102076
+L 179.224263 241.709175
+L 210.057666 234.839108
+L 240.891068 219.425201
+L 271.724471 206.91188
+L 302.557873 198.589617
+L 333.391276 188.103288
+L 364.224678 177.903318
+L 395.058081 166.207688
+L 425.891483 156.579494
+L 456.724886 145.848626
+L 487.558288 127.403298
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #e377c2; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="mbe61f33afa" d="M -0.666667 2
@@ -1516,32 +1516,32 @@ z
 " style="stroke: #e377c2; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#mbe61f33afa" x="86.724055" y="283.857941" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="117.557458" y="266.746455" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="148.39086" y="251.106751" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="179.224263" y="241.714954" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="210.057666" y="234.845695" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="240.891068" y="219.4336" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="271.724471" y="206.921749" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="302.557873" y="198.600465" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="333.391276" y="188.115368" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="364.224678" y="177.916597" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="395.058081" y="166.222342" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="425.891483" y="156.59528" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="456.724886" y="145.865673" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="487.558288" y="127.422513" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="86.724055" y="283.857117" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="117.557458" y="266.743619" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="148.39086" y="251.102076" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="179.224263" y="241.709175" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="210.057666" y="234.839108" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="240.891068" y="219.425201" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="271.724471" y="206.91188" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="302.557873" y="198.589617" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="333.391276" y="188.103288" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="364.224678" y="177.903318" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="395.058081" y="166.207688" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="425.891483" y="156.579494" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="456.724886" y="145.848626" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="487.558288" y="127.403298" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_113">
-    <path d="M 86.724055 248.893291
-L 117.557458 230.174845
-L 148.39086 212.250411
-L 179.224263 201.974252
-L 210.057666 192.856065
-L 240.891068 175.446588
-L 271.724471 156.77352
-L 302.557873 137.183558
-L 333.391276 126.350564
+    <path d="M 86.724055 248.888356
+L 117.557458 230.16771
+L 148.39086 212.241168
+L 179.224263 201.963801
+L 210.057666 192.844542
+L 240.891068 175.433019
+L 271.724471 156.757755
+L 302.557873 137.16549
+L 333.391276 126.331222
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="m579b7dcafa" d="M 0 -2
@@ -1558,23 +1558,23 @@ z
 " style="stroke: #ff7f0e; stroke-linejoin: bevel"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#m579b7dcafa" x="86.724055" y="248.893291" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="117.557458" y="230.174845" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="148.39086" y="212.250411" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="179.224263" y="201.974252" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="210.057666" y="192.856065" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="240.891068" y="175.446588" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="271.724471" y="156.77352" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="302.557873" y="137.183558" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="333.391276" y="126.350564" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="86.724055" y="248.888356" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="117.557458" y="230.16771" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="148.39086" y="212.241168" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="179.224263" y="201.963801" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="210.057666" y="192.844542" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="240.891068" y="175.433019" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="271.724471" y="156.757755" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="302.557873" y="137.16549" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="333.391276" y="126.331222" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_114">
-    <path d="M 86.724055 213.818397
-L 117.557458 195.845039
-L 148.39086 102.958417
-L 179.224263 78.054165
-L 210.057666 65.681719
+    <path d="M 86.724055 213.809338
+L 117.557458 195.833867
+L 148.39086 102.936325
+L 179.224263 78.029146
+L 210.057666 65.655246
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #bcbd22; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="m6a669b47a0" d="M 0 -2
@@ -1587,11 +1587,11 @@ z
 " style="stroke: #bcbd22; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#m6a669b47a0" x="86.724055" y="213.818397" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="117.557458" y="195.845039" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="148.39086" y="102.958417" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="179.224263" y="78.054165" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="210.057666" y="65.681719" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="86.724055" y="213.809338" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="117.557458" y="195.833867" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="148.39086" y="102.936325" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="179.224263" y="78.029146" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="210.057666" y="65.655246" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
@@ -2276,7 +2276,7 @@ z
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 60 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 61 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2400,7 +2400,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-19" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-13" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-swinnerton-dyer.svg
+++ b/reports/figures/hexbz-cactus-swinnerton-dyer.svg
@@ -1400,21 +1400,21 @@ z
     </g>
    </g>
    <g id="line2d_115">
-    <path d="M 86.724055 284.16506
-L 115.355072 268.827055
-L 143.986089 248.675512
-L 172.617105 238.285985
-L 201.248122 231.142211
-L 229.879139 213.062208
-L 258.510155 202.558265
-L 287.141172 195.426869
-L 315.772189 169.996333
-L 344.403205 158.008889
-L 373.034222 148.931743
-L 401.665238 133.346523
-L 430.296255 123.437989
-L 458.927272 116.459
-L 487.558288 94.87077
+    <path d="M 86.724055 283.92884
+L 115.355072 268.764213
+L 143.986089 248.014781
+L 172.617105 237.568593
+L 201.248122 230.479294
+L 229.879139 212.383216
+L 258.510155 201.905668
+L 287.141172 194.795617
+L 315.772189 168.870273
+L 344.403205 156.868514
+L 373.034222 147.810126
+L 401.665238 132.220711
+L 430.296255 122.382902
+L 458.927272 115.454305
+L 487.558288 94.063532
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1430,21 +1430,21 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="284.16506" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="115.355072" y="268.827055" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.986089" y="248.675512" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="172.617105" y="238.285985" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="201.248122" y="231.142211" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="229.879139" y="213.062208" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="258.510155" y="202.558265" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="195.426869" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="315.772189" y="169.996333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="344.403205" y="158.008889" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="373.034222" y="148.931743" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="401.665238" y="133.346523" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="430.296255" y="123.437989" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="458.927272" y="116.459" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="94.87077" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="283.92884" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="115.355072" y="268.764213" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.986089" y="248.014781" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="172.617105" y="237.568593" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="201.248122" y="230.479294" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="229.879139" y="212.383216" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="258.510155" y="201.905668" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="194.795617" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="315.772189" y="168.870273" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="344.403205" y="156.868514" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="373.034222" y="147.810126" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="401.665238" y="132.220711" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="430.296255" y="122.382902" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="458.927272" y="115.454305" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="94.063532" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -2326,7 +2326,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 60 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 61 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2433,7 +2433,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-19" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-13" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-wilkinson.svg
+++ b/reports/figures/hexbz-cactus-wilkinson.svg
@@ -1352,21 +1352,21 @@ z
     </g>
    </g>
    <g id="line2d_107">
-    <path d="M 86.724055 268.995809
-L 115.355072 247.818573
-L 143.986089 232.98742
-L 172.617105 216.254531
-L 201.248122 204.131027
-L 229.879139 193.385877
-L 258.510155 184.093959
-L 287.141172 175.069438
-L 315.772189 166.839349
-L 344.403205 157.906327
-L 373.034222 148.760362
-L 401.665238 140.757821
-L 430.296255 132.890741
-L 458.927272 123.504545
-L 487.558288 115.071748
+    <path d="M 86.724055 270.75793
+L 115.355072 248.180245
+L 143.986089 233.126866
+L 172.617105 216.433911
+L 201.248122 204.226479
+L 229.879139 193.635605
+L 258.510155 184.274988
+L 287.141172 175.148822
+L 315.772189 166.859268
+L 344.403205 157.894083
+L 373.034222 148.700212
+L 401.665238 140.685766
+L 430.296255 132.828876
+L 458.927272 123.439391
+L 487.558288 115.042031
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1382,21 +1382,21 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="268.995809" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="115.355072" y="247.818573" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.986089" y="232.98742" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="172.617105" y="216.254531" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="201.248122" y="204.131027" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="229.879139" y="193.385877" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="258.510155" y="184.093959" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="175.069438" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="315.772189" y="166.839349" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="344.403205" y="157.906327" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="373.034222" y="148.760362" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="401.665238" y="140.757821" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="430.296255" y="132.890741" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="458.927272" y="123.504545" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="115.071748" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="270.75793" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="115.355072" y="248.180245" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.986089" y="233.126866" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="172.617105" y="216.433911" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="201.248122" y="204.226479" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="229.879139" y="193.635605" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="258.510155" y="184.274988" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="175.148822" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="315.772189" y="166.859268" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="344.403205" y="157.894083" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="373.034222" y="148.700212" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="401.665238" y="140.685766" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="430.296255" y="132.828876" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="458.927272" y="123.439391" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="115.042031" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -2278,7 +2278,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 60 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 61 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2402,7 +2402,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-19" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-13" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-certificate-boundary.svg
+++ b/reports/figures/hexbz-runtime-degree-certificate-boundary.svg
@@ -1139,7 +1139,7 @@ z
     </g>
    </g>
    <g id="line2d_39">
-    <path d="M 290.301172 195.319787
+    <path d="M 290.301172 194.738277
 " clip-path="url(#p2299177b78)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1155,7 +1155,7 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p2299177b78)">
-     <use xlink:href="#md73ba6276e" x="290.301172" y="195.319787" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="290.301172" y="194.738277" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_40">
@@ -1851,7 +1851,7 @@ L 96.202344 96.641875
    </g>
   </g>
   <g id="text_25">
-   <!-- cutoff 10.0s; source newest-per-system across 60 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 61 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -1951,7 +1951,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-19" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-13" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-chebyshev.svg
+++ b/reports/figures/hexbz-runtime-degree-chebyshev.svg
@@ -1403,34 +1403,34 @@ z
     </g>
    </g>
    <g id="line2d_123">
-    <path d="M 86.469038 280.090951
-L 86.469038 272.854377
-L 105.313508 275.175581
-L 105.313508 266.894806
-L 124.157979 275.111438
-L 124.157979 264.201479
-L 143.002449 262.632795
-L 143.002449 256.702546
-L 161.846919 263.548123
-L 161.846919 263.378119
-L 180.69139 267.465404
-L 180.69139 249.052516
-L 199.53586 258.177643
-L 199.53586 254.857242
-L 218.380331 252.771876
-L 218.380331 248.260293
-L 256.069271 245.404873
-L 256.069271 244.314724
-L 312.602683 242.129735
-L 312.602683 235.100336
-L 331.447153 250.223312
-L 331.447153 239.938099
-L 369.136094 236.657272
-L 369.136094 224.175206
-L 406.825035 223.613014
-L 406.825035 217.966402
-L 482.202916 228.103954
-L 482.202916 221.852522
+    <path d="M 86.469038 279.729706
+L 86.469038 274.119925
+L 105.313508 275.254864
+L 105.313508 265.94329
+L 124.157979 275.053312
+L 124.157979 264.261371
+L 143.002449 262.913577
+L 143.002449 257.367021
+L 161.846919 264.466722
+L 161.846919 263.042582
+L 180.69139 267.643933
+L 180.69139 250.109714
+L 199.53586 257.997006
+L 199.53586 254.785506
+L 218.380331 253.784216
+L 218.380331 248.183727
+L 256.069271 247.036596
+L 256.069271 244.447281
+L 312.602683 242.413725
+L 312.602683 236.050002
+L 331.447153 250.645714
+L 331.447153 240.064566
+L 369.136094 237.036286
+L 369.136094 225.626161
+L 406.825035 224.179623
+L 406.825035 218.602969
+L 482.202916 228.544947
+L 482.202916 222.281888
 " clip-path="url(#pe3690171c9)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1446,34 +1446,34 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pe3690171c9)">
-     <use xlink:href="#md73ba6276e" x="86.469038" y="280.090951" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.469038" y="272.854377" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="105.313508" y="275.175581" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="105.313508" y="266.894806" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="124.157979" y="275.111438" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="124.157979" y="264.201479" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.002449" y="262.632795" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.002449" y="256.702546" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="161.846919" y="263.548123" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="161.846919" y="263.378119" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="180.69139" y="267.465404" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="180.69139" y="249.052516" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.53586" y="258.177643" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.53586" y="254.857242" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="218.380331" y="252.771876" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="218.380331" y="248.260293" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="256.069271" y="245.404873" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="256.069271" y="244.314724" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.602683" y="242.129735" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.602683" y="235.100336" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="331.447153" y="250.223312" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="331.447153" y="239.938099" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="369.136094" y="236.657272" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="369.136094" y="224.175206" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="406.825035" y="223.613014" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="406.825035" y="217.966402" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="482.202916" y="228.103954" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="482.202916" y="221.852522" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.469038" y="279.729706" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.469038" y="274.119925" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="105.313508" y="275.254864" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="105.313508" y="265.94329" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="124.157979" y="275.053312" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="124.157979" y="264.261371" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.002449" y="262.913577" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.002449" y="257.367021" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="161.846919" y="264.466722" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="161.846919" y="263.042582" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="180.69139" y="267.643933" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="180.69139" y="250.109714" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.53586" y="257.997006" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.53586" y="254.785506" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="218.380331" y="253.784216" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="218.380331" y="248.183727" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="256.069271" y="247.036596" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="256.069271" y="244.447281" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.602683" y="242.413725" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.602683" y="236.050002" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="331.447153" y="250.645714" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="331.447153" y="240.064566" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="369.136094" y="237.036286" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="369.136094" y="225.626161" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="406.825035" y="224.179623" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="406.825035" y="218.602969" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="482.202916" y="228.544947" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="482.202916" y="222.281888" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_124">
@@ -2427,7 +2427,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 60 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 61 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2564,7 +2564,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-19" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-13" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-conway.svg
+++ b/reports/figures/hexbz-runtime-degree-conway.svg
@@ -1583,88 +1583,87 @@ z
     </g>
    </g>
    <g id="line2d_139">
-    <path d="M 86.724055 273.89471
-L 86.724055 267.910795
-L 97.001856 269.714302
-L 97.001856 262.345006
-L 107.279657 269.354846
-L 107.279657 260.519331
-L 117.557458 265.951398
-L 117.557458 252.903944
-L 127.835259 264.406805
-L 127.835259 252.689621
-L 138.11306 261.228291
-L 138.11306 249.404195
-L 148.39086 258.600545
-L 148.39086 249.820121
-L 158.668661 255.484939
-L 158.668661 245.520077
-L 168.946462 255.345259
-L 168.946462 245.651436
-L 179.224263 252.551399
-L 179.224263 237.340825
-L 189.502064 252.401117
-L 189.502064 238.347486
-L 199.779865 248.146058
-L 199.779865 232.703675
-L 210.057666 250.056114
-L 210.057666 232.015084
-L 220.335466 243.29273
-L 220.335466 237.508008
-L 230.613267 243.656263
-L 230.613267 231.999751
-L 240.891068 242.920861
-L 240.891068 226.733098
-L 251.168869 244.667333
-L 251.168869 220.098603
-L 261.44667 238.207104
-L 261.44667 224.052373
-L 271.724471 241.715334
-L 271.724471 241.586431
-L 271.724471 222.677996
-L 282.002271 234.372708
-L 282.002271 224.337504
-L 292.280072 234.472548
-L 292.280072 226.851965
-L 302.557873 232.758345
-L 302.557873 217.911453
-L 312.835674 235.708081
-L 312.835674 217.835434
-L 323.113475 230.682065
-L 323.113475 217.774786
-L 333.391276 231.672906
-L 333.391276 213.913309
-L 343.669077 227.933362
-L 343.669077 215.791055
-L 353.946877 232.572788
-L 353.946877 213.412644
-L 364.224678 227.120552
-L 364.224678 207.558031
-L 374.502479 230.889017
-L 374.502479 221.611464
-L 384.78028 222.757099
-L 384.78028 205.49288
-L 395.058081 227.886034
-L 395.058081 209.852609
-L 405.335882 222.898492
-L 405.335882 213.842447
-L 415.613682 222.228696
-L 415.613682 202.118083
-L 425.891483 219.63429
-L 425.891483 206.777982
-L 436.169284 221.486431
-L 436.169284 197.681228
-L 446.447085 217.011598
-L 446.447085 198.884364
-L 456.724886 221.91548
-L 456.724886 200.237999
-L 467.002687 215.637939
-L 467.002687 196.184458
-L 477.280488 217.654061
-L 477.280488 200.377715
-L 487.558288 214.221129
-L 487.558288 199.23862
-L 487.558288 199.23862
+    <path d="M 86.724055 274.164753
+L 86.724055 268.066144
+L 97.001856 269.003064
+L 97.001856 261.971127
+L 107.279657 270.073386
+L 107.279657 260.855674
+L 117.557458 266.208569
+L 117.557458 251.615143
+L 127.835259 264.524906
+L 127.835259 250.575188
+L 138.11306 261.305806
+L 138.11306 249.348555
+L 148.39086 259.549837
+L 148.39086 250.341943
+L 158.668661 256.147691
+L 158.668661 245.749089
+L 168.946462 255.072443
+L 168.946462 245.441112
+L 179.224263 252.772369
+L 179.224263 237.460852
+L 189.502064 252.737355
+L 189.502064 236.874861
+L 199.779865 247.474335
+L 199.779865 232.592816
+L 210.057666 249.931787
+L 210.057666 231.822546
+L 220.335466 243.194713
+L 220.335466 237.433373
+L 230.613267 243.463034
+L 230.613267 231.693708
+L 240.891068 242.646518
+L 240.891068 226.627644
+L 251.168869 244.113186
+L 251.168869 219.092694
+L 261.44667 238.283813
+L 261.44667 224.301421
+L 271.724471 241.638488
+L 271.724471 223.403878
+L 282.002271 234.015477
+L 282.002271 223.712608
+L 292.280072 234.712432
+L 292.280072 226.818187
+L 302.557873 232.778757
+L 302.557873 217.783647
+L 312.835674 235.89024
+L 312.835674 218.079377
+L 323.113475 230.881773
+L 323.113475 218.167017
+L 333.391276 232.158199
+L 333.391276 214.244586
+L 343.669077 228.056344
+L 343.669077 215.990155
+L 353.946877 232.863032
+L 353.946877 213.677196
+L 364.224678 227.378701
+L 364.224678 207.702947
+L 374.502479 230.86427
+L 374.502479 221.563323
+L 384.78028 222.709909
+L 384.78028 205.602813
+L 395.058081 227.542219
+L 395.058081 209.591832
+L 405.335882 223.179292
+L 405.335882 214.019827
+L 415.613682 222.241022
+L 415.613682 201.927038
+L 425.891483 219.54303
+L 425.891483 206.647553
+L 436.169284 221.347654
+L 436.169284 197.741667
+L 446.447085 217.12508
+L 446.447085 199.027871
+L 456.724886 222.022028
+L 456.724886 200.237838
+L 467.002687 215.548377
+L 467.002687 196.211414
+L 477.280488 217.805625
+L 477.280488 200.640709
+L 487.558288 214.17273
+L 487.558288 198.574428
+L 487.558288 198.574428
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1680,192 +1679,192 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="273.89471" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="273.612519" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="273.434371" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="273.425972" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="273.325481" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.814193" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.789856" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.451742" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="267.910795" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="269.714302" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="268.573723" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="268.32448" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="268.235437" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="265.056362" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="264.757736" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="263.515952" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="263.231532" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="262.345006" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="269.354846" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="268.923704" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="268.432424" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="267.743892" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="267.584593" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="263.681632" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="262.468169" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="262.413783" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="260.519331" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="265.951398" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="265.258759" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="264.437406" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="260.776312" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="259.561523" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="258.607936" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="255.373047" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="254.556291" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="252.903944" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="264.406805" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="263.938001" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="261.070863" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="258.372553" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="257.960652" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="255.509829" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="254.172923" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="252.689621" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="261.228291" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="261.003209" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="260.726368" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="260.392402" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="257.446687" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="253.577711" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="252.101934" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="249.404195" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="258.600545" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="257.4918" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="253.809139" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="253.687425" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="253.316371" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="253.053324" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="251.962749" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="249.820121" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="255.484939" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="252.093944" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="250.715736" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="249.370924" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="248.824377" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="245.920715" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="245.680315" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="245.520077" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="168.946462" y="255.345259" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="168.946462" y="249.150228" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="168.946462" y="247.273551" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="168.946462" y="245.651436" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="252.551399" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="251.210193" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="244.920496" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="237.340825" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="189.502064" y="252.401117" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="189.502064" y="250.818688" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="189.502064" y="242.675708" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="189.502064" y="238.347486" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.779865" y="248.146058" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.779865" y="241.55478" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.779865" y="235.893391" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.779865" y="232.703675" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="250.056114" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="247.677175" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="245.379005" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="232.015084" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="243.29273" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="240.560504" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="237.767546" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="237.508008" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="230.613267" y="243.656263" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="230.613267" y="239.113279" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="230.613267" y="234.605293" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="230.613267" y="231.999751" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="242.920861" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="241.881573" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="227.902898" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="226.733098" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.168869" y="244.667333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.168869" y="228.788814" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.168869" y="226.142996" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.168869" y="220.098603" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="261.44667" y="238.207104" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="261.44667" y="230.885832" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="261.44667" y="227.182766" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="261.44667" y="224.052373" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="241.715334" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="241.586431" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="227.961845" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="222.677996" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="282.002271" y="234.372708" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="282.002271" y="229.880203" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="282.002271" y="228.054302" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="282.002271" y="224.337504" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.280072" y="234.472548" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.280072" y="228.212408" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.280072" y="227.349813" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.280072" y="226.851965" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="232.758345" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="221.536692" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="219.708" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="217.911453" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.835674" y="235.708081" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.835674" y="233.354556" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.835674" y="226.186516" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.835674" y="217.835434" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="323.113475" y="230.682065" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="323.113475" y="222.247978" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="323.113475" y="218.497627" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="323.113475" y="217.774786" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.391276" y="231.672906" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.391276" y="219.182117" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.391276" y="216.584058" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.391276" y="213.913309" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="343.669077" y="227.933362" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="343.669077" y="217.312488" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="343.669077" y="217.079772" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="343.669077" y="215.791055" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="232.572788" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="223.206901" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="215.304852" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="213.412644" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="227.120552" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="225.799225" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="211.662044" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="207.558031" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.502479" y="230.889017" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.502479" y="224.943395" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.502479" y="223.791066" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.502479" y="221.611464" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="384.78028" y="222.757099" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="384.78028" y="211.437201" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="384.78028" y="206.52446" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="384.78028" y="205.49288" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="395.058081" y="227.886034" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="395.058081" y="226.258646" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="395.058081" y="211.682152" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="395.058081" y="209.852609" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="405.335882" y="222.898492" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="405.335882" y="213.842447" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="415.613682" y="222.228696" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="415.613682" y="216.410879" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="415.613682" y="202.118083" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="425.891483" y="219.63429" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="425.891483" y="206.777982" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="436.169284" y="221.486431" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="436.169284" y="215.566772" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="436.169284" y="205.108218" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="436.169284" y="197.681228" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.447085" y="217.011598" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.447085" y="205.539057" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.447085" y="204.817577" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.447085" y="198.884364" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="456.724886" y="221.91548" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="456.724886" y="219.333686" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="456.724886" y="205.575924" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="456.724886" y="200.237999" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="467.002687" y="215.637939" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="467.002687" y="196.184458" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="477.280488" y="217.654061" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="477.280488" y="216.657511" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="477.280488" y="200.377715" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="214.221129" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="199.23862" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="274.164753" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="274.033135" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="273.86027" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="273.64564" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="273.333834" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="272.66061" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="272.652562" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="272.564278" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="268.066144" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="269.003064" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="268.61871" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="268.502616" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="268.432424" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="265.599035" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="264.846285" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="263.491231" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="262.634165" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="261.971127" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="270.073386" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="268.72196" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="268.683172" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="268.173178" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="267.997626" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="262.222678" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="261.877857" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="261.829194" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="260.855674" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="266.208569" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="265.736194" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="264.168869" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="260.359384" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="259.175245" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="257.533544" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="256.070448" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="255.203591" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="251.615143" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="264.524906" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="263.511102" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="261.215902" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="258.489677" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="257.638327" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="256.58911" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="253.76923" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="250.575188" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="261.305806" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="260.759232" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="260.552232" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="260.072116" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="256.906536" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="254.367973" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="251.796979" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="249.348555" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="259.549837" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="256.916294" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="254.356286" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="254.327394" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="254.006007" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="252.443101" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="252.429971" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="250.341943" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="256.147691" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="252.218314" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="251.207739" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="249.648053" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="249.158987" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="246.532126" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="246.071638" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="245.749089" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="168.946462" y="255.072443" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="168.946462" y="248.60385" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="168.946462" y="246.343745" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="168.946462" y="245.441112" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="252.772369" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="251.325886" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="244.650092" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="237.460852" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="189.502064" y="252.737355" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="189.502064" y="250.346621" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="189.502064" y="242.295229" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="189.502064" y="236.874861" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.779865" y="247.474335" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.779865" y="241.03955" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.779865" y="235.739407" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.779865" y="232.592816" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="249.931787" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="247.279471" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="245.665689" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="231.822546" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="243.194713" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="240.096492" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="237.773491" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="237.433373" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="230.613267" y="243.463034" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="230.613267" y="238.956753" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="230.613267" y="234.245491" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="230.613267" y="231.693708" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="242.646518" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="241.269133" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="227.064929" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="226.627644" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.168869" y="244.113186" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.168869" y="227.39641" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.168869" y="226.172407" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.168869" y="219.092694" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="261.44667" y="238.283813" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="261.44667" y="230.514076" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="261.44667" y="226.755948" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="261.44667" y="224.301421" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="241.638488" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="241.067511" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="228.295812" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="223.403878" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="282.002271" y="234.015477" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="282.002271" y="229.713584" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="282.002271" y="227.372081" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="282.002271" y="223.712608" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.280072" y="234.712432" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.280072" y="228.117775" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.280072" y="227.014681" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.280072" y="226.818187" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="232.778757" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="221.571876" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="219.819542" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="217.783647" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.835674" y="235.89024" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.835674" y="233.400252" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.835674" y="226.632046" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.835674" y="218.079377" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="323.113475" y="230.881773" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="323.113475" y="222.140535" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="323.113475" y="219.1542" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="323.113475" y="218.167017" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.391276" y="232.158199" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.391276" y="218.996251" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.391276" y="215.749624" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.391276" y="214.244586" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="343.669077" y="228.056344" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="343.669077" y="217.073436" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="343.669077" y="216.847749" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="343.669077" y="215.990155" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="232.863032" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="223.56748" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="214.924668" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="213.677196" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="227.378701" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="226.122071" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="211.866662" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="207.702947" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.502479" y="230.86427" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.502479" y="225.040009" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.502479" y="223.715872" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.502479" y="221.563323" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="384.78028" y="222.709909" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="384.78028" y="211.408699" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="384.78028" y="206.409999" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="384.78028" y="205.602813" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="395.058081" y="227.542219" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="395.058081" y="226.536562" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="395.058081" y="211.379431" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="395.058081" y="209.591832" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="405.335882" y="223.179292" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="405.335882" y="214.019827" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="415.613682" y="222.241022" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="415.613682" y="216.524949" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="415.613682" y="201.927038" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="425.891483" y="219.54303" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="425.891483" y="206.647553" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="436.169284" y="221.347654" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="436.169284" y="215.558935" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="436.169284" y="205.255293" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="436.169284" y="197.741667" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.447085" y="217.12508" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.447085" y="205.676272" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.447085" y="204.807582" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.447085" y="199.027871" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="456.724886" y="222.022028" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="456.724886" y="219.478917" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="456.724886" y="205.886732" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="456.724886" y="200.237838" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="467.002687" y="215.548377" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="467.002687" y="196.211414" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="477.280488" y="217.805625" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="477.280488" y="216.896183" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="477.280488" y="200.640709" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="214.17273" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="198.574428" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_140">
@@ -3863,7 +3862,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_26">
-   <!-- cutoff 10.0s; source newest-per-system across 60 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 61 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -4000,7 +3999,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-19" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-13" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-cyclotomic-products.svg
+++ b/reports/figures/hexbz-runtime-degree-cyclotomic-products.svg
@@ -1455,25 +1455,25 @@ z
     </g>
    </g>
    <g id="line2d_119">
-    <path d="M 86.724055 271.990338
-L 104.151631 253.846198
-L 112.865418 250.500515
-L 115.770014 252.815183
-L 115.770014 244.00017
-L 127.388398 239.877727
-L 139.006781 233.450482
-L 139.006781 204.588266
-L 156.434357 210.919921
-L 162.243549 182.180151
-L 173.861932 201.377607
-L 185.480316 203.341409
-L 208.717083 171.542247
-L 243.572234 185.070057
-L 301.664151 161.953742
-L 374.279049 139.955325
-L 394.61122 149.8992
-L 417.847987 114.488715
-L 487.558288 133.037719
+    <path d="M 86.724055 271.459213
+L 104.151631 253.77813
+L 112.865418 249.856814
+L 115.770014 252.354953
+L 115.770014 243.254866
+L 127.388398 239.354011
+L 139.006781 232.805766
+L 139.006781 204.171446
+L 156.434357 210.83447
+L 162.243549 181.251607
+L 173.861932 200.93424
+L 185.480316 203.304669
+L 208.717083 171.297272
+L 243.572234 184.929427
+L 301.664151 161.877457
+L 374.279049 139.159532
+L 394.61122 149.229065
+L 417.847987 114.160571
+L 487.558288 132.861306
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1489,25 +1489,25 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="271.990338" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="104.151631" y="253.846198" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="112.865418" y="250.500515" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="115.770014" y="252.815183" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="115.770014" y="244.00017" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.388398" y="239.877727" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="139.006781" y="233.450482" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="139.006781" y="204.588266" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="156.434357" y="210.919921" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="162.243549" y="182.180151" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="173.861932" y="201.377607" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="185.480316" y="203.341409" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="208.717083" y="171.542247" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="243.572234" y="185.070057" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="301.664151" y="161.953742" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.279049" y="139.955325" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="394.61122" y="149.8992" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="417.847987" y="114.488715" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="133.037719" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="271.459213" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="104.151631" y="253.77813" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="112.865418" y="249.856814" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="115.770014" y="252.354953" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="115.770014" y="243.254866" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.388398" y="239.354011" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="139.006781" y="232.805766" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="139.006781" y="204.171446" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="156.434357" y="210.83447" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="162.243549" y="181.251607" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="173.861932" y="200.93424" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="185.480316" y="203.304669" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="208.717083" y="171.297272" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="243.572234" y="184.929427" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="301.664151" y="161.877457" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.279049" y="139.159532" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="394.61122" y="149.229065" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="417.847987" y="114.160571" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="132.861306" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_120">
@@ -2365,7 +2365,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 60 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 61 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2472,7 +2472,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-19" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-13" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-cyclotomic.svg
+++ b/reports/figures/hexbz-runtime-degree-cyclotomic.svg
@@ -1509,40 +1509,40 @@ z
     </g>
    </g>
    <g id="line2d_127">
-    <path d="M 86.724055 274.315542
-L 87.505409 270.509732
-L 88.286762 253.824899
-L 89.068115 254.151616
-L 89.849469 239.60484
-L 91.412175 253.894817
-L 92.193528 251.298755
-L 92.974882 249.442266
-L 93.756235 236.86362
-L 94.537588 229.917204
-L 96.100295 240.686279
-L 97.663001 231.587899
-L 99.225708 218.257893
-L 100.788414 197.421461
-L 101.569768 228.747513
-L 103.913828 179.088601
-L 105.476534 222.154191
-L 106.257887 218.098949
-L 108.601947 175.119
-L 110.164654 210.832634
-L 116.41548 171.215819
-L 119.540893 205.109484
-L 128.135779 139.056285
-L 135.167959 185.421175
-L 143.762845 145.77109
-L 148.450965 179.797125
-L 154.701791 143.734063
-L 163.296677 87.483073
-L 178.923743 120.630198
-L 185.174569 167.096649
-L 214.08464 157.316655
-L 280.499669 139.91078
-L 283.625082 141.325236
-L 487.558288 60.686881
+    <path d="M 86.724055 272.940383
+L 87.505409 269.851348
+L 88.286762 253.4963
+L 89.068115 253.995147
+L 89.849469 238.988418
+L 91.412175 253.444232
+L 92.193528 251.149276
+L 92.974882 249.149724
+L 93.756235 236.270989
+L 94.537588 230.034971
+L 96.100295 240.371426
+L 97.663001 230.599152
+L 99.225708 218.107587
+L 100.788414 196.646803
+L 101.569768 228.548249
+L 103.913828 178.793169
+L 105.476534 221.900849
+L 106.257887 217.967946
+L 108.601947 174.83856
+L 110.164654 210.568998
+L 116.41548 171.005531
+L 119.540893 204.098204
+L 128.135779 138.646453
+L 135.167959 184.952643
+L 143.762845 145.632075
+L 148.450965 179.267545
+L 154.701791 143.773301
+L 163.296677 87.345112
+L 178.923743 120.630203
+L 185.174569 166.742614
+L 214.08464 157.0105
+L 280.499669 139.40899
+L 283.625082 140.806081
+L 487.558288 60.685729
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1558,40 +1558,40 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="274.315542" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="87.505409" y="270.509732" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="88.286762" y="253.824899" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="89.068115" y="254.151616" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="89.849469" y="239.60484" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="91.412175" y="253.894817" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="92.193528" y="251.298755" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="92.974882" y="249.442266" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="93.756235" y="236.86362" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="94.537588" y="229.917204" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="96.100295" y="240.686279" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.663001" y="231.587899" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.225708" y="218.257893" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="100.788414" y="197.421461" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="101.569768" y="228.747513" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="103.913828" y="179.088601" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="105.476534" y="222.154191" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="106.257887" y="218.098949" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="108.601947" y="175.119" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="110.164654" y="210.832634" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="116.41548" y="171.215819" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="119.540893" y="205.109484" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="128.135779" y="139.056285" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="135.167959" y="185.421175" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.762845" y="145.77109" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.450965" y="179.797125" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="154.701791" y="143.734063" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="163.296677" y="87.483073" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="178.923743" y="120.630198" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="185.174569" y="167.096649" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="214.08464" y="157.316655" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="280.499669" y="139.91078" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="283.625082" y="141.325236" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="60.686881" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="272.940383" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="87.505409" y="269.851348" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="88.286762" y="253.4963" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="89.068115" y="253.995147" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="89.849469" y="238.988418" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="91.412175" y="253.444232" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="92.193528" y="251.149276" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="92.974882" y="249.149724" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="93.756235" y="236.270989" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="94.537588" y="230.034971" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="96.100295" y="240.371426" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.663001" y="230.599152" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.225708" y="218.107587" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="100.788414" y="196.646803" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="101.569768" y="228.548249" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="103.913828" y="178.793169" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="105.476534" y="221.900849" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="106.257887" y="217.967946" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="108.601947" y="174.83856" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="110.164654" y="210.568998" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="116.41548" y="171.005531" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="119.540893" y="204.098204" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="128.135779" y="138.646453" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="135.167959" y="184.952643" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.762845" y="145.632075" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.450965" y="179.267545" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="154.701791" y="143.773301" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="163.296677" y="87.345112" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="178.923743" y="120.630203" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="185.174569" y="166.742614" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="214.08464" y="157.0105" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="280.499669" y="139.40899" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="283.625082" y="140.806081" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="60.685729" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_128">
@@ -2570,7 +2570,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 60 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 61 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2677,7 +2677,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-19" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-13" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-hoeij-zimmermann.svg
+++ b/reports/figures/hexbz-runtime-degree-hoeij-zimmermann.svg
@@ -600,8 +600,8 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_11">
-      <path d="M 66.682344 275.546077
-L 507.6 275.546077
+      <path d="M 66.682344 275.559818
+L 507.6 275.559818
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
@@ -611,12 +611,12 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="275.546077" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="275.559818" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 10ms -->
-      <g transform="translate(32.007344 279.344906) scale(0.1 -0.1)">
+      <g transform="translate(32.007344 279.358646) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-14" d="M 794 531
 L 1825 531
@@ -673,18 +673,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_13">
-      <path d="M 66.682344 183.73435
-L 507.6 183.73435
+      <path d="M 66.682344 183.830405
+L 507.6 183.830405
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="183.73435" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="183.830405" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 100ms -->
-      <g transform="translate(25.644844 187.533178) scale(0.1 -0.1)">
+      <g transform="translate(25.644844 187.629233) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
@@ -695,18 +695,18 @@ L 507.6 183.73435
     </g>
     <g id="ytick_3">
      <g id="line2d_15">
-      <path d="M 66.682344 91.922623
-L 507.6 91.922623
+      <path d="M 66.682344 92.100992
+L 507.6 92.100992
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="91.922623" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="92.100992" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 1s -->
-      <g transform="translate(48.110469 95.721451) scale(0.1 -0.1)">
+      <g transform="translate(48.110469 95.89982) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(63.625 0)"/>
       </g>
@@ -714,8 +714,8 @@ L 507.6 91.922623
     </g>
     <g id="ytick_4">
      <g id="line2d_17">
-      <path d="M 66.682344 303.184161
-L 507.6 303.184161
+      <path d="M 66.682344 303.173123
+L 507.6 303.173123
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
@@ -725,295 +725,295 @@ L -2 0
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="303.184161" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="303.173123" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_19">
-      <path d="M 66.682344 295.914394
-L 507.6 295.914394
+      <path d="M 66.682344 295.909874
+L 507.6 295.909874
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="295.914394" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="295.909874" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_21">
-      <path d="M 66.682344 289.767894
-L 507.6 289.767894
+      <path d="M 66.682344 289.768884
+L 507.6 289.768884
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.767894" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.768884" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_23">
-      <path d="M 66.682344 284.443553
-L 507.6 284.443553
+      <path d="M 66.682344 284.449317
+L 507.6 284.449317
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.443553" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.449317" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_25">
-      <path d="M 66.682344 279.747152
-L 507.6 279.747152
+      <path d="M 66.682344 279.757126
+L 507.6 279.757126
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="279.747152" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="279.757126" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_27">
-      <path d="M 66.682344 247.907994
-L 507.6 247.907994
+      <path d="M 66.682344 247.946513
+L 507.6 247.946513
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="247.907994" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="247.946513" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_29">
-      <path d="M 66.682344 231.740751
-L 507.6 231.740751
+      <path d="M 66.682344 231.793766
+L 507.6 231.793766
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="231.740751" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="231.793766" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_31">
-      <path d="M 66.682344 220.26991
-L 507.6 220.26991
+      <path d="M 66.682344 220.333209
+L 507.6 220.333209
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="220.26991" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="220.333209" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_33">
-      <path d="M 66.682344 211.372434
-L 507.6 211.372434
+      <path d="M 66.682344 211.44371
+L 507.6 211.44371
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="211.372434" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="211.44371" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_35">
-      <path d="M 66.682344 204.102667
-L 507.6 204.102667
+      <path d="M 66.682344 204.180461
+L 507.6 204.180461
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="204.102667" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="204.180461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_37">
-      <path d="M 66.682344 197.956167
-L 507.6 197.956167
+      <path d="M 66.682344 198.039471
+L 507.6 198.039471
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="197.956167" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="198.039471" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_39">
-      <path d="M 66.682344 192.631826
-L 507.6 192.631826
+      <path d="M 66.682344 192.719904
+L 507.6 192.719904
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="192.631826" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="192.719904" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_41">
-      <path d="M 66.682344 187.935424
-L 507.6 187.935424
+      <path d="M 66.682344 188.027713
+L 507.6 188.027713
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="187.935424" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="188.027713" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_43">
-      <path d="M 66.682344 156.096266
-L 507.6 156.096266
+      <path d="M 66.682344 156.2171
+L 507.6 156.2171
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="156.096266" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="156.2171" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_45">
-      <path d="M 66.682344 139.929024
-L 507.6 139.929024
+      <path d="M 66.682344 140.064353
+L 507.6 140.064353
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="139.929024" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="140.064353" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_47">
-      <path d="M 66.682344 128.458183
-L 507.6 128.458183
+      <path d="M 66.682344 128.603796
+L 507.6 128.603796
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="128.458183" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="128.603796" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_49">
-      <path d="M 66.682344 119.560707
-L 507.6 119.560707
+      <path d="M 66.682344 119.714297
+L 507.6 119.714297
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="119.560707" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="119.714297" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_51">
-      <path d="M 66.682344 112.29094
-L 507.6 112.29094
+      <path d="M 66.682344 112.451048
+L 507.6 112.451048
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="112.29094" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="112.451048" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_53">
-      <path d="M 66.682344 106.144439
-L 507.6 106.144439
+      <path d="M 66.682344 106.310058
+L 507.6 106.310058
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="106.144439" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="106.310058" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_55">
-      <path d="M 66.682344 100.820099
-L 507.6 100.820099
+      <path d="M 66.682344 100.990491
+L 507.6 100.990491
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="100.820099" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="100.990491" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_57">
-      <path d="M 66.682344 96.123697
-L 507.6 96.123697
+      <path d="M 66.682344 96.2983
+L 507.6 96.2983
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="96.123697" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="96.2983" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_59">
-      <path d="M 66.682344 64.284539
-L 507.6 64.284539
+      <path d="M 66.682344 64.487687
+L 507.6 64.487687
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="64.284539" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="64.487687" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_61">
-      <path d="M 66.682344 48.117297
-L 507.6 48.117297
+      <path d="M 66.682344 48.33494
+L 507.6 48.33494
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="48.117297" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="48.33494" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_63">
-      <path d="M 66.682344 36.646455
-L 507.6 36.646455
+      <path d="M 66.682344 36.874383
+L 507.6 36.874383
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="36.646455" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="36.874383" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_65">
-      <path d="M 66.682344 27.74898
-L 507.6 27.74898
+      <path d="M 66.682344 27.984884
+L 507.6 27.984884
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="27.74898" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="27.984884" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1101,9 +1101,9 @@ z
     </g>
    </g>
    <g id="line2d_67">
-    <path d="M 86.724055 157.839691
-L 89.917954 92.555963
-L 136.229479 48.584615
+    <path d="M 86.724055 157.178789
+L 89.917954 92.628403
+L 136.229479 48.783429
 L 188.9288 38.765348
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
@@ -1120,22 +1120,22 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="157.839691" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="89.917954" y="92.555963" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="136.229479" y="48.584615" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="157.178789" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="89.917954" y="92.628403" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="136.229479" y="48.783429" style="fill: #1f77b4; stroke: #1f77b4"/>
      <use xlink:href="#md73ba6276e" x="188.9288" y="38.765348" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_68">
-    <path d="M 86.724055 223.910591
+    <path d="M 86.724055 223.970626
 L 89.917954 290.872308
-L 136.229479 252.021852
-L 137.826428 127.13971
-L 188.9288 104.403782
-L 188.9288 83.299979
-L 264.783884 172.117942
-L 291.133545 177.934479
-L 487.558288 121.880495
+L 136.229479 252.056683
+L 137.826428 127.286506
+L 188.9288 104.570962
+L 188.9288 83.486079
+L 264.783884 172.224411
+L 291.133545 178.035733
+L 487.558288 122.032005
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #9467bd; stroke-linecap: square"/>
     <defs>
      <path id="meef3cfac8d" d="M 0 -2
@@ -1145,27 +1145,27 @@ z
 " style="stroke: #9467bd; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#meef3cfac8d" x="86.724055" y="223.910591" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="86.724055" y="223.970626" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
      <use xlink:href="#meef3cfac8d" x="89.917954" y="290.872308" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="136.229479" y="252.021852" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="137.826428" y="127.13971" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="188.9288" y="104.403782" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="188.9288" y="83.299979" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="264.783884" y="172.117942" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="291.133545" y="177.934479" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="487.558288" y="121.880495" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="136.229479" y="252.056683" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="137.826428" y="127.286506" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="188.9288" y="104.570962" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="188.9288" y="83.486079" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="264.783884" y="172.224411" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="291.133545" y="178.035733" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="487.558288" y="122.032005" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
-    <path d="M 86.724055 185.810486
-L 89.917954 253.257362
-L 136.229479 225.339316
-L 137.826428 136.920671
-L 188.9288 91.511373
-L 188.9288 81.31394
-L 264.783884 172.241454
-L 291.133545 141.543436
-L 487.558288 105.137389
+    <path d="M 86.724055 185.904679
+L 89.917954 253.291086
+L 136.229479 225.39807
+L 137.826428 137.058697
+L 188.9288 91.690111
+L 188.9288 81.50182
+L 264.783884 172.347813
+L 291.133545 141.677318
+L 487.558288 105.303911
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #8c564b; stroke-linecap: square"/>
     <defs>
      <path id="m975a81c4ea" d="M -0 2
@@ -1175,27 +1175,27 @@ z
 " style="stroke: #8c564b; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#m975a81c4ea" x="86.724055" y="185.810486" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="89.917954" y="253.257362" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="136.229479" y="225.339316" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="137.826428" y="136.920671" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="188.9288" y="91.511373" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="188.9288" y="81.31394" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="264.783884" y="172.241454" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="291.133545" y="141.543436" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="487.558288" y="105.137389" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="86.724055" y="185.904679" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="89.917954" y="253.291086" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="136.229479" y="225.39807" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="137.826428" y="137.058697" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="188.9288" y="91.690111" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="188.9288" y="81.50182" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="264.783884" y="172.347813" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="291.133545" y="141.677318" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="487.558288" y="105.303911" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
-    <path d="M 86.724055 216.494348
-L 89.917954 253.68041
-L 136.229479 235.475724
-L 137.826428 162.326297
-L 188.9288 121.043002
-L 188.9288 117.001792
-L 264.783884 155.190767
-L 291.133545 166.272179
-L 487.558288 93.516494
+    <path d="M 86.724055 216.561031
+L 89.917954 253.713754
+L 136.229479 235.52539
+L 137.826428 162.441546
+L 188.9288 121.195263
+L 188.9288 117.157676
+L 264.783884 155.312413
+L 291.133545 166.38389
+L 487.558288 93.693435
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #e377c2; stroke-linecap: square"/>
     <defs>
      <path id="mbe61f33afa" d="M -0.666667 2
@@ -1214,15 +1214,15 @@ z
 " style="stroke: #e377c2; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#mbe61f33afa" x="86.724055" y="216.494348" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="89.917954" y="253.68041" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="136.229479" y="235.475724" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="137.826428" y="162.326297" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="188.9288" y="121.043002" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="188.9288" y="117.001792" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="264.783884" y="155.190767" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="291.133545" y="166.272179" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="487.558288" y="93.516494" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="86.724055" y="216.561031" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="89.917954" y="253.713754" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="136.229479" y="235.52539" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="137.826428" y="162.441546" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="188.9288" y="121.195263" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="188.9288" y="117.157676" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="264.783884" y="155.312413" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="291.133545" y="166.38389" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="487.558288" y="93.693435" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
@@ -1711,7 +1711,7 @@ z
    </g>
   </g>
   <g id="text_16">
-   <!-- cutoff 10.0s; source newest-per-system across 60 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 61 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -1818,7 +1818,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-19" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-13" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-laguerre.svg
+++ b/reports/figures/hexbz-runtime-degree-laguerre.svg
@@ -1424,26 +1424,26 @@ z
     </g>
    </g>
    <g id="line2d_121">
-    <path d="M 86.724055 273.409235
-L 100.545925 265.02568
-L 114.367796 257.660576
-L 128.189666 254.696026
-L 142.011536 247.003315
-L 155.833406 251.683887
-L 169.655276 251.561161
-L 183.477146 237.910057
-L 197.299016 244.531473
-L 211.120886 229.077319
-L 224.942756 227.224523
-L 238.764627 220.321276
-L 252.586497 215.946903
-L 266.408367 210.145305
-L 294.052107 208.160671
-L 321.695847 198.37176
-L 349.339587 209.982816
-L 376.983328 198.562766
-L 432.270808 189.453891
-L 487.558288 176.190869
+    <path d="M 86.724055 276.230455
+L 100.545925 264.244446
+L 114.367796 257.642202
+L 128.189666 254.294712
+L 142.011536 246.913945
+L 155.833406 251.517088
+L 169.655276 251.14731
+L 183.477146 238.198495
+L 197.299016 244.395285
+L 211.120886 229.198863
+L 224.942756 227.755709
+L 238.764627 220.730109
+L 252.586497 216.092146
+L 266.408367 210.358799
+L 294.052107 208.168505
+L 321.695847 198.368961
+L 349.339587 209.944087
+L 376.983328 198.608061
+L 432.270808 189.852285
+L 487.558288 176.335397
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1459,26 +1459,26 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="273.409235" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="100.545925" y="265.02568" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="114.367796" y="257.660576" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="128.189666" y="254.696026" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="142.011536" y="247.003315" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="155.833406" y="251.683887" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="169.655276" y="251.561161" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="183.477146" y="237.910057" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="197.299016" y="244.531473" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="211.120886" y="229.077319" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="224.942756" y="227.224523" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="238.764627" y="220.321276" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="252.586497" y="215.946903" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="266.408367" y="210.145305" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="294.052107" y="208.160671" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="321.695847" y="198.37176" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="349.339587" y="209.982816" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="376.983328" y="198.562766" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="432.270808" y="189.453891" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="176.190869" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="276.230455" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="100.545925" y="264.244446" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="114.367796" y="257.642202" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="128.189666" y="254.294712" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="142.011536" y="246.913945" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="155.833406" y="251.517088" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="169.655276" y="251.14731" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="183.477146" y="238.198495" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="197.299016" y="244.395285" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="211.120886" y="229.198863" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="224.942756" y="227.755709" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="238.764627" y="220.730109" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="252.586497" y="216.092146" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="266.408367" y="210.358799" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="294.052107" y="208.168505" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="321.695847" y="198.368961" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="349.339587" y="209.944087" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="376.983328" y="198.608061" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="432.270808" y="189.852285" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="176.335397" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_122">
@@ -2347,7 +2347,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 60 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 61 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2484,7 +2484,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-19" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-13" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-legendre.svg
+++ b/reports/figures/hexbz-runtime-degree-legendre.svg
@@ -1443,26 +1443,26 @@ z
     </g>
    </g>
    <g id="line2d_123">
-    <path d="M 86.724055 272.11338
-L 98.176462 272.478017
-L 109.628869 262.205741
-L 121.081275 254.348338
-L 132.533682 258.898852
-L 143.986089 243.070562
-L 155.438495 242.314122
-L 166.890902 232.345387
-L 189.795715 237.501099
-L 212.700529 217.421341
-L 235.605342 220.577319
-L 258.510155 203.07881
-L 281.414969 196.309751
-L 304.319782 208.327011
-L 327.224595 197.016374
-L 350.129408 168.84422
-L 373.034222 195.66625
-L 395.939035 165.255954
-L 441.748662 186.132937
-L 487.558288 181.810841
+    <path d="M 86.724055 272.823292
+L 98.176462 272.777319
+L 109.628869 261.666552
+L 121.081275 254.872125
+L 132.533682 258.563426
+L 143.986089 244.231044
+L 155.438495 242.499223
+L 166.890902 232.817409
+L 189.795715 237.093219
+L 212.700529 217.354014
+L 235.605342 220.546072
+L 258.510155 203.545021
+L 281.414969 196.224782
+L 304.319782 208.377797
+L 327.224595 197.271755
+L 350.129408 169.100931
+L 373.034222 195.777137
+L 395.939035 165.464361
+L 441.748662 186.238783
+L 487.558288 181.979029
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1478,26 +1478,26 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.11338" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="98.176462" y="272.478017" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="109.628869" y="262.205741" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="121.081275" y="254.348338" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="132.533682" y="258.898852" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.986089" y="243.070562" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="155.438495" y="242.314122" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="166.890902" y="232.345387" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="189.795715" y="237.501099" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="212.700529" y="217.421341" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="235.605342" y="220.577319" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="258.510155" y="203.07881" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="281.414969" y="196.309751" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="304.319782" y="208.327011" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="327.224595" y="197.016374" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="350.129408" y="168.84422" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="373.034222" y="195.66625" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="395.939035" y="165.255954" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="441.748662" y="186.132937" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="181.810841" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="272.823292" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="98.176462" y="272.777319" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="109.628869" y="261.666552" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="121.081275" y="254.872125" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="132.533682" y="258.563426" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.986089" y="244.231044" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="155.438495" y="242.499223" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="166.890902" y="232.817409" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="189.795715" y="237.093219" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="212.700529" y="217.354014" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="235.605342" y="220.546072" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="258.510155" y="203.545021" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="281.414969" y="196.224782" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="304.319782" y="208.377797" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="327.224595" y="197.271755" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="350.129408" y="169.100931" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="373.034222" y="195.777137" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="395.939035" y="165.464361" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="441.748662" y="186.238783" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="181.979029" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_124">
@@ -2360,7 +2360,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 60 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 61 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2497,7 +2497,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-19" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-13" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-random-products.svg
+++ b/reports/figures/hexbz-runtime-degree-random-products.svg
@@ -1419,36 +1419,36 @@ z
     </g>
    </g>
    <g id="line2d_121">
-    <path d="M 86.724055 265.737535
-L 153.529761 254.899119
-L 153.529761 254.832733
-L 153.529761 251.329101
-L 175.798329 257.445109
-L 198.066898 250.448779
-L 220.335466 251.376883
-L 220.335466 243.517927
-L 242.604035 249.818698
-L 242.604035 242.415664
-L 242.604035 242.270699
-L 242.604035 240.881051
-L 242.604035 240.240595
-L 242.604035 230.565574
-L 264.872603 247.527022
-L 264.872603 239.473922
-L 287.141172 247.253239
-L 287.141172 245.261519
-L 287.141172 241.915665
-L 309.40974 236.014284
-L 331.678309 238.077171
-L 353.946877 236.233494
-L 353.946877 233.821835
-L 353.946877 224.965694
-L 353.946877 223.076758
-L 376.215446 224.25003
-L 398.484014 229.468799
-L 420.752583 226.47245
-L 443.021151 218.910168
-L 487.558288 212.195418
+    <path d="M 86.724055 265.479605
+L 153.529761 254.700947
+L 153.529761 254.590035
+L 153.529761 251.287405
+L 175.798329 257.809214
+L 198.066898 250.855398
+L 220.335466 250.857384
+L 220.335466 243.435477
+L 242.604035 249.523767
+L 242.604035 242.637225
+L 242.604035 242.017029
+L 242.604035 240.647194
+L 242.604035 240.207698
+L 242.604035 230.533172
+L 264.872603 247.365683
+L 264.872603 239.612797
+L 287.141172 247.628953
+L 287.141172 245.417306
+L 287.141172 241.689282
+L 309.40974 235.966888
+L 331.678309 238.233681
+L 353.946877 236.213672
+L 353.946877 233.852671
+L 353.946877 224.948951
+L 353.946877 223.140537
+L 376.215446 224.166349
+L 398.484014 229.413794
+L 420.752583 226.773824
+L 443.021151 218.823167
+L 487.558288 212.1507
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1464,36 +1464,36 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="265.737535" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="153.529761" y="254.899119" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="153.529761" y="254.832733" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="153.529761" y="251.329101" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="175.798329" y="257.445109" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="198.066898" y="250.448779" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="251.376883" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="243.517927" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="249.818698" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="242.415664" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="242.270699" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="240.881051" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="240.240595" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="230.565574" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.872603" y="247.527022" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.872603" y="239.473922" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="247.253239" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="245.261519" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="241.915665" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="309.40974" y="236.014284" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="331.678309" y="238.077171" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="236.233494" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="233.821835" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="224.965694" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="223.076758" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="376.215446" y="224.25003" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="398.484014" y="229.468799" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="420.752583" y="226.47245" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="443.021151" y="218.910168" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="212.195418" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="265.479605" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="153.529761" y="254.700947" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="153.529761" y="254.590035" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="153.529761" y="251.287405" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="175.798329" y="257.809214" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="198.066898" y="250.855398" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="250.857384" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="243.435477" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="249.523767" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="242.637225" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="242.017029" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="240.647194" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="240.207698" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="230.533172" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.872603" y="247.365683" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.872603" y="239.612797" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="247.628953" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="245.417306" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="241.689282" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="309.40974" y="235.966888" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="331.678309" y="238.233681" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="236.213672" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="233.852671" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="224.948951" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="223.140537" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="376.215446" y="224.166349" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="398.484014" y="229.413794" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="420.752583" y="226.773824" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="443.021151" y="218.823167" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="212.1507" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_122">
@@ -2475,7 +2475,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 60 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 61 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2605,7 +2605,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-19" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-13" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-sd-products.svg
+++ b/reports/figures/hexbz-runtime-degree-sd-products.svg
@@ -612,8 +612,8 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_13">
-      <path d="M 66.682344 277.305585
-L 507.6 277.305585
+      <path d="M 66.682344 277.304693
+L 507.6 277.304693
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
@@ -623,12 +623,12 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="277.305585" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="277.304693" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 100us -->
-      <g transform="translate(29.047969 281.104413) scale(0.1 -0.1)">
+      <g transform="translate(29.047969 281.103521) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-58" d="M 544 1381
 L 544 3500
@@ -694,18 +694,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_15">
-      <path d="M 66.682344 223.91881
-L 507.6 223.91881
+      <path d="M 66.682344 223.914405
+L 507.6 223.914405
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="223.91881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="223.914405" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 1ms -->
-      <g transform="translate(38.369844 227.717638) scale(0.1 -0.1)">
+      <g transform="translate(38.369844 227.713234) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-50" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(161.03125 0)"/>
@@ -714,18 +714,18 @@ L 507.6 223.91881
     </g>
     <g id="ytick_3">
      <g id="line2d_17">
-      <path d="M 66.682344 170.532034
-L 507.6 170.532034
+      <path d="M 66.682344 170.524118
+L 507.6 170.524118
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="170.532034" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="170.524118" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 10ms -->
-      <g transform="translate(32.007344 174.330862) scale(0.1 -0.1)">
+      <g transform="translate(32.007344 174.322946) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-50" transform="translate(127.25 0)"/>
@@ -735,18 +735,18 @@ L 507.6 170.532034
     </g>
     <g id="ytick_4">
      <g id="line2d_19">
-      <path d="M 66.682344 117.145259
-L 507.6 117.145259
+      <path d="M 66.682344 117.13383
+L 507.6 117.13383
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="117.145259" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="117.13383" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 100ms -->
-      <g transform="translate(25.644844 120.944087) scale(0.1 -0.1)">
+      <g transform="translate(25.644844 120.932659) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
@@ -757,18 +757,18 @@ L 507.6 117.145259
     </g>
     <g id="ytick_5">
      <g id="line2d_21">
-      <path d="M 66.682344 63.758483
-L 507.6 63.758483
+      <path d="M 66.682344 63.743543
+L 507.6 63.743543
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="63.758483" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="63.743543" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 1s -->
-      <g transform="translate(48.110469 67.557311) scale(0.1 -0.1)">
+      <g transform="translate(48.110469 67.542371) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(63.625 0)"/>
       </g>
@@ -776,8 +776,8 @@ L 507.6 63.758483
     </g>
     <g id="ytick_6">
      <g id="line2d_23">
-      <path d="M 66.682344 298.550319
-L 507.6 298.550319
+      <path d="M 66.682344 298.550824
+L 507.6 298.550824
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
@@ -787,499 +787,499 @@ L -2 0
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="298.550319" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="298.550824" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_25">
-      <path d="M 66.682344 293.376606
-L 507.6 293.376606
+      <path d="M 66.682344 293.376771
+L 507.6 293.376771
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="293.376606" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="293.376771" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_27">
-      <path d="M 66.682344 289.149375
-L 507.6 289.149375
+      <path d="M 66.682344 289.149261
+L 507.6 289.149261
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.149375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.149261" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_29">
-      <path d="M 66.682344 285.575301
-L 507.6 285.575301
+      <path d="M 66.682344 285.574953
+L 507.6 285.574953
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="285.575301" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="285.574953" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_31">
-      <path d="M 66.682344 282.479298
-L 507.6 282.479298
+      <path d="M 66.682344 282.478746
+L 507.6 282.478746
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="282.479298" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="282.478746" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_33">
-      <path d="M 66.682344 279.74843
-L 507.6 279.74843
+      <path d="M 66.682344 279.747698
+L 507.6 279.747698
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="279.74843" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="279.747698" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_35">
-      <path d="M 66.682344 261.234565
-L 507.6 261.234565
+      <path d="M 66.682344 261.232615
+L 507.6 261.232615
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="261.234565" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="261.232615" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_37">
-      <path d="M 66.682344 251.83362
-L 507.6 251.83362
+      <path d="M 66.682344 251.831052
+L 507.6 251.831052
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="251.83362" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="251.831052" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_39">
-      <path d="M 66.682344 245.163544
-L 507.6 245.163544
+      <path d="M 66.682344 245.160537
+L 507.6 245.160537
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="245.163544" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="245.160537" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_41">
-      <path d="M 66.682344 239.989831
-L 507.6 239.989831
+      <path d="M 66.682344 239.986483
+L 507.6 239.986483
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="239.989831" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="239.986483" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_43">
-      <path d="M 66.682344 235.762599
-L 507.6 235.762599
+      <path d="M 66.682344 235.758974
+L 507.6 235.758974
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="235.762599" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="235.758974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_45">
-      <path d="M 66.682344 232.188526
-L 507.6 232.188526
+      <path d="M 66.682344 232.184666
+L 507.6 232.184666
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="232.188526" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="232.184666" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_47">
-      <path d="M 66.682344 229.092523
-L 507.6 229.092523
+      <path d="M 66.682344 229.088459
+L 507.6 229.088459
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="229.092523" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="229.088459" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_49">
-      <path d="M 66.682344 226.361655
-L 507.6 226.361655
+      <path d="M 66.682344 226.357411
+L 507.6 226.357411
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="226.361655" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="226.357411" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_51">
-      <path d="M 66.682344 207.847789
-L 507.6 207.847789
+      <path d="M 66.682344 207.842327
+L 507.6 207.842327
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="207.847789" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="207.842327" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_53">
-      <path d="M 66.682344 198.446844
-L 507.6 198.446844
+      <path d="M 66.682344 198.440764
+L 507.6 198.440764
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="198.446844" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="198.440764" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_55">
-      <path d="M 66.682344 191.776768
-L 507.6 191.776768
+      <path d="M 66.682344 191.770249
+L 507.6 191.770249
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="191.776768" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="191.770249" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_57">
-      <path d="M 66.682344 186.603055
-L 507.6 186.603055
+      <path d="M 66.682344 186.596196
+L 507.6 186.596196
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="186.603055" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="186.596196" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_59">
-      <path d="M 66.682344 182.375824
-L 507.6 182.375824
+      <path d="M 66.682344 182.368686
+L 507.6 182.368686
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="182.375824" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="182.368686" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_61">
-      <path d="M 66.682344 178.80175
-L 507.6 178.80175
+      <path d="M 66.682344 178.794378
+L 507.6 178.794378
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="178.80175" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="178.794378" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_63">
-      <path d="M 66.682344 175.705747
-L 507.6 175.705747
+      <path d="M 66.682344 175.698171
+L 507.6 175.698171
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="175.705747" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="175.698171" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_65">
-      <path d="M 66.682344 172.974879
-L 507.6 172.974879
+      <path d="M 66.682344 172.967123
+L 507.6 172.967123
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="172.974879" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="172.967123" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_67">
-      <path d="M 66.682344 154.461013
-L 507.6 154.461013
+      <path d="M 66.682344 154.45204
+L 507.6 154.45204
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="154.461013" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="154.45204" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_69">
-      <path d="M 66.682344 145.060069
-L 507.6 145.060069
+      <path d="M 66.682344 145.050477
+L 507.6 145.050477
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="145.060069" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="145.050477" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_71">
-      <path d="M 66.682344 138.389993
-L 507.6 138.389993
+      <path d="M 66.682344 138.379962
+L 507.6 138.379962
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="138.389993" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="138.379962" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_73">
-      <path d="M 66.682344 133.21628
-L 507.6 133.21628
+      <path d="M 66.682344 133.205908
+L 507.6 133.205908
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="133.21628" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="133.205908" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_75">
-      <path d="M 66.682344 128.989048
-L 507.6 128.989048
+      <path d="M 66.682344 128.978399
+L 507.6 128.978399
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_76">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="128.989048" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="128.978399" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_77">
-      <path d="M 66.682344 125.414975
-L 507.6 125.414975
+      <path d="M 66.682344 125.404091
+L 507.6 125.404091
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_78">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="125.414975" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="125.404091" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_34">
      <g id="line2d_79">
-      <path d="M 66.682344 122.318972
-L 507.6 122.318972
+      <path d="M 66.682344 122.307884
+L 507.6 122.307884
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_80">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="122.318972" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="122.307884" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_35">
      <g id="line2d_81">
-      <path d="M 66.682344 119.588104
-L 507.6 119.588104
+      <path d="M 66.682344 119.576836
+L 507.6 119.576836
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_82">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="119.588104" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="119.576836" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_36">
      <g id="line2d_83">
-      <path d="M 66.682344 101.074238
-L 507.6 101.074238
+      <path d="M 66.682344 101.061752
+L 507.6 101.061752
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_84">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="101.074238" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="101.061752" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_37">
      <g id="line2d_85">
-      <path d="M 66.682344 91.673293
-L 507.6 91.673293
+      <path d="M 66.682344 91.660189
+L 507.6 91.660189
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_86">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="91.673293" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="91.660189" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_38">
      <g id="line2d_87">
-      <path d="M 66.682344 85.003217
-L 507.6 85.003217
+      <path d="M 66.682344 84.989674
+L 507.6 84.989674
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_88">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="85.003217" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="84.989674" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_39">
      <g id="line2d_89">
-      <path d="M 66.682344 79.829504
-L 507.6 79.829504
+      <path d="M 66.682344 79.815621
+L 507.6 79.815621
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_90">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="79.829504" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="79.815621" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_40">
      <g id="line2d_91">
-      <path d="M 66.682344 75.602273
-L 507.6 75.602273
+      <path d="M 66.682344 75.588111
+L 507.6 75.588111
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_92">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="75.602273" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="75.588111" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_41">
      <g id="line2d_93">
-      <path d="M 66.682344 72.028199
-L 507.6 72.028199
+      <path d="M 66.682344 72.013803
+L 507.6 72.013803
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_94">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="72.028199" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="72.013803" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_42">
      <g id="line2d_95">
-      <path d="M 66.682344 68.932196
-L 507.6 68.932196
+      <path d="M 66.682344 68.917596
+L 507.6 68.917596
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_96">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="68.932196" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="68.917596" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_43">
      <g id="line2d_97">
-      <path d="M 66.682344 66.201328
-L 507.6 66.201328
+      <path d="M 66.682344 66.186549
+L 507.6 66.186549
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_98">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="66.201328" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="66.186549" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_44">
      <g id="line2d_99">
-      <path d="M 66.682344 47.687462
-L 507.6 47.687462
+      <path d="M 66.682344 47.671465
+L 507.6 47.671465
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_100">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="47.687462" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="47.671465" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_45">
      <g id="line2d_101">
-      <path d="M 66.682344 38.286518
-L 507.6 38.286518
+      <path d="M 66.682344 38.269902
+L 507.6 38.269902
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_102">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="38.286518" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="38.269902" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_46">
      <g id="line2d_103">
-      <path d="M 66.682344 31.616442
-L 507.6 31.616442
+      <path d="M 66.682344 31.599387
+L 507.6 31.599387
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_104">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="31.616442" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="31.599387" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_47">
      <g id="line2d_105">
-      <path d="M 66.682344 26.442728
-L 507.6 26.442728
+      <path d="M 66.682344 26.425333
+L 507.6 26.425333
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_106">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="26.442728" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="26.425333" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1367,16 +1367,16 @@ z
     </g>
    </g>
    <g id="line2d_107">
-    <path d="M 86.724055 270.527138
-L 86.724055 270.094346
-L 113.446338 241.026379
-L 113.446338 237.609444
-L 113.446338 228.307034
-L 166.890902 201.330971
-L 166.890902 162.602048
-L 193.613184 158.417159
-L 200.293755 114.355139
-L 247.057749 95.456559
+    <path d="M 86.724055 270.043594
+L 86.724055 269.234307
+L 113.446338 240.486842
+L 113.446338 237.048523
+L 113.446338 227.195039
+L 166.890902 200.880189
+L 166.890902 162.330732
+L 193.613184 157.982469
+L 200.293755 114.619194
+L 247.057749 95.57902
 L 313.863454 38.765348
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
@@ -1393,34 +1393,34 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="270.527138" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="270.094346" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="113.446338" y="241.026379" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="113.446338" y="237.609444" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="113.446338" y="228.307034" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="166.890902" y="201.330971" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="166.890902" y="162.602048" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="193.613184" y="158.417159" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="200.293755" y="114.355139" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="247.057749" y="95.456559" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="270.043594" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="269.234307" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="113.446338" y="240.486842" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="113.446338" y="237.048523" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="113.446338" y="227.195039" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="166.890902" y="200.880189" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="166.890902" y="162.330732" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="193.613184" y="157.982469" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="200.293755" y="114.619194" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="247.057749" y="95.57902" style="fill: #1f77b4; stroke: #1f77b4"/>
      <use xlink:href="#md73ba6276e" x="313.863454" y="38.765348" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_108">
     <path d="M 86.724055 290.872308
-L 86.724055 288.907195
-L 113.446338 275.463307
-L 113.446338 270.121543
-L 113.446338 262.647117
-L 166.890902 242.333448
-L 166.890902 224.406345
-L 193.613184 230.154222
-L 200.293755 218.662333
-L 247.057749 211.418126
-L 273.780031 186.115342
-L 313.863454 185.376432
-L 434.113724 178.380386
-L 487.558288 136.403685
+L 86.724055 288.907066
+L 113.446338 275.462294
+L 113.446338 270.120178
+L 113.446338 262.64526
+L 166.890902 242.330255
+L 166.890902 224.401973
+L 193.613184 230.150228
+L 200.293755 218.657583
+L 247.057749 211.412899
+L 273.780031 186.10845
+L 313.863454 185.369493
+L 434.113724 178.372986
+L 487.558288 136.393524
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #9467bd; stroke-linecap: square"/>
     <defs>
      <path id="meef3cfac8d" d="M 0 -2
@@ -1431,36 +1431,36 @@ z
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
      <use xlink:href="#meef3cfac8d" x="86.724055" y="290.872308" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="86.724055" y="288.907195" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="113.446338" y="275.463307" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="113.446338" y="270.121543" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="113.446338" y="262.647117" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="166.890902" y="242.333448" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="166.890902" y="224.406345" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="193.613184" y="230.154222" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="200.293755" y="218.662333" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="247.057749" y="211.418126" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="273.780031" y="186.115342" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="313.863454" y="185.376432" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="434.113724" y="178.380386" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="487.558288" y="136.403685" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="86.724055" y="288.907066" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="113.446338" y="275.462294" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="113.446338" y="270.120178" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="113.446338" y="262.64526" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="166.890902" y="242.330255" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="166.890902" y="224.401973" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="193.613184" y="230.150228" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="200.293755" y="218.657583" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="247.057749" y="211.412899" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="273.780031" y="186.10845" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="313.863454" y="185.369493" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="434.113724" y="178.372986" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="487.558288" y="136.393524" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_109">
-    <path d="M 86.724055 261.485862
-L 86.724055 258.676323
-L 113.446338 243.98577
-L 113.446338 242.547651
-L 113.446338 240.632503
-L 166.890902 219.871071
-L 166.890902 201.921144
-L 193.613184 212.304587
-L 200.293755 195.539941
-L 247.057749 191.957542
-L 273.780031 167.109016
-L 313.863454 164.261813
-L 434.113724 156.641305
-L 487.558288 120.16676
+    <path d="M 86.724055 261.483929
+L 86.724055 258.674205
+L 113.446338 243.982686
+L 113.446338 242.544472
+L 113.446338 240.629198
+L 166.890902 219.8664
+L 166.890902 201.915292
+L 193.613184 212.299418
+L 200.293755 195.53367
+L 247.057749 191.951035
+L 273.780031 167.100874
+L 313.863454 164.253484
+L 434.113724 156.632475
+L 487.558288 120.155531
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #8c564b; stroke-linecap: square"/>
     <defs>
      <path id="m975a81c4ea" d="M -0 2
@@ -1470,37 +1470,37 @@ z
 " style="stroke: #8c564b; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#m975a81c4ea" x="86.724055" y="261.485862" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="86.724055" y="258.676323" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="113.446338" y="243.98577" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="113.446338" y="242.547651" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="113.446338" y="240.632503" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="166.890902" y="219.871071" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="166.890902" y="201.921144" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="193.613184" y="212.304587" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="200.293755" y="195.539941" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="247.057749" y="191.957542" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="273.780031" y="167.109016" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="313.863454" y="164.261813" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="434.113724" y="156.641305" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="487.558288" y="120.16676" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="86.724055" y="261.483929" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="86.724055" y="258.674205" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="113.446338" y="243.982686" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="113.446338" y="242.544472" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="113.446338" y="240.629198" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="166.890902" y="219.8664" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="166.890902" y="201.915292" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="193.613184" y="212.299418" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="200.293755" y="195.53367" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="247.057749" y="191.951035" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="273.780031" y="167.100874" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="313.863454" y="164.253484" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="434.113724" y="156.632475" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="487.558288" y="120.155531" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_110">
-    <path d="M 86.724055 283.774973
-L 86.724055 281.352487
-L 113.446338 266.956379
-L 113.446338 266.402917
-L 113.446338 265.503521
-L 166.890902 235.146245
-L 166.890902 226.000849
-L 193.613184 225.077587
-L 200.293755 210.129437
-L 247.057749 200.317989
-L 273.780031 186.009493
-L 313.863454 179.813585
-L 434.113724 166.959713
-L 487.558288 139.230419
+    <path d="M 86.724055 283.774506
+L 86.724055 281.351861
+L 113.446338 266.954805
+L 113.446338 266.401307
+L 113.446338 265.501852
+L 166.890902 235.142579
+L 166.890902 225.996582
+L 193.613184 225.073259
+L 200.293755 210.124126
+L 247.057749 200.312032
+L 273.780031 186.002595
+L 313.863454 179.80628
+L 434.113724 166.951562
+L 487.558288 139.220443
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #e377c2; stroke-linecap: square"/>
     <defs>
      <path id="mbe61f33afa" d="M -0.666667 2
@@ -1519,32 +1519,32 @@ z
 " style="stroke: #e377c2; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#mbe61f33afa" x="86.724055" y="283.774973" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="86.724055" y="281.352487" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="113.446338" y="266.956379" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="113.446338" y="266.402917" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="113.446338" y="265.503521" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="166.890902" y="235.146245" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="166.890902" y="226.000849" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="193.613184" y="225.077587" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="200.293755" y="210.129437" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="247.057749" y="200.317989" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="273.780031" y="186.009493" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="313.863454" y="179.813585" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="434.113724" y="166.959713" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="487.558288" y="139.230419" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="86.724055" y="283.774506" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="86.724055" y="281.351861" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="113.446338" y="266.954805" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="113.446338" y="266.401307" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="113.446338" y="265.501852" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="166.890902" y="235.142579" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="166.890902" y="225.996582" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="193.613184" y="225.073259" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="200.293755" y="210.124126" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="247.057749" y="200.312032" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="273.780031" y="186.002595" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="313.863454" y="179.80628" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="434.113724" y="166.951562" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="487.558288" y="139.220443" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_111">
-    <path d="M 86.724055 248.396747
-L 86.724055 242.975284
-L 113.446338 225.495069
-L 113.446338 224.521185
-L 113.446338 217.522472
-L 166.890902 188.704405
-L 166.890902 168.742144
-L 193.613184 148.209123
-L 200.293755 147.03965
+    <path d="M 86.724055 248.393953
+L 86.724055 242.972133
+L 113.446338 225.490768
+L 113.446338 224.51682
+L 113.446338 217.517647
+L 166.890902 188.697684
+L 166.890902 168.73411
+L 193.613184 148.199738
+L 200.293755 147.030188
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
     <defs>
      <path id="m579b7dcafa" d="M 0 -2
@@ -1561,23 +1561,23 @@ z
 " style="stroke: #ff7f0e; stroke-linejoin: bevel"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#m579b7dcafa" x="86.724055" y="248.396747" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="86.724055" y="242.975284" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="113.446338" y="225.495069" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="113.446338" y="224.521185" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="113.446338" y="217.522472" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="166.890902" y="188.704405" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="166.890902" y="168.742144" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="193.613184" y="148.209123" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="200.293755" y="147.03965" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="86.724055" y="248.393953" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="86.724055" y="242.972133" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="113.446338" y="225.490768" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="113.446338" y="224.51682" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="113.446338" y="217.517647" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="166.890902" y="188.697684" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="166.890902" y="168.73411" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="193.613184" y="148.199738" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="200.293755" y="147.030188" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_112">
-    <path d="M 86.724055 212.906973
-L 86.724055 208.854002
-L 113.446338 101.141725
-L 113.446338 85.075599
-L 113.446338 83.285781
+    <path d="M 86.724055 212.901845
+L 86.724055 208.848607
+L 113.446338 101.129244
+L 113.446338 85.062061
+L 113.446338 83.272126
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #bcbd22; stroke-linecap: square"/>
     <defs>
      <path id="m6a669b47a0" d="M 0 -2
@@ -1590,11 +1590,11 @@ z
 " style="stroke: #bcbd22; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#m6a669b47a0" x="86.724055" y="212.906973" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="86.724055" y="208.854002" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="113.446338" y="101.141725" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="113.446338" y="85.075599" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="113.446338" y="83.285781" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="86.724055" y="212.901845" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="86.724055" y="208.848607" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="113.446338" y="101.129244" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="113.446338" y="85.062061" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="113.446338" y="83.272126" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
@@ -2193,7 +2193,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_21">
-   <!-- cutoff 10.0s; source newest-per-system across 60 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 61 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2300,7 +2300,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-19" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-13" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-swinnerton-dyer.svg
+++ b/reports/figures/hexbz-runtime-degree-swinnerton-dyer.svg
@@ -1363,21 +1363,21 @@ z
     </g>
    </g>
    <g id="line2d_105">
-    <path d="M 86.724055 283.553365
-L 86.724055 282.927226
-L 99.654192 256.743874
-L 99.654192 256.394626
-L 99.654192 255.82112
-L 125.514465 219.486097
-L 125.514465 217.206531
-L 125.514465 216.883272
-L 177.235011 167.762379
-L 177.235011 166.204273
-L 177.235011 161.427909
-L 280.676104 134.831193
-L 280.676104 131.953564
-L 280.676104 131.146753
-L 487.558288 87.940885
+    <path d="M 86.724055 283.295603
+L 86.724055 283.044372
+L 99.654192 255.605932
+L 99.654192 255.511407
+L 99.654192 255.250993
+L 125.514465 218.731694
+L 125.514465 216.540782
+L 125.514465 216.254456
+L 177.235011 166.295033
+L 177.235011 164.938718
+L 177.235011 160.243487
+L 280.676104 133.598349
+L 280.676104 130.936291
+L 280.676104 130.19609
+L 487.558288 87.187475
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1393,21 +1393,21 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="283.553365" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="282.927226" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.654192" y="256.743874" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.654192" y="256.394626" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.654192" y="255.82112" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="125.514465" y="219.486097" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="125.514465" y="217.206531" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="125.514465" y="216.883272" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="177.235011" y="167.762379" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="177.235011" y="166.204273" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="177.235011" y="161.427909" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="280.676104" y="134.831193" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="280.676104" y="131.953564" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="280.676104" y="131.146753" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="87.940885" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="283.295603" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="283.044372" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.654192" y="255.605932" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.654192" y="255.511407" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.654192" y="255.250993" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="125.514465" y="218.731694" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="125.514465" y="216.540782" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="125.514465" y="216.254456" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="177.235011" y="166.295033" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="177.235011" y="164.938718" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="177.235011" y="160.243487" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="280.676104" y="133.598349" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="280.676104" y="130.936291" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="280.676104" y="130.19609" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="87.187475" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_106">
@@ -2217,7 +2217,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 60 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 61 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2324,7 +2324,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-19" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-13" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-wilkinson.svg
+++ b/reports/figures/hexbz-runtime-degree-wilkinson.svg
@@ -1298,21 +1298,21 @@ z
     </g>
    </g>
    <g id="line2d_99">
-    <path d="M 86.724055 267.694652
-L 102.140757 257.891212
-L 117.557458 248.007904
-L 132.974159 228.206316
-L 148.39086 221.097371
-L 163.807562 212.011395
-L 179.224263 205.026472
-L 194.640964 196.051081
-L 210.057666 189.2033
-L 240.891068 178.072466
-L 271.724471 167.90855
-L 302.557873 162.146643
-L 364.224678 154.163911
-L 425.891483 140.631643
-L 487.558288 133.859165
+    <path d="M 86.724055 269.56158
+L 102.140757 257.326321
+L 117.557458 247.894992
+L 132.974159 228.436502
+L 148.39086 221.069395
+L 163.807562 212.556219
+L 179.224263 205.071039
+L 194.640964 195.91003
+L 210.057666 189.076952
+L 240.891068 177.987035
+L 271.724471 167.740028
+L 302.557873 162.039684
+L 364.224678 154.125151
+L 425.891483 140.555623
+L 487.558288 133.913625
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1328,21 +1328,21 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="267.694652" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="102.140757" y="257.891212" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="248.007904" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="132.974159" y="228.206316" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="221.097371" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="163.807562" y="212.011395" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="205.026472" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="194.640964" y="196.051081" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="189.2033" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="178.072466" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="167.90855" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="162.146643" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="154.163911" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="425.891483" y="140.631643" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="133.859165" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="269.56158" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="102.140757" y="257.326321" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="247.894992" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="132.974159" y="228.436502" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="221.069395" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="163.807562" y="212.556219" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="205.071039" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="194.640964" y="195.91003" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="189.076952" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="177.987035" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="167.740028" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="162.039684" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="154.125151" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="425.891483" y="140.555623" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="133.913625" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_100">
@@ -2168,7 +2168,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_20">
-   <!-- cutoff 10.0s; source newest-per-system across 60 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 61 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2305,7 +2305,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-19" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-13" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/hex-bareiss-performance.md
+++ b/reports/hex-bareiss-performance.md
@@ -55,10 +55,21 @@ Five-repeat medians on the same deterministic
 | 256 | 263.939 ms | 148.041 ms | 0.561x | 1.02x |
 | 384 | 825.551 ms | 512.178 ms | 0.620x | 1.02x |
 
-Both required rungs pass the no-regression ceiling. An additional same-binary
-comparison through a deliberately unspecialized quotient value was slower;
-that check confirms why the public `Int` specialization and its direct-call
-code-generation check are part of this gate.
+Both required rungs pass the no-regression ceiling.
+
+The SPEC's same-binary A/B comparison measures the retained `bareiss` entry
+against `bareissWith Hex.exactDiv`. Five repeats were pinned to verified-idle
+CPU 2 on `chungus2`; output hashes agreed at both rungs.
+
+| n | direct `Int` specialization | `bareissWith Hex.exactDiv` | generic/direct |
+|---:|---:|---:|---:|
+| 256 | 150.466 ms | 259.076 ms | 1.722x |
+| 384 | 523.082 ms | 919.823 ms | 1.758x |
+
+`Hex.exactDiv` is the guarded quotient derived from ordinary integer division,
+whereas the retained specialization reaches `lean_int_div_exact` directly.
+The A/B result records the material reason the direct-call code-generation
+check is part of the no-regression gate.
 
 ## Comparator Ratios
 

--- a/reports/hex-bareiss-performance.md
+++ b/reports/hex-bareiss-performance.md
@@ -38,6 +38,28 @@ covering both the magnitude and the sign of the determinant (Hex's row-pivoted
 Bareiss tracks the swap permutation parity; FLINT's multimodular CRT returns the
 signed determinant in the same convention).
 
+### Generic-coefficient regression gate
+
+The generic coefficient implementation retains `bareiss` as an `Int`
+specialization of `bareissWith`. The specialization annotations propagate the
+fixed exact quotient into the inner loop: generated C for the benchmark calls
+`lean_int_div_exact` directly and contains no closure application at the
+division site.
+
+Five-repeat medians on the same deterministic
+`structured-bareiss-determinant` inputs compared this branch with
+`origin/main` (`32ac5850a`). The observed determinant hashes agreed.
+
+| n | `origin/main` | generic branch | branch/base | limit |
+|---:|---:|---:|---:|---:|
+| 256 | 263.939 ms | 148.041 ms | 0.561x | 1.02x |
+| 384 | 825.551 ms | 512.178 ms | 0.620x | 1.02x |
+
+Both required rungs pass the no-regression ceiling. An additional same-binary
+comparison through a deliberately unspecialized quotient value was slower;
+that check confirms why the public `Int` specialization and its direct-call
+code-generation check are part of this gate.
+
 ## Comparator Ratios
 
 Input family `structured-bareiss-determinant`, declared complexity `n³`. Hex's

--- a/reports/hexbz-factor-sweep.md
+++ b/reports/hexbz-factor-sweep.md
@@ -6,7 +6,7 @@ algorithm variants.
 ## Systems
 
 - `hex-factor`: public Hex production factorization at clean revision
-  `7425e083`
+  `7bcb3861`
 - `flint`: python-flint 0.9.0
 - `pari`: PARI/GP 2.17.2 through cypari2 2.2.4
 - `ntl`: NTL 11.6.0 `ZZXFactoring`
@@ -22,7 +22,7 @@ session and Haskell-export builds completed before timed calls.
 
 - Host: `chungus2`, AMD EPYC 9455, Linux x86-64
 - CPU placement: harness and each service pinned to one core. The committed
-  external record used CPU 0; the current Hex record used verified-idle CPU 19.
+  external record used CPU 0; the current Hex record used verified-idle CPU 1.
   Other work shares this host, so regeneration selects a verified-idle core
   rather than assuming that CPU 0 is free; record the chosen core with any new
   result. The CPU 0/70 control in
@@ -46,7 +46,7 @@ session and Haskell-export builds completed before timed calls.
 - Cross-check: committed expected factor degrees where available, pairwise
   agreement otherwise
 
-The per-system protocol overheads were 19.148 us for Hex, 15.493 us for FLINT,
+The per-system protocol overheads were 21.933 us for Hex, 15.493 us for FLINT,
 11.027 us for NTL, 18.006 us for PARI, 18.628 us for Isabelle BZ, and 18.848 us
 for Isabelle LLL. Reported service times do not subtract them.
 
@@ -54,9 +54,9 @@ for Isabelle LLL. Reported service times do not subtract them.
 
 The plotting tool selects the newest valid record for each system:
 
-- `reports/bench-results/hexbz-factor-sweep-7425e083-hex-chungus2-cpu19.json`
+- `reports/bench-results/hexbz-factor-sweep-7bcb3861-chungus2.json`
   supplies Hex; SHA-256
-  `3c166d993e7847bac66667338407630d273e7d015472f09968719484e71bcef0`.
+  `d7c7f2876991bd5cc33f878df834d7f8e3821c8dc30264dff13c6f511e79d06f`.
 - `reports/bench-results/hexbz-factor-sweep-aa68c920-chungus2.json`
   supplies FLINT, NTL, PARI, Isabelle BZ, and Isabelle LLL; SHA-256
   `4de27e389d738abc1e878f0be273485c3723216211a101c3eba55860e7b8a242`.
@@ -74,7 +74,7 @@ above. All answering systems agree.
 
 | System | Answered | Timed out | Median | p90 | Slowest answer |
 |---|---:|---:|---:|---:|---:|
-| Hex public factorization | 383 | 9 | 267.797 us | 6.546 ms | 3.793 s |
+| Hex public factorization | 383 | 9 | 275.158 us | 6.603 ms | 3.815 s |
 | FLINT 0.9.0 | 391 | 1 | 60.089 us | 1.139 ms | 1.241 s |
 | PARI/GP 2.17.2 | 391 | 1 | 65.687 us | 1.008 ms | 960.815 ms |
 | NTL 11.6.0 | 391 | 1 | 88.160 us | 2.365 ms | 1.305 s |

--- a/reports/hexbz-factor-sweep.md
+++ b/reports/hexbz-factor-sweep.md
@@ -6,7 +6,7 @@ algorithm variants.
 ## Systems
 
 - `hex-factor`: public Hex production factorization at clean revision
-  `7bcb3861`
+  `62d17719`
 - `flint`: python-flint 0.9.0
 - `pari`: PARI/GP 2.17.2 through cypari2 2.2.4
 - `ntl`: NTL 11.6.0 `ZZXFactoring`
@@ -54,7 +54,7 @@ for Isabelle LLL. Reported service times do not subtract them.
 
 The plotting tool selects the newest valid record for each system:
 
-- `reports/bench-results/hexbz-factor-sweep-7bcb3861-chungus2.json`
+- `reports/bench-results/hexbz-factor-sweep-62d17719-chungus2.json`
   supplies Hex; SHA-256
   `d7c7f2876991bd5cc33f878df834d7f8e3821c8dc30264dff13c6f511e79d06f`.
 - `reports/bench-results/hexbz-factor-sweep-aa68c920-chungus2.json`

--- a/scripts/release/check_released_manifest.py
+++ b/scripts/release/check_released_manifest.py
@@ -324,11 +324,7 @@ def main() -> int:
     # were already published before this rule existed and are grandfathered at
     # the phase they had then: each may only move up (a regression fails), no
     # library may join this list, and an entry leaves it by reaching Phase 7.
-    prepublished_floor = {
-        "HexRowReduceMathlib": 5,
-        "HexDeterminantMathlib": 5,
-        "HexBareissMathlib": 5,
-    }
+    prepublished_floor = {}
     graduated = sorted(
         lib for lib in prepublished_floor
         if lib in libraries and libraries[lib].done_through >= 7


### PR DESCRIPTION
Closes #9656.

## What changed

- generalizes the executable Bareiss state/data/loop surface over a coefficient type and caller-supplied exact quotient
- proves the generic Bareiss/Hex determinant and Bareiss/Mathlib determinant correspondences over commutative rings with decidable equality and exact right cancellation
- preserves the established integer entry points and downstream theorem signatures
- completes the Phase 6 API, import, linter, docstring, dead-surface, trust, DAG, and computational-owner audit
- adds substantive Mathlib correspondence documentation and validates all three README quickstarts/manual chapters
- advances HexRowReduceMathlib, HexDeterminantMathlib, and HexBareissMathlib independently through Phase 7

## Integer performance contract

The retained Int specialization compiles its inner update to a direct lean_int_div_exact call, with no quotient-closure application.

Five-repeat medians on structured-bareiss-determinant:

| n | origin/main baseline | branch | branch/base |
|---:|---:|---:|---:|
| 256 | 263.939 ms | 148.041 ms | 0.561x |
| 384 | 825.551 ms | 512.178 ms | 0.620x |

Both are below the required 1.02 ceiling and result hashes match.

## Verification

- lake build HexRowReduceMathlib HexDeterminantMathlib HexBareissMathlib HexManual
- lake build HexBareiss.Conformance hexbareiss_bench
- lake exe runLinter --no-build HexRowReduceMathlib HexDeterminantMathlib HexBareissMathlib
- all three README quickstarts compiled verbatim
- Matrix, determinant, and all Lean-side Bareiss performance verification targets
- DAG, Phase 4, Phase 7, Mathlib-free bench, manual-split, release-manifest, and published trust-surface checks

The full local Bareiss registry also includes external FLINT comparators; those require python-flint, which is unavailable in this worker environment. CI supplies the configured external dependency.