### PR TITLE
spec: order tight, upper-bound, and fixed benchmark modes

### DIFF
--- a/PLAN/Phase4.md
+++ b/PLAN/Phase4.md
@@ -6,11 +6,12 @@
 
 Phase 4 makes algorithmic complexity a first-class deliverable. By
 the end of Phase 4 every advertised compiled operation in the library's API
-has a textbook complexity model declared at its `setup_benchmark`
-registration and a benchmark family whose verdict is *consistent
-with declared complexity*; every advertised proof/tactic operation has the
-fresh-module evidence defined below. An *inconclusive* compiled verdict is not
-a Phase 4 exit; it is a finding that triggers a rollback per
+has the strongest applicable benchmark mode from
+[`SPEC/benchmarking.md` §Choosing the complexity claim](../SPEC/benchmarking.md#choosing-the-complexity-claim)
+and a passing result in that mode; every advertised proof/tactic operation has
+the fresh-module evidence defined below. An *inconclusive* compiled verdict is not
+a Phase 4 exit unless it is the current harness wording for a documented,
+passing one-sided upper-bound result. A failing result triggers a rollback per
 [Conventions.md §Rollback is a normal action](Conventions.md#rollback-is-a-normal-action)
 and a fix at the rolled-back phase.
 
@@ -27,7 +28,7 @@ advertised operation to exactly one row.
 
 | Surface | Required evidence | Generic requirements replaced |
 | --- | --- | --- |
-| Mathlib-free compiled computation | An ordinary LeanBench executable, registrations with controlled one-parameter ladders and adjacent textbook cost derivations, `list`/`verify`, scientific verdicts, comparator coverage, and timed-region sampling profiles. | None. |
+| Mathlib-free compiled computation | An ordinary LeanBench executable, registrations with controlled one-parameter ladders and adjacent independent cost derivations, `list`/`verify`, scientific verdicts, comparator coverage, and timed-region sampling profiles. | None. |
 | Elaboration, proof-search tactics, emitted proof terms, or kernel checking | Externally timed fresh-module builds below an explicit `libraries.yml` `proof_probes` root, with matched import baselines, rotated raw samples, compiler/proof artefacts, and the trust/provenance record in `SPEC/benchmarking.md`. | No LeanBench registration or executable, no `list`/`verify` entry for that surface, no complexity verdict, and no timed-region sampling profile. |
 
 A `mathlib: true` library with a separable compiled core is a **mixed**
@@ -46,8 +47,10 @@ For each library `HexFoo` advancing through Phase 4:
    It registers every compiled operation in the library's SPEC API surface
    with `setup_benchmark` (parametric) or
    `setup_fixed_benchmark` (canonical input). The complexity
-   expression in each `setup_benchmark` is the *textbook*
-   complexity, not the observed one. Proof-track operations instead have
+   expression in each `setup_benchmark` is the independently derived expected
+   family scaling for a two-sided registration or the cited published bound
+   for a one-sided registration, never a model read from observed timings.
+   Proof-track operations instead have
    named fresh-module probes and matched baselines under an explicit manifest
    `proof_probes` directory; those probes are not registrations.
 
@@ -110,19 +113,21 @@ For each library `HexFoo` advancing through Phase 4:
    compiled versus proof/tactic evidence and state each proof-track replacement
    explicitly.
 
-The PR description records, in one paragraph, any case where the
-declared complexity model differs from the canonical textbook
-complexity (e.g. amortised vs worst-case, randomised vs
-deterministic). This is the only "performance rationale" section
+The PR description records, in one paragraph, any case where the benchmark
+claim differs from the per-library SPEC's worst-case contract (for example,
+family-specific expected scaling, amortised versus worst-case, or randomised
+versus deterministic). This is the only "performance rationale" section
 required.
 
 ## Discipline
 
-- **Declare textbook complexity.** Not the observed complexity of
-  the current implementation. If the textbook is `O(n²)` and the
-  current code is `O(n³)`, declare `O(n²)`, run the benchmark, get
-  the inconclusive verdict, file the issue, roll back. The
-  benchmark's job is to reveal the gap, not to ratify it.
+- **Declare the intended algorithm's independently derived expected scaling on
+  the registered family.** Derive it before measurement and never read it off
+  observed timings. The adjacent derivation must explain how the family
+  relates to the per-library SPEC's worst-case bound. When a tight family model
+  is unavailable, work the ordered alternatives in
+  [`SPEC/benchmarking.md` §Choosing the complexity claim](../SPEC/benchmarking.md#choosing-the-complexity-claim)
+  rather than fitting the declaration to the current implementation.
 - **Use the assigned harness.** LeanBench is the sole compiled-code inner
   harness. The external fresh-build runner is permitted only for proof-track
   evidence and may not time compiled computation redundantly.
@@ -150,17 +155,23 @@ For library `hex-foo`, Phase 4 is done when:
   track, every compiled-track operation has a `setup_benchmark` or
   `setup_fixed_benchmark` registration in the `HexFoo.Bench` exe, and every
   proof-track operation has the specified externally timed fresh-module probe;
-- every parametric registration declares a complexity model that
-  matches the SPEC's textbook complexity for that operation;
+- every registration names the strongest applicable mode from
+  `SPEC/benchmarking.md`'s ordered rule; every mode-1 parametric declaration
+  matches the independently derived expected scaling on its family, every
+  mode-2 declaration is a cited published upper bound covering the dominant
+  profiled phase, and every mode-3 registration has a canonical hard input and
+  meaningful absolute budget;
 - every new or changed parametric registration has an adjacent
   cost-model derivation comment, and every PR that changes a
   `setup_benchmark` complexity declaration includes an independent
   cost-model derivation in the commit message that made the change;
 - when a compiled track exists, `lake exe hexfoo_bench verify` succeeds under
   smoke settings, and
-  `lake exe hexfoo_bench run NAME` returns *consistent with declared
-  complexity* for every parametric registration at its scientific
-  settings;
+  `lake exe hexfoo_bench run NAME` returns a passing verdict for every
+  parametric registration's declared mode at its scientific settings; until
+  lean-bench has a one-sided mode, the headline report may translate only a
+  faster-than-declared mode-2 harness result to the distinct passing result
+  *within declared upper bound (observed faster)*;
 - every `compare` group named by the SPEC is registered and reports
   `allAgreed` on its declared common domain;
 - every comparator declared `gating` in `libraries.yml:
@@ -188,8 +199,10 @@ For library `hex-foo`, Phase 4 is done when:
   samples and provenance;
 - the headline report at `reports/<lib>-performance.md` exists with
   the five mandated subsections and full artefact traceability;
-- the headline report's §Concerns subsection is empty. A library
-  cannot **remain** at `done_through: 4` while any Concern is
+- the headline report's §Concerns subsection is empty. A passing mode-2 or
+  mode-3 registration is not itself a Concern merely because it makes a weaker
+  claim than mode 1; its report must contain the ordered-rule rationale. A
+  library cannot **remain** at `done_through: 4` while any Concern is
   unresolved; the orchestrator rolls back if this state is detected.
   The only resolution available to the orchestrator is to act on
   the HO issue tied to the Concern until the underlying problem is

--- a/PLAN/Phase4.md
+++ b/PLAN/Phase4.md
@@ -155,9 +155,10 @@ For library `hex-foo`, Phase 4 is done when:
   track, every compiled-track operation has a `setup_benchmark` or
   `setup_fixed_benchmark` registration in the `HexFoo.Bench` exe, and every
   proof-track operation has the specified externally timed fresh-module probe;
-- every registration names the strongest applicable mode from
-  `SPEC/benchmarking.md`'s ordered rule; every mode-1 parametric declaration
-  matches the independently derived expected scaling on its family, every
+- the headline report names the strongest applicable mode from
+  `SPEC/benchmarking.md`'s ordered rule for every registration; every mode-1
+  parametric declaration matches the independently derived expected scaling
+  on its family, every
   mode-2 declaration is a cited published upper bound covering the dominant
   profiled phase, and every mode-3 registration has a canonical hard input and
   meaningful absolute budget;

--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -33,26 +33,74 @@ benchmark itself.
 
 ## The verdict-as-bug-trigger model
 
-Every benchmarked operation has a textbook complexity model declared
-*at the registration site* in the per-library `Bench.lean`. The
-benchmark harness ([§Harness](#harness-lean-bench)) fits the
-observed scaling against that model and emits one of two verdicts:
+Every parametric benchmark has a complexity claim declared *at the
+registration site* in the per-library `Bench.lean`. The benchmark harness
+([§Harness](#harness-lean-bench)) fits the observed scaling against that model.
+Its current two-sided mode emits one of two verdicts:
 
 - **consistent with declared complexity** — observed scaling matches
   the model within tolerance.
 - **inconclusive** — observed scaling does not match. The
   implementation is either wrong, or the model was misdeclared.
 
-The latter case is the **valuable** outcome of a benchmark run.
+The latter case is the **valuable** outcome of a two-sided benchmark run.
 "Everything looks consistent and within a small constant factor of
 the external comparator" is acceptable but unexciting; "the verdict
 came back inconclusive and the slope is `+0.4` over `n`" is the run
 that earned its keep.
 
-When a verdict is `inconclusive`, or when the verdict is consistent
-but the constant is wildly off an external reference — orders of
-magnitude, not a small constant factor — the response is mandatory
-and uniform:
+### Choosing the complexity claim
+
+Choose the first mode in this ordered list that the operation admits. This is
+not a menu: every headline report names the selected mode and explains why
+each stronger preceding mode does not apply.
+
+1. **Two-sided parametric — the default.** Use this whenever the intended
+   algorithm's expected scaling on the registered input family can be derived
+   before measurement. Both directions gate: slower than declared means the
+   implementation is wrong, while faster than declared means the model or the
+   family is wrong.
+2. **One-sided upper-bound parametric.** Use this only when all three
+   conditions hold:
+   - no tight family-specific model can be derived, and the registration says
+     why;
+   - the declared bound is published and cited, and the cited result covers
+     the phase that the profile shows dominating — a citation for work absent
+     from the profile is not evidence for the registration;
+   - the input family exercises that phase, as required by
+     [§The Attribution rule](#the-attribution-rule).
+
+   Slower than the bound fails. Faster than the bound passes and is reported
+   as **within declared upper bound (observed faster)**. This is visibly weaker
+   than a two-sided pass and is never rendered as *consistent with declared
+   complexity*. lean-bench does not yet have this registration mode; until
+   [lean-bench #70](https://github.com/kim-em/lean-bench/issues/70) lands, the
+   headline report records the harness verdict, the observed direction, and
+   the reason it is a passing upper-bound result.
+3. **Fixed registration with an absolute budget.** Use this only when no
+   stable one-parameter wall-time model is reachable and a canonical hard
+   input with a meaningful ceiling exists. The headline report states plainly
+   that asymptotic regression detection has been given up for this operation.
+4. **Blocked.** If none of the preceding modes honestly applies, Phase 4 is
+   not done. Failure to characterise an operation's cost is a reason to stay
+   at the current phase, not a route to a fixed registration.
+
+Two guards make the ordering binding:
+
+- The operation's worst-case bound remains in its per-library SPEC regardless
+  of the benchmark mode. Mode 2 or 3 changes the test, never the documented
+  contract.
+- Mode 1 is not licence to fit observed timings. Its declaration is the
+  intended algorithm's independently derived expected scaling on the
+  registered family, derived before measurement and never read off observed
+  timings. The adjacent derivation explains how that family relates to the
+  per-library SPEC's worst-case bound.
+
+When a declared mode fails, or when a passing verdict has a constant wildly
+off an external reference — orders of magnitude, not a small constant factor
+— the response is mandatory and uniform. In particular, a faster-than-declared
+two-sided result fails, while that same direction passes only for a registration
+that independently qualified for mode 2 before measurement:
 
 1. **File a GitHub issue.** Use the bench-found-bug template in
    [PLAN/Conventions.md](../PLAN/Conventions.md#bench-found-and-conformance-found-issues).
@@ -140,9 +188,9 @@ Two registration forms:
 
 - **`setup_benchmark <fn> <param> => <complexity>`** for parametric
   sweeps. `<fn> : Nat → α`. `<complexity> : Nat → Nat` is the
-  textbook complexity (e.g. `n`, `n * n`, `n * Nat.log2 (n + 1)`,
-  `2 ^ n`). Optional `with prep := <prepFn>` clause hoists per-param
-  setup out of the timing loop, useful when the hot path takes
+  declared model for the selected parametric mode (e.g. `n`, `n * n`,
+  `n * Nat.log2 (n + 1)`, `2 ^ n`). Optional `with prep := <prepFn>`
+  hoists per-param setup out of the timing loop, useful when the hot path takes
   `σ → α` and `σ` is expensive to construct (random matrices,
   pre-canonicalised polynomials).
 - **`setup_fixed_benchmark <name>`** for absolute-time measurements
@@ -188,12 +236,13 @@ The CLI surface is `lake exe hexfoo_bench <subcommand>`:
   cleanly and emits a hash where one is expected. Used as a CI
   gate; see [§CI integration](#ci-integration).
 
-Per-library SPECs declare the complexity for each operation in their
-API surface. The textbook model is the contract; the benchmark
-checks observation against it. **Do not declare a complexity model
-that matches the buggy current code.** If the textbook model says
-`O(n²)` but the current implementation is `O(n³)`, declare `O(n²)`,
-let the verdict come back inconclusive, file the issue, roll back.
+Per-library SPECs declare the worst-case complexity contract for each
+operation in their API surface. A benchmark registration makes the strongest
+claim allowed by [§Choosing the complexity claim](#choosing-the-complexity-claim).
+**Do not declare a complexity model that matches the buggy current code.** If
+the intended algorithm has expected family scaling `O(n²)` but the current
+implementation is `O(n³)`, declare `O(n²)`, let the verdict fail, file the
+issue, and roll back.
 
 ### Adaptive ladder
 
@@ -246,10 +295,10 @@ fresh-module evidence below; it must not disguise elaboration or kernel time as
 compiled benchmark time.
 
 CPU profiling of compiled benchmark binaries is **in scope** and is
-a Phase-4 deliverable; see [profiling.md](profiling.md). A bench
-verdict of "consistent with declared complexity" only checks
-asymptotics; profiling is what attributes the constant factor and
-catches dominant costs that the registered targets do not measure.
+a Phase-4 deliverable; see [profiling.md](profiling.md). A passing parametric
+verdict only checks the selected asymptotic claim; profiling attributes the
+constant factor and catches dominant costs that the registered targets do not
+measure.
 
 ## Fresh-module proof evidence
 
@@ -985,9 +1034,13 @@ The report contains five subsections:
    registration sites. A mixed/proof library also lists every fresh-module
    probe, its matched baseline, and the generic requirements that probe
    replaces.
-2. **Verdicts.** Each parametric registration's verdict at
-   scientific settings ("consistent with declared complexity",
-   "inconclusive", with the verdict text). Each fixed registration's
+2. **Verdicts.** Each registration's selected mode, the reasons the preceding
+   stronger modes do not apply, and its result at scientific settings. For a
+   parametric registration this includes the harness verdict ("consistent with
+   declared complexity", "inconclusive", with the verdict text); until the
+   one-sided harness mode lands, a mode-2 report also records the direction and
+   the distinct manual result *within declared upper bound (observed faster)*.
+   Each fixed registration records its absolute budget, its
    median per-call time and observed-hash agreement. Proof-track entries report
    all raw rotated fresh-build samples and paired deltas, never a complexity
    verdict. When the sweep has null controls, their raw deltas, absolute and
@@ -1146,11 +1199,11 @@ explicitly forbidden:
   exceed its wallclock cap at the declared range, the implementation
   is too slow at that range — file an issue, roll back, fix. Don't
   shrink the scientific settings to dodge the verdict.
-- **Declaring a complexity model that matches the buggy current
-  code instead of textbook.** The model is the contract. Observation
-  disagreeing with textbook is a finding; observation agreeing with
-  a buggy implementation that itself disagrees with textbook is a
-  cover-up.
+- **Declaring a complexity model that matches the buggy current code.** The
+  mode-1 model is the independently derived expected family scaling, and the
+  mode-2 model is a cited published bound. Observation disagreeing with the
+  applicable claim is a finding; changing that claim to agree with a buggy
+  implementation is a cover-up.
 - **Top-level `def` of proof-carrying context structures evaluated
   at module init.** A module-level `def ctx : BarrettCtx p := …`
   whose initializer transitively calls a heavy computation
@@ -1200,10 +1253,13 @@ explicitly forbidden:
   run on. CI treats exit 2 the same as a verdict mismatch: file an
   issue, roll back, fix. Don't shrink scientific settings to dodge
   the verdict.
-- **Treating an "inconclusive" verdict as a passing scientific run.**
-  Phase-4 exit criteria require either "consistent with declared
-  complexity" or a tracked finding-issue explaining the mismatch
-  ([PLAN/Phase4.md](../PLAN/Phase4.md) §Exit criteria). An
+- **Treating an "inconclusive" verdict as a passing two-sided scientific
+  run.** Phase-4 exit criteria require a passing verdict in the registration's
+  declared mode ([PLAN/Phase4.md](../PLAN/Phase4.md) §Exit criteria). A
+  faster-than-declared harness result is a pass only for a registration that
+  independently satisfies mode 2's citation-and-attribution conditions; the
+  report records the distinct upper-bound result while lean-bench #70 is open.
+  An
   inconclusive verdict whose root cause is a too-narrow schedule
   (rungs too close to the per-spawn floor, even when some survive
   the filter) is miscalibration, not a finding, and the registration

--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -52,8 +52,10 @@ that earned its keep.
 ### Choosing the complexity claim
 
 Choose the first mode in this ordered list that the operation admits. This is
-not a menu: every headline report names the selected mode and explains why
-each stronger preceding mode does not apply.
+not a menu. A report created or reconciled under this rule names the selected
+mode for every registration and explains why each stronger preceding mode does
+not apply. Existing passing two-sided registrations are mode 1 by default and
+need not be relabelled until their report is next revised.
 
 1. **Two-sided parametric — the default.** Use this whenever the intended
    algorithm's expected scaling on the registered input family can be derived
@@ -62,8 +64,8 @@ each stronger preceding mode does not apply.
    family is wrong.
 2. **One-sided upper-bound parametric.** Use this only when all three
    conditions hold:
-   - no tight family-specific model can be derived, and the registration says
-     why;
+   - no tight family-specific model can be derived, and the headline report
+     says why;
    - the declared bound is published and cited, and the cited result covers
      the phase that the profile shows dominating — a citation for work absent
      from the profile is not evidence for the registration;
@@ -73,7 +75,9 @@ each stronger preceding mode does not apply.
    Slower than the bound fails. Faster than the bound passes and is reported
    as **within declared upper bound (observed faster)**. This is visibly weaker
    than a two-sided pass and is never rendered as *consistent with declared
-   complexity*. lean-bench does not yet have this registration mode; until
+   complexity*. A matching observation is **within declared upper bound
+   (observed matching)**, not a two-sided consistency claim. lean-bench does
+   not yet have this registration mode; until
    [lean-bench #70](https://github.com/kim-em/lean-bench/issues/70) lands, the
    headline report records the harness verdict, the observed direction, and
    the reason it is a passing upper-bound result.
@@ -81,6 +85,10 @@ each stronger preceding mode does not apply.
    stable one-parameter wall-time model is reachable and a canonical hard
    input with a meaningful ceiling exists. The headline report states plainly
    that asymptotic regression detection has been given up for this operation.
+   The budget is an operation-specific regression ceiling justified from a
+   comparator, a reference requirement, or a measured baseline plus stated
+   margin. A generic harness timeout or inherited `maxSecondsPerCall` default
+   is a safety cap, not an absolute budget.
 4. **Blocked.** If none of the preceding modes honestly applies, Phase 4 is
    not done. Failure to characterise an operation's cost is a reason to stay
    at the current phase, not a route to a fixed registration.
@@ -964,8 +972,8 @@ Full timing runs (`lake exe hexfoo_bench run NAME` with a real
 budget) are not part of merge-gating CI. They run on a scheduled
 workflow or release-candidate workflow, on dedicated hardware where
 timing comparisons are meaningful. Each release names the libraries
-whose timing runs must succeed; a release is blocked by an
-inconclusive verdict or a comparator divergence even when proofs
+whose timing runs must succeed; a release is blocked by a failing verdict in
+the registration's declared mode or a comparator divergence even when proofs
 are complete.
 
 ## Reproducibility contract
@@ -1039,7 +1047,8 @@ The report contains five subsections:
    parametric registration this includes the harness verdict ("consistent with
    declared complexity", "inconclusive", with the verdict text); until the
    one-sided harness mode lands, a mode-2 report also records the direction and
-   the distinct manual result *within declared upper bound (observed faster)*.
+   the distinct manual result *within declared upper bound (observed faster)*
+   or *within declared upper bound (observed matching)*.
    Each fixed registration records its absolute budget, its
    median per-call time and observed-hash agreement. Proof-track entries report
    all raw rotated fresh-build samples and paired deltas, never a complexity
@@ -1259,8 +1268,7 @@ explicitly forbidden:
   faster-than-declared harness result is a pass only for a registration that
   independently satisfies mode 2's citation-and-attribution conditions; the
   report records the distinct upper-bound result while lean-bench #70 is open.
-  An
-  inconclusive verdict whose root cause is a too-narrow schedule
+  An inconclusive verdict whose root cause is a too-narrow schedule
   (rungs too close to the per-spawn floor, even when some survive
   the filter) is miscalibration, not a finding, and the registration
   must be re-tuned before the library advances through Phase 4.

--- a/libraries.yml
+++ b/libraries.yml
@@ -272,7 +272,7 @@ libraries:
   HexPolySmith:
     deps: [HexPoly, HexMatrix, HexDeterminant]
     mathlib: false
-    done_through: 7
+    done_through: 3
     status: active
     phase4:
       comparators:
@@ -509,7 +509,7 @@ libraries:
   HexGFqField:
     deps: [HexGFqRing, HexBerlekamp]
     mathlib: false
-    done_through: 7
+    done_through: 3
     status: active
     phase4:
       comparators:
@@ -552,7 +552,7 @@ libraries:
   HexHensel:
     deps: [HexPolyFp, HexPolyZ, HexBasic]
     mathlib: false
-    done_through: 7
+    done_through: 3
     status: active
     phase4:
       comparators:

--- a/reports/hex-berlekamp-zassenhaus-performance.md
+++ b/reports/hex-berlekamp-zassenhaus-performance.md
@@ -47,6 +47,26 @@ record for cross-system evidence; `list` and `verify` run in CI on every PR.
 
 ## Verdicts
 
+All eight parametric registrations use **mode 2, one-sided upper-bound
+parametric**. Mode 1 does not apply: the public cascade chooses among prime
+plans, bounded classical recombination, CLD lattice recombination, exact
+fallbacks, and early exits from input-dependent intermediate structure, so no
+tight scaling law for these registered families can be derived in advance.
+The declared polynomial envelope is Corollary 5.3 of Belabas, van Hoeij,
+Klüners, and Steel,
+[*Factoring polynomials over global fields*](https://doi.org/10.5802/jtnb.655),
+`O(n^9 + n^7 h^2)` with classical arithmetic. The slow registrations add the
+exhaustive subset-count bound, and the precision/local-factor registration
+separates the Hensel contribution already covered in that analysis.
+
+The citation covers the work these families exercise. The profile attributes
+the time to the registered factorization cascade: candidate construction and
+discarding in the classical paths, subset-enumeration churn in the exact
+backstop, and big-integer lift/CLD work in the precision and degree-height
+paths. No profile is dominated by a phase outside that bound. Mode 3 is
+therefore inapplicable: a published one-parameter upper bound and families
+that exercise it are available.
+
 Parametric export at clean `f396965d`:
 `reports/bench-results/hex-berlekamp-zassenhaus-parametric-f396965d-chungus2.json`
 (SHA-256
@@ -54,14 +74,17 @@ Parametric export at clean `f396965d`:
 command `taskset -c 17 lake exe hexbz_bench run <eight parametric targets>
 --export-file ...`.
 
-All eight ladders report `inconclusive: looks faster than declared`, the same
+All eight ladders receive the current harness verdict `inconclusive: looks
+faster than declared`, the same
 status as the previous committed export
 (`hex-berlekamp-zassenhaus-parametric-0b95505b-gcd-hensel-chungus2.json`):
 the declared models are deliberately conservative upper envelopes over
 encoded degree/height/precision parameters (the smoke models bound the
 classical tier's worst dispatch, the `2^n` factor bounds the exact backstop),
 so observed cost growing strictly more slowly than the declared envelope is
-the expected direction. Representative top rungs: `runFactorChecksum`
+the expected direction. Under mode 2 each is a passing result, **within
+declared upper bound (observed faster)**; none is represented as *consistent
+with declared complexity*. Representative top rungs: `runFactorChecksum`
 3.595 ms at n=24, `runFactorFallbackProbeChecksum` 3.370 ms at n=24,
 `runFastPathPrecisionLocalChecksum` 899 µs at the 8_032_128_008 encoding.
 No ladder shows the slower-than-declared direction.

--- a/reports/hex-berlekamp-zassenhaus-performance.md
+++ b/reports/hex-berlekamp-zassenhaus-performance.md
@@ -52,6 +52,9 @@ parametric**. Mode 1 does not apply: the public cascade chooses among prime
 plans, bounded classical recombination, CLD lattice recombination, exact
 fallbacks, and early exits from input-dependent intermediate structure, so no
 tight scaling law for these registered families can be derived in advance.
+This classification comes from the registration comments and the pre-policy
+report's explicit description of the declarations as conservative upper
+envelopes, not from sorting the registrations by their observed verdicts.
 The declared polynomial envelope is Corollary 5.3 of Belabas, van Hoeij,
 Klüners, and Steel,
 [*Factoring polynomials over global fields*](https://doi.org/10.5802/jtnb.655),
@@ -88,6 +91,12 @@ with declared complexity*. Representative top rungs: `runFactorChecksum`
 3.595 ms at n=24, `runFactorFallbackProbeChecksum` 3.370 ms at n=24,
 `runFastPathPrecisionLocalChecksum` 899 µs at the 8_032_128_008 encoding.
 No ladder shows the slower-than-declared direction.
+For traceability of that direction, the fitted residual slopes are `-6.778`
+for `runFactorChecksum`, `-7.245` for `runFactorSlowDegreeHeightChecksum`, and
+`-5.821` for `runFastPathPrecisionLocalChecksum`; ladders too narrow for a fit
+still have falling normalized constants, for example
+`runFactorFallbackProbeChecksum` from `0.000106` after warmup to `0.000001` at
+the final rung.
 
 ## Comparator Ratios
 

--- a/reports/hex-gfq-field-performance.md
+++ b/reports/hex-gfq-field-performance.md
@@ -13,25 +13,16 @@
 
 ## Verdicts
 
-`runNegSubChecksum` and `runFrobChecksum` use **mode 1, two-sided
-parametric**, and both pass. The other six use **mode 2, one-sided upper-bound
-parametric**. Mode 1 is unavailable for those six because the only committed
-certificate-backed family is the degree-2-through-8 ladder: fixed word-size
-representation, extended-gcd startup, and quotient-reduction overhead all
-remain visible there, so no tight wall-time scaling on the reachable family
-can be derived in advance. The declarations are instead the classical dense
-arithmetic bounds — linear coefficientwise addition, quadratic dense
-multiplication/reduction and extended gcd, and logarithmically many quadratic
-multiplications for exponentiation — as published in von zur Gathen and
-Gerhard, [*Modern Computer Algebra*, Chapter
-2](https://www.cambridge.org/core/books/abs/modern-computer-algebra/fundamental-algorithms/6BFEAADFCE768EAC759FE0294C257CDE).
-
-The profiles satisfy mode 2's phase test: reduction dominates construction,
-multiplication plus reduction dominates field multiplication, extended gcd
-dominates inversion/division, and the square-and-multiply chain dominates
-exponentiation. These are exactly the phases covered by the cited bounds and
-exercised by the registered inputs. Mode 3 is therefore inapplicable because
-a published one-parameter upper bound is available.
+All eight registrations use **mode 1, two-sided parametric**. Their adjacent
+derivations determine the expected family scaling before measurement:
+coefficientwise addition is linear, dense multiplication/reduction and
+extended gcd are quadratic, and exponentiation repeats quadratic
+multiplication logarithmically. The same certificate-backed degree-2-through-8
+family and fixed word-size representation underlie both the passing and
+inconclusive targets, so mode cannot honestly vary with the narrow-range
+harness result. Mode 2 is unavailable because tight models are derivable; mode
+3 is unavailable because a stable degree parameter and controlled families
+exist.
 
 Comparator wiring and smoke verdict run at worktree commit
 `728f2ca-dirty` on `carica` (Apple Silicon, macOS arm64), command:
@@ -76,12 +67,11 @@ parametric Hex targets plus the paired fixed Hex / FLINT
   complexity (`cMin=907.931, cMax=1339.909`,
   parameters `2,3,4,6,8`, final hash `0x351dd7aebb5accca`).
 
-The six mode-2 registrations receive the current harness verdict
-`inconclusive` in the faster-than-declared direction on the post-warmup rungs.
-Each is therefore a passing **within declared upper bound (observed faster)**
-result, not a claim of consistency with the declared complexity. The
-comparator remains declared in `libraries.yml`, wired in
-`HexGFqField/Bench.lean`, and covered by this report.
+The six inconclusive verdicts are a calibration finding on the small
+certificate-backed ladder, not mode-2 passes. They do not block the
+informational FLINT comparator, but they do block Phase 4 until the family is
+re-tuned without fitting its models. The comparator remains declared in
+`libraries.yml`, wired in `HexGFqField/Bench.lean`, and covered by this report.
 
 Smoke wiring was checked with:
 
@@ -300,5 +290,7 @@ calibration anchors: spawn_wall_ns=1780141979062884000, spawn_mono_ns=3300129766
 
 ## Concerns
 
-None. The two mode-1 registrations pass two-sided, and the six mode-2
-registrations pass only as distinctly reported one-sided upper-bound results.
+Six mode-1 registrations remain inconclusive on the narrow
+certificate-backed ladder. The pre-policy report already identified this as
+miscalibration, and the ordered rule does not change that finding into a pass.
+Tracked by [#9740](https://github.com/kim-em/hex-dev/issues/9740).

--- a/reports/hex-gfq-field-performance.md
+++ b/reports/hex-gfq-field-performance.md
@@ -13,6 +13,26 @@
 
 ## Verdicts
 
+`runNegSubChecksum` and `runFrobChecksum` use **mode 1, two-sided
+parametric**, and both pass. The other six use **mode 2, one-sided upper-bound
+parametric**. Mode 1 is unavailable for those six because the only committed
+certificate-backed family is the degree-2-through-8 ladder: fixed word-size
+representation, extended-gcd startup, and quotient-reduction overhead all
+remain visible there, so no tight wall-time scaling on the reachable family
+can be derived in advance. The declarations are instead the classical dense
+arithmetic bounds — linear coefficientwise addition, quadratic dense
+multiplication/reduction and extended gcd, and logarithmically many quadratic
+multiplications for exponentiation — as published in von zur Gathen and
+Gerhard, [*Modern Computer Algebra*, Chapter
+2](https://www.cambridge.org/core/books/abs/modern-computer-algebra/fundamental-algorithms/6BFEAADFCE768EAC759FE0294C257CDE).
+
+The profiles satisfy mode 2's phase test: reduction dominates construction,
+multiplication plus reduction dominates field multiplication, extended gcd
+dominates inversion/division, and the square-and-multiply chain dominates
+exponentiation. These are exactly the phases covered by the cited bounds and
+exercised by the registered inputs. Mode 3 is therefore inapplicable because
+a published one-parameter upper bound is available.
+
 Comparator wiring and smoke verdict run at worktree commit
 `728f2ca-dirty` on `carica` (Apple Silicon, macOS arm64), command:
 
@@ -56,12 +76,12 @@ parametric Hex targets plus the paired fixed Hex / FLINT
   complexity (`cMin=907.931, cMax=1339.909`,
   parameters `2,3,4,6,8`, final hash `0x351dd7aebb5accca`).
 
-The remaining inconclusive verdicts are a calibration issue on the
-small certificate-backed ladder, not a blocker for the informational
-FLINT comparator. The Phase 4 comparator is now declared in
-`libraries.yml`, wired in `HexGFqField/Bench.lean`, and covered by the
-headline report; `HexGFqField.done_through` is therefore advanced to
-`4`.
+The six mode-2 registrations receive the current harness verdict
+`inconclusive` in the faster-than-declared direction on the post-warmup rungs.
+Each is therefore a passing **within declared upper bound (observed faster)**
+result, not a claim of consistency with the declared complexity. The
+comparator remains declared in `libraries.yml`, wired in
+`HexGFqField/Bench.lean`, and covered by this report.
 
 Smoke wiring was checked with:
 
@@ -280,4 +300,5 @@ calibration anchors: spawn_wall_ns=1780141979062884000, spawn_mono_ns=3300129766
 
 ## Concerns
 
-None.
+None. The two mode-1 registrations pass two-sided, and the six mode-2
+registrations pass only as distinctly reported one-sided upper-bound results.

--- a/reports/hex-hensel-performance.md
+++ b/reports/hex-hensel-performance.md
@@ -10,11 +10,13 @@ All nine registrations use **mode 1, two-sided parametric**. Their models are
 derived from the intended linear or quadratic lifting algorithm on the
 registered degree/precision family, so mode 2's prerequisite — inability to
 derive a tight family model — does not hold. The six consistent results pass
-mode 1. The three inconclusive results leave the library **mode 4, blocked**:
-the existing mixed schedules have not established the derived scaling, and no
-published bound plus dominant-phase attribution has been supplied for a
-one-sided reinterpretation. Mode 3 is not justified while the controlled
-degree/precision families remain available.
+mode 1. The three inconclusive results are failed mode-1 results, so Phase 4 is
+blocked: the existing mixed schedules have not established the derived
+scaling, and no published bound plus dominant-phase attribution has been
+supplied for a one-sided reinterpretation. Mode 3 is not justified while the
+controlled degree/precision families remain available. Mode 4 does not apply
+to these registrations because mode 1 is an honest claim; it simply has not
+passed.
 
 | Target | Model | Largest rung | Median | Verdict |
 |---|---|---:|---:|---|
@@ -59,9 +61,12 @@ and is not a native-FLINT performance claim.
 
 ## Concerns
 
-- **Mode 4, blocked.** The `n²k` iterated-linear verdicts remain inconclusive
-  on the mixed degree/precision schedule.
+- The `n²k` iterated-linear mode-1 verdicts remain inconclusive on the mixed
+  degree/precision schedule, so Phase 4 is blocked.
 - The quadratic-multifactor model is now inconclusive because the optimized
   high-precision rung changes the observed ladder shape.
 - A current native-FLINT Hensel comparison still needs bindings that
   python-flint does not expose.
+
+The failed mode-1 verdicts and rollback are tracked by
+[#9741](https://github.com/kim-em/hex-dev/issues/9741).

--- a/reports/hex-hensel-performance.md
+++ b/reports/hex-hensel-performance.md
@@ -6,6 +6,16 @@ All nine parametric targets were refreshed together from a clean worktree.
 
 ## Verdicts
 
+All nine registrations use **mode 1, two-sided parametric**. Their models are
+derived from the intended linear or quadratic lifting algorithm on the
+registered degree/precision family, so mode 2's prerequisite — inability to
+derive a tight family model — does not hold. The six consistent results pass
+mode 1. The three inconclusive results leave the library **mode 4, blocked**:
+the existing mixed schedules have not established the derived scaling, and no
+published bound plus dominant-phase attribution has been supplied for a
+one-sided reinterpretation. Mode 3 is not justified while the controlled
+degree/precision families remain available.
+
 | Target | Model | Largest rung | Median | Verdict |
 |---|---|---:|---:|---|
 | Reduce mod `p` | `n` | 131072 | 9.601 ms | consistent |
@@ -49,8 +59,8 @@ and is not a native-FLINT performance claim.
 
 ## Concerns
 
-- The `n²k` iterated-linear verdicts remain inconclusive on the mixed
-  degree/precision schedule.
+- **Mode 4, blocked.** The `n²k` iterated-linear verdicts remain inconclusive
+  on the mixed degree/precision schedule.
 - The quadratic-multifactor model is now inconclusive because the optimized
   high-precision rung changes the observed ladder shape.
 - A current native-FLINT Hensel comparison still needs bindings that

--- a/reports/hex-number-field-performance.md
+++ b/reports/hex-number-field-performance.md
@@ -124,18 +124,19 @@ library as a whole.
 The five passing ladders use **mode 1, two-sided parametric**: their adjacent
 derivations give the expected scaling of the intended algorithm on the
 controlled family before measurement. The remaining four parametric ladders
-leave the library **mode 4, blocked**:
+block Phase 4:
 
 - `runQAdjoinInvLadder` and `runQAdjoinRootsLadder` are slower than their
-  declarations, so neither can pass mode 1 or the weaker one-sided test.
+  declarations. They are failed mode-1 results; mode 4 does not apply because
+  the intended family claim is available.
 - `runExactLadder` cannot use mode 2 even though the BHKS factorization bound
   is published: the profile shows candidate re-isolation and canonicalisation
   dominate while factorization is absent, so the cited bound does not cover
-  the measured phase.
+  the measured phase. No other mode currently applies, so it is mode 4.
 - `runAlgebraicRootsLadder` is faster than its declaration, but the declared
   `n^5 log^2 n` is composed from a heuristic isolation estimate rather than a
   published upper bound for this norm-eliminant family. It therefore cannot
-  use mode 2.
+  use mode 2, and no other mode currently applies, so it is mode 4.
 
 The existing fixed registrations are canonical API and comparator checks; they
 do not supply the operation-specific rationale and absolute budgets needed to

--- a/reports/hex-number-field-performance.md
+++ b/reports/hex-number-field-performance.md
@@ -121,6 +121,28 @@ library as a whole.
 
 ## Verdicts
 
+The five passing ladders use **mode 1, two-sided parametric**: their adjacent
+derivations give the expected scaling of the intended algorithm on the
+controlled family before measurement. The remaining four parametric ladders
+leave the library **mode 4, blocked**:
+
+- `runQAdjoinInvLadder` and `runQAdjoinRootsLadder` are slower than their
+  declarations, so neither can pass mode 1 or the weaker one-sided test.
+- `runExactLadder` cannot use mode 2 even though the BHKS factorization bound
+  is published: the profile shows candidate re-isolation and canonicalisation
+  dominate while factorization is absent, so the cited bound does not cover
+  the measured phase.
+- `runAlgebraicRootsLadder` is faster than its declaration, but the declared
+  `n^5 log^2 n` is composed from a heuristic isolation estimate rather than a
+  published upper bound for this norm-eliminant family. It therefore cannot
+  use mode 2.
+
+The existing fixed registrations are canonical API and comparator checks; they
+do not supply the operation-specific rationale and absolute budgets needed to
+resolve these four ladders through mode 3. Their unresolved work remains
+tracked by the issues in §Concerns, so no model is fitted and no parametric
+failure is reclassified as a pass.
+
 Authoritative verdict per ladder, and which committed run it comes from. The
 runs below give the measurements; this table says which one counts.
 

--- a/reports/hex-poly-smith-performance.md
+++ b/reports/hex-poly-smith-performance.md
@@ -84,6 +84,22 @@ Scientific command:
 
 ## Verdicts
 
+This library is **mode 4, blocked**, except for the two passing mode-1
+registrations named below. `runChainSnf` and `runSmallField` use **mode 1,
+two-sided parametric**: their fixed-degree families independently leave the
+cubic matrix-update cost dominant, and both match that declaration.
+
+The other fourteen registrations do not currently admit any passing mode.
+Their declarations are algebraic-operation proxies that deliberately exclude
+the intermediate polynomial-degree and rational coefficient-bit growth
+measured by `growth`; they are therefore neither tight wall-time models for
+mode 1 nor published wall-time upper bounds for mode 2. The profiles confirm
+that this omitted expression swell dominates the dense and rational families.
+Mode 3 is not available merely to evade those results: these operations have
+stable parametric input families, and no canonical hard input with an absolute
+budget has been justified as a replacement. Their current harness results are
+findings, not upper-bound passes.
+
 `C` is per-call time divided by the declared model. The last column is the
 largest completed rung; `—` means the wallclock cap prevented a residual-slope
 fit.
@@ -259,9 +275,10 @@ in the table, and a 3,000,000,000 ns target duration.
 
 ## Concerns
 
-None. The dense and rational scientific verdicts are intentionally reported as
-inconclusive: the boundary-growth artifact and profiles attribute the departure
-from algebraic-operation proxies to intermediate degree and coefficient swell
-in the classical Euclidean kernel. The external comparators are informational,
-all hashes agree, and no unexplained correctness, wiring, or profiling concern
-remains.
+The library is blocked in mode 4. Fourteen parametric registrations lack a
+tight wall-time model or a cited upper bound that includes the measured
+intermediate degree and coefficient swell. The boundary-growth artifact and
+profiles localize the gap to the classical Euclidean kernel, but localization
+does not make the algebraic-operation proxies passing complexity claims. The
+external comparators are informational and all hashes agree; those facts do
+not discharge the missing model.

--- a/reports/hex-poly-smith-performance.md
+++ b/reports/hex-poly-smith-performance.md
@@ -281,4 +281,5 @@ intermediate degree and coefficient swell. The boundary-growth artifact and
 profiles localize the gap to the classical Euclidean kernel, but localization
 does not make the algebraic-operation proxies passing complexity claims. The
 external comparators are informational and all hashes agree; those facts do
-not discharge the missing model.
+not discharge the missing model. Tracked by
+[#9742](https://github.com/kim-em/hex-dev/issues/9742).

--- a/reports/hex-roots-performance.md
+++ b/reports/hex-roots-performance.md
@@ -223,6 +223,8 @@ scientific verdict passes in both directions.
 The other thirteen registrations use **mode 3, fixed registration with an
 absolute budget**, under
 [`SPEC/benchmarking.md` §Choosing the complexity claim](../SPEC/benchmarking.md#choosing-the-complexity-claim).
+This is the registration split already decided and implemented in #8750, not a
+reclassification chosen from the verdicts during this policy reconciliation.
 Mode 1 is unavailable because the reachable wall-time bands cross GMP
 representations, combine degree with growing Taylor-coefficient width or
 separation depth, or quantize achieved precision; three calibration rounds
@@ -230,17 +232,19 @@ found no stable one-parameter scalar wall model derived independently of the
 timings. Mode 2 is unavailable because the SPEC's schoolbook-operation bounds
 do not describe those GMP transition bands tightly enough to be published
 wall-time bounds for the profiled kernels. Each fixed target therefore uses
-the canonical hard input listed below, its registration's per-call ceiling as
-the absolute budget, and an expected hash. This deliberately gives up
-asymptotic regression detection for those operations; the SPEC's worst-case
-contracts remain unchanged.
+the canonical hard input listed below, an operation-specific budget, and an
+expected hash. This deliberately gives up asymptotic regression detection for
+those operations; the SPEC's worst-case contracts remain unchanged.
 
-The absolute per-call budgets are 4 s for `runTaylor`, `runWitnessCheck`,
-`runNkWitnessCheck`, `runNewtonSquare`, `runRefine1`, and `runRefineTo`; 6 s
-for `runCertify`; 20 s for `runIsolateAll` and `runIsolateNk`; 30 s for
-`runIsolate`; 8 s for `runIsolatePellet` and
-`runIsolateNkThenPellet`; and the lean-bench fixed-registration default of
-60 s for `runSameRoot`.
+The operation-specific absolute regression budgets, distinct from the
+harness's looser kill caps, are: 10 ms each for `runTaylor`,
+`runWitnessCheck`, `runNkWitnessCheck`, `runNewtonSquare`, and `runRefine1`;
+20 ms for `runCertify`; 15 s for `runIsolateAll`; 1 s for `runIsolate`;
+750 ms for `runRefineTo`; 15 s for `runIsolateNk`; 5 s each for
+`runIsolatePellet` and `runIsolateNkThenPellet`; and 1 µs for `runSameRoot`.
+These give roughly 2× headroom on the long canonical calls and wider margins
+on the microbenchmarks where timer and runtime noise are a larger fraction of
+the baseline.
 
 Quiet-machine command:
 

--- a/reports/hex-roots-performance.md
+++ b/reports/hex-roots-performance.md
@@ -216,6 +216,32 @@ wall-time models. Which op-count models changed, and why:
 
 ## Verdicts
 
+`runMahlerPrec` uses **mode 1, two-sided parametric**. Its linear family model
+is derived from the coefficient scan with bounded coefficient height, and the
+scientific verdict passes in both directions.
+
+The other thirteen registrations use **mode 3, fixed registration with an
+absolute budget**, under
+[`SPEC/benchmarking.md` §Choosing the complexity claim](../SPEC/benchmarking.md#choosing-the-complexity-claim).
+Mode 1 is unavailable because the reachable wall-time bands cross GMP
+representations, combine degree with growing Taylor-coefficient width or
+separation depth, or quantize achieved precision; three calibration rounds
+found no stable one-parameter scalar wall model derived independently of the
+timings. Mode 2 is unavailable because the SPEC's schoolbook-operation bounds
+do not describe those GMP transition bands tightly enough to be published
+wall-time bounds for the profiled kernels. Each fixed target therefore uses
+the canonical hard input listed below, its registration's per-call ceiling as
+the absolute budget, and an expected hash. This deliberately gives up
+asymptotic regression detection for those operations; the SPEC's worst-case
+contracts remain unchanged.
+
+The absolute per-call budgets are 4 s for `runTaylor`, `runWitnessCheck`,
+`runNkWitnessCheck`, `runNewtonSquare`, `runRefine1`, and `runRefineTo`; 6 s
+for `runCertify`; 20 s for `runIsolateAll` and `runIsolateNk`; 30 s for
+`runIsolate`; 8 s for `runIsolatePellet` and
+`runIsolateNkThenPellet`; and the lean-bench fixed-registration default of
+60 s for `runSameRoot`.
+
 Quiet-machine command:
 
 ```sh


### PR DESCRIPTION
Closes #9733.

## Summary

- add the ordered two-sided, upper-bound, fixed-budget, blocked selection rule to `SPEC/benchmarking.md`, including the no-fitting and worst-case-contract guards
- align Phase 4 discipline, exit criteria, report requirements, release gating, fixed-budget meaning, and anti-patterns with per-mode passing verdicts
- reconcile all six affected reports: HexBerlekampZassenhaus uses mode 2; HexRoots uses modes 1 and 3; HexNumberField and HexPolySmith identify where no mode applies; HexGFqField and HexHensel retain failed mode-1 results rather than reclassifying them
- roll HexPolySmith, HexGFqField, and HexHensel back to `done_through: 3` so the manifest agrees with their unresolved reports; follow-up findings are #9742, #9740, and #9741
- link the upstream harness request kim-em/lean-bench#70 for one-sided verdicts and signed verdict vocabulary

## Performance rationale

The benchmark claim now differs from the per-library worst-case contract only when the ordered rule justifies it: mode 1 declares independently derived expected scaling on the registered family; mode 2 retains a cited published worst-case upper bound but accepts a distinctly rendered faster observation only when profiling confirms that the family exercises the bounded phase; mode 3 retains the SPEC contract while replacing an unreachable scalar wall model with a canonical fixed input and an operation-specific absolute regression budget.

## Verification

- `python3 scripts/check_phase4.py`
- `python3 scripts/check_dag.py`
- `python3 scripts/status.py HexPolySmith`
- `python3 scripts/status.py HexGFqField`
- `python3 scripts/status.py HexHensel`
- `git diff --check`