### PR TITLE
chore: advance the NumberField cluster to done_through 7

### DIFF
--- a/libraries.yml
+++ b/libraries.yml
@@ -939,7 +939,7 @@ libraries:
   HexNumberField:
     deps: [HexPolyZ, HexRoots, HexResultant, HexBerlekampZassenhaus, HexMatrix, HexRowReduce]
     mathlib: false
-    done_through: 4
+    done_through: 7
     status: active
     phase4:
       comparators:
@@ -964,12 +964,12 @@ libraries:
   HexNumberFieldMathlib:
     deps: [HexNumberField, HexResultantMathlib, HexBerlekampZassenhausMathlib, HexRootsMathlib, HexPolyZMathlib]
     mathlib: true
-    done_through: 4
+    done_through: 7
     status: active
   HexNumberFieldTower:
     deps: [HexNumberField, HexResultant, HexBerlekampZassenhaus]
     mathlib: false
-    done_through: 4
+    done_through: 7
     status: active
     phase4:
       comparators:
@@ -988,7 +988,7 @@ libraries:
   HexNumberFieldTowerMathlib:
     deps: [HexNumberFieldTower, HexNumberFieldMathlib, HexResultantMathlib, HexBerlekampZassenhausMathlib, HexRowReduceMathlib]
     mathlib: true
-    done_through: 4
+    done_through: 7
     status: active
   HexRealRoots:
     deps: [HexPolyZ]


### PR DESCRIPTION
This PR advance HexNumberField, HexNumberFieldMathlib, HexNumberFieldTower, and HexNumberFieldTowerMathlib to done_through 7, completing the release wave's phase ladder. Phase 5 holds on the sorry-free trees with the conforming headline reports merged in #9736 and #9772, Phase 6 is the polishing passes merged in #9621 and #9687, and Phase 7 is carried by the chapters' existing Mathlib-correspondence sections; check_phase7, check_phase4, and check_dag all pass.

🤖 Prepared with Claude Code