### PR TITLE
feat(release): permit evidenced post-publication phase rollback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # The release-manifest admission check reads release-sync-baseline.
           fetch-depth: 0
       # --- Structural + source lints ---
       - run: python3 scripts/check_copyright_headers.py
@@ -43,7 +44,10 @@ jobs:
         run: |
           python3 -m unittest scripts/test_check_dag.py
           python3 scripts/check_dag.py
-      - run: python3 scripts/release/check_released_manifest.py
+      - name: Check the released manifest and Phase-7 admission state
+        run: |
+          python3 -m unittest scripts/release/test_check_released_manifest.py
+          python3 scripts/release/check_released_manifest.py
       - name: Check the manual's released/unreleased split matches released.yml
         run: python3 scripts/release/check_manual_split.py
       - run: python3 -m unittest scripts/release/test_sync_released.py

--- a/PLAN/Releases.md
+++ b/PLAN/Releases.md
@@ -223,6 +223,18 @@ order:
    https://github.com/settings/personal-access-tokens; then
 3. add its entry to `released.yml` here and run the sync.
 
+A new source-bearing entry must name a library at `done_through: 7`; the
+manifest checker rejects an entry created before the library completes the
+phase pipeline. This is an admission rule, not a permanent claim that a
+published library remains valid through Phase 7. If a later audit triggers the
+normal rollback described in [Conventions](Conventions.md#rollback-is-a-normal-action),
+keep its manifest entry so fixes continue to publish to the existing split
+repository. The checker distinguishes that case from premature admission by
+reading the repository names in the live `release-sync-baseline` branch, with
+`scripts/release/synced.json` as the bootstrap fallback. The CI checkout must
+therefore retain `fetch-depth: 0`. An entry that has never completed a real sync
+still requires Phase 7 even if its intended split repository already exists.
+
 The repository has to exist before step 2 can name it, which is why step 1
 comes first; nothing in this order is circular. Step 2 is the one with a
 human in the loop, so start it early. Rotating a token means redoing step 2

--- a/scripts/release/check_released_manifest.py
+++ b/scripts/release/check_released_manifest.py
@@ -3,9 +3,12 @@
 
 from __future__ import annotations
 
+import json
 import re
+import subprocess
 import sys
 from pathlib import Path
+from typing import NoReturn
 
 import yaml
 
@@ -17,8 +20,81 @@ from release.sync_released import MANIFEST, managed_paths  # noqa: E402
 from release import aggregate_readme  # noqa: E402
 
 
-def fail(message: str) -> None:
+def fail(message: str) -> NoReturn:
     raise ValueError(message)
+
+
+def parse_sync_baseline(text: str, source: str) -> set[str]:
+    """Return repository names from a validated release-sync baseline."""
+    try:
+        document = json.loads(text)
+    except json.JSONDecodeError as error:
+        fail(f"{source}: invalid JSON: {error}")
+    if not isinstance(document, dict):
+        fail(f"{source}: sync baseline must be a JSON object")
+    published: set[str] = set()
+    for repo, revision in document.items():
+        if repo == "_comment":
+            continue
+        if (
+            not isinstance(repo, str)
+            or not isinstance(revision, str)
+            or re.fullmatch(r"[0-9a-f]{40}", revision) is None
+        ):
+            fail(f"{source}: malformed baseline entry {repo!r}: {revision!r}")
+        published.add(repo)
+    return published
+
+
+def published_repositories(repo_root: Path = REPO_ROOT) -> set[str]:
+    """Read the live publication ledger, falling back to its bootstrap seed."""
+    live_ref = "refs/remotes/origin/release-sync-baseline"
+    probe = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "--verify", "--quiet", live_ref],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if probe.returncode == 0:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "show", f"{live_ref}:synced.json"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            fail(
+                f"cannot read synced.json from {live_ref}: "
+                f"{result.stderr.strip()}"
+            )
+        return parse_sync_baseline(result.stdout, live_ref)
+
+    bootstrap = repo_root / "scripts" / "release" / "synced.json"
+    if not bootstrap.is_file():
+        fail(
+            "release-sync-baseline is unavailable and the bootstrap "
+            "scripts/release/synced.json does not exist"
+        )
+    return parse_sync_baseline(
+        bootstrap.read_text(encoding="utf-8"), str(bootstrap.relative_to(repo_root))
+    )
+
+
+def check_phase_admission(entries: list[dict], libraries: dict, published: set[str]) -> None:
+    """Require Phase 7 for entries that have never completed a real sync."""
+    for entry in entries:
+        lib = entry.get("lib")
+        if lib not in libraries:
+            continue
+        recorded = libraries[lib].done_through
+        repo = entry["repo"]
+        short = repo.split("/", 1)[1]
+        if recorded < 7 and short not in published:
+            fail(
+                f"{repo}: {lib} is recorded at done_through {recorded}; a new "
+                "released.yml entry requires the completed phase pipeline. "
+                "Finish Phase 7 or withdraw the entry until then"
+            )
 
 
 def release_test_modules() -> set[str]:
