### PR TITLE
audit: reconcile completed Phase-4 reports with ordered modes

### DIFF
--- a/libraries.yml
+++ b/libraries.yml
@@ -730,12 +730,12 @@ libraries:
   HexRowReduceMathlib:
     deps: [HexMatrixMathlib, HexRowReduce]
     mathlib: true
-    done_through: 7
+    done_through: 3
     status: active
   HexDeterminantMathlib:
     deps: [HexBareiss, HexDeterminant, HexMatrixMathlib]
     mathlib: true
-    done_through: 7
+    done_through: 3
     status: active
   HexCharPolyMathlib:
     deps: [HexCharPoly, HexMatrixMathlib, HexPolyMathlib, HexDeterminantMathlib]
@@ -750,32 +750,32 @@ libraries:
   HexBareissMathlib:
     deps: [HexDeterminantMathlib]
     mathlib: true
-    done_through: 7
+    done_through: 3
     status: active
   HexModArithMathlib:
     deps: [HexModArith]
     mathlib: true
-    done_through: 7
+    done_through: 3
     status: active
   HexGramSchmidtMathlib:
     deps: [HexGramSchmidt, HexBareissMathlib]
     mathlib: true
-    done_through: 7
+    done_through: 3
     status: active
   HexPolyZMathlib:
     deps: [HexPolyZ, HexHensel, HexPolyMathlib, HexModArithMathlib]
     mathlib: true
-    done_through: 7
+    done_through: 3
     status: active
   HexPolyZGcdMathlib:
     deps: [HexPolyZGcd, HexPolyZMathlib, HexPolyMathlib]
     mathlib: true
-    done_through: 7
+    done_through: 3
     status: active
   HexLLLMathlib:
     deps: [HexLLL, HexGramSchmidtMathlib, HexRowReduceMathlib]
     mathlib: true
-    done_through: 7
+    done_through: 3
     status: active
   HexHermiteMathlib:
     deps: [HexHermite, HexRowReduceMathlib]
@@ -809,7 +809,7 @@ libraries:
   HexHenselMathlib:
     deps: [HexHensel, HexPolyMathlib]
     mathlib: true
-    done_through: 7
+    done_through: 3
     status: active
   HexGF2Mathlib:
     deps: [HexGF2, HexPolyFp, HexGFqField, HexPolyFpMathlib]

--- a/libraries.yml
+++ b/libraries.yml
@@ -110,7 +110,7 @@ libraries:
   HexPoly:
     deps: []
     mathlib: false
-    done_through: 7
+    done_through: 3
     status: active
     phase4:
       comparators:
@@ -152,7 +152,7 @@ libraries:
   HexMvPoly:
     deps: [HexPoly, HexBasic]
     mathlib: false
-    done_through: 7
+    done_through: 3
     status: active
     phase4:
       comparators:
@@ -176,7 +176,7 @@ libraries:
   HexMvGcd:
     deps: [HexBasic, HexMvPoly, HexPoly, HexPolyFp, HexResultant, HexArith, HexModArith, HexModular, HexPolyZGcd]
     mathlib: false
-    done_through: 4
+    done_through: 3
     status: active
     phase4:
       comparators:
@@ -241,7 +241,7 @@ libraries:
   HexRowReduce:
     deps: [HexMatrix]
     mathlib: false
-    done_through: 7
+    done_through: 3
     status: active
   HexDeterminant:
     deps: [HexMatrix]
@@ -255,7 +255,7 @@ libraries:
   HexBareiss:
     deps: [HexArith, HexDeterminant, HexMatrix]
     mathlib: false
-    done_through: 7
+    done_through: 3
     status: active
     phase4:
       comparators:
@@ -374,7 +374,7 @@ libraries:
   HexGF2:
     deps: [HexBasic]
     mathlib: false
-    done_through: 7
+    done_through: 3
     status: active
     phase4:
       comparators:
@@ -475,7 +475,7 @@ libraries:
   HexLLL:
     deps: [HexGramSchmidt, HexMatrix, HexBasic]
     mathlib: false
-    done_through: 7
+    done_through: 3
     status: active
     phase4:
       comparators:
