### PR TITLE
review(primality): tighten the Mathlib bridge boundary

### DIFF
--- a/HexPrimalityMathlib/NormNum.lean
+++ b/HexPrimalityMathlib/NormNum.lean
@@ -49,7 +49,7 @@ open Lean Meta Elab Qq Mathlib.Meta.NormNum
 trial division; 25-bit and larger numerals use bounded certificate search. -/
 def natPrimeCertThreshold : Nat := 16777216
 
-theorem isNat_prime_of_hex : {n n' : ℕ} → IsNat n n' →
+theorem isNat_prime : {n n' : ℕ} → IsNat n n' →
     _root_.Nat.Prime n' → _root_.Nat.Prime n
   | _, _, ⟨rfl⟩, hp => by simpa using hp
 
@@ -69,7 +69,7 @@ verdicts at and above `natPrimeCertThreshold`. -/
         let prf : Q(_root_.Nat.Prime $nn) :=
           mkApp3 (mkConst ``Hex.Nat.natPrime_of_checkPrimeAt) nn
             (reifyPrimeCert c.raw) reflTrue
-        return .isTrue q(isNat_prime_of_hex $pn $prf)
+        return .isTrue q(isNat_prime $pn $prf)
     | .error f =>
         match f.stop with
         | .exhausted => failure

--- a/HexPrimalityMathlib/Prime.lean
+++ b/HexPrimalityMathlib/Prime.lean
@@ -30,23 +30,7 @@ namespace Nat
 /-- The whole correspondence: the Mathlib-free predicate and `Nat.Prime`
 agree. Everything else transports along it. -/
 theorem prime_iff {n : Nat} : Prime n ↔ _root_.Nat.Prime n := by
-  rw [prime_iff_forall_lt, _root_.Nat.prime_def_lt]
-  constructor
-  · rintro ⟨h2, hdiv⟩
-    refine ⟨h2, fun m hmlt hdvd => ?_⟩
-    rcases Nat.lt_or_ge m 2 with hm2 | hm2
-    · rcases Nat.lt_or_ge m 1 with hm0 | hm1
-      · exfalso
-        have hm : m = 0 := by omega
-        subst hm
-        have := Nat.eq_zero_of_zero_dvd hdvd
-        omega
-      · omega
-    · exact absurd hdvd (hdiv m hmlt hm2)
-  · rintro ⟨h2, hdiv⟩
-    refine ⟨h2, fun m hmlt hm2 hdvd => ?_⟩
-    have := hdiv m hmlt hdvd
-    omega
+  simpa only [Hex.Nat.Prime] using (_root_.Nat.prime_def (p := n)).symm
 
 /-- Checker soundness, in Mathlib's vocabulary. -/
 theorem natPrime_of_checkPrime {c : PrimeCert} (h : checkPrime c = true) :
@@ -65,7 +49,7 @@ theorem isPrime_iff_natPrime {n : Nat} :
   isPrime_iff.trans prime_iff
 
 /-- A Miller-Rabin witness refutes `Nat.Prime`. -/
-theorem not_natPrime_of_millerRabin_false {n a : Nat}
+theorem millerRabin_not_natPrime {n a : Nat}
     (h : millerRabin n a = false) : ¬ _root_.Nat.Prime n :=
   fun hp => not_prime_of_millerRabin_false h (prime_iff.mpr hp)
 

--- a/HexPrimalityMathlib/Prime.lean
+++ b/HexPrimalityMathlib/Prime.lean
@@ -49,7 +49,7 @@ theorem isPrime_iff_natPrime {n : Nat} :
   isPrime_iff.trans prime_iff
 
 /-- A Miller-Rabin witness refutes `Nat.Prime`. -/
-theorem millerRabin_not_natPrime {n a : Nat}
+theorem millerRabin_refutes_natPrime {n a : Nat}
     (h : millerRabin n a = false) : ¬ _root_.Nat.Prime n :=
   fun hp => not_prime_of_millerRabin_false h (prime_iff.mpr hp)
 

--- a/HexPrimalityMathlib/Segment.lean
+++ b/HexPrimalityMathlib/Segment.lean
@@ -39,7 +39,8 @@ theorem primesIn_spec (lo hi : Nat) :
 
 /-- The `Finset` of primes below a bound inside the table's range is the
 filtered table. -/
-theorem filter_prime_range {bound : Nat} (h : bound ≤ primeTableBound) :
+theorem filter_prime_range [DecidablePred (_root_.Nat.Prime)]
+    {bound : Nat} (h : bound ≤ primeTableBound) :
     (Finset.range bound).filter _root_.Nat.Prime =
       (primeTable.toList.filter (fun p => p < bound)).toFinset := by
   ext n

--- a/HexPrimalityMathlib/Segment.lean
+++ b/HexPrimalityMathlib/Segment.lean
@@ -11,9 +11,9 @@ import Mathlib.Data.Finset.Basic
 Segment statements over the committed prime table, in the form a Mathlib
 consumer states them.
 
-`forall_prime_lt` is the scaffold for "every prime in `[1, x]` satisfies
-`P`": combined with a decidable fold over the table literal it discharges
-the universally quantified segment statements the SPEC calls unlocked.
+`forall_prime_lt` reduces "every prime below `x` satisfies `P`" to the
+committed prime table: combined with a decidable fold over the table literal,
+it discharges the universally quantified segment statements in the SPEC.
 -/
 
 namespace Hex


### PR DESCRIPTION
## Summary

- complete the independent Phase-2 audit of the primality Mathlib bridge and record the report on #9756
- use pinned Mathlib `Nat.prime_def` directly for the predicate correspondence
- remove forbidden scaffold prose and shorten misleading transport/helper names
- make `filter_prime_range` respect a caller-local `DecidablePred Nat.Prime`
- re-audit the merged #9798 tactic-contract implementation; retain #9779 for shared elaboration-size policy and file #9803 for the unmeasured negative rho budget
- file #9800 for the missing bridge-owned SPEC and add all review blockers to the #9759 attestation DAG
- leave review tokens and registry counters unchanged

## Verification

- `lake build HexPrimalityMathlib`
- fresh umbrella-import checks for `Hex.Nat.Prime` and `Nat.Prime` `primality`
- fresh default and `use_hex_primality_norm_num` checks for positive/negative certificate and trial tiers
- fresh local-instance checks for `filter_prime_range`
- instance audit: `#synth DecidablePred Nat.Prime` resolves to `Nat.decidablePrime`
- Phase-2 marker, long-name, banned-token, and `git diff --check` scans

Closes #9756.
Closes #9780.