### PR TITLE
spec: order tight and upper-bound benchmark modes

### DIFF
--- a/PLAN/Conventions.md
+++ b/PLAN/Conventions.md
@@ -631,6 +631,19 @@ further) means:
    (above) makes this mechanical: any `M` with `L ∈ M.deps` and a
    dep-coupled phase ≥ K is now ineligible until L recovers.
 
+This last step blocks new or incomplete dep-coupled work. It does not
+retroactively roll back a downstream library whose dep-coupled phase was
+genuinely completed while the dependency satisfied its gate; later local
+phases remain valid as stated above. Roll the downstream library back too only
+when the finding invalidates evidence that its own completed phase relied on.
+
+The rolled-back library itself cannot retain a separate `done_through` record
+for later phases: the field is a completed prefix, so a Phase-4 rollback to 3
+also removes its recorded Phase-5–7 completion and the Phase-7 checker stops
+covering it. The later-phase evidence remains in git and the manual; once
+Phase 4 recovers, re-attesting those phases is bookkeeping against that
+preserved evidence unless the finding invalidated it too.
+
 The next agent picking up `L` enters the rolled-back phase with the
 bug-finding evidence (the issue, the JSONL artefact for a bench
 finding, the failing `#guard` for a conformance finding) as its

--- a/PLAN/Phase4.md
+++ b/PLAN/Phase4.md
@@ -6,11 +6,12 @@
 
 Phase 4 makes algorithmic complexity a first-class deliverable. By
 the end of Phase 4 every advertised compiled operation in the library's API
