### PR TITLE
fix(hex-primality): guard certificate products before multiplication

### DIFF
--- a/HexIntFactor/Cert.lean
+++ b/HexIntFactor/Cert.lean
@@ -76,28 +76,8 @@ structure CheckedFactorization (n : Nat) where
   /-- Full checker replay succeeds. -/
   valid : checkFactorization raw = true
 
-private theorem boundedPowMul_eq {bound q : Nat} :
-    ∀ (e acc r : Nat), boundedPowMul bound q acc e = some r →
-      r = acc * q ^ e := by
-  intro e
-  induction e with
-  | zero =>
-      intro acc r h
-      unfold boundedPowMul at h
-      injection h with h
-      subst h
-      simp
-  | succ e ih =>
-      intro acc r h
-      unfold boundedPowMul at h
-      by_cases hb : bound < acc * q
-      · rw [if_pos hb] at h
-        cases h
-      · rw [if_neg hb] at h
-        rw [ih (acc * q) r h, Nat.pow_succ, Nat.mul_assoc,
-          Nat.mul_comm q (q ^ e)]
-
-private theorem factorProduct_eq {bound : Nat} :
+/-- On success, the factor accumulator computes the ordinary product. -/
+theorem factorProduct_eq {bound : Nat} :
     ∀ (l : List PrimePower) (acc r : Nat),
       factorProduct bound l acc = some r →
         r = acc * (l.map fun e => e.prime ^ e.exponent).prod := by
@@ -117,6 +97,25 @@ private theorem factorProduct_eq {bound : Nat} :
       next acc' hp =>
         rw [ih acc' r h, boundedPowMul_eq e.exponent acc acc' hp]
         simp [Nat.mul_assoc]
+
+/-- A successful factor-list fold preserves the bound on its accumulator. -/
+theorem factorProduct_le {bound : Nat} :
+    ∀ (l : List PrimePower) (acc r : Nat), acc ≤ bound →
+      factorProduct bound l acc = some r → r ≤ bound := by
+  intro l
+  induction l with
+  | nil =>
+      intro acc r hacc h
+      unfold factorProduct at h
+      injection h with h
+      simpa [h] using hacc
+  | cons e rest ih =>
+      intro acc r hacc h
+      unfold factorProduct at h
+      split at h
+      · cases h
+      next acc' hp =>
+        exact ih acc' r (boundedPowMul_le hacc hp) h
 
 theorem checkEntries_positive : ∀ {l : List PrimePower},
     checkEntries l = true → ∀ e ∈ l, 0 < e.exponent := by

--- a/HexIntFactor/Factor.lean
+++ b/HexIntFactor/Factor.lean
@@ -266,8 +266,9 @@ def acceptPartial? (n : Nat) (hn : 0 < n) (raw : PartialFactorization)
     Except FactorFailure (CheckedPartialFactorization n × Rand) :=
   let fallback : PartialFactorization := ⟨n, [], n⟩
   have hf : checkPartial fallback = true := by
+    have hn0 : n ≠ 0 := Nat.ne_of_gt hn
     dsimp [fallback]