@@ -506,7 +506,7 @@ libraries:
   HexPolyFp:
     deps: [HexPoly, HexModArith, HexPolyFast, HexModular]
     mathlib: false
-    done_through: 7
+    done_through: 3
     status: active
     phase4:
       input_families:
@@ -594,7 +594,7 @@ libraries:
   HexConway:
     deps: [HexBerlekamp]
     mathlib: false
-    done_through: 7
+    done_through: 3
     status: active
     phase4:
       input_families:
@@ -605,7 +605,7 @@ libraries:
   HexGFq:
     deps: [HexGFqField, HexConway, HexGF2]
     mathlib: false
-    done_through: 7
+    done_through: 3
     status: active
     phase4:
       input_families:
@@ -690,7 +690,7 @@ libraries:
   HexMvPolyMathlib:
     deps: [HexMvPoly, HexPolyMathlib]
     mathlib: true
-    done_through: 7
+    done_through: 3
     status: active
     proof_probes: [bench/HexMvPolyMathlib/ProofProbe]
     phase4:
@@ -962,7 +962,7 @@ libraries:
   HexNumberField:
     deps: [HexPolyZ, HexRoots, HexResultant, HexBerlekampZassenhaus, HexMatrix, HexRowReduce]
     mathlib: false
-    done_through: 7
+    done_through: 3
     status: active
     phase4:
       comparators:
@@ -992,7 +992,7 @@ libraries:
   HexNumberFieldTower:
     deps: [HexNumberField, HexResultant, HexBerlekampZassenhaus]
     mathlib: false
-    done_through: 7
+    done_through: 3
     status: active
     phase4:
       comparators:

--- a/reports/hex-bareiss-performance.md
+++ b/reports/hex-bareiss-performance.md
@@ -126,6 +126,8 @@ target. No unattributed dominant cost was observed.
 
 ## Concerns
 