-has a textbook complexity model declared at its `setup_benchmark`
-registration and a benchmark family whose verdict is *consistent
-with declared complexity*; every advertised proof/tactic operation has the
-fresh-module evidence defined below. An *inconclusive* compiled verdict is not
-a Phase 4 exit; it is a finding that triggers a rollback per
+has the strongest applicable benchmark mode from
+[`SPEC/benchmarking.md` §Choosing the complexity claim](../SPEC/benchmarking.md#choosing-the-complexity-claim)
+and a passing result in that mode; every advertised proof/tactic operation has
+the fresh-module evidence defined below. An *inconclusive* compiled verdict is not
+a Phase 4 exit unless it is the current harness wording for a documented,
+passing one-sided upper-bound result. A failing result triggers a rollback per
 [Conventions.md §Rollback is a normal action](Conventions.md#rollback-is-a-normal-action)
 and a fix at the rolled-back phase.
 
@@ -27,7 +28,7 @@ advertised operation to exactly one row.
 
 | Surface | Required evidence | Generic requirements replaced |
 | --- | --- | --- |
-| Mathlib-free compiled computation | An ordinary LeanBench executable, registrations with controlled one-parameter ladders and adjacent textbook cost derivations, `list`/`verify`, scientific verdicts, comparator coverage, and timed-region sampling profiles. | None. |
+| Mathlib-free compiled computation | An ordinary LeanBench executable, registrations with controlled one-parameter ladders and adjacent independent cost derivations, `list`/`verify`, scientific verdicts, comparator coverage, and timed-region sampling profiles. | None. |
 | Elaboration, proof-search tactics, emitted proof terms, or kernel checking | Externally timed fresh-module builds below an explicit `libraries.yml` `proof_probes` root, with matched import baselines, rotated raw samples, compiler/proof artefacts, and the trust/provenance record in `SPEC/benchmarking.md`. | No LeanBench registration or executable, no `list`/`verify` entry for that surface, no complexity verdict, and no timed-region sampling profile. |
 
 A `mathlib: true` library with a separable compiled core is a **mixed**
@@ -46,8 +47,10 @@ For each library `HexFoo` advancing through Phase 4:
    It registers every compiled operation in the library's SPEC API surface
    with `setup_benchmark` (parametric) or
    `setup_fixed_benchmark` (canonical input). The complexity
-   expression in each `setup_benchmark` is the *textbook*
-   complexity, not the observed one. Proof-track operations instead have
+   expression in each `setup_benchmark` is the independently derived expected
+   family scaling for a two-sided registration or the cited published bound
+   for a one-sided registration, never a model read from observed timings.
+   Proof-track operations instead have
    named fresh-module probes and matched baselines under an explicit manifest
    `proof_probes` directory; those probes are not registrations.
 
@@ -110,19 +113,21 @@ For each library `HexFoo` advancing through Phase 4:
    compiled versus proof/tactic evidence and state each proof-track replacement
    explicitly.
 
-The PR description records, in one paragraph, any case where the
-declared complexity model differs from the canonical textbook
-complexity (e.g. amortised vs worst-case, randomised vs
-deterministic). This is the only "performance rationale" section
+The PR description records, in one paragraph, any case where the benchmark
+claim differs from the per-library SPEC's worst-case contract (for example,
+family-specific expected scaling, amortised versus worst-case, or randomised
+versus deterministic). This is the only "performance rationale" section
 required.
 
 ## Discipline
 
-- **Declare textbook complexity.** Not the observed complexity of
-  the current implementation. If the textbook is `O(n²)` and the
-  current code is `O(n³)`, declare `O(n²)`, run the benchmark, get
-  the inconclusive verdict, file the issue, roll back. The
-  benchmark's job is to reveal the gap, not to ratify it.
+- **Declare the intended algorithm's independently derived expected scaling on
+  the registered family.** Derive it before measurement and never read it off
+  observed timings. The adjacent derivation must explain how the family
+  relates to the per-library SPEC's worst-case bound. When a tight family model
+  is unavailable, work the ordered alternatives in
+  [`SPEC/benchmarking.md` §Choosing the complexity claim](../SPEC/benchmarking.md#choosing-the-complexity-claim)
+  rather than fitting the declaration to the current implementation.
 - **Use the assigned harness.** LeanBench is the sole compiled-code inner
   harness. The external fresh-build runner is permitted only for proof-track
   evidence and may not time compiled computation redundantly.
@@ -150,17 +155,23 @@ For library `hex-foo`, Phase 4 is done when:
   track, every compiled-track operation has a `setup_benchmark` or
   `setup_fixed_benchmark` registration in the `HexFoo.Bench` exe, and every
   proof-track operation has the specified externally timed fresh-module probe;
-- every parametric registration declares a complexity model that
-  matches the SPEC's textbook complexity for that operation;
+- every registration names the strongest applicable mode from
+  `SPEC/benchmarking.md`'s ordered rule; every mode-1 parametric declaration
+  matches the independently derived expected scaling on its family, every
+  mode-2 declaration is a cited published upper bound covering the dominant
+  profiled phase, and every mode-3 registration has a canonical hard input and
+  meaningful absolute budget;
 - every new or changed parametric registration has an adjacent
   cost-model derivation comment, and every PR that changes a
   `setup_benchmark` complexity declaration includes an independent
   cost-model derivation in the commit message that made the change;
 - when a compiled track exists, `lake exe hexfoo_bench verify` succeeds under
   smoke settings, and
-  `lake exe hexfoo_bench run NAME` returns *consistent with declared
-  complexity* for every parametric registration at its scientific
-  settings;
+  `lake exe hexfoo_bench run NAME` returns a passing verdict for every
+  parametric registration's declared mode at its scientific settings; until
+  lean-bench has a one-sided mode, the headline report may translate only a
+  faster-than-declared mode-2 harness result to the distinct passing result
+  *within declared upper bound (observed faster)*;
 - every `compare` group named by the SPEC is registered and reports
   `allAgreed` on its declared common domain;
 - every comparator declared `gating` in `libraries.yml:
@@ -188,8 +199,10 @@ For library `hex-foo`, Phase 4 is done when:
   samples and provenance;
 - the headline report at `reports/<lib>-performance.md` exists with
   the five mandated subsections and full artefact traceability;
-- the headline report's §Concerns subsection is empty. A library
-  cannot **remain** at `done_through: 4` while any Concern is
+- the headline report's §Concerns subsection is empty. A passing mode-2 or
+  mode-3 registration is not itself a Concern merely because it makes a weaker
+  claim than mode 1; its report must contain the ordered-rule rationale. A
+  library cannot **remain** at `done_through: 4` while any Concern is
   unresolved; the orchestrator rolls back if this state is detected.
   The only resolution available to the orchestrator is to act on
   the HO issue tied to the Concern until the underlying problem is

--- a/PLAN/Phase4.md
+++ b/PLAN/Phase4.md
@@ -155,9 +155,12 @@ For library `hex-foo`, Phase 4 is done when:
   track, every compiled-track operation has a `setup_benchmark` or
   `setup_fixed_benchmark` registration in the `HexFoo.Bench` exe, and every
   proof-track operation has the specified externally timed fresh-module probe;
-- every registration names the strongest applicable mode from
-  `SPEC/benchmarking.md`'s ordered rule; every mode-1 parametric declaration
-  matches the independently derived expected scaling on its family, every
+- the headline report names the strongest applicable mode from
+  `SPEC/benchmarking.md`'s ordered rule for every performance-evidence
+  registration; fixed registrations used only as hash, comparator, or protocol
+  anchors are labelled as such and cannot satisfy operation coverage; every mode-1
+  parametric declaration matches the independently derived expected scaling
+  on its family, every
   mode-2 declaration is a cited published upper bound covering the dominant
   profiled phase, and every mode-3 registration has a canonical hard input and
   meaningful absolute budget;
@@ -169,9 +172,11 @@ For library `hex-foo`, Phase 4 is done when:
   smoke settings, and
   `lake exe hexfoo_bench run NAME` returns a passing verdict for every
   parametric registration's declared mode at its scientific settings; until
-  lean-bench has a one-sided mode, the headline report may translate only a
-  faster-than-declared mode-2 harness result to the distinct passing result
-  *within declared upper bound (observed faster)*;
+  lean-bench has a one-sided mode, the headline report may translate a mode-2
+  harness result to the distinct passing result *within declared upper bound
+  (observed faster)* or *within declared upper bound (observed matching)*, as
+  its observed direction requires; a slower-than-declared observation fails
+  mode 2 and admits no translation;
 - every `compare` group named by the SPEC is registered and reports
   `allAgreed` on its declared common domain;
 - every comparator declared `gating` in `libraries.yml:
@@ -264,5 +269,12 @@ issue with a checkbox per library; per-library follow-on issues
 are filed only when the audit identifies actual gaps. Libraries
 already passing all new criteria stay at `done_through: 4`
 unchanged.
+
+The ordered complexity-mode rule is likewise an audit reset. Its merge queues
+one umbrella audit of every library at `done_through ≥ 4`; existing passing
+two-sided registrations need no relabelling until their report is revised, but
+an inconclusive result or non-empty Concern is not grandfathered. The audit
+files per-library remediation issues only where the ordered rule exposes an
+actual gap, and applies the normal rollback rule there.
 
 Record completion by bumping `libraries.yml[L].done_through` to `4`.

--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -52,8 +52,18 @@ that earned its keep.
 ### Choosing the complexity claim
 
 Choose the first mode in this ordered list that the operation admits. This is
-not a menu: every headline report names the selected mode and explains why
-each stronger preceding mode does not apply.
+not a menu. A report created or reconciled under this rule names the selected
+mode for every performance-evidence registration and explains why each
+stronger preceding mode does not apply. Existing passing two-sided
+registrations are mode 1 by default and need not be relabelled until their
+report is next revised.
+
+This ordering applies to registrations used as Phase-4 performance evidence
+for an operation. A fixed registration used only as an expected-hash anchor,
+an external-comparator endpoint, or protocol-overhead control makes no
+complexity claim and has no mode. The report labels that limited purpose
+explicitly, and such an anchor cannot discharge performance coverage for an
+advertised operation.
 
 1. **Two-sided parametric — the default.** Use this whenever the intended
    algorithm's expected scaling on the registered input family can be derived
@@ -62,8 +72,8 @@ each stronger preceding mode does not apply.
    family is wrong.
 2. **One-sided upper-bound parametric.** Use this only when all three
    conditions hold:
-   - no tight family-specific model can be derived, and the registration says
-     why;
+   - no tight family-specific model can be derived, and the headline report
+     says why;
    - the declared bound is published and cited, and the cited result covers
      the phase that the profile shows dominating — a citation for work absent
      from the profile is not evidence for the registration;
@@ -73,7 +83,9 @@ each stronger preceding mode does not apply.
    Slower than the bound fails. Faster than the bound passes and is reported
    as **within declared upper bound (observed faster)**. This is visibly weaker
    than a two-sided pass and is never rendered as *consistent with declared
-   complexity*. lean-bench does not yet have this registration mode; until
+   complexity*. A matching observation is **within declared upper bound
+   (observed matching)**, not a two-sided consistency claim. lean-bench does
+   not yet have this registration mode; until
    [lean-bench #70](https://github.com/kim-em/lean-bench/issues/70) lands, the
    headline report records the harness verdict, the observed direction, and
    the reason it is a passing upper-bound result.
@@ -81,6 +93,18 @@ each stronger preceding mode does not apply.
    stable one-parameter wall-time model is reachable and a canonical hard
    input with a meaningful ceiling exists. The headline report states plainly
    that asymptotic regression detection has been given up for this operation.
+   It also records the attempted parameterisations and schedules and explains
+   why each failed to yield a stable independently derived model. When a
+   comparator or external requirement supplies a meaningful ceiling, use it;
+   a measured baseline plus stated margin is the fallback only when neither is
+   available.
+   The budget is an operation-specific regression ceiling justified from a
+   comparator, a reference requirement, or a measured baseline plus stated
+   margin. A generic harness timeout or inherited `maxSecondsPerCall` default
+   is a safety cap, not an absolute budget. The scientific evidence recorded
+   in the report must show the canonical input completing within the budget;
+   the budget remains a Phase-4 gate even when the current harness only emits
+   the measurement rather than a distinct fixed-budget verdict.
 4. **Blocked.** If none of the preceding modes honestly applies, Phase 4 is
    not done. Failure to characterise an operation's cost is a reason to stay
    at the current phase, not a route to a fixed registration.
@@ -751,10 +775,16 @@ hard inputs, not parameter sweeps:
   `(2, 409)`,
 - computing a `GF(p^n)` inverse for fixed `(p, n)` and chosen element.
 
-Use `setup_fixed_benchmark` for these. The bench module's docstring
-records the canonical input, the source it came from, and the
-reference timing the project considers reasonable (typically: time
-on the same canonical input in a comparator like FLINT or fpLLL).
+For Phase-4 performance evidence, use `setup_fixed_benchmark` only through
+mode 3 of [§Choosing the complexity claim](#choosing-the-complexity-claim),
+after modes 1 and 2 have been ruled out. Fixed hash, comparator, and protocol
+anchors have the narrower non-performance role stated there and do not need a
+mode-3 justification. The bench module's adjacent comment or docstring records
+the canonical input, the source it came from, and the absolute budget,
+including the reference timing the project considers reasonable (typically:
+time on the same canonical input in a comparator like FLINT or fpLLL). The
+headline report repeats that budget and records the scientific measurement
+against it.
 Comparison against the comparator is then a `compare` invocation
 across two `setup_fixed_benchmark` registrations, one per
 implementation.
@@ -964,8 +994,8 @@ Full timing runs (`lake exe hexfoo_bench run NAME` with a real
 budget) are not part of merge-gating CI. They run on a scheduled
 workflow or release-candidate workflow, on dedicated hardware where
 timing comparisons are meaningful. Each release names the libraries
-whose timing runs must succeed; a release is blocked by an
-inconclusive verdict or a comparator divergence even when proofs
+whose timing runs must succeed; a release is blocked by a failing verdict in
+the registration's declared mode or a comparator divergence even when proofs
 are complete.
 
 ## Reproducibility contract
@@ -1034,14 +1064,19 @@ The report contains five subsections:
    registration sites. A mixed/proof library also lists every fresh-module
    probe, its matched baseline, and the generic requirements that probe
    replaces.
-2. **Verdicts.** Each registration's selected mode, the reasons the preceding
-   stronger modes do not apply, and its result at scientific settings. For a
-   parametric registration this includes the harness verdict ("consistent with
+2. **Verdicts.** Each performance-evidence registration's selected mode, the
+   reasons the preceding stronger modes do not apply, and its result at
+   scientific settings. Fixed hash/comparator anchors instead name their
+   limited non-performance purpose. For a parametric performance registration
+   this includes the harness verdict ("consistent with
    declared complexity", "inconclusive", with the verdict text); until the
    one-sided harness mode lands, a mode-2 report also records the direction and
-   the distinct manual result *within declared upper bound (observed faster)*.
-   Each fixed registration records its absolute budget, its
-   median per-call time and observed-hash agreement. Proof-track entries report
+   the distinct manual result *within declared upper bound (observed faster)*
+   or *within declared upper bound (observed matching)*.
+   Each mode-3 fixed registration records its absolute budget, median per-call
+   time, and observed-hash agreement. Fixed hash, comparator, and protocol
+   anchors record their median per-call time and observed-hash agreement but
+   do not acquire a performance budget. Proof-track entries report
    all raw rotated fresh-build samples and paired deltas, never a complexity
    verdict. When the sweep has null controls, their raw deltas, absolute and
    relative ranges, and medians precede the substantive proof deltas in
@@ -1259,8 +1294,7 @@ explicitly forbidden:
   faster-than-declared harness result is a pass only for a registration that
   independently satisfies mode 2's citation-and-attribution conditions; the
   report records the distinct upper-bound result while lean-bench #70 is open.
-  An
-  inconclusive verdict whose root cause is a too-narrow schedule
+  An inconclusive verdict whose root cause is a too-narrow schedule
   (rungs too close to the per-spawn floor, even when some survive
   the filter) is miscalibration, not a finding, and the registration
   must be re-tuned before the library advances through Phase 4.

--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -33,26 +33,74 @@ benchmark itself.
 
 ## The verdict-as-bug-trigger model
 
-Every benchmarked operation has a textbook complexity model declared
-*at the registration site* in the per-library `Bench.lean`. The
-benchmark harness ([§Harness](#harness-lean-bench)) fits the
-observed scaling against that model and emits one of two verdicts:
+Every parametric benchmark has a complexity claim declared *at the
+registration site* in the per-library `Bench.lean`. The benchmark harness
+([§Harness](#harness-lean-bench)) fits the observed scaling against that model.
+Its current two-sided mode emits one of two verdicts:
 
 - **consistent with declared complexity** — observed scaling matches
   the model within tolerance.
 - **inconclusive** — observed scaling does not match. The
   implementation is either wrong, or the model was misdeclared.
 
-The latter case is the **valuable** outcome of a benchmark run.
+The latter case is the **valuable** outcome of a two-sided benchmark run.
 "Everything looks consistent and within a small constant factor of
 the external comparator" is acceptable but unexciting; "the verdict
 came back inconclusive and the slope is `+0.4` over `n`" is the run
 that earned its keep.
 
-When a verdict is `inconclusive`, or when the verdict is consistent
-but the constant is wildly off an external reference — orders of
-magnitude, not a small constant factor — the response is mandatory
-and uniform:
+### Choosing the complexity claim
+
+Choose the first mode in this ordered list that the operation admits. This is
+not a menu: every headline report names the selected mode and explains why
+each stronger preceding mode does not apply.
+
+1. **Two-sided parametric — the default.** Use this whenever the intended
+   algorithm's expected scaling on the registered input family can be derived
+   before measurement. Both directions gate: slower than declared means the
+   implementation is wrong, while faster than declared means the model or the
+   family is wrong.
+2. **One-sided upper-bound parametric.** Use this only when all three
+   conditions hold:
+   - no tight family-specific model can be derived, and the registration says
+     why;
+   - the declared bound is published and cited, and the cited result covers
+     the phase that the profile shows dominating — a citation for work absent
+     from the profile is not evidence for the registration;
+   - the input family exercises that phase, as required by
+     [§The Attribution rule](#the-attribution-rule).
+
+   Slower than the bound fails. Faster than the bound passes and is reported
+   as **within declared upper bound (observed faster)**. This is visibly weaker
+   than a two-sided pass and is never rendered as *consistent with declared
+   complexity*. lean-bench does not yet have this registration mode; until
+   [lean-bench #70](https://github.com/kim-em/lean-bench/issues/70) lands, the
+   headline report records the harness verdict, the observed direction, and
+   the reason it is a passing upper-bound result.
+3. **Fixed registration with an absolute budget.** Use this only when no
+   stable one-parameter wall-time model is reachable and a canonical hard
+   input with a meaningful ceiling exists. The headline report states plainly
+   that asymptotic regression detection has been given up for this operation.
+4. **Blocked.** If none of the preceding modes honestly applies, Phase 4 is
+   not done. Failure to characterise an operation's cost is a reason to stay
+   at the current phase, not a route to a fixed registration.
+
+Two guards make the ordering binding:
+
+- The operation's worst-case bound remains in its per-library SPEC regardless
+  of the benchmark mode. Mode 2 or 3 changes the test, never the documented
+  contract.
+- Mode 1 is not licence to fit observed timings. Its declaration is the
+  intended algorithm's independently derived expected scaling on the
+  registered family, derived before measurement and never read off observed
+  timings. The adjacent derivation explains how that family relates to the
+  per-library SPEC's worst-case bound.
+
+When a declared mode fails, or when a passing verdict has a constant wildly
+off an external reference — orders of magnitude, not a small constant factor
+— the response is mandatory and uniform. In particular, a faster-than-declared
+two-sided result fails, while that same direction passes only for a registration
+that independently qualified for mode 2 before measurement:
 
 1. **File a GitHub issue.** Use the bench-found-bug template in
    [PLAN/Conventions.md](../PLAN/Conventions.md#bench-found-and-conformance-found-issues).
@@ -140,9 +188,9 @@ Two registration forms:
 
 - **`setup_benchmark <fn> <param> => <complexity>`** for parametric
   sweeps. `<fn> : Nat → α`. `<complexity> : Nat → Nat` is the
-  textbook complexity (e.g. `n`, `n * n`, `n * Nat.log2 (n + 1)`,
-  `2 ^ n`). Optional `with prep := <prepFn>` clause hoists per-param
-  setup out of the timing loop, useful when the hot path takes
+  declared model for the selected parametric mode (e.g. `n`, `n * n`,
+  `n * Nat.log2 (n + 1)`, `2 ^ n`). Optional `with prep := <prepFn>`
+  hoists per-param setup out of the timing loop, useful when the hot path takes
   `σ → α` and `σ` is expensive to construct (random matrices,
   pre-canonicalised polynomials).
 - **`setup_fixed_benchmark <name>`** for absolute-time measurements
@@ -188,12 +236,13 @@ The CLI surface is `lake exe hexfoo_bench <subcommand>`:
   cleanly and emits a hash where one is expected. Used as a CI
   gate; see [§CI integration](#ci-integration).
 
-Per-library SPECs declare the complexity for each operation in their
-API surface. The textbook model is the contract; the benchmark
-checks observation against it. **Do not declare a complexity model
-that matches the buggy current code.** If the textbook model says
-`O(n²)` but the current implementation is `O(n³)`, declare `O(n²)`,
-let the verdict come back inconclusive, file the issue, roll back.
+Per-library SPECs declare the worst-case complexity contract for each
+operation in their API surface. A benchmark registration makes the strongest
+claim allowed by [§Choosing the complexity claim](#choosing-the-complexity-claim).
+**Do not declare a complexity model that matches the buggy current code.** If
+the intended algorithm has expected family scaling `O(n²)` but the current
+implementation is `O(n³)`, declare `O(n²)`, let the verdict fail, file the
+issue, and roll back.
 
 ### Adaptive ladder
 
@@ -246,10 +295,10 @@ fresh-module evidence below; it must not disguise elaboration or kernel time as
 compiled benchmark time.
 
 CPU profiling of compiled benchmark binaries is **in scope** and is
-a Phase-4 deliverable; see [profiling.md](profiling.md). A bench
-verdict of "consistent with declared complexity" only checks
-asymptotics; profiling is what attributes the constant factor and
-catches dominant costs that the registered targets do not measure.
+a Phase-4 deliverable; see [profiling.md](profiling.md). A passing parametric
+verdict only checks the selected asymptotic claim; profiling attributes the
+constant factor and catches dominant costs that the registered targets do not
+measure.
 
 ## Fresh-module proof evidence
 
@@ -985,9 +1034,13 @@ The report contains five subsections:
    registration sites. A mixed/proof library also lists every fresh-module
    probe, its matched baseline, and the generic requirements that probe
    replaces.
-2. **Verdicts.** Each parametric registration's verdict at
-   scientific settings ("consistent with declared complexity",
-   "inconclusive", with the verdict text). Each fixed registration's
+2. **Verdicts.** Each registration's selected mode, the reasons the preceding
+   stronger modes do not apply, and its result at scientific settings. For a
+   parametric registration this includes the harness verdict ("consistent with
+   declared complexity", "inconclusive", with the verdict text); until the
+   one-sided harness mode lands, a mode-2 report also records the direction and
+   the distinct manual result *within declared upper bound (observed faster)*.
+   Each fixed registration records its absolute budget, its
    median per-call time and observed-hash agreement. Proof-track entries report
    all raw rotated fresh-build samples and paired deltas, never a complexity
    verdict. When the sweep has null controls, their raw deltas, absolute and
@@ -1146,11 +1199,11 @@ explicitly forbidden:
   exceed its wallclock cap at the declared range, the implementation
   is too slow at that range — file an issue, roll back, fix. Don't
   shrink the scientific settings to dodge the verdict.
-- **Declaring a complexity model that matches the buggy current
-  code instead of textbook.** The model is the contract. Observation
-  disagreeing with textbook is a finding; observation agreeing with
-  a buggy implementation that itself disagrees with textbook is a
-  cover-up.
+- **Declaring a complexity model that matches the buggy current code.** The
+  mode-1 model is the independently derived expected family scaling, and the
+  mode-2 model is a cited published bound. Observation disagreeing with the
+  applicable claim is a finding; changing that claim to agree with a buggy
+  implementation is a cover-up.
 - **Top-level `def` of proof-carrying context structures evaluated
   at module init.** A module-level `def ctx : BarrettCtx p := …`
   whose initializer transitively calls a heavy computation
@@ -1200,10 +1253,13 @@ explicitly forbidden:
   run on. CI treats exit 2 the same as a verdict mismatch: file an
   issue, roll back, fix. Don't shrink scientific settings to dodge
   the verdict.
-- **Treating an "inconclusive" verdict as a passing scientific run.**
-  Phase-4 exit criteria require either "consistent with declared
-  complexity" or a tracked finding-issue explaining the mismatch
-  ([PLAN/Phase4.md](../PLAN/Phase4.md) §Exit criteria). An
+- **Treating an "inconclusive" verdict as a passing two-sided scientific
+  run.** Phase-4 exit criteria require a passing verdict in the registration's
+  declared mode ([PLAN/Phase4.md](../PLAN/Phase4.md) §Exit criteria). A
+  faster-than-declared harness result is a pass only for a registration that
+  independently satisfies mode 2's citation-and-attribution conditions; the
+  report records the distinct upper-bound result while lean-bench #70 is open.
+  An
   inconclusive verdict whose root cause is a too-narrow schedule
   (rungs too close to the per-spawn floor, even when some survive
   the filter) is miscalibration, not a finding, and the registration

--- a/libraries.yml
+++ b/libraries.yml
@@ -272,7 +272,7 @@ libraries:
   HexPolySmith:
     deps: [HexPoly, HexMatrix, HexDeterminant]
     mathlib: false
-    done_through: 7
+    done_through: 3
     status: active
     phase4:
       comparators:
@@ -509,7 +509,7 @@ libraries:
   HexGFqField:
     deps: [HexGFqRing, HexBerlekamp]
     mathlib: false
-    done_through: 7
+    done_through: 3
     status: active
     phase4:
       comparators:
@@ -552,7 +552,7 @@ libraries:
   HexHensel:
     deps: [HexPolyFp, HexPolyZ, HexBasic]
     mathlib: false
-    done_through: 7
+    done_through: 3
     status: active
     phase4:
       comparators:
@@ -595,7 +595,7 @@ libraries:
   HexBerlekampZassenhaus:
     deps: [HexBerlekamp, HexHensel, HexLLL]
     mathlib: false
-    done_through: 7
+    done_through: 3
     status: active
     phase4:
       comparators:
@@ -824,7 +824,7 @@ libraries:
   HexRoots:
     deps: [HexPolyZ]
     mathlib: false
-    done_through: 7
+    done_through: 3
     status: active
     phase4:
       comparators:

--- a/reports/hex-berlekamp-zassenhaus-performance.md
+++ b/reports/hex-berlekamp-zassenhaus-performance.md
@@ -47,25 +47,36 @@ record for cross-system evidence; `list` and `verify` run in CI on every PR.
 
 ## Verdicts
 
-All eight parametric registrations use **mode 2, one-sided upper-bound
-parametric**. Mode 1 does not apply: the public cascade chooses among prime
-plans, bounded classical recombination, CLD lattice recombination, exact
-fallbacks, and early exits from input-dependent intermediate structure, so no
-tight scaling law for these registered families can be derived in advance.
-The declared polynomial envelope is Corollary 5.3 of Belabas, van Hoeij,
-Klüners, and Steel,
-[*Factoring polynomials over global fields*](https://doi.org/10.5802/jtnb.655),
-`O(n^9 + n^7 h^2)` with classical arithmetic. The slow registrations add the
-exhaustive subset-count bound, and the precision/local-factor registration
-separates the Hensel contribution already covered in that analysis.
+All eight parametric registrations are currently **mode 4, blocked**. Mode 1
+does not apply: the public cascade chooses among prime plans, bounded classical
+recombination, CLD lattice recombination, exact fallbacks, and early exits from
+input-dependent intermediate structure, so no tight scaling law for these
+registered families can be derived in advance.
 
-The citation covers the work these families exercise. The profile attributes
-the time to the registered factorization cascade: candidate construction and
-discarding in the classical paths, subset-enumeration churn in the exact
-backstop, and big-integer lift/CLD work in the precision and degree-height
-paths. No profile is dominated by a phase outside that bound. Mode 3 is
-therefore inapplicable: a published one-parameter upper bound and families
-that exercise it are available.
+Five registrations are candidates for mode 2 because their declarations use
+the polynomial bound in Corollary 5.9 of Belabas, van Hoeij, Klüners, and
+Steel,
+[*Factoring polynomials over global fields*](https://doi.org/10.5802/jtnb.655),
+`O(n^9 + n^7 h^2)` with classical arithmetic. The current profiles do not
+complete mode 2's dominant-phase test, however. They record leaf categories
+and symbols, not inclusive time by prime selection, Hensel lifting, classical
+recombination, and CLD. Allocation and Lean runtime dominate every category
+table, so this report cannot show that the phase covered by the cited bound is
+the phase controlling a registration.
+
+The three `runFactorSlow*` registrations do not even have the right candidate
+citation. Their timed implementation is `factorTrial`, an exhaustive integer
+trial-division path, not the modular-factor subset recombination analysed by
+van Hoeij's
+[*Factoring polynomials and the knapsack problem*](https://doi.org/10.1006/jnth.2001.2763).
+The slow profile is led by integer-divisor/list construction and allocator
+work. Its declared `2^n` multiplier therefore lacks a published citation that
+covers the measured algorithm and dominant phase. Mode 3 has not been
+established: doing so would require an operation-specific canonical hard input
+and justified absolute budget, which the existing fixed adversarial checks do
+not provide. Until that work is attempted, the ladders remain blocked.
+The `runIsabelle*` fixed endpoints are comparator anchors: they make no
+complexity claim, have no mode, and cannot replace performance coverage.
 
 Parametric export at clean `f396965d`:
 `reports/bench-results/hex-berlekamp-zassenhaus-parametric-f396965d-chungus2.json`
@@ -79,15 +90,18 @@ faster than declared`, the same
 status as the previous committed export
 (`hex-berlekamp-zassenhaus-parametric-0b95505b-gcd-hensel-chungus2.json`):
 the declared models are deliberately conservative upper envelopes over
-encoded degree/height/precision parameters (the smoke models bound the
-classical tier's worst dispatch, the `2^n` factor bounds the exact backstop),
-so observed cost growing strictly more slowly than the declared envelope is
-the expected direction. Under mode 2 each is a passing result, **within
-declared upper bound (observed faster)**; none is represented as *consistent
-with declared complexity*. Representative top rungs: `runFactorChecksum`
+encoded degree/height/precision parameters. The ordered rule does not turn
+that direction into a pass without the missing citation-and-attribution
+evidence. Representative top rungs: `runFactorChecksum`
 3.595 ms at n=24, `runFactorFallbackProbeChecksum` 3.370 ms at n=24,
 `runFastPathPrecisionLocalChecksum` 899 µs at the 8_032_128_008 encoding.
 No ladder shows the slower-than-declared direction.
+For traceability of that direction, the fitted residual slopes are `-6.778`
+for `runFactorChecksum`, `-7.245` for `runFactorSlowDegreeHeightChecksum`, and
+`-5.821` for `runFastPathPrecisionLocalChecksum`; ladders too narrow for a fit
+still have falling normalized constants, for example
+`runFactorFallbackProbeChecksum` from `0.000106` after warmup to `0.000001` at
+the final rung.
 
 ## Comparator Ratios
 
@@ -209,4 +223,11 @@ coverage for that family, not an omission.
 
 ## Concerns
 
-None.
+The eight parametric registrations have no passing mode. Five lack the
+inclusive dominant-phase attribution required for their candidate published
+upper bound; three slow registrations cite a modular-subset algorithm that the
+timed integer trial-division implementation does not run. The fixed
+adversarial checks do not supply budgeted mode-3 replacements. This finding
+and the rollback are recorded by
+[#9733](https://github.com/kim-em/hex-dev/issues/9733); a focused remediation
+issue follows after the policy lands.

--- a/reports/hex-berlekamp-zassenhaus-performance.md
+++ b/reports/hex-berlekamp-zassenhaus-performance.md
@@ -47,6 +47,26 @@ record for cross-system evidence; `list` and `verify` run in CI on every PR.
 
 ## Verdicts
 
+All eight parametric registrations use **mode 2, one-sided upper-bound
+parametric**. Mode 1 does not apply: the public cascade chooses among prime
+plans, bounded classical recombination, CLD lattice recombination, exact
+fallbacks, and early exits from input-dependent intermediate structure, so no
+tight scaling law for these registered families can be derived in advance.
+The declared polynomial envelope is Corollary 5.3 of Belabas, van Hoeij,
+Klüners, and Steel,
+[*Factoring polynomials over global fields*](https://doi.org/10.5802/jtnb.655),
+`O(n^9 + n^7 h^2)` with classical arithmetic. The slow registrations add the
+exhaustive subset-count bound, and the precision/local-factor registration
+separates the Hensel contribution already covered in that analysis.
+
+The citation covers the work these families exercise. The profile attributes
+the time to the registered factorization cascade: candidate construction and
+discarding in the classical paths, subset-enumeration churn in the exact
+backstop, and big-integer lift/CLD work in the precision and degree-height
+paths. No profile is dominated by a phase outside that bound. Mode 3 is
+therefore inapplicable: a published one-parameter upper bound and families
+that exercise it are available.
+
 Parametric export at clean `f396965d`:
 `reports/bench-results/hex-berlekamp-zassenhaus-parametric-f396965d-chungus2.json`
 (SHA-256
@@ -54,14 +74,17 @@ Parametric export at clean `f396965d`:
 command `taskset -c 17 lake exe hexbz_bench run <eight parametric targets>
 --export-file ...`.
 
-All eight ladders report `inconclusive: looks faster than declared`, the same
+All eight ladders receive the current harness verdict `inconclusive: looks
+faster than declared`, the same
 status as the previous committed export
 (`hex-berlekamp-zassenhaus-parametric-0b95505b-gcd-hensel-chungus2.json`):
 the declared models are deliberately conservative upper envelopes over
 encoded degree/height/precision parameters (the smoke models bound the
 classical tier's worst dispatch, the `2^n` factor bounds the exact backstop),
 so observed cost growing strictly more slowly than the declared envelope is
-the expected direction. Representative top rungs: `runFactorChecksum`
+the expected direction. Under mode 2 each is a passing result, **within
+declared upper bound (observed faster)**; none is represented as *consistent
+with declared complexity*. Representative top rungs: `runFactorChecksum`
 3.595 ms at n=24, `runFactorFallbackProbeChecksum` 3.370 ms at n=24,
 `runFastPathPrecisionLocalChecksum` 899 µs at the 8_032_128_008 encoding.
 No ladder shows the slower-than-declared direction.

--- a/reports/hex-gfq-field-performance.md
+++ b/reports/hex-gfq-field-performance.md
@@ -13,6 +13,26 @@
 
 ## Verdicts
 
+`runNegSubChecksum` and `runFrobChecksum` use **mode 1, two-sided
+parametric**, and both pass. The other six use **mode 2, one-sided upper-bound
+parametric**. Mode 1 is unavailable for those six because the only committed
+certificate-backed family is the degree-2-through-8 ladder: fixed word-size
+representation, extended-gcd startup, and quotient-reduction overhead all
+remain visible there, so no tight wall-time scaling on the reachable family
+can be derived in advance. The declarations are instead the classical dense
+arithmetic bounds — linear coefficientwise addition, quadratic dense
+multiplication/reduction and extended gcd, and logarithmically many quadratic
+multiplications for exponentiation — as published in von zur Gathen and
+Gerhard, [*Modern Computer Algebra*, Chapter
+2](https://www.cambridge.org/core/books/abs/modern-computer-algebra/fundamental-algorithms/6BFEAADFCE768EAC759FE0294C257CDE).
+
+The profiles satisfy mode 2's phase test: reduction dominates construction,
+multiplication plus reduction dominates field multiplication, extended gcd
+dominates inversion/division, and the square-and-multiply chain dominates
+exponentiation. These are exactly the phases covered by the cited bounds and
+exercised by the registered inputs. Mode 3 is therefore inapplicable because
+a published one-parameter upper bound is available.
+
 Comparator wiring and smoke verdict run at worktree commit
 `728f2ca-dirty` on `carica` (Apple Silicon, macOS arm64), command:
 
@@ -56,12 +76,12 @@ parametric Hex targets plus the paired fixed Hex / FLINT
   complexity (`cMin=907.931, cMax=1339.909`,
   parameters `2,3,4,6,8`, final hash `0x351dd7aebb5accca`).
 
-The remaining inconclusive verdicts are a calibration issue on the
-small certificate-backed ladder, not a blocker for the informational
-FLINT comparator. The Phase 4 comparator is now declared in
-`libraries.yml`, wired in `HexGFqField/Bench.lean`, and covered by the
-headline report; `HexGFqField.done_through` is therefore advanced to
-`4`.
+The six mode-2 registrations receive the current harness verdict
+`inconclusive` in the faster-than-declared direction on the post-warmup rungs.
+Each is therefore a passing **within declared upper bound (observed faster)**
+result, not a claim of consistency with the declared complexity. The
+comparator remains declared in `libraries.yml`, wired in
+`HexGFqField/Bench.lean`, and covered by this report.
 
 Smoke wiring was checked with:
 
@@ -280,4 +300,5 @@ calibration anchors: spawn_wall_ns=1780141979062884000, spawn_mono_ns=3300129766
 
 ## Concerns
 
-None.
+None. The two mode-1 registrations pass two-sided, and the six mode-2
+registrations pass only as distinctly reported one-sided upper-bound results.

--- a/reports/hex-gfq-field-performance.md
+++ b/reports/hex-gfq-field-performance.md
@@ -13,27 +13,24 @@
 
 ## Verdicts
 
-`runNegSubChecksum` and `runFrobChecksum` use **mode 1, two-sided
-parametric**, and both pass. The other six use **mode 2, one-sided upper-bound
-parametric**. Mode 1 is unavailable for those six because the only committed
-certificate-backed family is the degree-2-through-8 ladder: fixed word-size
-representation, extended-gcd startup, and quotient-reduction overhead all
-remain visible there, so no tight wall-time scaling on the reachable family
-can be derived in advance. The declarations are instead the classical dense
-arithmetic bounds — linear coefficientwise addition, quadratic dense
-multiplication/reduction and extended gcd, and logarithmically many quadratic
-multiplications for exponentiation — as published in von zur Gathen and
-Gerhard, [*Modern Computer Algebra*, Chapter
-2](https://www.cambridge.org/core/books/abs/modern-computer-algebra/fundamental-algorithms/6BFEAADFCE768EAC759FE0294C257CDE).
+All eight parametric performance registrations use **mode 1, two-sided
+parametric**. Their adjacent
+derivations determine the expected family scaling before measurement:
+coefficientwise addition is linear, dense multiplication/reduction and
+extended gcd are quadratic, and exponentiation repeats quadratic
+multiplication logarithmically. The same certificate-backed degree-2-through-8
+family and fixed word-size representation underlie both the passing and
+inconclusive targets, so mode cannot honestly vary with the narrow-range
+harness result. Mode 2 is unavailable because tight models are derivable;
+mode 3 cannot replace an attainable mode-1 test whose present failure is
+schedule calibration rather than model existence.
 
-The profiles satisfy mode 2's phase test: reduction dominates construction,
-multiplication plus reduction dominates field multiplication, extended gcd
-dominates inversion/division, and the square-and-multiply chain dominates
-exponentiation. These are exactly the phases covered by the cited bounds and
-exercised by the registered inputs. Mode 3 is therefore inapplicable because
-a published one-parameter upper bound is available.
+The 96 fixed registrations are comparator endpoints and canonical
+expected-hash checks. They make no complexity claim, have no mode, and do not
+replace the eight performance registrations.
 
-Comparator wiring and smoke verdict run at worktree commit
+The only recorded verdict run is comparator wiring under smoke settings at
+worktree commit
 `728f2ca-dirty` on `carica` (Apple Silicon, macOS arm64), command:
 
 ```sh
@@ -76,12 +73,14 @@ parametric Hex targets plus the paired fixed Hex / FLINT
   complexity (`cMin=907.931, cMax=1339.909`,
   parameters `2,3,4,6,8`, final hash `0x351dd7aebb5accca`).
 
-The six mode-2 registrations receive the current harness verdict
-`inconclusive` in the faster-than-declared direction on the post-warmup rungs.
-Each is therefore a passing **within declared upper bound (observed faster)**
-result, not a claim of consistency with the declared complexity. The
-comparator remains declared in `libraries.yml`, wired in
-`HexGFqField/Bench.lean`, and covered by this report.
+This dirty smoke run is not reproducible scientific evidence and cannot pass
+Phase 4. Its six inconclusive results indicate that the small
+certificate-backed ladder is miscalibrated; they are not mode-2 passes. The
+results do not block the
+informational FLINT comparator, but they do block Phase 4 until the family is
+re-tuned without fitting its models and rerun scientifically from a clean
+tree. The comparator remains declared in
+`libraries.yml`, wired in `HexGFqField/Bench.lean`, and covered by this report.
 
 Smoke wiring was checked with:
 
@@ -300,5 +299,10 @@ calibration anchors: spawn_wall_ns=1780141979062884000, spawn_mono_ns=3300129766
 
 ## Concerns
 
-None. The two mode-1 registrations pass two-sided, and the six mode-2
-registrations pass only as distinctly reported one-sided upper-bound results.
+Six mode-1 registrations remain inconclusive on the narrow
+certificate-backed ladder. The pre-policy report already identified this as
+miscalibration, and the ordered rule does not change it into a pass. No clean
+scientific run exists for any of the eight registrations.
+This finding and the rollback are recorded by
+[#9733](https://github.com/kim-em/hex-dev/issues/9733); a focused remediation
+issue follows after the policy lands.

--- a/reports/hex-hensel-performance.md
+++ b/reports/hex-hensel-performance.md
@@ -4,29 +4,53 @@ Current at revision `0b95505b7c926911a9f487bac56676a8c7da48f6`, measured
 2026-07-29 on `chungus2` (AMD EPYC 9455, Linux x86-64), pinned to CPU 0.
 All nine parametric targets were refreshed together from a clean worktree.
 
+## Bench targets
+
+The nine performance registrations and their declarations, copied from
+`bench/HexHensel/Bench.lean`, are:
+
+| registration | model | family |
+|---|---|---|
+| `runModPChecksum` | `n` | bridge operations |
+| `runLiftToZChecksum` | `n` | bridge operations |
+| `runReduceModPowChecksum` | `n` | bridge operations |
+| `runLinearHenselStepChecksum` | `n * n` | linear Hensel |
+| `runHenselLiftChecksum` | `n^2 k` through `liftLinearComplexity` | linear Hensel |
+| `runQuadraticHenselStepChecksum` | `n * n` | quadratic Hensel |
+| `runPolyProductChecksum` | `n * n` | multifactor lifting |
+| `runMultifactorLiftChecksum` | `n^2 k` through `liftLinearComplexity` | multifactor lifting |
+| `runMultifactorLiftQuadraticChecksum` | `n^2 log k` through `liftQuadraticComplexity` | multifactor lifting |
+
 ## Verdicts
 
-All nine registrations use **mode 1, two-sided parametric**. Their models are
+All nine parametric performance registrations use **mode 1, two-sided
+parametric**. Their models are
 derived from the intended linear or quadratic lifting algorithm on the
 registered degree/precision family, so mode 2's prerequisite — inability to
 derive a tight family model — does not hold. The six consistent results pass
-mode 1. The three inconclusive results leave the library **mode 4, blocked**:
-the existing mixed schedules have not established the derived scaling, and no
-published bound plus dominant-phase attribution has been supplied for a
-one-sided reinterpretation. Mode 3 is not justified while the controlled
-degree/precision families remain available.
+mode 1. The three inconclusive results are failed mode-1 results, so Phase 4 is
+blocked: the existing mixed schedules have not established the derived
+scaling, and no published bound plus dominant-phase attribution has been
+supplied for a one-sided reinterpretation. Mode 3 is not justified while the
+independently derived mode-1 models remain attainable on controlled
+degree/precision families. Mode 4 does not apply to these registrations
+because mode 1 is an honest claim; it simply has not passed.
+
+The fixed FLINT endpoints are comparator and protocol anchors. They make no
+complexity claim, have no mode, and do not replace the nine performance
+registrations.
 
 | Target | Model | Largest rung | Median | Verdict |
 |---|---|---:|---:|---|
-| Reduce mod `p` | `n` | 131072 | 9.601 ms | consistent |
-| Lift to `Z` | `n` | 131072 | 2.582 ms | consistent |
-| Reduce mod `p^k` | `n` | 131072 | 733.006 µs | consistent |
-| Linear step | `n²` | 512 | 15.568 ms | consistent |
-| Iterated linear lift | `n²k` | `(192,64)` | 145.374 ms | inconclusive |
-| Quadratic step | `n²` | 512 | 8.481 ms | consistent |
-| Product | `n²` | 1024 | 161.314 ms | consistent |
-| Linear multifactor | `n²k` | `(192,64)` | 147.330 ms | inconclusive |
-| Quadratic multifactor | `n² log k` | `(192,64)` | 48.711 ms | inconclusive |
+| `runModPChecksum` | `n` | 131072 | 9.601 ms | consistent |
+| `runLiftToZChecksum` | `n` | 131072 | 2.582 ms | consistent |
+| `runReduceModPowChecksum` | `n` | 131072 | 733.006 µs | consistent |
+| `runLinearHenselStepChecksum` | `n²` | 512 | 15.568 ms | consistent |
+| `runHenselLiftChecksum` | `n²k` | `(192,64)` | 145.374 ms | inconclusive |
+| `runQuadraticHenselStepChecksum` | `n²` | 512 | 8.481 ms | consistent |
+| `runPolyProductChecksum` | `n²` | 1024 | 161.314 ms | consistent |
+| `runMultifactorLiftChecksum` | `n²k` | `(192,64)` | 147.330 ms | inconclusive |
+| `runMultifactorLiftQuadraticChecksum` | `n² log k` | `(192,64)` | 48.711 ms | inconclusive |
 
 The packed verified kernels remain visible in the quadratic row: the
 degree-512 step is 15.2× faster than the 128.731 ms pre-kernel record. The new
@@ -46,7 +70,15 @@ Raw export:
 The covered input families are `bridge-operations`, `linear-hensel`,
 `quadratic-hensel`, and `multifactor-lifting`.
 
-## External Comparator Status
+## Profile
+
+No inclusive profile is recorded for the three failed mode-1 registrations.
+Before Phase 4 can be reclaimed, profile their largest completed rungs and
+separate schedule/encoding effects from a wrong implementation shape. That
+missing attribution evidence is part of the remediation, not grounds for a
+one-sided reinterpretation.
+
+## Comparator Ratios
 
 The declared comparator is `FLINT nmod_poly_hensel_lift_* via python-flint`.
 The five python-flint comparator exports from 2026-07-28 remain valid records
@@ -59,9 +91,15 @@ and is not a native-FLINT performance claim.
 
 ## Concerns
 
-- **Mode 4, blocked.** The `n²k` iterated-linear verdicts remain inconclusive
-  on the mixed degree/precision schedule.
+- The `n²k` iterated-linear mode-1 verdicts remain inconclusive on the mixed
+  degree/precision schedule, so Phase 4 is blocked.
 - The quadratic-multifactor model is now inconclusive because the optimized
   high-precision rung changes the observed ladder shape.
+- Inclusive profiles for the three failed top rungs have not yet separated a
+  schedule/encoding problem from an implementation-shape problem.
 - A current native-FLINT Hensel comparison still needs bindings that
   python-flint does not expose.
+
+The failed mode-1 verdicts and rollback are recorded by
+[#9733](https://github.com/kim-em/hex-dev/issues/9733); a focused remediation
+issue follows after the policy lands.

--- a/reports/hex-hensel-performance.md
+++ b/reports/hex-hensel-performance.md
@@ -6,6 +6,16 @@ All nine parametric targets were refreshed together from a clean worktree.
 
 ## Verdicts
 
+All nine registrations use **mode 1, two-sided parametric**. Their models are
+derived from the intended linear or quadratic lifting algorithm on the
+registered degree/precision family, so mode 2's prerequisite — inability to
+derive a tight family model — does not hold. The six consistent results pass
+mode 1. The three inconclusive results leave the library **mode 4, blocked**:
+the existing mixed schedules have not established the derived scaling, and no
+published bound plus dominant-phase attribution has been supplied for a
+one-sided reinterpretation. Mode 3 is not justified while the controlled
+degree/precision families remain available.
+
 | Target | Model | Largest rung | Median | Verdict |
 |---|---|---:|---:|---|
 | Reduce mod `p` | `n` | 131072 | 9.601 ms | consistent |
@@ -49,8 +59,8 @@ and is not a native-FLINT performance claim.
 
 ## Concerns
 
-- The `n²k` iterated-linear verdicts remain inconclusive on the mixed
-  degree/precision schedule.
+- **Mode 4, blocked.** The `n²k` iterated-linear verdicts remain inconclusive
+  on the mixed degree/precision schedule.
 - The quadratic-multifactor model is now inconclusive because the optimized
   high-precision rung changes the observed ladder shape.
 - A current native-FLINT Hensel comparison still needs bindings that

--- a/reports/hex-number-field-performance.md
+++ b/reports/hex-number-field-performance.md
@@ -94,13 +94,15 @@ adaptive working precision eventually reached by the isolator:
 | algebraic roots | 6 | 12 | 366,720 | 19 | 274 |
 | algebraic roots | 8 | 16 | 602,625 | 20 | 389 |
 
-This operation-specific assessment does not reclassify the three other
-registrations whose comments contain the HexRoots isolation proxy:
-`runExactFactorLadder` and `runCanonicalRepLadder` already remain open
-faster-than-envelope concerns under #9733, while `runQAdjoinRootsLadder` has a
-different repeated-component path repaired under #9724. Their heuristic
-isolation terms are not presented here as consequences of the BSSY theorem or
-as support for this fixed-mode decision.
+This operation-specific assessment does not resolve the three other
+registrations whose comments contain the HexRoots isolation proxy.
+`runExactFactorLadder` and `runCanonicalRepLadder` remain open
+faster-than-envelope concerns. The #9724 repair removed
+`runQAdjoinRootsLadder`'s repeated-component exactification pathology, but it
+did not establish the provenance of that ladder's declaration; the ordered
+rule therefore classifies it as mode 4 too. None of those heuristic isolation
+terms is presented here as a consequence of the BSSY theorem or as support for
+this fixed-mode decision.
 
 The current local `hexnumberfield_bench verify` invocation completes in 11.84 s
 on the reference host, below the per-library 30 s soft-warning threshold. Both
@@ -217,25 +219,42 @@ library as a whole.
 
 ## Verdicts
 
-The five passing ladders use **mode 1, two-sided parametric**: their adjacent
-derivations give the expected scaling of the intended algorithm on the
-controlled family before measurement. The remaining four parametric ladders
-leave the library **mode 4, blocked**:
+Five ladders use **mode 1, two-sided parametric**:
+`runQAdjoinAddLadder`, `runQAdjoinMulLadder`, `runAddEliminantLadder`,
+`runCommonPresentationLadder`, and `runMergeRootListLadder`. Their adjacent
+derivations give the intended algorithms' expected scaling on the controlled
+families before measurement, and all five pass.
 
-- `runQAdjoinInvLadder` and `runQAdjoinRootsLadder` are slower than their
-  declarations, so neither can pass mode 1 or the weaker one-sided test.
+`runLazyAddLadder` and `runAlgebraicRootsLadder` use **mode 3, fixed
+registration with an absolute budget**. The adjacent isolation-mode assessment
+records why modes 1 and 2 do not apply, identifies their canonical inputs, and
+sets 12 s and 15 s ceilings. Both fixed measurements and hashes pass. This
+deliberately gives up asymptotic detection for those two operations without
+changing their per-library worst-case contracts.
+
+The remaining five parametric ladders block Phase 4:
+
+- `runQAdjoinInvLadder` is faster than its conservative worst-case bit-cost
+  proxy. A tighter aggregate family model has not yet been derived, and the
+  proxy is not supplied as a published, cited mode-2 bound covering the
+  profiled chain. It is therefore mode 4, tracked by #9743.
+- `runQAdjoinRootsLadder` declares the same composed `n^5 log^2 n` heuristic
+  isolation estimate withdrawn from the two fixed registrations. Its
+  statistically matching harness result does not turn that heuristic into an
+  independently derived mode-1 model, and no published upper bound for this
+  norm-eliminant family supports mode 2. It is mode 4.
 - `runExactLadder` cannot use mode 2 even though the BHKS factorization bound
-  is published: the profile shows candidate re-isolation and canonicalisation
-  dominate while factorization is absent, so the cited bound does not cover
-  the measured phase.
-- `runAlgebraicRootsLadder` is faster than its declaration, but the declared
-  `n^5 log^2 n` is composed from a heuristic isolation estimate rather than a
-  published upper bound for this norm-eliminant family. It therefore cannot
-  use mode 2.
+  is published: the profile shows certification and candidate re-isolation
+  dominate, while factorization is only 18.64% of the end-to-end call. The
+  cited bound therefore does not cover the dominant measured phase.
+- `runExactFactorLadder` and `runCanonicalRepLadder` expose those dominant
+  certification phases, but their declarations add the same heuristic
+  isolation estimate rather than a published upper bound. They are also
+  mode 4.
 
-The existing fixed registrations are canonical API and comparator checks; they
-do not supply the operation-specific rationale and absolute budgets needed to
-resolve these four ladders through mode 3. Their unresolved work remains
+The other 35 fixed registrations are canonical API, comparator, and protocol
+checks. They make no complexity claim, have no mode, and do not replace the
+twelve performance registrations. The five unresolved registrations remain
 tracked by the issues in §Concerns, so no model is fitted and no parametric
 failure is reclassified as a pass.
 
@@ -257,10 +276,13 @@ runs below give the measurements; this table says which one counts.
 | `runQAdjoinRootsLadder` | **consistent** | -0.251 | root-merge fix |
 | `runAlgebraicRootsLadder` | **fixed: 5.955 s, hash match** | — | isolation fixed |
 
-Six parametric registrations fit their declared models. The four that do not
-are §Concerns entries,
-each with a filed issue; none of them is a measurement artefact, and §Profile
-identifies the phase controlling each profiled end-to-end call.
+Six parametric registrations receive a statistically matching two-sided
+harness verdict, but only the five named above have independently derived
+mode-1 claims. `runQAdjoinRootsLadder` matches a withdrawn heuristic isolation
+proxy and remains mode 4. The other four parametric ladders are faster than
+declared. None of these five blocked classifications is a measurement
+artefact, and §Profile identifies the phase controlling each profiled
+end-to-end call.
 For the normalized inversion chain specifically, the former
 slower-than-declared defect is fixed. The single-root fixture now carries the
 normalized chain through degree 96; its remaining faster-than-declared result
@@ -422,12 +444,15 @@ registered `signalFloorMultiplier := 1.0` disables the conservative default
 10× exclusion without timing parent-side startup as algorithm work.
 
 All three remain in the faster-than-declared direction. `canonicalRep?` uses
-the textbook isolation envelope; `exactFactor?` uses that envelope plus the
-BHKS factorization it invokes for its irreducibility guard; and the end-to-end
-model is BHKS evaluated at the fixture's actual degree and height. These are
-large monotone shape mismatches, quantified below, not constant-factor slack.
-Under the harness's current two-sided verdict none is a Phase-4 pass; issue
-9733 tracks the cross-library policy question without reclassifying this data.
+the declared heuristic isolation envelope; `exactFactor?` uses that envelope
+plus the BHKS factorization it invokes for its irreducibility guard; and the
+end-to-end model is BHKS evaluated at the fixture's actual degree and height.
+These are large monotone shape mismatches, quantified below, not
+constant-factor slack.
+Under the harness's current two-sided verdict none is a Phase-4 pass. The
+ordered rule classifies all three as mode 4 because the declarations do not
+cover the profiled dominant phases with independently derived tight models or
+published upper bounds.
 
 A second quiet run historically covered the three ladders too expensive to fit
 in the same window, at three outer trials, on the idle host. The two
@@ -570,8 +595,8 @@ are:
 
 The end-to-end replacement therefore exercises the missing phase but does not
 repair the model fit: its decline in `C` is larger than the former family's.
-That result remains an open finding, as required; issue 9733 asks what verdict
-an honest upper envelope should receive across Phase 4.
+That result remains an open finding, as required. The ordered rule classifies
+it as mode 4 until the model-provenance gap is repaired.
 
 (The historical exactification and lazy-addition figures are from the quiet
 runs, the repaired fixed-field-root figure is from the root-merge fix run,
@@ -1034,7 +1059,7 @@ pass are each tracked:
   nothing measures, so the Attribution rule is not satisfied.
   https://github.com/kim-em/hex-dev/issues/9722 — audit-found: HexNumberField's
   advertised API surface is not fully registered for Phase 4.
-- **The exactification ladders remain faster than their textbook envelopes.**
+- **The exactification ladders remain faster than their declared envelopes.**
   The end-to-end family now enters multifactor Hensel lifting and combination
   search, and the dominant certification phases have their own registrations.
   That fixes attribution, not fit: cMax/cMin is 664.357 for end-to-end
@@ -1043,5 +1068,13 @@ pass are each tracked:
   `inconclusive` in the faster-than-declared direction. This is explicitly an
   open shape mismatch; the two-sided upper-envelope policy is not being used
   to call it a pass.
-  https://github.com/kim-em/hex-dev/issues/9733 — audit-found: Phase 4 has no
-  rule for a model that is an upper bound.
+  https://github.com/kim-em/hex-dev/issues/9733 — the ordered-rule audit that
+  records this blocked classification until its focused remediation issue is
+  filed after the policy lands.
+- **`runQAdjoinRootsLadder` still uses the withdrawn heuristic isolation
+  proxy.** The statistically matching harness verdict does not validate the
+  composed `n^5 log^2 n` declaration. The sibling lazy-add and algebraic-roots
+  operations now use justified mode-3 fixed registrations, but this repeated-
+  component family has not yet been worked through the ordered rule on its own.
+  https://github.com/kim-em/hex-dev/issues/9733 records this classification
+  until its focused follow-up is filed after the policy merge.

--- a/reports/hex-number-field-performance.md
+++ b/reports/hex-number-field-performance.md
@@ -217,6 +217,28 @@ library as a whole.
 
 ## Verdicts
 
+The five passing ladders use **mode 1, two-sided parametric**: their adjacent
+derivations give the expected scaling of the intended algorithm on the
+controlled family before measurement. The remaining four parametric ladders
+leave the library **mode 4, blocked**:
+
+- `runQAdjoinInvLadder` and `runQAdjoinRootsLadder` are slower than their
+  declarations, so neither can pass mode 1 or the weaker one-sided test.
+- `runExactLadder` cannot use mode 2 even though the BHKS factorization bound
+  is published: the profile shows candidate re-isolation and canonicalisation
+  dominate while factorization is absent, so the cited bound does not cover
+  the measured phase.
+- `runAlgebraicRootsLadder` is faster than its declaration, but the declared
+  `n^5 log^2 n` is composed from a heuristic isolation estimate rather than a
+  published upper bound for this norm-eliminant family. It therefore cannot
+  use mode 2.
+
+The existing fixed registrations are canonical API and comparator checks; they
+do not supply the operation-specific rationale and absolute budgets needed to
+resolve these four ladders through mode 3. Their unresolved work remains
+tracked by the issues in §Concerns, so no model is fitted and no parametric
+failure is reclassified as a pass.
+
 Authoritative verdict per ladder, and which committed run it comes from. The
 runs below give the measurements; this table says which one counts.
 

--- a/reports/hex-poly-smith-performance.md
+++ b/reports/hex-poly-smith-performance.md
@@ -84,6 +84,22 @@ Scientific command:
 
 ## Verdicts
 
+This library is **mode 4, blocked**, except for the two passing mode-1
+registrations named below. `runChainSnf` and `runSmallField` use **mode 1,
+two-sided parametric**: their fixed-degree families independently leave the
+cubic matrix-update cost dominant, and both match that declaration.
+
+The other fourteen registrations do not currently admit any passing mode.
+Their declarations are algebraic-operation proxies that deliberately exclude
+the intermediate polynomial-degree and rational coefficient-bit growth
+measured by `growth`; they are therefore neither tight wall-time models for
+mode 1 nor published wall-time upper bounds for mode 2. The profiles confirm
+that this omitted expression swell dominates the dense and rational families.
+Mode 3 is not available merely to evade those results: these operations have
+stable parametric input families, and no canonical hard input with an absolute
+budget has been justified as a replacement. Their current harness results are
+findings, not upper-bound passes.
+
 `C` is per-call time divided by the declared model. The last column is the
 largest completed rung; `—` means the wallclock cap prevented a residual-slope
 fit.
@@ -259,9 +275,10 @@ in the table, and a 3,000,000,000 ns target duration.
 
 ## Concerns
 
-None. The dense and rational scientific verdicts are intentionally reported as
-inconclusive: the boundary-growth artifact and profiles attribute the departure
-from algebraic-operation proxies to intermediate degree and coefficient swell
-in the classical Euclidean kernel. The external comparators are informational,
-all hashes agree, and no unexplained correctness, wiring, or profiling concern
-remains.
+The library is blocked in mode 4. Fourteen parametric registrations lack a
+tight wall-time model or a cited upper bound that includes the measured
+intermediate degree and coefficient swell. The boundary-growth artifact and
+profiles localize the gap to the classical Euclidean kernel, but localization
+does not make the algebraic-operation proxies passing complexity claims. The
+external comparators are informational and all hashes agree; those facts do
+not discharge the missing model.

--- a/reports/hex-poly-smith-performance.md
+++ b/reports/hex-poly-smith-performance.md
@@ -84,21 +84,33 @@ Scientific command:
 
 ## Verdicts
 
-This library is **mode 4, blocked**, except for the two passing mode-1
-registrations named below. `runChainSnf` and `runSmallField` use **mode 1,
+Fourteen parametric performance registrations are **mode 4, blocked**; the two
+passing registrations named below use mode 1. `runChainSnf` and
+`runSmallField` use **mode 1,
 two-sided parametric**: their fixed-degree families independently leave the
 cubic matrix-update cost dominant, and both match that declaration.
 
 The other fourteen registrations do not currently admit any passing mode.
-Their declarations are algebraic-operation proxies that deliberately exclude
-the intermediate polynomial-degree and rational coefficient-bit growth
-measured by `growth`; they are therefore neither tight wall-time models for
-mode 1 nor published wall-time upper bounds for mode 2. The profiles confirm
-that this omitted expression swell dominates the dense and rational families.
-Mode 3 is not available merely to evade those results: these operations have
-stable parametric input families, and no canonical hard input with an absolute
-budget has been justified as a replacement. Their current harness results are
-findings, not upper-bound passes.
+For twelve dense, rational, consumer, and evaluation registrations, the
+declarations are algebraic-operation proxies that exclude the intermediate
+polynomial-degree and rational coefficient-bit growth measured by `growth`;
+they are therefore neither tight wall-time models for mode 1 nor published
+wall-time upper bounds for mode 2. The profiles confirm that this omitted
+expression swell dominates the dense and rational families.
+
+Two failures have a different direction and cannot be explained by omitted
+swell. `runDirectProductCert` is faster than declared (`beta = -0.786`), so
+its model or family is wrong. `runDiagonalSnf` is marginally faster than its
+mode-1 tolerance (`beta = -0.155` against `0.15`) and requires an independent
+calibration diagnosis rather than being grouped with the slower swell cases.
+Mode 3 has not been established for any of the fourteen: doing so would
+require ruling out a reachable tight model and supplying a canonical hard
+input with a justified absolute budget. Until that work is done, their current
+harness results are blocked findings, not upper-bound or fixed passes.
+
+The fixed comparator endpoints and canonical expected-hash checks make no
+complexity claim, have no mode, and do not replace these sixteen performance
+registrations.
 
 `C` is per-call time divided by the declared model. The last column is the
 largest completed rung; `—` means the wallclock cap prevented a residual-slope
@@ -275,10 +287,15 @@ in the table, and a 3,000,000,000 ns target duration.
 
 ## Concerns
 
-The library is blocked in mode 4. Fourteen parametric registrations lack a
-tight wall-time model or a cited upper bound that includes the measured
-intermediate degree and coefficient swell. The boundary-growth artifact and
-profiles localize the gap to the classical Euclidean kernel, but localization
-does not make the algebraic-operation proxies passing complexity claims. The
+The library is blocked in mode 4. Twelve parametric registrations lack a tight
+wall-time model or a cited upper bound that includes the measured intermediate
+degree and coefficient swell. The boundary-growth artifact and profiles
+localize that gap to the classical Euclidean kernel, but localization does not
+make the algebraic-operation proxies passing complexity claims.
+`runDirectProductCert` instead has a faster model/family mismatch, while
+`runDiagonalSnf` needs a separate tolerance-boundary calibration audit. The
 external comparators are informational and all hashes agree; those facts do
-not discharge the missing model.
+not discharge either class of missing evidence. These findings and the
+rollback are recorded by
+[#9733](https://github.com/kim-em/hex-dev/issues/9733); a focused remediation
+issue follows after the policy lands.

--- a/reports/hex-roots-performance.md
+++ b/reports/hex-roots-performance.md
@@ -1,10 +1,12 @@
 # HexRoots Performance Report
 
-**Phase 4 is claimed for HexRoots.** The final registration split keeps the one
-honestly modelled helper sweep parametric and tracks all GMP-transition
-kernels, whole-polynomial drivers, and strategy experiments as canonical fixed
-regressions. The parametric registration is consistent, all fixed hashes agree, and §Concerns
-is empty. This report records the Phase-4 evidence per
+**Phase 4 is not currently claimed for HexRoots.** The ordered-mode audit keeps
+the one honestly modelled helper sweep as a passing mode-1 registration, but
+the other thirteen fixed performance registrations do not yet satisfy mode 3.
+Several have reachable parametric models whose old schedules need repair; the
+remaining fixed candidates lack an enforced, operation-specific budget with
+current clean evidence. `libraries.yml` therefore records `done_through: 3`.
+This report records the evidence per
 [PLAN/Phase4.md](../PLAN/Phase4.md) and
 [SPEC/benchmarking.md §Headline reports](../SPEC/benchmarking.md#headline-reports).
 
@@ -140,13 +142,11 @@ Canonical fixed registrations (`repeats = 5`) are `runIsolate`
 degree 12), `runRefineTo` (achieved precision 131077), the three strategy
 drivers (shared `linProdPoly 10`), and `runSameRoot`.
 
-The fixed classification is intentional: exact Taylor shifts have intrinsic
-linear output-bit growth and the reachable GMP transition admits no honest
-single scalar asymptotic model. Three calibration rounds, including a direct
-limb model, produced falling normalized constants because maximum output width
-is not mean operand width across the triangular computation. Fixed cases retain
-regression signal without asserting an inexpressible slope; lean-bench#67
-tracks structured op-count/operand-growth reporting.
+The fixed split predates the ordered rule. It remains useful diagnostic and
+hash-regression coverage, but fixed registration alone is not a mode-3 pass.
+The audit below separates cases with reachable parametric models from genuine
+fixed-mode candidates; lean-bench#67 tracks structured op-count/operand-growth
+reporting for the GMP-transition cases.
 
 ### Superseded round-one target record
 
@@ -220,27 +220,32 @@ wall-time models. Which op-count models changed, and why:
 is derived from the coefficient scan with bounded coefficient height, and the
 scientific verdict passes in both directions.
 
-The other thirteen registrations use **mode 3, fixed registration with an
-absolute budget**, under
+The other thirteen fixed performance registrations are currently **mode 4,
+blocked**, under
 [`SPEC/benchmarking.md` §Choosing the complexity claim](../SPEC/benchmarking.md#choosing-the-complexity-claim).
-Mode 1 is unavailable because the reachable wall-time bands cross GMP
-representations, combine degree with growing Taylor-coefficient width or
-separation depth, or quantize achieved precision; three calibration rounds
-found no stable one-parameter scalar wall model derived independently of the
-timings. Mode 2 is unavailable because the SPEC's schoolbook-operation bounds
-do not describe those GMP transition bands tightly enough to be published
-wall-time bounds for the profiled kernels. Each fixed target therefore uses
-the canonical hard input listed below, its registration's per-call ceiling as
-the absolute budget, and an expected hash. This deliberately gives up
-asymptotic regression detection for those operations; the SPEC's worst-case
-contracts remain unchanged.
+The fixed split implemented in #8750 predates the ordered rule and does not by
+itself establish mode 3.
 
-The absolute per-call budgets are 4 s for `runTaylor`, `runWitnessCheck`,
-`runNkWitnessCheck`, `runNewtonSquare`, `runRefine1`, and `runRefineTo`; 6 s
-for `runCertify`; 20 s for `runIsolateAll` and `runIsolateNk`; 30 s for
-`runIsolate`; 8 s for `runIsolatePellet` and
-`runIsolateNkThenPellet`; and the lean-bench fixed-registration default of
-60 s for `runSameRoot`.
+Ten registrations do not yet establish mode 3. The historical record either
+shows the proposed model passing on a sibling or target (`runNkWitnessCheck`,
+`runRefine1`, and `runIsolateNk`) or prescribes a schedule, family, or
+parameter repair for `runWitnessCheck`, `runNewtonSquare`, `runCertify`,
+`runIsolateAll`, `runRefineTo`, `runIsolatePellet`, and
+`runIsolateNkThenPellet`. The report does not record those attempts failing on
+the current fixtures, so the adjacent transition-band assertions are not yet
+enough to prove that no stable parametric model is reachable. A fixed
+registration may not replace those tests without that evidence.
+
+`runTaylor` and `runIsolate` are mode-3 candidates because the reachable GMP
+transition lacks a stable scalar wall model for the former and the honestly
+derived `~n^7` isolation family is outside the usable wall-time band for the
+latter. `runSameRoot` likewise has no justified parametric model. None of the
+three currently has an independently sourced or enforced operation-specific
+absolute budget with clean current evidence; a generic per-call cap is not
+such a budget. Mode 2 is unavailable for all thirteen because no cited
+published bound covers these executable wall-time paths. They therefore stay
+blocked rather than being grandfathered as fixed passes. The per-library
+worst-case contracts remain unchanged.
 
 Quiet-machine command:
 
@@ -264,7 +269,8 @@ honestly derived wall from `O(n³·B²)` is `~n⁷`, unreachable in the
 30 s/call band. Per the no-fitting rule the registration was demoted to
 a fixed case rather than kept on a fitted model; see issue #8750.)
 
-Fixed medians (all five repeats agree on the shown hash):
+Historical fixed medians (all five repeats agreed on the shown hash at the
+export's source revision):
 
 | registration | canonical input | median | hash |
 |---|---|---:|---|
@@ -275,12 +281,17 @@ Fixed medians (all five repeats agree on the shown hash):
 | `runNewtonSquare` | bounded-height degree 128 | 2.090 ms | `0x450307c7dcbe905c` |
 | `runRefine1` | fixed-separation degree 8 | 2.121 ms | `0x6dd99fc71c5233ae` |
 | `runCertify` | pinned-NK degree 128 | 4.311 ms | `0x1698ec123da6112f` |
-| `runIsolateAll` | fixed-separation degree 12 | 8.541 s | `0x5e4b3fd1d798497a` |
-| `runRefineTo` | achieved precision 131077 | 313.955 ms | `0x8dd3e4ee56489bf8` |
+| `runIsolateAll` | fixed-separation degree 12 | 8.541 s | `0x5e4b3fd1d798497a` (current registration expects `0x1d4ce3e46eb351de`) |
+| `runRefineTo` | achieved precision 131077 | 313.955 ms | `0x8dd3e4ee56489bf8` (current registration expects `0xd9e59c44612d0e21`) |
 | `runIsolateNk` | `linProdPoly 10` | 9.809 s | `0xda631bdf13415a4f` |
 | `runIsolatePellet` | `linProdPoly 10` | 2.500 s | `0xda631bdf13415a4f` |
 | `runIsolateNkThenPellet` | `linProdPoly 10` | 2.469 s | `0xda631bdf13415a4f` |
 | `runSameRoot` | fixed refined atom | 131 ns | `0xb` |
+
+The dirty post-ratchet export matched the expected hashes at its source
+revision. Later output-shape changes updated the two expectations shown above,
+so this table is diagnostic history, not current clean mode-3 evidence; a
+remediation run must refresh it.
 
 ### Superseded round-one verdict record
 
@@ -324,9 +335,10 @@ slope, iff `cMax/cMin ≤ max(1.5, exp(0.15·xRange))`):
 median `132 ns` (min `130`, max `134`, `×2^13` inner repeats), all repeats
 agree on hash `0xb`, matching the registered `expectedHash`.
 
-The nine inconclusive verdicts are analysed in §Concerns. They fall into four
+The nine inconclusive verdicts are analysed in the historical calibration
+record below. They fall into four
 root causes, none of which is a wrong-asymptotic *implementation* bug that a
-`done_through` rollback of the `def` would fix: the fixed non-integer Taylor
+rollback of the implementation would fix: the fixed non-integer Taylor
 centre's transition-band growth, the startup-dominated microsecond band of the
 small-degree witness benches, the seeded family's degree-dependent (hence
 non-power-law) root geometry, and `refineTo`'s Newton-doubling precision
@@ -532,11 +544,13 @@ unregistered helper dominates and no new target is required. (Lean's
 closure-call unwinding fragments some inclusive attribution into an unresolved
 `0x1` frame ~6 %, a `perf`/RTS artefact, not an unregistered hot path.)
 
-## Resolved Historical Concerns
+## Historical Calibration Record
 
 The preceding Phase-3 audit blocked Phase 4 and kept `done_through` at `3`.
-Each Concern below is retained as historical evidence, together with the
-diagnosis and resolution that now permit `done_through: 4`.
+Each item below is retained as historical evidence, together with its
+diagnosis and proposed resolution. The older fixed/parametric split treated
+these as resolved, but the ordered rule does not: schedule and family repairs
+must be attempted before mode 3 can replace a reachable parametric model.
 None is a wrong-asymptotic implementation bug that rolling back a `def` would
 fix; the resolutions are Phase-4 benchmark re-scaffolding (new schedules, a
 smooth driver family, an integer Taylor centre) plus a SPEC time-budget
@@ -608,11 +622,18 @@ For reference, the one budget that is met: **degree 10 @ prec 32** runs in
 `runIsolateAll` `n=10` bench row of `138 ms`), comfortably under the `< 1 s`
 target.
 
-The transition-band and family/schedule items above are resolved by the final
-fixed/parametric split. The two obsolete time-budget items were reality-anchored
-by #8762 and subsequently tightened by the Graeffe/soft-Pellet ratchet recorded
-at the top of this report.
+The two obsolete time-budget items were reality-anchored by #8762 and
+subsequently tightened by the Graeffe/soft-Pellet ratchet recorded at the top
+of this report. The transition-band and family/schedule items remain Phase-4
+work under the ordered rule.
 
 ## Concerns
 
-None.
+Thirteen fixed performance registrations have no passing mode. Ten were made
+fixed before the report recorded the proposed schedule, family, or parameter
+repairs failing on the current fixtures. The other three lack justified,
+enforced absolute budgets and clean current evidence for mode 3; two hashes in
+the latest recorded dirty export also predate the current registration values.
+The rollback is recorded by
+[#9733](https://github.com/kim-em/hex-dev/issues/9733); a focused remediation
+issue follows after the policy lands.

--- a/reports/hex-roots-performance.md
+++ b/reports/hex-roots-performance.md
@@ -216,6 +216,32 @@ wall-time models. Which op-count models changed, and why:
 
 ## Verdicts
 
+`runMahlerPrec` uses **mode 1, two-sided parametric**. Its linear family model
+is derived from the coefficient scan with bounded coefficient height, and the
+scientific verdict passes in both directions.
+
+The other thirteen registrations use **mode 3, fixed registration with an
+absolute budget**, under
+[`SPEC/benchmarking.md` §Choosing the complexity claim](../SPEC/benchmarking.md#choosing-the-complexity-claim).
+Mode 1 is unavailable because the reachable wall-time bands cross GMP
+representations, combine degree with growing Taylor-coefficient width or
+separation depth, or quantize achieved precision; three calibration rounds
+found no stable one-parameter scalar wall model derived independently of the
+timings. Mode 2 is unavailable because the SPEC's schoolbook-operation bounds
+do not describe those GMP transition bands tightly enough to be published
+wall-time bounds for the profiled kernels. Each fixed target therefore uses
+the canonical hard input listed below, its registration's per-call ceiling as
+the absolute budget, and an expected hash. This deliberately gives up
+asymptotic regression detection for those operations; the SPEC's worst-case
+contracts remain unchanged.
+
+The absolute per-call budgets are 4 s for `runTaylor`, `runWitnessCheck`,
+`runNkWitnessCheck`, `runNewtonSquare`, `runRefine1`, and `runRefineTo`; 6 s
+for `runCertify`; 20 s for `runIsolateAll` and `runIsolateNk`; 30 s for
+`runIsolate`; 8 s for `runIsolatePellet` and
+`runIsolateNkThenPellet`; and the lean-bench fixed-registration default of
+60 s for `runSameRoot`.
+
 Quiet-machine command:
 
 ```sh


### PR DESCRIPTION
Addresses #9733.

## What changed

- define the ordered four-mode selection rule in `SPEC/benchmarking.md`, including the no-fitting and preserved-worst-case-contract guards
- scope modes to registrations used as performance evidence; fixed hash, comparator, and protocol anchors remain explicitly non-performance evidence
- align Phase 4 discipline and exit criteria with passing results in each declared mode, and queue an audit of existing Phase-4 reports
- link lean-bench feature request [#70](https://github.com/kim-em/lean-bench/issues/70) for one-sided verdicts and signed direction vocabulary
- reconcile all six named headline reports against the ordered rule
- roll `HexBerlekampZassenhaus`, `HexPolySmith`, `HexGFqField`, `HexHensel`, and `HexRoots` back to `done_through: 3` because their current evidence does not pass Phase 4

## Performance rationale

The benchmark claim differs from the per-library worst-case contract only where the ordered rule permits it. `HexNumberField` now has five passing mode-1 ladders and two passing mode-3 fixed isolation registrations from #9768; its other five performance ladders remain blocked. `HexBerlekampZassenhaus` is mode 4: five ladders lack inclusive dominant-phase attribution for their candidate BHKS bound, while the three slow ladders time integer trial division rather than the modular recombination algorithm covered by their previous citation. `HexRoots` also rolls back: its earlier fixed split predates the ordered rule, and the report does not establish mode 3 for thirteen fixed performance registrations. The other affected libraries retain their worst-case SPEC contracts but are recorded as failed mode 1 or blocked mode 4 rather than fitting or reclassifying their measurements.

The second-opinion reviews prompted the Berlekamp–Zassenhaus correction, the fixed-anchor scope clarification, the mode-3 calibration and budget requirements, the audit-reset language, the stricter Roots reassessment, and separate treatment of PolySmith's faster and slower failures. Follow-up remediation issues will be filed after this policy PR merges, then #9733 will be closed.

## Verification

- `python3 -m unittest scripts/test_check_dag.py`
- `python3 -m unittest scripts/release/test_check_released_manifest.py`
- `python3 -m unittest scripts/release/test_sync_released.py`
- `python3 -m unittest scripts/test_check_phase7.py`
- `python3 scripts/check_dag.py`
- `python3 scripts/release/check_released_manifest.py`
- `python3 scripts/release/check_manual_split.py`
- `python3 scripts/release/check_trust_surface.py`
- `python3 scripts/check_phase4.py`
- `python3 scripts/check_phase7.py`
- `python3 scripts/check_copyright_headers.py`
- `python3 scripts/check_file_line_counts.py`
- `git diff --check`

Depends on merged bookkeeping PR #9750.
