### PR TITLE
fix(hex-primality): harden reviewed generation surfaces

### DIFF
--- a/HexPrimality/Elab.lean
+++ b/HexPrimality/Elab.lean
@@ -204,6 +204,8 @@ syntax (name := primalityTac)
           let ty ← inferType proof
           let (_, g) ← (← g.assert `this ty proof).intro1P
           return [g]
+    | `(tactic| primality $_h:ident :) =>
+        throwError "primality: expected a natural-number term after the colon"
     | `(tactic| primality $h:ident : $t:term) => do
         let proof ← Tactic.withMainContext do
           elabPrimalityArgument t
@@ -214,29 +216,3 @@ syntax (name := primalityTac)
     | _ => Elab.throwUnsupportedSyntax
 
 end Hex.PrimalityTactic
-
-/-! Elaboration tests: every syntax form across the table, trial, and
-certificate tiers, and the two failure messages. -/
-
-example : Hex.Nat.Prime 97 := primality 97
-example : Hex.Nat.Prime 9973 := primality 9973
-example : Hex.Nat.Prime 10007 := primality 10007
-example : Hex.Nat.Prime 2147483647 := primality 2147483647
-example : Hex.Nat.Prime 101 := by primality
-example : Hex.Nat.Prime 2147483647 := by primality
-example : True := by
-  primality 65537
-  primality fermat : 257
-  exact trivial
-
-/-- error: primality: 561 is not prime (Miller-Rabin witness 2) -/
-#guard_msgs in
-example : Hex.Nat.Prime 561 := primality 561
-
-/--
-error: primality: the goal
-  Hex.Nat.Prime (2 + 2)
-is not about a natural-number numeral
--/
-#guard_msgs in
-example : Hex.Nat.Prime (2 + 2) := by primality

--- a/HexPrimality/SPEC/hex-primality.md
+++ b/HexPrimality/SPEC/hex-primality.md
@@ -852,14 +852,17 @@ design principle 8's third remedy again.
 ```
 primality n         -- term: Hex.Nat.Prime n
 primality           -- tactic: closes a `Hex.Nat.Prime e` goal
+primality n         -- tactic: adds `this : Hex.Nat.Prime n`
+primality h : n     -- tactic: adds `h : Hex.Nat.Prime n`
 ```
 
 Following `factor_poly` and `irreducibility` in hex-berlekamp: the
-search runs at elaboration time as untrusted compiled code, and the
-emitted term is `prime_of_checkPrime (c := literalCert) (by decide +kernel)`
-with the inductive certificate reified by its constructors. The kernel replays only
-`checkPrime`, which is `O(k log n)` modular multiplications on
-GMP-backed `Nat`, and never the search.
+search runs at elaboration time as untrusted compiled code. The emitted
+term applies `prime_of_checkPrimeAt` to the requested numeral, the inductive
+certificate reified by its constructors, and one `Eq.refl true` slot. The
+kernel reduces the subject-equality and `checkPrime` Boolean in that slot, so
+it replays `O(k log n)` modular multiplications on GMP-backed `Nat`, and never
+the search.
 
 For reproducible syntax with no seed argument, the elaborator uses
 `Rand.ofSeed n`; the lower `primeCert?` API remains explicitly seeded,
@@ -947,9 +950,11 @@ a large integer rather than an array write. **Whether a compiled
 `ByteArray` sieve would beat it is a benchmark hypothesis, not a
 theorem** -- compiled `Nat` bit operations are big-integer operations
 too. The two are nonetheless different products and the SPEC keeps them
-apart: the bitset sieve exists to verify the committed table in the
-kernel, and `primesIn` for runtime use is the array version. The
-"segment generation" bench family below measures both.
+apart: the bitset sieve exists to verify the committed table in the kernel,
+while `primesIn` is the unrestricted trial-division range/filter route whose
+result is converted to an `Array`. The "segment generation" bench family
+below measures `primesIn`; the bitset sieve is priced by the "table
+verification" family's module-elaboration cost.
 
 ## Conformance
 

--- a/HexPrimality/Sieve.lean
+++ b/HexPrimality/Sieve.lean
@@ -7,8 +7,6 @@ Authors: Kim Morrison
 module
 
 public import HexArith.Nat.Prime
--- For the `#guard` regression block only.
-meta import HexArith.Nat.Prime
 
 public section
 
@@ -676,17 +674,6 @@ theorem prime_mod_six {n : Nat} (hp : Prime n) (h5 : 5 ≤ n) :
     intro h
     rcases hp.2 3 (Nat.dvd_of_mod_eq_zero h) with h' | h' <;> omega
   omega
-
-/-! Regression coverage: the value map, the mask, and the sieve at a
-small bound against trial division. -/
-
-#guard (List.range 8).map numOfIndex = [1, 5, 7, 11, 13, 17, 19, 23]
-#guard indexWidth 10000 = 3333
-#guard numOfIndex (indexWidth 10000) ≥ 10000
--- The sieve at bound 100 (sqrt bound 10) agrees with trial division on
--- every represented index above 0.
-#guard (List.range (indexWidth 100)).all fun t =>
-  t == 0 || ((sieve 100 10).testBit t == isPrimeTrial (numOfIndex t))
 
 end Nat
 

--- a/HexPrimality/SieveElab.lean
+++ b/HexPrimality/SieveElab.lean
@@ -44,6 +44,8 @@ private meta def renderChunk (width start size : Nat) (idx : Nat) : String :=
 
 private meta def renderChain (bound sqrtB width cnt : Nat)
     (plan : List (Nat × Nat)) : String := Id.run do
+  if plan.length == 1 then
+    return s!"private theorem sieve_eq_final : sieve {bound} {sqrtB} = sieveStateFinal := by\n  show sieveGoRange {width} 1 {cnt} (sieveInit {width}) = _\n  exact sieveChunk1\n"
   -- One line per rewrite group, matching the committed block: the size
   -- split, fold split, and chunk equation together, then the start-index
   -- fold on its own line; the final chunk closes the bracket.
@@ -66,7 +68,7 @@ private meta def renderChain (bound sqrtB width cnt : Nat)
     consumed := consumed + size
     idx := idx + 1
   let rws := String.intercalate "\n    " lines
-  return s!"private theorem sieve_eq_final : sieve {bound} {sqrtB} = sieveState{total} := by\n  show sieveGoRange {width} 1 {cnt} (sieveInit {width}) = _\n  rw [{rws}\n"
+  return s!"private theorem sieve_eq_final : sieve {bound} {sqrtB} = sieveStateFinal := by\n  show sieveGoRange {width} 1 {cnt} (sieveInit {width}) = _\n  rw [{rws}\n"
 
 private meta def renderTable (primes : List Nat) : String := Id.run do
   let mut linesAcc : List String := []
@@ -143,13 +145,15 @@ syntax (name := rebuildPrimeTable) "#rebuild_primeTable" num num num : command
       for state in states do
         out := out ++ s!"private def sieveState{idx} : Nat :=\n  {state}\n\n"
         idx := idx + 1
+      out := out ++ s!"private abbrev sieveStateFinal : Nat := \
+        sieveState{plan.length}\n\n"
       idx := 1
       for (s0, size) in plan do
         out := out ++ renderChunk width s0 size idx ++ "\n"
         idx := idx + 1
       out := out ++ renderChain bound sqrtB width cnt plan
       out := out ++ s!"\nprivate theorem primeTable_eq_bits :\n    \
-        primeTable = (2 :: 3 :: bitsToList sieveState{plan.length} \
+        primeTable = (2 :: 3 :: bitsToList sieveStateFinal \
         {bound}).toArray := by\n  decide +kernel\n"
       logInfo out
   | _ => throwUnsupportedSyntax

--- a/HexPrimality/Table.lean
+++ b/HexPrimality/Table.lean
@@ -149,8 +149,6 @@ def primeTable : Array Nat :=
     9781, 9787, 9791, 9803, 9811, 9817, 9829, 9833, 9839, 9851, 9857, 9859,
     9871, 9883, 9887, 9901, 9907, 9923, 9929, 9931, 9941, 9949, 9967, 9973]
 