+- [#9806](https://github.com/kim-em/hex-dev/issues/9806) tracks the expected
+  different-complexity-class finding's policy-correct reclassification.
 - The FLINT `fmpz_mat.det` comparator pulls steadily ahead of `runBareissDet`
   across the ladder: raw ratio `0.973x → 0.062x` from `n = 128` to `n = 512`,
   and within the eligible range the adjusted ratio drifts from `0.057x` to

--- a/reports/hex-conway-performance.md
+++ b/reports/hex-conway-performance.md
@@ -242,3 +242,6 @@ falls outside the registered bench target, so no Attribution-rule follow-up
 is required.
 
 ## Concerns
+
+- [#9813](https://github.com/kim-em/hex-dev/issues/9813) tracks the fixed
+  Tier-1/Tier-2 mode gap and the stale 36-entry lookup verdict.

--- a/reports/hex-gf2-performance.md
+++ b/reports/hex-gf2-performance.md
@@ -492,6 +492,9 @@ target.
 
 ## Concerns
 
+- [#9807](https://github.com/kim-em/hex-dev/issues/9807) tracks both the
+  expected-trend reclassification and the marshalling-dominated addition
+  evidence below.
 - NTL `GF2X` `mul` / `div` / `rem` / `gcd` show a diverging trend
   against Hex `GF2Poly` across the eligible upper rungs of each
   ladder. At `n = 2048` (mul) and `n = 1024–1536` (div / rem / gcd)

--- a/reports/hex-gfq-performance.md
+++ b/reports/hex-gfq-performance.md
@@ -206,3 +206,6 @@ filtered profile:   /tmp/hex-profile-runPackedGenericSharedChecksum-256.json.gz
 ```
 
 ## Concerns
+
+- [#9814](https://github.com/kim-em/hex-dev/issues/9814) tracks the fixed
+  verdict surfaces' missing ordered modes, budgets, and expected hashes.

--- a/reports/hex-lll-performance.md
+++ b/reports/hex-lll-performance.md
@@ -886,6 +886,8 @@ within ~1.2–2.5× of raw fpLLL. The generators are structurally validated by
 
 ## Concerns
 
+- [#9808](https://github.com/kim-em/hex-dev/issues/9808) tracks completion of
+  the verified-Isabelle comparison ladders.
 - **The verified Isabelle certified-LLL series has only one committed point
   per family.** This is sufficient for the five-way plot legend and the
   bottom/shared-rung fast-check verdict above, but it does not yet provide a

--- a/reports/hex-mv-gcd-performance.md
+++ b/reports/hex-mv-gcd-performance.md
@@ -237,6 +237,8 @@ No dominant inclusive cost lies outside the corresponding registered target.
 
 ## Concerns
 
-None. The absent sparse route is an explicit SPEC limitation and is measured
-honestly by both the bounded degree-4096 declines and the matched end-to-end
-comparator gap; it is not a regression against a claimed Phase 4 goal.
+- [#9812](https://github.com/kim-em/hex-dev/issues/9812) tracks the fixed
+  performance matrix's missing ordered-mode and absolute-budget evidence.
+
+The absent sparse route remains an explicit SPEC limitation; it is not a
+separate regression claim.

--- a/reports/hex-mv-poly-mathlib-performance.md
+++ b/reports/hex-mv-poly-mathlib-performance.md
@@ -191,6 +191,9 @@ reported no validity violation.
 
 ## Concerns
 
+[Issue #9810](https://github.com/kim-em/hex-dev/issues/9810) tracks the
+unresolved proof-track gate described below.
+
 The implementation milestone is complete, but all five terminal threshold
 comparisons remain statistically unresolved: their point estimates are not
 evidence that the conservative 2× threshold was crossed. Under the

--- a/reports/hex-mv-poly-performance.md
+++ b/reports/hex-mv-poly-performance.md
@@ -348,6 +348,9 @@ from the same corpus and are byte-identifiable by the hashes above.
 
 ## Concerns
 
+[Issue #9805](https://github.com/kim-em/hex-dev/issues/9805) tracks the
+unresolved representation experiment described below.
+
 The implementation milestone is complete. The representation experiment is
 not a positive performance result: all five terminal comparisons remain
 statistically unresolved. Under the predeclared gate, zero families pass.

--- a/reports/hex-number-field-performance.md
+++ b/reports/hex-number-field-performance.md
@@ -1068,13 +1068,12 @@ pass are each tracked:
   `inconclusive` in the faster-than-declared direction. This is explicitly an
   open shape mismatch; the two-sided upper-envelope policy is not being used
   to call it a pass.
-  https://github.com/kim-em/hex-dev/issues/9733 — the ordered-rule audit that
-  records this blocked classification until its focused remediation issue is
-  filed after the policy lands.
+  https://github.com/kim-em/hex-dev/issues/9795 — the focused remediation for
+  the exactification and certification models.
 - **`runQAdjoinRootsLadder` still uses the withdrawn heuristic isolation
   proxy.** The statistically matching harness verdict does not validate the
   composed `n^5 log^2 n` declaration. The sibling lazy-add and algebraic-roots
   operations now use justified mode-3 fixed registrations, but this repeated-
   component family has not yet been worked through the ordered rule on its own.
-  https://github.com/kim-em/hex-dev/issues/9733 records this classification
-  until its focused follow-up is filed after the policy merge.
+  https://github.com/kim-em/hex-dev/issues/9796 tracks the focused ordered-mode
+  remediation.

--- a/reports/hex-number-field-tower-performance.md
+++ b/reports/hex-number-field-tower-performance.md
@@ -500,11 +500,12 @@ Processor, 96 logical CPUs, measurements pinned to preregistered CPU 13.
 
 ## Concerns
 
-None. The measurement defects surfaced while producing this evidence (the
+- [#9815](https://github.com/kim-em/hex-dev/issues/9815) tracks the failing
+  Trager envelope and the fixed component registrations' missing ordered-mode
+  evidence.
+
+The measurement defects surfaced while producing this evidence (the
 height-varying ladder fixture, the multiplication schedule ending inside its
 small-dimension transient, and fixed cases timing their lazily built
 fixtures) were repaired in the bench commits named in §Artefact traceability
-and every number above postdates the repairs; the Trager ladder's
-faster-than-envelope verdict is the expected direction for a declared
-worst-case model per §Verdicts, and no profiled dominant cost is
-unattributed.
+and every number above postdates the repairs; they are historical and resolved.

--- a/reports/hex-poly-fp-performance.md
+++ b/reports/hex-poly-fp-performance.md
@@ -41,6 +41,8 @@ no sampling trace was collected.
 
 ## Concerns
 
+- [#9809](https://github.com/kim-em/hex-dev/issues/9809) tracks the two
+  inconclusive registrations and missing profile evidence.
 - The GCD declaration remains deliberately conservative; observed scaling is
   faster than `n²`.
 - Frobenius `X` remains inconclusive; division and modular composition are

--- a/reports/hex-poly-performance.md
+++ b/reports/hex-poly-performance.md
@@ -434,6 +434,8 @@ was filed from this rerun.
 
 ## Concerns
 
+- [#9804](https://github.com/kim-em/hex-dev/issues/9804) tracks resolution
+  and policy-correct classification of both findings below.
 - The FLINT `fmpz_poly.compose` comparator pulls steadily ahead of
   `runComposeChecksum` across the eligible range: raw ratio
   `0.505x → 0.210x` from `n = 40` to `n = 64`, adjusted ratio

--- a/reports/hex-row-reduce-performance.md
+++ b/reports/hex-row-reduce-performance.md
@@ -32,4 +32,5 @@ additionally checks the executable span/nullspace API on committed examples.
 
 ## Concerns
 
-None. Row reduction is a correctness surface here, not a performance-tuned one.
+- [#9811](https://github.com/kim-em/hex-dev/issues/9811) tracks the missing
+  compiled performance evidence for the advertised row-reduction surface.

--- a/reports/phase4-ordered-mode-audit.md
+++ b/reports/phase4-ordered-mode-audit.md
@@ -1,9 +1,11 @@
 # Phase-4 Ordered-Mode Audit
 
-The current inventory contains 58 local libraries recorded at
-`done_through >= 4`. The ordered complexity-mode review finds 13 libraries
-with open Phase-4 evidence and 45 with no gap. All affected libraries are
-rolled back to `done_through: 3` in [`libraries.yml`](../libraries.yml).
+The pre-rollback inventory contains 58 local libraries recorded at
+`done_through >= 4`. The review finds 22 libraries with open Phase-4 evidence
+and 36 with no gap in the ordered-mode audit. All affected libraries are
+rolled back to `done_through: 3` in
+[`libraries.yml`](../libraries.yml) by PR
+[#9816](https://github.com/kim-em/hex-dev/pull/9816).
 
 The five libraries already rolled back directly by PR
 [#9769](https://github.com/kim-em/hex-dev/pull/9769) are outside the current
@@ -21,12 +23,12 @@ below because HexNumberFieldTower relies on it.
 
 | Library | Open evidence | Focused issue |
 | --- | --- | --- |
-| HexPoly | Two unresolved headline Concerns. | [#9804](https://github.com/kim-em/hex-dev/issues/9804) |
+| HexPoly | No multiplication comparator rung is eligible; the separate expected composition divergence is misfiled as a Concern and must move to the trend narrative. | [#9804](https://github.com/kim-em/hex-dev/issues/9804) |
 | HexMvPoly | The representation experiment remains unresolved under `## Concerns`. | [#9805](https://github.com/kim-em/hex-dev/issues/9805) |
 | HexMvGcd | Fixed shape/hash registrations are used as performance coverage without mode-3 budgets or ordered-mode exclusions. | [#9812](https://github.com/kim-em/hex-dev/issues/9812) |
 | HexRowReduce | Advertised compiled operations have conformance evidence but no performance mode. | [#9811](https://github.com/kim-em/hex-dev/issues/9811) |
 | HexBareiss | An unresolved informational-comparator finding remains under `## Concerns`. | [#9806](https://github.com/kim-em/hex-dev/issues/9806) |
-| HexGF2 | Two unresolved comparator/protocol findings remain under `## Concerns`. | [#9807](https://github.com/kim-em/hex-dev/issues/9807) |
+| HexGF2 | The addition comparison is marshalling-dominated; the separate expected NTL divergence is misfiled as a Concern and must move to the trend narrative. | [#9807](https://github.com/kim-em/hex-dev/issues/9807) |
 | HexLLL | The verified-Isabelle comparison has only one point per headline family. | [#9808](https://github.com/kim-em/hex-dev/issues/9808) |
 | HexPolyFp | Frobenius and GCD remain inconclusive; no ordered-mode rationale makes either a pass. | [#9809](https://github.com/kim-em/hex-dev/issues/9809) |
 | HexConway | Fixed Tier-1/Tier-2 checks lack mode-3 evidence, and the lookup verdict predates the current table. | [#9813](https://github.com/kim-em/hex-dev/issues/9813) |
@@ -34,6 +36,15 @@ below because HexNumberFieldTower relies on it.
 | HexMvPolyMathlib | All five proof-track threshold comparisons remain unresolved under `## Concerns`. | [#9810](https://github.com/kim-em/hex-dev/issues/9810) |
 | HexNumberField | The report remains blocked on incomplete API coverage and five registrations without passing modes. | [#9722](https://github.com/kim-em/hex-dev/issues/9722), [#9743](https://github.com/kim-em/hex-dev/issues/9743), [#9795](https://github.com/kim-em/hex-dev/issues/9795), [#9796](https://github.com/kim-em/hex-dev/issues/9796) |
 | HexNumberFieldTower | The Trager envelope fails mode 2's dominant-phase test, and fixed component anchors are used as coverage without mode-3 evidence. | [#9815](https://github.com/kim-em/hex-dev/issues/9815) |
+| HexRowReduceMathlib | The report-less correspondence-only exemption lacks the required SPEC declaration. | [#9817](https://github.com/kim-em/hex-dev/issues/9817) |
+| HexDeterminantMathlib | The report-less correspondence-only exemption lacks the required SPEC declaration. | [#9818](https://github.com/kim-em/hex-dev/issues/9818) |
+| HexBareissMathlib | The report-less correspondence-only exemption lacks the required SPEC declaration. | [#9819](https://github.com/kim-em/hex-dev/issues/9819) |
+| HexModArithMathlib | The report-less correspondence-only exemption lacks the required SPEC declaration. | [#9820](https://github.com/kim-em/hex-dev/issues/9820) |
+| HexGramSchmidtMathlib | The report-less correspondence-only exemption lacks the required SPEC declaration. | [#9821](https://github.com/kim-em/hex-dev/issues/9821) |
+| HexPolyZMathlib | The report-less correspondence-only exemption lacks the required SPEC declaration. | [#9822](https://github.com/kim-em/hex-dev/issues/9822) |
+| HexPolyZGcdMathlib | The report-less correspondence-only exemption lacks the required SPEC declaration. | [#9823](https://github.com/kim-em/hex-dev/issues/9823) |
+| HexLLLMathlib | The report-less correspondence-only exemption lacks the required SPEC declaration. | [#9824](https://github.com/kim-em/hex-dev/issues/9824) |
+| HexHenselMathlib | The report-less correspondence-only exemption lacks the required SPEC declaration. | [#9825](https://github.com/kim-em/hex-dev/issues/9825) |
 
 There is no valid manual mode-2 pass in the affected set.
 HexNumberFieldTower's candidate citation covers the BHKS factorization phase,
@@ -44,11 +55,15 @@ remaining inconclusive registrations as mode 4.
 
 ## Inspected with no gap
 
-The following headline reports contain passing two-sided registrations, no
+HexBasic has no SPEC API surface and therefore no performance-evidence
+registration to classify; the ordered-mode rule is vacuous for it. Its
+pre-existing report-shape omissions are outside this reset.
+
+The remaining headline reports contain passing two-sided registrations, no
 unresolved Concern, or explicitly resolved historical evidence. Their passing
 registrations remain unchanged:
 
-- [HexBasic](hex-basic-performance.md),
+- [HexBasic](hex-basic-performance.md) and
   [HexTruncatedSeries](hex-truncated-series-performance.md),
   [HexArith](hex-arith-performance.md),
   [HexPolyFast](hex-poly-fast-performance.md),
@@ -73,24 +88,16 @@ registrations remain unchanged:
   [HexRealRootsMathlib](hex-real-roots-mathlib-performance.md), and
   [HexRCF](hex-rcf-performance.md).
 
-The remaining 21 libraries are correspondence-only Mathlib layers. They have
+The remaining 12 libraries are correspondence-only Mathlib layers. They have
 no performance-evidence registration or proof probe of their own, declare no
-`phase4` block, and are exempt from a local headline report:
+`phase4` block, and carry the required `correspondence-only-layer` SPEC
+declaration, so they are exempt from a local headline report:
 
 - [HexPolySmithMathlib](../HexPolySmithMathlib/SPEC/hex-poly-smith-mathlib.md),
   [HexSparsePolyMathlib](../HexSparsePolyMathlib/SPEC/hex-sparse-poly-mathlib.md),
-  [HexRowReduceMathlib](../HexRowReduceMathlib/SPEC/hex-row-reduce-mathlib.md),
-  [HexDeterminantMathlib](../HexDeterminantMathlib/SPEC/hex-determinant-mathlib.md),
-  [HexBareissMathlib](../HexBareissMathlib/SPEC/hex-bareiss-mathlib.md),
-  [HexModArithMathlib](../HexModArithMathlib/SPEC/hex-mod-arith-mathlib.md),
-  [HexGramSchmidtMathlib](../HexGramSchmidtMathlib/SPEC/hex-gram-schmidt-mathlib.md),
-  [HexPolyZMathlib](../HexPolyZMathlib/SPEC/hex-poly-z-mathlib.md),
-  [HexPolyZGcdMathlib](../HexPolyZGcdMathlib/SPEC/hex-poly-z-gcd-mathlib.md),
-  [HexLLLMathlib](../HexLLLMathlib/SPEC/hex-lll-mathlib.md),
   [HexHermiteMathlib](../HexHermiteMathlib/SPEC/hex-hermite-mathlib.md),
   [HexSmithMathlib](../HexSmithMathlib/SPEC/hex-smith-mathlib.md),
   [HexPolyFpMathlib](../HexPolyFpMathlib/SPEC/hex-poly-fp-mathlib.md),
-  [HexHenselMathlib](../HexHenselMathlib/SPEC/hex-hensel-mathlib.md),
   [HexGF2Mathlib](../HexGF2Mathlib/SPEC/hex-gf2-mathlib.md),
   [HexGFqMathlib](../HexGFqMathlib/SPEC/hex-gfq-mathlib.md),
   [HexTruncatedSeriesMathlib](../HexTruncatedSeriesMathlib/SPEC/hex-truncated-series-mathlib.md),

--- a/reports/phase4-ordered-mode-audit.md
+++ b/reports/phase4-ordered-mode-audit.md
@@ -1,0 +1,100 @@
+# Phase-4 Ordered-Mode Audit
+
+The current inventory contains 58 local libraries recorded at
+`done_through >= 4`. The ordered complexity-mode review finds 13 libraries
+with open Phase-4 evidence and 45 with no gap. All affected libraries are
+rolled back to `done_through: 3` in [`libraries.yml`](../libraries.yml).
+
+The five libraries already rolled back directly by PR
+[#9769](https://github.com/kim-em/hex-dev/pull/9769) are outside the current
+inventory: HexBerlekampZassenhaus
+([#9793](https://github.com/kim-em/hex-dev/issues/9793)), HexPolySmith
+([#9742](https://github.com/kim-em/hex-dev/issues/9742)), HexGFqField
+([#9740](https://github.com/kim-em/hex-dev/issues/9740)), HexHensel
+([#9741](https://github.com/kim-em/hex-dev/issues/9741)), and HexRoots
+([#9794](https://github.com/kim-em/hex-dev/issues/9794)). HexNumberField was
+also reconciled and rolled back by #9769, but a later cluster bump restored it
+to 7 while its report still states that Phase 4 is blocked. It is included
+below because HexNumberFieldTower relies on it.
+
+## Findings and rollbacks
+
+| Library | Open evidence | Focused issue |
+| --- | --- | --- |
+| HexPoly | Two unresolved headline Concerns. | [#9804](https://github.com/kim-em/hex-dev/issues/9804) |
+| HexMvPoly | The representation experiment remains unresolved under `## Concerns`. | [#9805](https://github.com/kim-em/hex-dev/issues/9805) |
+| HexMvGcd | Fixed shape/hash registrations are used as performance coverage without mode-3 budgets or ordered-mode exclusions. | [#9812](https://github.com/kim-em/hex-dev/issues/9812) |
+| HexRowReduce | Advertised compiled operations have conformance evidence but no performance mode. | [#9811](https://github.com/kim-em/hex-dev/issues/9811) |
+| HexBareiss | An unresolved informational-comparator finding remains under `## Concerns`. | [#9806](https://github.com/kim-em/hex-dev/issues/9806) |
+| HexGF2 | Two unresolved comparator/protocol findings remain under `## Concerns`. | [#9807](https://github.com/kim-em/hex-dev/issues/9807) |
+| HexLLL | The verified-Isabelle comparison has only one point per headline family. | [#9808](https://github.com/kim-em/hex-dev/issues/9808) |
+| HexPolyFp | Frobenius and GCD remain inconclusive; no ordered-mode rationale makes either a pass. | [#9809](https://github.com/kim-em/hex-dev/issues/9809) |
+| HexConway | Fixed Tier-1/Tier-2 checks lack mode-3 evidence, and the lookup verdict predates the current table. | [#9813](https://github.com/kim-em/hex-dev/issues/9813) |
+| HexGFq | Fixed constructor/projection verdict surfaces lack mode-3 evidence and expected hashes. | [#9814](https://github.com/kim-em/hex-dev/issues/9814) |
+| HexMvPolyMathlib | All five proof-track threshold comparisons remain unresolved under `## Concerns`. | [#9810](https://github.com/kim-em/hex-dev/issues/9810) |
+| HexNumberField | The report remains blocked on incomplete API coverage and five registrations without passing modes. | [#9722](https://github.com/kim-em/hex-dev/issues/9722), [#9743](https://github.com/kim-em/hex-dev/issues/9743), [#9795](https://github.com/kim-em/hex-dev/issues/9795), [#9796](https://github.com/kim-em/hex-dev/issues/9796) |
+| HexNumberFieldTower | The Trager envelope fails mode 2's dominant-phase test, and fixed component anchors are used as coverage without mode-3 evidence. | [#9815](https://github.com/kim-em/hex-dev/issues/9815) |
+
+There is no valid manual mode-2 pass in the affected set.
+HexNumberFieldTower's candidate citation covers the BHKS factorization phase,
+but the report attributes only 5.26% of the measured call to that phase.
+HexPolyFp supplies neither a mode-2 citation nor the required inclusive
+dominant-phase profile. HexNumberField's report already classifies its
+remaining inconclusive registrations as mode 4.
+
+## Inspected with no gap
+
+The following headline reports contain passing two-sided registrations, no
+unresolved Concern, or explicitly resolved historical evidence. Their passing
+registrations remain unchanged:
+
+- [HexBasic](hex-basic-performance.md),
+  [HexTruncatedSeries](hex-truncated-series-performance.md),
+  [HexArith](hex-arith-performance.md),
+  [HexPolyFast](hex-poly-fast-performance.md),
+  [HexSparsePoly](hex-sparse-poly-performance.md),
+  [HexMatrix](hex-matrix-performance.md),
+  [HexDeterminant](hex-determinant-performance.md),
+  [HexModArith](hex-mod-arith-performance.md),
+  [HexModular](hex-modular-performance.md),
+  [HexGramSchmidt](hex-gram-schmidt-performance.md),
+  [HexPolyZ](hex-poly-z-performance.md),
+  [HexPolyZGcd](hex-poly-z-gcd-performance.md),
+  [HexHermite](hex-hermite-performance.md),
+  [HexSmith](hex-smith-performance.md),
+  [HexGFqRing](hex-gfq-ring-performance.md),
+  [HexBerlekamp](hex-berlekamp-performance.md),
+  [HexPolyMathlib](hex-poly-mathlib-performance.md),
+  [HexMatrixMathlib](hex-matrix-mathlib-performance.md),
+  [HexBerlekampMathlib](hex-berlekamp-mathlib-performance.md),
+  [HexBerlekampZassenhausMathlib](hex-berlekamp-zassenhaus-mathlib-performance.md),
+  [HexResultant](hex-resultant-performance.md),
+  [HexRealRoots](hex-real-roots-performance.md),
+  [HexRealRootsMathlib](hex-real-roots-mathlib-performance.md), and
+  [HexRCF](hex-rcf-performance.md).
+
+The remaining 21 libraries are correspondence-only Mathlib layers. They have
+no performance-evidence registration or proof probe of their own, declare no
+`phase4` block, and are exempt from a local headline report:
+
+- [HexPolySmithMathlib](../HexPolySmithMathlib/SPEC/hex-poly-smith-mathlib.md),
+  [HexSparsePolyMathlib](../HexSparsePolyMathlib/SPEC/hex-sparse-poly-mathlib.md),
+  [HexRowReduceMathlib](../HexRowReduceMathlib/SPEC/hex-row-reduce-mathlib.md),
+  [HexDeterminantMathlib](../HexDeterminantMathlib/SPEC/hex-determinant-mathlib.md),
+  [HexBareissMathlib](../HexBareissMathlib/SPEC/hex-bareiss-mathlib.md),
+  [HexModArithMathlib](../HexModArithMathlib/SPEC/hex-mod-arith-mathlib.md),
+  [HexGramSchmidtMathlib](../HexGramSchmidtMathlib/SPEC/hex-gram-schmidt-mathlib.md),
+  [HexPolyZMathlib](../HexPolyZMathlib/SPEC/hex-poly-z-mathlib.md),
+  [HexPolyZGcdMathlib](../HexPolyZGcdMathlib/SPEC/hex-poly-z-gcd-mathlib.md),
+  [HexLLLMathlib](../HexLLLMathlib/SPEC/hex-lll-mathlib.md),
+  [HexHermiteMathlib](../HexHermiteMathlib/SPEC/hex-hermite-mathlib.md),
+  [HexSmithMathlib](../HexSmithMathlib/SPEC/hex-smith-mathlib.md),
+  [HexPolyFpMathlib](../HexPolyFpMathlib/SPEC/hex-poly-fp-mathlib.md),
+  [HexHenselMathlib](../HexHenselMathlib/SPEC/hex-hensel-mathlib.md),
+  [HexGF2Mathlib](../HexGF2Mathlib/SPEC/hex-gf2-mathlib.md),
+  [HexGFqMathlib](../HexGFqMathlib/SPEC/hex-gfq-mathlib.md),
+  [HexTruncatedSeriesMathlib](../HexTruncatedSeriesMathlib/SPEC/hex-truncated-series-mathlib.md),
+  [HexRootsMathlib](../HexRootsMathlib/SPEC/hex-roots-mathlib.md),
+  [HexResultantMathlib](../HexResultantMathlib/SPEC/hex-resultant-mathlib.md),
+  [HexNumberFieldMathlib](../HexNumberFieldMathlib/SPEC/hex-number-field-mathlib.md), and
+  [HexNumberFieldTowerMathlib](../HexNumberFieldTowerMathlib/SPEC/hex-number-field-tower-mathlib.md).


### PR DESCRIPTION
Closes #9797.

## What changed

- audit all 58 local libraries recorded at `done_through >= 4` against the ordered complexity-mode and headline-report rules
- leave 36 libraries with passing or inapplicable evidence unchanged and record links to each inspected report or valid correspondence-only declaration
- file focused remediation issues #9804–#9815 and #9817–#9825 for every additional gap found
- link each open finding from the affected library's headline report
- restore `done_through: 3` for 22 libraries with inconclusive modes, invalid fixed-registration coverage, unresolved headline Concerns, or an unearned report-less correspondence-only exemption
- restore HexNumberField's #9769 rollback after #9801 re-promoted it while its headline report still recorded open Phase-4 blockers

## Performance rationale

No benchmark declaration changes. The audit rejects the candidate manual upper-bound reading for `HexNumberFieldTower.runTowerFactorLadder`: its cited BHKS phase is only 5.26% of the inclusive profile, so it does not cover the dominant measured work. Fixed hash, comparator, protocol, and bounded-decline registrations are not counted as performance coverage. Expected divergence against an informational comparator with a predeclared different complexity class is identified for relocation into the trend narrative, but remains rollback-triggering while the current report keeps it in a non-empty, non-resolved `## Concerns` section, as #9797 requires.

## Verification

- `python3 scripts/check_phase4.py`
- `python3 scripts/check_phase7.py`
- `python3 scripts/release/check_released_manifest.py`
- `python3 scripts/check_dag.py`
- `git diff --check`
