### PR TITLE
fix(hex-primality): keep orderOf scan arithmetic modular

### DIFF
--- a/HexPrimality/Order.lean
+++ b/HexPrimality/Order.lean
@@ -19,7 +19,8 @@ The multiplicative order of `a` modulo `n`, Mathlib-free.
 deliberate choice: `0 < orderOf a n` is the hypothesis that says "this is a
 real order", and every theorem below carries it. The scan carries the current
 power residue, reducing both it and the base before the next multiplication,
-so each candidate costs one multiplication of residues modulo `n`.
+so each candidate costs one multiplication of residues modulo `n`. Certificate
+checking uses only the theorems about this order and never evaluates the scan.
 -/
 
 namespace Hex
@@ -392,13 +393,9 @@ junk-input branch of the definition. -/
 #guard orderOf 4 15 = 2
 #guard orderOf 1 5 = 1
 #guard orderOf (7 * 2 ^ 100000 + 3) 7 = 6 -- large unreduced base
-#guard orderOf 3 31 = 30
-#guard orderOf 3 127 = 126
-#guard orderOf 3 257 = 256
-#guard orderOf 3 1013 = 1012
-#guard orderOf 3 4073 = 4072
-#guard orderOf 3 16363 = 16362
-#guard orderOf 3 65537 = 65536 -- benchmark ladder: order close to the modulus
+#guard orderOf 8 7 = 1  -- unreduced residue `1`
+#guard orderOf 13 7 = 2 -- unreduced residue `n - 1`
+#guard orderOf 3 257 = 256 -- order close to the modulus
 #guard orderOf 2 8 = 0   -- not coprime
 #guard orderOf (15 * 2 ^ 10000 + 5) 15 = 0 -- large unreduced nonunit
 #guard orderOf 0 5 = 0   -- not coprime

--- a/HexPrimality/Order.lean
+++ b/HexPrimality/Order.lean
@@ -392,7 +392,13 @@ junk-input branch of the definition. -/
 #guard orderOf 4 15 = 2
 #guard orderOf 1 5 = 1
 #guard orderOf (7 * 2 ^ 100000 + 3) 7 = 6 -- large unreduced base
-#guard orderOf 3 257 = 256              -- order close to the modulus
+#guard orderOf 3 31 = 30
+#guard orderOf 3 127 = 126
+#guard orderOf 3 257 = 256
+#guard orderOf 3 1013 = 1012
+#guard orderOf 3 4073 = 4072
+#guard orderOf 3 16363 = 16362
+#guard orderOf 3 65537 = 65536 -- benchmark ladder: order close to the modulus
 #guard orderOf 2 8 = 0   -- not coprime
 #guard orderOf (15 * 2 ^ 10000 + 5) 15 = 0 -- large unreduced nonunit
 #guard orderOf 0 5 = 0   -- not coprime

--- a/HexPrimality/Order.lean
+++ b/HexPrimality/Order.lean
@@ -17,68 +17,74 @@ The multiplicative order of `a` modulo `n`, Mathlib-free.
 `orderOf a n` is the least `k > 0` with `a ^ k % n = 1 % n` when `1 < n` and
 `a` is coprime to `n`, and `0` on every other input. The junk value is a
 deliberate choice: `0 < orderOf a n` is the hypothesis that says "this is a
-real order", and every theorem below carries it. The order appears only in
-proofs (the Pocklington checker never computes it), so the bounded-search
-definition needs no efficiency and no kernel exposure.
+real order", and every theorem below carries it. The scan carries the current
+power residue, reducing both it and the base before the next multiplication,
+so each candidate costs one multiplication of residues modulo `n`.
 -/
 
 namespace Hex
 
 namespace Nat
 