-#guard primeTable.size = 1229
-
 /-- Adjacent strict ascent of a list, structurally: `true` iff consecutive
 entries strictly increase. -/
 @[expose]
@@ -332,6 +330,8 @@ private def sieveState3 : Nat :=
 private def sieveState4 : Nat :=
   52744135752356285805936049398430563853758494609160225796514743786617123787620821399859121188119528101218220704463160359020095888945827635244508551010264497147167328698916098549052770734386406558041136130951220102097589450036487889862513102237711001722261432163007766193243016959423550658809307427773430294686683256681071210928838628543230569721425513953798750330765562118972569850882871190532603134328126767999785051707298755561378421812626158609156306647472120885083908582702272771219708333402279408395106681754643926429383297469258864876040886224701339896630672022302096628438499126987700336836567734457421391999963402097693015614183764830163944020476605413722530296274936433158534311607292874987555134543420113288105285420780192126190733639406080137861321897321781112012330763582464554593728659183893472014340227531384209118011000733524518182848382804666019367121594964961391550350451044259814842469661079561979434448449143257563380571818704504412933327123869610585710153823488183849678548714059518
 
+private abbrev sieveStateFinal : Nat := sieveState4
+
 private theorem sieveChunk1 :
     sieveGoRange 3333 1 8 (sieveInit 3333) = sieveState1 := by
   decide +kernel