-    simp [checkPartial, checkEntries, factorProduct, boundedPowMul, hn]
+    simp [checkPartial, checkEntries, factorProduct, boundedPowMul, hn, hn0]
   let rejected : FactorFailure :=
     { stop := .rejected
       attempts

--- a/HexIntFactor/Partial.lean
+++ b/HexIntFactor/Partial.lean
@@ -68,48 +68,6 @@ theorem CheckedPartialFactorization.pos {n : Nat}
   rw [← F.subject_eq]
   exact checkPartial_pos F.valid
 
-private theorem boundedPowMul_eq {bound q : Nat} :
-    ∀ (e acc r : Nat), boundedPowMul bound q acc e = some r →
-      r = acc * q ^ e := by
-  intro e
-  induction e with
-  | zero =>
-      intro acc r h
-      unfold boundedPowMul at h
-      injection h with h
-      subst h
-      simp
-  | succ e ih =>
-      intro acc r h
-      unfold boundedPowMul at h
-      by_cases hb : bound < acc * q
-      · rw [if_pos hb] at h
-        cases h
-      · rw [if_neg hb] at h
-        rw [ih (acc * q) r h, Nat.pow_succ, Nat.mul_assoc,
-          Nat.mul_comm q (q ^ e)]
-
-private theorem factorProduct_eq {bound : Nat} :
-    ∀ (l : List PrimePower) (acc r : Nat),
-      factorProduct bound l acc = some r →
-        r = acc * (l.map fun e => e.prime ^ e.exponent).prod := by
-  intro l
-  induction l with
-  | nil =>
-      intro acc r h
-      unfold factorProduct at h
-      injection h with h
-      subst h
-      simp
-  | cons e rest ih =>
-      intro acc r h
-      unfold factorProduct at h
-      split at h
-      · cases h
-      next acc' hp =>
-        rw [ih acc' r h, boundedPowMul_eq e.exponent acc acc' hp]
-        simp [Nat.mul_assoc]
-
 /-- Accepted partial data reconstructs its subject exactly. -/
 theorem checkPartial_prod {F : PartialFactorization}
     (h : checkPartial F = true) :

--- a/HexIntFactor/SPEC/hex-int-factor.md
+++ b/HexIntFactor/SPEC/hex-int-factor.md
@@ -1012,13 +1012,13 @@ the number of distinct primes, `B` a smoothness bound.
 | operation | cost | note |
 |---|---|---|
 | trailing-zero split | five bit operations on `b`-bit naturals | isolated-low-bit identity plus one shift; `O(b)` bit complexity |
-| perfect-power test | `O(b²)` bounded multiplications | the committed prime exponents plus only prime candidates above the table; a `k`th-root search has `O(b/k)` probes of a linear, early-aborting power loop |
+| perfect-power test | `O(b²)` bounded multiplication/division steps | the committed prime exponents plus only prime candidates above the table; a `k`th-root search has `O(b/k)` probes of a linear, early-aborting power loop |
 | trial division to `T` | `O(π(T))` divisions | `π(10^4) = 1229` |
 | Pollard rho | `O(√p)` iterations expected and one routine gcd per 32-step batch | `O(n^{1/4})` for a semiprime; cycle boundaries can flush shorter batches |
 | Pollard `p − 1` stage 1 | `O(B)` modular mults | `log M = Θ(B)`; smooth `p − 1` is sufficient but not decisive |
 | ECM stage 1, one curve | `O(B)` mults | scalar bit length is `Θ(B)`; success depends on the bound |
 | cyclotomic candidate table | `O(m + d²)` index work plus big-integer powers/products | `m` is the largest required index and `d` the number of its divisors; one ascending divisor-closed table is shared by all selected parts |
-| `checkFactorization` | `O(Σ eᵢ)` bounded multiplications plus `k` primality replays | `boundedPowMul` is linear in the claimed exponent and aborts above the subject |
+| `checkFactorization` | `O(Σ eᵢ)` bounded multiplication/division steps plus `k` primality replays | `boundedPowMul` is linear in the claimed exponent and aborts before constructing a product above the subject |
 | `checkOrder` | `O(k)` modular exponentiations plus `checkFactorization` | includes the order's primality replays |
 | `divisors` | `O(τ log τ)` | `τ = ∏(eᵢ + 1)` |
 | `sigma` | `O(k)` geometric sums | each entry uses `O(log r + log e)` multiplications for power argument `r`; for fixed `p` and `r`, its output has `Θ(e)` bits |
@@ -1027,8 +1027,8 @@ the number of distinct primes, `B` a smoothness bound.
 
 These are **arithmetic-operation counts on `Nat`** except where the table says
 bit complexity explicitly: the operands are big integers throughout,
-`boundedPowMul` uses up to `e` multiplications for `p^e`, and the divisor functions
-are `O(k)` only if the output's bit length is ignored. A bit-complexity
+`boundedPowMul` uses up to `e` divisions and `e` multiplications for `p^e`, and
+the divisor functions are `O(k)` only if the output's bit length is ignored. A bit-complexity
 model would have to name a multiplication cost and multiply through,
 and this SPEC does not attempt one.
 

--- a/HexPrimality/Cert.lean
+++ b/HexPrimality/Cert.lean
@@ -67,13 +67,18 @@ deriving Repr
 def PrimeCert.subject : PrimeCert → Nat
   | .small n | .pock n _ | .pock3 n _ _ _ _ => n
 
-/-- `acc * q ^ e`, aborting as soon as the running product exceeds `bound`,
-so an attacker-chosen enormous power is never constructed. -/
+/-- `acc * q ^ e`, checking each nonzero multiplication by division before
+constructing it. A zero accumulator or base returns zero immediately; otherwise
+the computation aborts as soon as the next product would exceed `bound`, so an
+attacker-chosen enormous power is never constructed. -/
 @[expose]
 def boundedPowMul (bound q : Nat) : Nat → Nat → Option Nat
   | acc, 0 => some acc
   | acc, e + 1 =>
-      if bound < acc * q then none else boundedPowMul bound q (acc * q) e
+      if acc = 0 then some 0
+      else if q = 0 then some 0
+      else if acc ≤ bound / q then boundedPowMul bound q (acc * q) e
+      else none
 
 /-- The factored part `F = ∏ qᵢ ^ (eᵢ + 1)` of a factor list, aborting as
 soon as the running product exceeds `bound`. -/
@@ -86,7 +91,7 @@ def certProduct (bound : Nat) : List (Nat × Nat × PrimeCert) → Option Nat
       | some pw =>
           match certProduct bound rest with
           | none => none
-          | some f => if bound < pw * f then none else some (pw * f)
+          | some f => boundedPowMul bound f pw 1
 
 /-- Structural check on the factor list: every claimed prime is at least
 `2`, and the claimed primes are pairwise distinct. -/
@@ -168,7 +173,8 @@ end
 
 /-! Accumulator lemmas -/
 
-private theorem boundedPowMul_eq {bound q : Nat} :
+/-- On success, the bounded accumulator computes the ordinary product. -/
+theorem boundedPowMul_eq {bound q : Nat} :
     ∀ (e acc r : Nat), boundedPowMul bound q acc e = some r →
       r = acc * q ^ e := by
   intro e
@@ -182,12 +188,76 @@ private theorem boundedPowMul_eq {bound q : Nat} :
   | succ e ih =>
       intro acc r h
       unfold boundedPowMul at h
-      by_cases hb : bound < acc * q
-      · rw [if_pos hb] at h
-        cases h
-      · rw [if_neg hb] at h
-        rw [ih (acc * q) r h, Nat.pow_succ, Nat.mul_assoc,
-          Nat.mul_comm q (q ^ e)]
+      by_cases ha : acc = 0
+      · rw [if_pos ha] at h
+        injection h with h
+        subst h
+        simp [ha]
+      · rw [if_neg ha] at h
+        by_cases hq : q = 0
+        · rw [if_pos hq] at h
+          injection h with h
+          subst h
+          simp [hq]
+        · rw [if_neg hq] at h
+          by_cases hb : acc ≤ bound / q
+          · rw [if_pos hb] at h
+            rw [ih (acc * q) r h, Nat.pow_succ, Nat.mul_assoc,
+              Nat.mul_comm q (q ^ e)]
+          · rw [if_neg hb] at h
+            cases h
+
+/-- A successful bounded multiplication preserves the accumulator bound. The
+incoming bound is needed only for the zero-exponent case; every positive step
+establishes it before constructing the next accumulator. -/
+theorem boundedPowMul_le {bound q acc e r : Nat} (hacc : acc ≤ bound)
+    (h : boundedPowMul bound q acc e = some r) : r ≤ bound := by
+  induction e generalizing acc r with
+  | zero =>
+      unfold boundedPowMul at h
+      injection h with h
+      simpa [h] using hacc
+  | succ e ih =>
+      unfold boundedPowMul at h
+      by_cases ha : acc = 0
+      · rw [if_pos ha] at h
+        injection h with h
+        subst h
+        exact Nat.zero_le _
+      · rw [if_neg ha] at h
+        by_cases hq : q = 0
+        · rw [if_pos hq] at h
+          injection h with h
+          subst h
+          exact Nat.zero_le _
+        · rw [if_neg hq] at h
+          by_cases hb : acc ≤ bound / q
+          · rw [if_pos hb] at h
+            exact ih ((Nat.le_div_iff_mul_le (Nat.pos_of_ne_zero hq)).mp hb) h
+          · rw [if_neg hb] at h
+            cases h
+
+/-- A successful certificate product is bounded when its initial accumulator
+`1` is bounded. -/
+theorem certProduct_le {bound : Nat} (hbound : 1 ≤ bound) :
+    ∀ (l : List (Nat × Nat × PrimeCert)) (F : Nat),
+      certProduct bound l = some F → F ≤ bound := by
+  intro l F h
+  cases l with
+  | nil =>
+      unfold certProduct at h
+      injection h with h
+      simpa [h] using hbound
+  | cons a rest =>
+      obtain ⟨a1, e, c⟩ := a
+      unfold certProduct at h
+      split at h
+      · cases h
+      next pw hpw =>
+        split at h
+        · cases h
+        next f hcp =>
+          exact boundedPowMul_le (boundedPowMul_le hbound hpw) h
 
 /-- The unbounded product the accumulator computes when it does not abort. -/
 private def certProd : List (Nat × Nat × PrimeCert) → Nat
@@ -215,13 +285,10 @@ private theorem certProduct_eq {bound : Nat} :
         split at h
         · cases h
         next f hcp =>
-          split at h
-          · cases h
-          · injection h with h
-            subst h
-            have h1 := boundedPowMul_eq (e + 1) 1 pw hpw
-            have h2 := ih f hcp
-            simp [certProd, h1, h2]
+          have h1 := boundedPowMul_eq (e + 1) 1 pw hpw
+          have h2 := ih f hcp
+          have h3 := boundedPowMul_eq 1 pw F h
+          simpa [certProd, h1, h2] using h3
 
 private theorem subjectsOk_cons {a : Nat × Nat × PrimeCert}
     {rest : List (Nat × Nat × PrimeCert)}
@@ -645,6 +712,14 @@ set_option maxRecDepth 100000   -- table walks in the guards below
 #guard checkPrime (.pock 7 [(2, 0, .small 4)]) = false       -- composite factor
 #guard checkPrime (.pock 7 [(6, 0, .small 3)]) = false       -- gcd witness fails
 #guard checkPrime (.pock 11 [(2, 0, .small 7)]) = false      -- 7 ∤ 10
+#guard boundedPowMul 0 0 1 1 = some 0                        -- zero base
+#guard boundedPowMul 0 5 0 1048576 = some 0                  -- zero accumulator
+#guard checkPrime (.pock 7 [(2, 0, .small (2 ^ 4096))]) = false
+  -- huge child subject is rejected before multiplying it by the accumulator
+#guard checkPrime (.pock 97 [(5, 1048576, .small 2)]) = false
+  -- huge exponent aborts when its next bounded multiplication would cross 96
+#guard checkPrime (.pock 31 [(3, 0, .small 5), (3, 0, .small 7)]) = false
+  -- each factor fits under 30, but their next combined product would be 35
 -- Cube-root arm: n = 199 with F = 6 sits squarely in the cube-root regime
 -- (F² = 36 ≤ 199 < 847 = (F+1)(2F² + (r-1)F + 1), R = 33 = 2·6·2 + 9,
 -- discriminant 9² - 8·2 = 65 with witness 8² < 65 < 9²).

--- a/HexPrimality/Cert.lean
+++ b/HexPrimality/Cert.lean
@@ -694,11 +694,11 @@ structure CheckedPrimeCert (n : Nat) where
 theorem CheckedPrimeCert.prime {n : Nat} (c : CheckedPrimeCert n) : Prime n :=
   c.subject_eq ▸ prime_of_checkPrime c.valid
 
-/-! Regression coverage: table leaves, an accepted single-factor node, an
-accepted two-factor node, an accepted two-level node, and one rejected
-certificate of each kind (bound too small, composite claimed factor, failed
-gcd witness, factor not dividing `n - 1`). The checker's negative cases
-matter as much as its positive ones, and no oracle produces them. -/
+/-! Regression coverage: table leaves, accepted single-factor, two-factor, and
+two-level nodes; explicit zero and truncating-division boundaries for bounded
+multiplication; and rejected certificates covering the arithmetic clauses and
+adversarial product inputs. The checker's negative cases matter as much as its
+positive ones, and no oracle produces them. -/
 
 set_option maxRecDepth 100000   -- table walks in the guards below
 
@@ -714,8 +714,10 @@ set_option maxRecDepth 100000   -- table walks in the guards below
 #guard checkPrime (.pock 11 [(2, 0, .small 7)]) = false      -- 7 ∤ 10
 #guard boundedPowMul 0 0 1 1 = some 0                        -- zero base
 #guard boundedPowMul 0 5 0 1048576 = some 0                  -- zero accumulator
+#guard boundedPowMul 7 2 3 1 = some 6                        -- rounded bound accepts
+#guard boundedPowMul 7 2 4 1 = none                          -- next product is 8
 #guard checkPrime (.pock 7 [(2, 0, .small (2 ^ 4096))]) = false
-  -- huge child subject is rejected before multiplying it by the accumulator
+  -- huge child subject is rejected at the first guarded product step
 #guard checkPrime (.pock 97 [(5, 1048576, .small 2)]) = false
   -- huge exponent aborts when its next bounded multiplication would cross 96
 #guard checkPrime (.pock 31 [(3, 0, .small 5), (3, 0, .small 7)]) = false

--- a/HexPrimality/SPEC/hex-primality.md
+++ b/HexPrimality/SPEC/hex-primality.md
@@ -356,9 +356,8 @@ arithmetic rejections before recursive certificate replay:
 2. The subjects `q` of the child certificates satisfy `2 ≤ q` and are
    pairwise distinct.
 3. `F = ∏ q^(e+1)` divides `n - 1`; each power is accumulated by a
-   bounded loop and the whole product aborts as soon as its running
-   value exceeds `n - 1`, rather than constructing an attacker-chosen
-   enormous power.
+   bounded loop that tests each nonzero step by division, and the whole
+   product aborts before constructing a running value above `n - 1`.
 4. `n < F * F`.
 5. For each `(a, e, child)`, with `q = child.subject`:
    `HexArith.powModNat a (n-1) n = 1 % n` and

--- a/bench/HexIntFactor/Bench.lean
+++ b/bench/HexIntFactor/Bench.lean
@@ -51,17 +51,21 @@ def runReplay (e : Nat) : Nat :=
 
 def runOrder (p : Nat) : Nat := orderOf 2 p
 
-private theorem boundedPowMul_exact (q acc : Nat) (hq : 0 < q) : ∀ e : Nat,
+private theorem boundedPowMul_exact (q acc : Nat) (hq : 0 < q)
+    (hacc : 0 < acc) : ∀ e : Nat,
     boundedPowMul (acc * q ^ e) q acc e = some (acc * q ^ e)
   | 0 => by simp [boundedPowMul]
   | e + 1 => by
-      rw [boundedPowMul, ite_eq_right]
-      · simpa only [Nat.pow_succ, Nat.mul_assoc, Nat.mul_comm,
-          Nat.mul_left_comm] using boundedPowMul_exact q (acc * q) hq e
-      · have hpow : 0 < q ^ e := Nat.pow_pos hq
-        have hle : q ≤ q ^ e * q := Nat.le_mul_of_pos_left q hpow
-        exact Nat.not_lt_of_ge (by
-          simpa only [Nat.pow_succ] using Nat.mul_le_mul_left acc hle)
+      have hpow : 0 < q ^ e := Nat.pow_pos hq
+      have hle : q ≤ q ^ e * q := Nat.le_mul_of_pos_left q hpow
+      have hmul : acc * q ≤ acc * q ^ (e + 1) := by
+        simpa only [Nat.pow_succ] using Nat.mul_le_mul_left acc hle
+      rw [boundedPowMul, if_neg (Nat.ne_of_gt hacc),
+        if_neg (Nat.ne_of_gt hq),
+        if_pos ((Nat.le_div_iff_mul_le hq).2 hmul)]
+      simpa only [Nat.pow_succ, Nat.mul_assoc, Nat.mul_comm,
+        Nat.mul_left_comm] using
+        boundedPowMul_exact q (acc * q) hq (Nat.mul_pos hacc hq) e
 
 private def sigmaExponentInput (e : Nat) : CheckedFactorization (3 ^ (e + 1)) :=
   ⟨⟨3 ^ (e + 1), [⟨e + 1, .small 3⟩]⟩, rfl, by
@@ -71,7 +75,7 @@ private def sigmaExponentInput (e : Nat) : CheckedFactorization (3 ^ (e + 1)) :=
     · simp only [factorProduct, PrimePower.prime, PrimeCert.subject]
       have h : boundedPowMul (3 ^ (e + 1)) 3 1 (e + 1) =
           some (3 ^ (e + 1)) := by
-        simpa using boundedPowMul_exact 3 1 (by decide) (e + 1)
+        simpa using boundedPowMul_exact 3 1 (by decide) (by decide) (e + 1)
       rw [h]⟩
 
 structure SigmaExponentInput where
@@ -195,8 +199,9 @@ setup_benchmark runCyclotomic n => n * n
     targetInnerNanos := 100000000
   }
 