-/-- First exponent `e` in `[k, k + fuel)` with `a ^ e % n = 1 % n`, and `0`
-if there is none. -/
-def orderOfAux (a n : Nat) : Nat → Nat → Nat
-  | 0, _ => 0
-  | fuel + 1, k => if a ^ k % n = 1 % n then k else orderOfAux a n fuel (k + 1)
+/-- Scan consecutive exponents while carrying the current power residue. -/
+private def orderOfAux (b n : Nat) : Nat → Nat → Nat → Nat
+  | 0, _, _ => 0
+  | fuel + 1, k, r =>
+      if r = 1 % n then k
+      else orderOfAux b n fuel (k + 1) (r * b % n)
 
 /-- Multiplicative order of `a` modulo `n`: the least `k > 0` with
 `a ^ k % n = 1 % n` when `1 < n` and `Nat.Coprime a n`, and `0` on every
 other input. -/
 def orderOf (a n : Nat) : Nat :=
-  if 1 < n ∧ Nat.Coprime a n then orderOfAux a n n 1 else 0
+  if 1 < n ∧ Nat.Coprime a n then orderOfAux (a % n) n n 1 (a % n) else 0
 
 private theorem orderOfAux_spec (a n : Nat) :
-    ∀ fuel k, orderOfAux a n fuel k ≠ 0 →
-      k ≤ orderOfAux a n fuel k ∧
-      a ^ orderOfAux a n fuel k % n = 1 % n ∧
-      ∀ j, k ≤ j → j < orderOfAux a n fuel k → a ^ j % n ≠ 1 % n := by
+    ∀ fuel k r, r = a ^ k % n → orderOfAux (a % n) n fuel k r ≠ 0 →
+      k ≤ orderOfAux (a % n) n fuel k r ∧
+      a ^ orderOfAux (a % n) n fuel k r % n = 1 % n ∧
+      ∀ j, k ≤ j → j < orderOfAux (a % n) n fuel k r → a ^ j % n ≠ 1 % n := by
   intro fuel
   induction fuel with
   | zero =>
-      intro k h
+      intro k r _ h
       simp [orderOfAux] at h
   | succ fuel ih =>
-      intro k h
+      intro k r hr h
       unfold orderOfAux at h ⊢
-      by_cases hk : a ^ k % n = 1 % n
+      by_cases hk : r = 1 % n
       · rw [if_pos hk] at h ⊢
-        exact ⟨Nat.le_refl _, hk, fun j hkj hjk => by omega⟩
+        exact ⟨Nat.le_refl _, hr ▸ hk, fun j hkj hjk => by omega⟩
       · rw [if_neg hk] at h ⊢
-        obtain ⟨hle, hpow, hmin⟩ := ih (k + 1) h
+        have hr' : r * (a % n) % n = a ^ (k + 1) % n := by
+          rw [hr, ← Nat.mul_mod, ← Nat.pow_succ]
+        obtain ⟨hle, hpow, hmin⟩ := ih (k + 1) _ hr' h
         refine ⟨by omega, hpow, ?_⟩
         intro j hkj hjlt
         rcases Nat.eq_or_lt_of_le hkj with rfl | hlt
-        · exact hk
+        · exact fun hpow => hk (hr.trans hpow)
         · exact hmin j hlt hjlt
 
 private theorem orderOfAux_ne_zero_of_witness (a n : Nat) :
-    ∀ fuel k, 0 < k → ∀ j, k ≤ j → j < k + fuel → a ^ j % n = 1 % n →
-      orderOfAux a n fuel k ≠ 0 := by
+    ∀ fuel k r, r = a ^ k % n → 0 < k →
+      ∀ j, k ≤ j → j < k + fuel → a ^ j % n = 1 % n →
+        orderOfAux (a % n) n fuel k r ≠ 0 := by
   intro fuel
   induction fuel with
   | zero =>
-      intro k hk j hkj hjb _
+      intro k r hr hk j hkj hjb _
       omega
   | succ fuel ih =>
-      intro k hk j hkj hjb hj
+      intro k r hr hk j hkj hjb hj
       unfold orderOfAux
-      by_cases hcase : a ^ k % n = 1 % n
+      by_cases hcase : r = 1 % n
       · rw [if_pos hcase]
         omega
       · rw [if_neg hcase]
