### PR TITLE
doc: declare the number-field bridges' comparator absence

### DIFF
--- a/HexNumberFieldMathlib/SPEC/hex-number-field-mathlib.md
+++ b/HexNumberFieldMathlib/SPEC/hex-number-field-mathlib.md
@@ -297,6 +297,18 @@ libraries consume.
 The library is verified by building it. Executable conformance belongs to
 `hex-number-field`.
 
+## External comparators
+
+No external comparator is required.
+
+**Justification:** `correspondence-only-layer` per
+`SPEC/benchmarking.md §"Comparator naming"`. The library introduces no
+number-field arithmetic algorithm; it verifies the executable QAdjoin
+arithmetic, root isolation, and Yun decomposition implemented
+elsewhere. The computational performance owner is hex-number-field,
+where the arithmetic and root ladders and the PARI/GP comparator are
+measured.
+
 ## References
 
 - Cohen, H. *A Course in Computational Algebraic Number Theory.* Springer,

--- a/HexNumberFieldTowerMathlib/SPEC/hex-number-field-tower-mathlib.md
+++ b/HexNumberFieldTowerMathlib/SPEC/hex-number-field-tower-mathlib.md
@@ -207,6 +207,18 @@ HexNumberFieldTowerMathlib/
 The library is verified by building it. Executable conformance belongs to
 `hex-number-field-tower`.
 
+## External comparators
+
+No external comparator is required.
+
+**Justification:** `correspondence-only-layer` per
+`SPEC/benchmarking.md §"Comparator naming"`. The library introduces no
+tower arithmetic or factorization algorithm; it verifies the executable
+tower operations and the Trager pipeline implemented elsewhere. The
+computational performance owners are hex-number-field-tower, where the
+dimension ladders and the PARI/GP nffactor comparator are measured, and
+hex-number-field for the base-level arithmetic it transports.
+
 ## References
 
 - Trager, B. M. *Algebraic factoring and rational function


### PR DESCRIPTION
This PR add the External comparators section to the HexNumberFieldMathlib and HexNumberFieldTowerMathlib SPECs with the correspondence-only-layer justification from SPEC/benchmarking.md's absence-reason list, naming the computational performance owners (hex-number-field and hex-number-field-tower) whose bench targets and PARI comparators carry the evidence for the operations each layer transports. This is the remaining Phase-4 declaration for both bridges ahead of their done_through bumps.

🤖 Prepared with Claude Code