-/- `boundedPowMul` replays the single exponent one multiplication at a time,
-so a certificate with exponent `n` has linear arithmetic-operation cost. -/
+/- `boundedPowMul` replays the single exponent one guarded multiplication at a
+time, using one division to authorize each multiplication, so a certificate
+with exponent `n` has linear arithmetic-operation cost. -/
 setup_benchmark runReplay n => n
   where {
     paramFloor := 1

--- a/conformance/HexIntFactor/Conformance.lean
+++ b/conformance/HexIntFactor/Conformance.lean
@@ -69,6 +69,10 @@ example {n : Nat} (F : CheckedPartialFactorization n) :
 #guard !checkFactorization ⟨12, [⟨1, .small 2⟩, ⟨1, .small 2⟩, ⟨1, .small 3⟩]⟩
 #guard !checkFactorization ⟨12, [⟨0, .small 2⟩, ⟨1, .small 3⟩]⟩
 #guard !checkFactorization ⟨12, [⟨1, .small 3⟩, ⟨2, .small 2⟩]⟩
+#guard !checkFactorization ⟨12, [⟨1048576, .small 2⟩]⟩
+  -- a huge exponent aborts before constructing the attacker-chosen power
+#guard !checkFactorization ⟨12, [⟨3, .small 2⟩, ⟨1, .small 3⟩]⟩
+  -- the next multiplication after 2³ crosses the subject bound
 
 #guard divisors checked1 == #[1]
 #guard numDivisors checked1 == 1

--- a/conformance/HexPrimality/Conformance.lean
+++ b/conformance/HexPrimality/Conformance.lean
@@ -83,6 +83,10 @@ open Hex.Nat
   -- duplicate subjects: each entry alone passes its witness check
 #guard checkPrime (.pock 97 [(5, 1048576, .small 2)]) = false
   -- bounded-product abort on a huge exponent
+#guard checkPrime (.pock 7 [(2, 0, .small (2 ^ 4096))]) = false
+  -- huge child subject is rejected before multiplying it by the accumulator
+#guard checkPrime (.pock 31 [(3, 0, .small 5), (3, 0, .small 7)]) = false
+  -- each power fits under 30, but the combined product would cross the bound
 #guard checkPrime (.pock3 193 8 2 0 [(5, 0, .small 2), (5, 0, .small 3)]) = false
   -- cofactor R = 32 is even
 #guard checkPrime (.pock3 199 8 2 8 [(3, 0, .small 2), (2, 0, .small 3)]) = false

--- a/conformance/HexPrimality/Conformance.lean
+++ b/conformance/HexPrimality/Conformance.lean
@@ -84,7 +84,7 @@ open Hex.Nat
 #guard checkPrime (.pock 97 [(5, 1048576, .small 2)]) = false
   -- bounded-product abort on a huge exponent
 #guard checkPrime (.pock 7 [(2, 0, .small (2 ^ 4096))]) = false
-  -- huge child subject is rejected before multiplying it by the accumulator
+  -- huge child subject is rejected at the first guarded product step
 #guard checkPrime (.pock 31 [(3, 0, .small 5), (3, 0, .small 7)]) = false
   -- each power fits under 30, but the combined product would cross the bound
 #guard checkPrime (.pock3 193 8 2 0 [(5, 0, .small 2), (5, 0, .small 3)]) = false

--- a/scripts/oracle/primality_pari.py
+++ b/scripts/oracle/primality_pari.py
@@ -113,9 +113,9 @@ def _check_cert(pari, cert: dict[str, Any]) -> bool:
         return False
     if n < 2 or n % 2 == 0:
         return False
-    # Mirror `Hex.Nat.boundedPowMul`: accumulate one multiplication at a
-    # time and abort as soon as the running product exceeds `n - 1`, so an
-    # adversarial exponent is rejected without constructing a huge power.
+    # Match `Hex.Nat.certProduct`'s verdict: accumulate one multiplication at
+    # a time and reject when the total first exceeds `n - 1`. The Lean checker
+    # authorizes each multiplication before constructing it.
     F = 1
     for (_, e, ch) in factors:
         q = int(ch["n"])


### PR DESCRIPTION
Closes #9774.

## Summary

- guard every nonzero bounded multiplication with a division check before constructing the product, with explicit zero-base and zero-accumulator paths
- route `certProduct`'s combined product through `boundedPowMul`
- expose exact-product and bound-preservation invariants, reuse them in `HexIntFactor`, and remove duplicate downstream proofs
- add adversarial rejection coverage for a huge child subject, huge exponent, and a combined product crossing its bound

## Verification

- `lake build HexPrimality HexIntFactor HexPrimalityKernelProbe HexIntFactorKernelProbe`
- `lake build +HexPrimality.Conformance +HexIntFactor.Conformance`
- `git diff --check`
- fixture oracle pipelines attempted; local oracle reported `SKIP: cypari2 not installed` (CI provides the dependency)