@@ -348,7 +348,7 @@ private theorem sieveChunk4 :
     sieveGoRange 3333 25 8 sieveState3 = sieveState4 := by
   decide +kernel
 
-private theorem sieve_eq_final : sieve 10000 100 = sieveState4 := by
+private theorem sieve_eq_final : sieve 10000 100 = sieveStateFinal := by
   show sieveGoRange 3333 1 32 (sieveInit 3333) = _
   rw [show (32 : Nat) = 8 + 24 from rfl, sieveGoRange_add, sieveChunk1,
     show (1 + 8 : Nat) = 9 from rfl,
@@ -358,12 +358,12 @@ private theorem sieve_eq_final : sieve 10000 100 = sieveState4 := by
     show (17 + 8 : Nat) = 25 from rfl, sieveChunk4]
 
 private theorem primeTable_eq_bits :
-    primeTable = (2 :: 3 :: bitsToList sieveState4 10000).toArray := by
+    primeTable = (2 :: 3 :: bitsToList sieveStateFinal 10000).toArray := by
   decide +kernel
 
 private theorem mem_primeTable_iff_bits {n : Nat} :
     n ∈ primeTable ↔
-      n = 2 ∨ n = 3 ∨ n ∈ bitsToList sieveState4 10000 := by
+      n = 2 ∨ n = 3 ∨ n ∈ bitsToList sieveStateFinal 10000 := by
   rw [primeTable_eq_bits, List.mem_toArray, List.mem_cons, List.mem_cons]
 
 /-- Every table entry is prime: the committed literal read back through
@@ -430,19 +430,6 @@ theorem mem_primesIn {lo hi n : Nat} :
     refine ⟨by omega, by omega, hp⟩
   · rintro ⟨hlo, hhi, hp⟩
     exact ⟨⟨n - lo, by omega, by omega⟩, hp⟩
-
-/-! Regression coverage: bound edges, small entries, the largest entry, a
-prime just above the bound, and the classical prime counts. -/
-
-#guard isTablePrime 2 = true
-#guard isTablePrime 3 = true
-#guard isTablePrime 4 = false
-#guard isTablePrime 9973 = true
-#guard isTablePrime 9999 = false
-#guard isTablePrime 10007 = false  -- prime, but above the bound
-#guard (primesIn 0 100).size = 25
-#guard (primesIn 90 100).toList = [97]
-#guard primesIn 10 10 = #[]
 
 end Nat
 

--- a/conformance/HexPrimality/Conformance.lean
+++ b/conformance/HexPrimality/Conformance.lean
@@ -22,14 +22,18 @@ Covered operations:
 - `Hex.Nat.rhoFactor?`, its counted internal form, and batched-Brent route
   instrumentation
 - `Hex.Nat.millerRabin` / `Hex.Nat.isProbablePrime`
+- `Hex.Nat.sieve` and its residue-index mapping
 - `Hex.Nat.isTablePrime`
 - `Hex.Nat.primesIn`
 - `Hex.Nat.nextPrime?`
+- `primality` term and tactic forms
 Covered properties:
 - the total decision agrees with trial division on an initial segment
 - a `.composite` certificate-search verdict never contradicts `isPrime`
 - accepted certificates replay; each rejection reason rejects
 - the committed table window and the runtime segment listing agree
+- the small sieve agrees with trial division on every represented index
+- term and tactic elaboration reach the table and certificate tiers
 Covered edge cases:
 - `0`, `1`, `2`, and the parity edge `4`
 - Carmichael numbers, where a Fermat test would pass and Miller-Rabin
@@ -186,3 +190,86 @@ private def rhoRecoveryTrace : Hex.Nat.Internal.RhoTrace :=
 #guard (match nextPrime? 9973 (Hex.Rand.ofSeed 0) 64 with
         | .ok (p, _) => p == 10007
         | .error _ => false)