-        have hne : j ≠ k := fun h => hcase (h ▸ hj)
-        exact ih (k + 1) (by omega) j (by omega) (by omega) hj
+        have hne : j ≠ k := fun h => hcase (hr.trans (h ▸ hj))
+        have hr' : r * (a % n) % n = a ^ (k + 1) % n := by
+          rw [hr, ← Nat.mul_mod, ← Nat.pow_succ]
+        exact ih (k + 1) _ hr' (by omega) j (by omega) (by omega) hj
 
 private theorem dvd_pow_self' (a : Nat) {k : Nat} (hk : k ≠ 0) : a ∣ a ^ k := by
   cases k with
@@ -133,7 +139,7 @@ theorem pow_pred_mod {p a : Nat} (hp : Prime p) (h : Nat.Coprime a p) :
   exact pow_mod_cancel h hfermat
 
 private theorem orderOf_eq_aux {a n : Nat} (h1 : 1 < n) (hcop : Nat.Coprime a n) :
-    orderOf a n = orderOfAux a n n 1 := by
+    orderOf a n = orderOfAux (a % n) n n 1 (a % n) := by
   unfold orderOf
   rw [if_pos ⟨h1, hcop⟩]
 
@@ -160,7 +166,7 @@ theorem orderOf_pow_mod {a n : Nat} (h : 0 < orderOf a n) :
   have h1 := one_lt_of_orderOf_pos h
   have hcop := coprime_of_orderOf_pos h
   rw [orderOf_eq_aux h1 hcop] at h ⊢
-  exact (orderOfAux_spec a n n 1 (by omega)).2.1
+  exact (orderOfAux_spec a n n 1 (a % n) (by simp) (by omega)).2.1
 
 /-- Minimality of a positive order among positive exponents. -/
 theorem orderOf_min {a n : Nat} (h : 0 < orderOf a n) :
@@ -169,7 +175,7 @@ theorem orderOf_min {a n : Nat} (h : 0 < orderOf a n) :
   have hcop := coprime_of_orderOf_pos h
   rw [orderOf_eq_aux h1 hcop] at h ⊢
   intro j hj hjlt
-  exact (orderOfAux_spec a n n 1 (by omega)).2.2 j (by omega) hjlt
+  exact (orderOfAux_spec a n n 1 (a % n) (by simp) (by omega)).2.2 j (by omega) hjlt
 
 /-- Distinct power residues below `d` force `d ≤ n`, by pigeonhole inside
 `List.range n`. -/
@@ -219,16 +225,17 @@ up to `n` therefore also finds it. -/
 theorem orderOf_pos_of_pow_eq_one {a n k : Nat} (h1 : 1 < n) (hk : 0 < k)
     (h : a ^ k % n = 1 % n) : 0 < orderOf a n := by
   have hcop := coprime_of_pow_mod_eq_one h1 hk h
-  have hne : orderOfAux a n k 1 ≠ 0 :=
-    orderOfAux_ne_zero_of_witness a n k 1 (by omega) k (by omega) (by omega) h
-  obtain ⟨hd1, hdpow, hdmin⟩ := orderOfAux_spec a n k 1 hne
-  have hdn : orderOfAux a n k 1 ≤ n :=
+  have hne : orderOfAux (a % n) n k 1 (a % n) ≠ 0 :=
+    orderOfAux_ne_zero_of_witness a n k 1 (a % n) (by simp) (by omega)
+      k (by omega) (by omega) h
+  obtain ⟨hd1, hdpow, hdmin⟩ := orderOfAux_spec a n k 1 (a % n) (by simp) hne
+  have hdn : orderOfAux (a % n) n k 1 (a % n) ≤ n :=
     le_of_least_pow_witness h1 hcop hdmin
-  have hne' : orderOfAux a n n 1 ≠ 0 :=
-    orderOfAux_ne_zero_of_witness a n n 1 (by omega) (orderOfAux a n k 1)
-      hd1 (by omega) hdpow
+  have hne' : orderOfAux (a % n) n n 1 (a % n) ≠ 0 :=
+    orderOfAux_ne_zero_of_witness a n n 1 (a % n) (by simp) (by omega)
+      (orderOfAux (a % n) n k 1 (a % n)) hd1 (by omega) hdpow
   rw [orderOf_eq_aux h1 hcop]
