### PR TITLE
docs(primality): describe and probe live certificate checker

### DIFF
--- a/HexPrimality/Cert.lean
+++ b/HexPrimality/Cert.lean
@@ -21,19 +21,19 @@ The Pocklington primality certificate, its kernel-replayable checker, and
 checker soundness.
 
 `PrimeCert` is one inductive: a stored-table leaf, the square-root
-Pocklington node, and the cube-root Brillhart-Lehmer-Selfridge node (whose
-arithmetic checks are a documented `false` stub until milestone 4, keeping
-its soundness case vacuous). The prime of each factor entry is not stored;
-it is read off as the child certificate's subject, which removes a
-redundancy an attacker could otherwise exploit.
+Pocklington node, and the cube-root Brillhart-Lehmer-Selfridge node. Both
+Pocklington arms check their arithmetic conditions and recursively replay
+every child certificate. The prime of each factor entry is not stored; it is
+read off as the child certificate's subject, which removes a redundancy an
+attacker could otherwise exploit.
 
-`checkPrime` and everything it calls are `@[expose]` and structurally
-recursive, so an accepted certificate replays by kernel reduction alone:
-the closure is `HexArith.powModNat` (the kernel-facing specification whose
-`@[csimp]` twin takes the Montgomery path at runtime), `Nat.gcd`,
-`Nat.mod`, and the table's binary search. `prime_of_checkPrime` is checker
-soundness; per the SPEC, no certificate-existence, checker-completeness, or
-search-completeness claim accompanies it.
+The checker-owned definitions are `@[expose]` and structurally recursive.
+An accepted certificate therefore replays by kernel reduction alone through
+`HexArith.powModNat` (the kernel-facing specification whose `@[csimp]` twin
+takes the Montgomery path at runtime), core `Nat.gcd` and `Nat.mod`, and the
+table's exposed binary search. `prime_of_checkPrime` proves soundness of both
+Pocklington arms; per the SPEC, no certificate-existence,
+checker-completeness, or search-completeness claim accompanies it.
 -/
 
 namespace Hex

--- a/HexPrimality/Cert.lean
+++ b/HexPrimality/Cert.lean
@@ -27,12 +27,14 @@ every child certificate. The prime of each factor entry is not stored; it is
 read off as the child certificate's subject, which removes a redundancy an
 attacker could otherwise exploit.
 
-The checker-owned definitions are `@[expose]` and structurally recursive.
-An accepted certificate therefore replays by kernel reduction alone through
-`HexArith.powModNat` (the kernel-facing specification whose `@[csimp]` twin
-takes the Montgomery path at runtime), core `Nat.gcd` and `Nat.mod`, and the
-table's exposed binary search. `prime_of_checkPrime` proves soundness of both
-Pocklington arms; per the SPEC, no certificate-existence,
+The checker-owned definitions are `@[expose]` and structurally recursive. The
+replay closure runs through `HexArith.powModNat` (the kernel-facing
+specification whose `@[csimp]` twin takes the Montgomery path at runtime),
+core `Nat` arithmetic including `Nat.gcd`, `Nat.mod`, and `Nat.div`, and the
+table's exposed binary search. The `decide +kernel` probes in
+`HexBench.PrimalityKernel` confirm that accepted certificates in both
+Pocklington forms replay by kernel reduction alone. `prime_of_checkPrime`
+proves soundness of both arms; per the SPEC, no certificate-existence,
 checker-completeness, or search-completeness claim accompanies it.
 -/
 

--- a/bench/HexBench/PrimalityKernel.lean
+++ b/bench/HexBench/PrimalityKernel.lean
@@ -65,4 +65,10 @@ theorem replay256 : checkPrime cert256 = true := by decide +kernel
 
 theorem replay511 : checkPrime cert511 = true := by decide +kernel
 
+/-- The cube-root checker arm also replays through the kernel-facing closure. -/
+theorem replayPock3 :
+    checkPrime
+      (.pock3 199 9 2 8 [(3, 0, .small 2), (2, 0, .small 3)]) = true := by
+  decide +kernel
+
 end HexBench.PrimalityKernel


### PR DESCRIPTION
## Summary

- complete the independent certificate/Pocklington/order audit requested by #9753 and post the declaration-by-declaration report on that issue
- file #9773, #9774, #9775, #9776, and #9791 for every finding and add all five dependency edges to the Phase-2 attestation #9759
- correct `Cert.lean`'s stale claims that Pocklington-3 is a false stub and that every kernel-replay dependency carries `@[expose]`
- add the missing `decide +kernel` Pocklington-3 replay theorem and make the documentation cite actual probe evidence

The substantive executable/asymptotic findings remain separate blockers; this PR resolves the self-contained documentation and kernel-probe findings. It does not add a review token or change a registry counter. The `boundedPowMul` / `certProduct` docstrings are deliberately left for #9774 because that blocker should fix the bodies rather than weaken their contract.

## Verification

- `lake build HexPrimality HexPrimalityKernelProbe`
- `lake build HexIntFactor HexIntFactorMathlib`
- `python3 scripts/release/check_trust_surface.py`
- focused declaration, banned-token, randomness, and fallback scans
- `git diff --check`

Closes #9753
Closes #9776
Closes #9791