+
+-- Sieve representation and a complete small-bound comparison with the
+-- independent trial-division decision route.
+#guard (List.range 8).map numOfIndex = [1, 5, 7, 11, 13, 17, 19, 23]
+#guard indexWidth 10000 = 3333
+#guard numOfIndex (indexWidth 10000) ≥ 10000
+#guard (List.range (indexWidth 100)).all fun t =>
+  t == 0 || ((sieve 100 10).testBit t == isPrimeTrial (numOfIndex t))
+
+-- Table bound edges, the largest entry, an above-bound prime, and empty
+-- segment behavior.
+#guard primeTable.size = 1229
+#guard isTablePrime 2 = true
+#guard isTablePrime 3 = true
+#guard isTablePrime 4 = false
+#guard isTablePrime 9973 = true
+#guard isTablePrime 9999 = false
+#guard isTablePrime 10007 = false
+#guard (primesIn 90 100).toList = [97]
+#guard primesIn 10 10 = #[]
+
+-- Every Mathlib-free elaborator syntax form, across the table and certificate
+-- tiers.
+example : Hex.Nat.Prime 97 := primality 97
+example : Hex.Nat.Prime 9973 := primality 9973
+example : Hex.Nat.Prime 10007 := primality 10007
+example : Hex.Nat.Prime 2147483647 := primality 2147483647
+example : Hex.Nat.Prime 101 := by primality
+example : Hex.Nat.Prime 2147483647 := by primality
+example : True := by
+  primality 65537
+  primality fermat : 257
+  exact trivial
+
+/-- error: primality: 561 is not prime (Miller-Rabin witness 2) -/
+#guard_msgs in
+example : Hex.Nat.Prime 561 := primality 561
+
+/--
+error: primality: the goal
+  Prime (2 + 2)
+is not about a natural-number numeral
+-/
+#guard_msgs in
+example : Hex.Nat.Prime (2 + 2) := by primality
+
+/-- error: primality: expected a natural-number term after the colon -/
+#guard_msgs in
+example : True := by primality h :
+
+/-! The generator emits a complete, batch-count-independent one-batch replay
+block. The committed four-batch path is regenerated separately because its
+literal is intentionally large. -/
+
+/--
+info: @[expose]
+def primeTableBound : Nat := 25
+
+@[expose]
+def primeTable : Array Nat :=
+  #[2, 3, 5, 7, 11, 13, 17, 19, 23]
+
+-- #rebuild_primeTable 25 5 1
+
+private def sieveState1 : Nat :=
+  254
+
+private abbrev sieveStateFinal : Nat := sieveState1
+
+private theorem sieveChunk1 :
+    sieveGoRange 8 1 1 (sieveInit 8) = sieveState1 := by
+  decide +kernel
+
+private theorem sieve_eq_final : sieve 25 5 = sieveStateFinal := by
+  show sieveGoRange 8 1 1 (sieveInit 8) = _
+  exact sieveChunk1
+
+private theorem primeTable_eq_bits :
+    primeTable = (2 :: 3 :: bitsToList sieveStateFinal 25).toArray := by
+  decide +kernel
+-/
+#guard_msgs in
+#rebuild_primeTable 25 5 1


### PR DESCRIPTION
## Summary

- move sieve, table, segment, and Mathlib-free `primality` regression coverage out of public modules and into core conformance
- make one-batch `#rebuild_primeTable` plans emit a direct replay proof, add a batch-independent final-state name, and pin the one-batch output in conformance
- align the SPEC with the audited trial-division `primesIn` route, exact `prime_of_checkPrimeAt` proof shape, and actual benchmark ownership
- diagnose the incomplete `primality h :` form explicitly
- record the independent #9755 findings as Phase-2 blockers; the measured elaborator policy remains #9779

## Verification

- `lake build HexPrimality HexPrimalityKernelProbe`
- `lake build HexPrimality.Conformance`
- regenerated `#rebuild_primeTable 10000 100 4`; committed literal and replay evidence match apart from a trailing blank line
- generated `#rebuild_primeTable 25 5 1`; compiled the emitted replay source successfully
- pinned one-batch generator output with `#guard_msgs`
- public-module regression-command scan
- banned-token scan
- `git diff --check`

Closes #9755.
Closes #9777.
Closes #9778.
Closes #9786.
Closes #9792.