@@ -316,37 +392,12 @@ def main() -> int:
                 )
 
     libraries = load_libraries()
-    # A manifest entry is a publication commitment, and three entries in one
-    # week arrived with their implementation merges while the library's phase
-    # pipeline was still at 0 — each one broke every full sync on its empty
-    # repository until it was withdrawn by hand. A new entry may only exist
-    # once the library has completed the whole pipeline. The libraries below
-    # were already published before this rule existed and are grandfathered at
-    # the phase they had then: each may only move up (a regression fails), no
-    # library may join this list, and an entry leaves it by reaching Phase 7.
-    prepublished_floor = {}
-    graduated = sorted(
-        lib for lib in prepublished_floor
-        if lib in libraries and libraries[lib].done_through >= 7
-    )
-    if graduated:
-        fail(
-            "Phase-7 libraries must leave prepublished_floor: "
-            + ", ".join(graduated)
-        )
-    for entry in entries:
-        lib = entry.get("lib")
-        if lib not in libraries:
-            continue
-        recorded = libraries[lib].done_through
-        required = prepublished_floor.get(lib, 7)
-        if recorded < required:
-            fail(
-                f"{entry['repo']}: {lib} is recorded at done_through "
-                f"{recorded}; a released.yml entry requires done_through "
-                f"{required} ({'its grandfathered floor' if lib in prepublished_floor else 'the completed phase pipeline'}) "
-                "— finish the phases first, or withdraw the entry until then"
-            )
+    # Three entries once landed at phase 0 and broke every full sync against
+    # their empty split repositories. Phase 7 is therefore required for a new
+    # entry. Once the sync's live baseline proves that a repository has really
+    # been published, normal done_through rollback no longer removes it from
+    # the source-of-truth publication graph.
+    check_phase_admission(entries, libraries, published_repositories())
     closure = reachable_dependencies(libraries)
     repo_by_library = {
         entry["lib"]: entry["repo"].split("/", 1)[1]

--- a/scripts/release/test_check_released_manifest.py
+++ b/scripts/release/test_check_released_manifest.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Tests for release-manifest Phase-7 admission and rollback."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from scripts.release.check_released_manifest import (
+    check_phase_admission,
+    parse_sync_baseline,
+    published_repositories,
+)
+
+
+class Phase7AdmissionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.repo = Path(self.temporary.name)
+        self.git_env = {
+            **os.environ,
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_NOSYSTEM": "1",
+        }
+        self._git("init", "-q")
+        (self.repo / "synced.json").write_text(
+            json.dumps({"hex-example": "a" * 40}), encoding="utf-8"
+        )
+        self._git("add", "synced.json")
+        self._git(
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "-qm",
+            "baseline",
+        )
+        self._git(
+            "update-ref", "refs/remotes/origin/release-sync-baseline", "HEAD"
+        )
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def _git(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", "-C", str(self.repo), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=self.git_env,
+        )
+
+    @staticmethod
+    def entry() -> dict:
+        return {"repo": "leanprover/hex-example", "lib": "HexExample"}
+
+    def test_live_baseline_records_published_repository(self) -> None:
+        self.assertEqual(published_repositories(self.repo), {"hex-example"})
+
+    def test_published_repository_may_roll_back(self) -> None:
+        check_phase_admission(
+            [self.entry()],
+            {"HexExample": SimpleNamespace(done_through=3)},
+            {"hex-example"},
+        )
+
+    def test_unpublished_repository_cannot_enter_below_phase7(self) -> None:
+        with self.assertRaisesRegex(ValueError, "new released.yml entry requires"):
+            check_phase_admission(
+                [self.entry()],
+                {"HexExample": SimpleNamespace(done_through=3)},
+                set(),
+            )
+
+    def test_unpublished_repository_may_enter_at_phase7(self) -> None:
+        check_phase_admission(
+            [self.entry()],
+            {"HexExample": SimpleNamespace(done_through=7)},
+            set(),
+        )
+
+    def test_malformed_baseline_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "malformed baseline entry"):
+            parse_sync_baseline('{"hex-example": "short"}', "test baseline")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #9749.

## What changed

- preserve the Phase-7 admission gate for split repositories that have never completed a sync
- derive actual publication from the live `release-sync-baseline`, with the committed bootstrap seed as fallback
- allow an actually published library to remain in the publication graph after normal `done_through` rollback
- document the admission/rollback distinction and full-history checkout requirement
- add focused regression coverage to the existing single CI job

## Verification

- `python3 -m unittest scripts/release/test_check_released_manifest.py scripts/release/test_sync_released.py`
- `python3 scripts/release/check_released_manifest.py`
- `python3 scripts/release/check_manual_split.py`
- `python3 scripts/check_dag.py`
- `python3 scripts/check_phase4.py`
- `python3 -m py_compile scripts/release/check_released_manifest.py scripts/release/test_check_released_manifest.py`
- `git diff --check`

Prerequisite for #9733.