-  have := (orderOfAux_spec a n n 1 hne').1
+  have := (orderOfAux_spec a n n 1 (a % n) (by simp) hne').1
   omega
 
 /-- The order divides every exponent sending `a` to `1` modulo `n`. -/
@@ -360,13 +367,14 @@ repeat into a witness exponent. -/
 theorem orderOf_pos {a n : Nat} (h1 : 1 < n) (h : Nat.Coprime a n) :
     0 < orderOf a n := by
   rw [orderOf_eq_aux h1 h]
-  rcases Nat.eq_zero_or_pos (orderOfAux a n n 1) with hzero | hpos
+  rcases Nat.eq_zero_or_pos (orderOfAux (a % n) n n 1 (a % n)) with hzero | hpos
   · exfalso
     -- With no witness exponent in [1, n], all n + 1 residues
     -- a ^ 0 % n, …, a ^ n % n are pairwise distinct inside [0, n).
     have hnowit : ∀ j, 1 ≤ j → j < 1 + n → a ^ j % n ≠ 1 % n := by
       intro j h1j hjb hj
-      exact orderOfAux_ne_zero_of_witness a n n 1 (by omega) j h1j hjb hj hzero
+      exact orderOfAux_ne_zero_of_witness a n n 1 (a % n) (by simp) (by omega)
+        j h1j hjb hj hzero
     have hdist : ∀ i j, i < j → j < n + 1 → a ^ i % n ≠ a ^ j % n := by
       intro i j hij hjd heq
       exact hnowit (j - i) (by omega) (by omega)
@@ -383,7 +391,10 @@ junk-input branch of the definition. -/
 #guard orderOf 2 15 = 4
 #guard orderOf 4 15 = 2
 #guard orderOf 1 5 = 1
+#guard orderOf (7 * 2 ^ 100000 + 3) 7 = 6 -- large unreduced base
+#guard orderOf 3 257 = 256              -- order close to the modulus
 #guard orderOf 2 8 = 0   -- not coprime
+#guard orderOf (15 * 2 ^ 10000 + 5) 15 = 0 -- large unreduced nonunit
 #guard orderOf 0 5 = 0   -- not coprime
 #guard orderOf 5 1 = 0   -- trivial modulus
 #guard orderOf 5 0 = 0   -- trivial modulus

--- a/bench/HexIntFactor/Bench.lean
+++ b/bench/HexIntFactor/Bench.lean
@@ -51,6 +51,10 @@ def runReplay (e : Nat) : Nat :=
 
 def runOrder (p : Nat) : Nat := orderOf 3 p
 
+private def orderLadder : Array Nat := #[257, 1013, 4073, 16363, 65537]
+
+#guard orderLadder.all fun p => orderOf 3 p == p - 1
+
 private theorem boundedPowMul_exact (q acc : Nat) (hq : 0 < q) : ∀ e : Nat,
     boundedPowMul (acc * q ^ e) q acc e = some (acc * q ^ e)
   | 0 => by simp [boundedPowMul]
@@ -212,12 +216,11 @@ so each run exercises `p - 1` scan steps and the declared arithmetic-operation
 model is linear. -/
 setup_benchmark runOrder n => n
   where {
-    paramFloor := 7
+    paramFloor := 257
     paramCeiling := 65537
-    paramSchedule := .custom #[7, 31, 127, 257, 1013, 4073, 16363, 65537]
+    paramSchedule := .custom orderLadder
     maxSecondsPerCall := 5.0
-    targetInnerNanos := 250000000
-    signalFloorMultiplier := 1.0
+    targetInnerNanos := 2500000000
     outerTrials := 3
   }
 

--- a/bench/HexIntFactor/Bench.lean
+++ b/bench/HexIntFactor/Bench.lean
@@ -214,9 +214,11 @@ setup_benchmark runOrder n => n
   where {
     paramFloor := 7
     paramCeiling := 65537
-    paramSchedule := .custom #[7, 31, 257, 65537]
+    paramSchedule := .custom #[7, 31, 127, 257, 1013, 4073, 16363, 65537]
     maxSecondsPerCall := 5.0
-    targetInnerNanos := 100000000
+    targetInnerNanos := 250000000
+    signalFloorMultiplier := 1.0
+    outerTrials := 3
   }
 
 /- These targets are much faster per call than the route-search targets

--- a/bench/HexIntFactor/Bench.lean
+++ b/bench/HexIntFactor/Bench.lean
@@ -49,7 +49,7 @@ def replayInput (e : Nat) : Factorization :=
 def runReplay (e : Nat) : Nat :=
   if checkFactorization (replayInput e) then 1 else 0
 
-def runOrder (p : Nat) : Nat := orderOf 2 p
+def runOrder (p : Nat) : Nat := orderOf 3 p
 
 private theorem boundedPowMul_exact (q acc : Nat) (hq : 0 < q) : ∀ e : Nat,
     boundedPowMul (acc * q ^ e) q acc e = some (acc * q ^ e)
@@ -206,8 +206,10 @@ setup_benchmark runReplay n => n
     targetInnerNanos := 100000000
   }
 
-/- `orderOf` scans candidate exponents up to the modulus and performs a bounded
-modular-power check at each step, so the declared worst-case model is linear. -/
+/- `orderOf` carries one bounded residue and performs one modular multiplication
+per candidate exponent. On every prime in this ladder, `3` has order `p - 1`,
+so each run exercises `p - 1` scan steps and the declared arithmetic-operation
+model is linear. -/
 setup_benchmark runOrder n => n
   where {
     paramFloor := 7

--- a/conformance-fixtures/HexIntFactor/intfactor.jsonl
+++ b/conformance-fixtures/HexIntFactor/intfactor.jsonl
@@ -110,6 +110,8 @@
 {"kind":"result","lib":"HexIntFactor","case":"order/primepower/2mod9","op":"order","value":6}
 {"kind":"order","lib":"HexIntFactor","case":"order/noncyclic/5mod8","base":5,"modulus":8}
 {"kind":"result","lib":"HexIntFactor","case":"order/noncyclic/5mod8","op":"order","value":2}
+{"kind":"order","lib":"HexIntFactor","case":"order/unreduced/10mod7","base":10,"modulus":7}
+{"kind":"result","lib":"HexIntFactor","case":"order/unreduced/10mod7","op":"order","value":6}
 {"kind":"cyclotomic","lib":"HexIntFactor","case":"cyclotomic/grid/2/1/minus","b":2,"n":1,"sign":"minus"}
 {"kind":"result","lib":"HexIntFactor","case":"cyclotomic/grid/2/1/minus","op":"cyclotomic","value":[[1,1]]}
 {"kind":"cyclotomic","lib":"HexIntFactor","case":"cyclotomic/grid/2/1/plus","b":2,"n":1,"sign":"plus"}

--- a/conformance/HexIntFactor/EmitFixtures.lean
+++ b/conformance/HexIntFactor/EmitFixtures.lean
@@ -117,6 +117,7 @@ def main : IO Unit := do
   emitOrder "nonprimitive/2mod7" 2 7
   emitOrder "primepower/2mod9" 2 9
   emitOrder "noncyclic/5mod8" 5 8
+  emitOrder "unreduced/10mod7" 10 7
   for b in [2, 3, 5, 7, 10] do
     for i in List.range 32 do
       emitCyclotomic b (i + 1) .minus


### PR DESCRIPTION
Closes #9773

## Summary
- replace repeated raw-power checks with an incremental residue scan after reducing the base once
- preserve the documented order API proofs over the carried-residue invariant and add adversarial plus oracle-backed regressions
- make the Phase-4 order benchmark share an exact maximal-order ladder assertion and collect verdict-eligible measurements

## Verification
- `lake build HexPrimality HexIntFactor HexIntFactorMathlib`
- `lake exe hexintfactor_bench list`
- `lake exe hexintfactor_bench verify`
- fixture emitter output exactly matches `conformance-fixtures/HexIntFactor/intfactor.jsonl`
- `lake exe hexintfactor_bench run Hex.IntFactorBench.runOrder --auto-fit` (linear verdict consistent, beta = -0.004; auto-fit ranks n first)

The local PARI oracle command was attempted but skipped because `cypari2` is not installed; CI exercises the committed fixture.