### PR TITLE
fix(hex-primality): run deterministic verdict tiers before certificate fuel

### DIFF
--- a/HexPrimality/SPEC/hex-primality.md
+++ b/HexPrimality/SPEC/hex-primality.md
@@ -845,8 +845,8 @@ witness returns `.composite` at every fuel. Only a candidate at or above
 returns `.exhausted` without starting factorization, while a positive fuel
 begins one certificate node and passes its predecessor to every child. A table
 child can consequently close when that predecessor is zero, whereas a child
-that itself needs construction exhausts. Thus the fuel is the maximum number
-of constructed certificate nodes along a root-to-child path; it neither counts
+that itself needs construction exhausts. Thus the fuel bounds the number of
+constructed certificate nodes along any root-to-leaf path; it neither counts
 deterministic verdict work nor bounds the randomized attempt total within a
 node.
 
@@ -867,9 +867,9 @@ critical path, so `NextPrimeFailure` reports exhaustion with the attempt
 count and advanced state. The theorem records that a success is the
 *least* such prime.
 
-`primeCert?` distinguishes `PrimeCertStop.composite`, justified by trial
-division or a failed Miller-Rabin base, from `.exhausted`, which makes
-no primality claim. Exhaustion is reachable: the certificate search needs `n - 1`
+`primeCert?` distinguishes `PrimeCertStop.composite`, justified by the size
+check, table completeness, or a failed Miller-Rabin base, from `.exhausted`,
+which makes no primality claim. Exhaustion is reachable: the certificate search needs `n - 1`
 factored past a square root (or a cube root), and there are `n` for
 which that is out of reach. `PrimeCertFailure` retains the advanced state and
 exact attempt count because `partialFactor` runs Pollard rho.

--- a/HexPrimality/SPEC/hex-primality.md
+++ b/HexPrimality/SPEC/hex-primality.md
@@ -834,6 +834,22 @@ returns `.error` rather than falling into an unbounded computation. The
 indexed success prevents a certificate for one number from answering a
 request about another.
 
+Certificate fuel bounds construction depth after the fixed deterministic
+front end, not the front end itself. At every recursive `primeCert?` invocation,
+the size check, complete table lookup, and fixed Miller--Rabin base scan run
+before fuel is inspected; these tiers consume no attempts and leave `Rand`
+unchanged. Therefore a table prime can return its small certificate at fuel
+zero, and a composite proved by size, table completeness, or a Miller--Rabin
+witness returns `.composite` at every fuel. Only a candidate at or above
+`primeTableBound` that passes every fixed base needs construction fuel: zero
+returns `.exhausted` without starting factorization, while a positive fuel
+begins one certificate node and passes its predecessor to every child. A table
+child can consequently close when that predecessor is zero, whereas a child
+that itself needs construction exhausts. Thus the fuel is the maximum number
+of constructed certificate nodes along a root-to-child path; it neither counts
+deterministic verdict work nor bounds the randomized attempt total within a
+node.
+
 `isPrime` is the pure total convenience API. It runs `isPrime?` with
 `defaultPrimeFuel n` from the reproducible seed `Rand.ofSeed n` and
 falls back to `isPrimeTrial` only if the bounded path exhausts its fuel.

--- a/HexPrimality/Search.lean
+++ b/HexPrimality/Search.lean
@@ -636,25 +636,29 @@ private def mkPock3 (n F : Nat) (entries : List (Nat × Nat × PrimeCert)) :
 
 mutual
 
-/-- One level of certificate search: verdict tiers first (size, table with
-its completeness, a Miller-Rabin witness scan), then `n - 1` is partially
-factored and every claimed prime-power entry becomes a certified child with
-a searched witness. The candidate entries are sorted into the checker's
-canonical subject order, then the assembled node is validated by the public
-wrapper; neither the factorization nor this preprocessing is trusted. -/
+/-- One level of certificate search. Size, the complete table tier, and the
+fixed Miller-Rabin witness scan run before fuel is inspected and leave attempts
+and random state unchanged. A survivor consumes one recursion-depth unit to
+begin construction; its children receive the predecessor, so table children
+can still close at depth zero while children needing construction cannot.
+Then `n - 1` is partially factored and every claimed prime-power entry becomes
+a certified child with a searched witness. The candidate entries are sorted
+into the checker's canonical subject order, then the assembled node is
+validated by the public wrapper; neither the factorization nor this
+preprocessing is trusted. -/
 private def primeCertGo (fuel n : Nat) (r : Rand) :
     Except PrimeCertFailure (Counted PrimeCert) :=
-  match fuel with
-  | 0 => .error ⟨.exhausted, 0, r⟩
-  | fuel + 1 =>
-      if n < 2 then .error ⟨.composite, 0, r⟩
-      else if n < primeTableBound then
-        if isTablePrime n then .ok ⟨.small n, 0, r⟩
-        else .error ⟨.composite, 0, r⟩
-      else
-        match defaultBases.find? (fun a => !(millerRabin n a)) with
-        | some _ => .error ⟨.composite, 0, r⟩
-        | none =>
+  if n < 2 then .error ⟨.composite, 0, r⟩
+  else if n < primeTableBound then
+    if isTablePrime n then .ok ⟨.small n, 0, r⟩
+    else .error ⟨.composite, 0, r⟩
+  else
+    match defaultBases.find? (fun a => !(millerRabin n a)) with
+    | some _ => .error ⟨.composite, 0, r⟩
+    | none =>
+        match fuel with
+        | 0 => .error ⟨.exhausted, 0, r⟩
+        | fuel + 1 =>
             let factored := partialFactor (n - 1) r (2 * n.log2 + 8)
             match assembleGo fuel n factored.raw.factors [] factored.attempts
                 factored.rand with
@@ -780,49 +784,46 @@ private theorem assembleGo_error_stop {fuel n : Nat} :
 private theorem primeCertGo_composite {fuel n : Nat} {r : Rand}
     {f : PrimeCertFailure} (h : primeCertGo fuel n r = .error f)
     (hstop : f.stop = .composite) : ¬ Prime n := by
-  match fuel with
-  | 0 =>
-      unfold primeCertGo at h
-      injection h with h
-      subst h
-      cases hstop
-  | fuel + 1 =>
-      unfold primeCertGo at h
-      by_cases h2 : n < 2
-      · rw [if_pos h2] at h
+  unfold primeCertGo at h
+  by_cases h2 : n < 2
+  · rw [if_pos h2] at h
+    intro hp
+    have := hp.two_le
+    omega
+  · rw [if_neg h2] at h
+    by_cases htab : n < primeTableBound
+    · rw [if_pos htab] at h
+      by_cases hhit : isTablePrime n = true
+      · rw [if_pos hhit] at h
+        cases h
+      · rw [if_neg hhit] at h
         intro hp
-        have := hp.two_le
-        omega
-      · rw [if_neg h2] at h
-        by_cases htab : n < primeTableBound
-        · rw [if_pos htab] at h
-          by_cases hhit : isTablePrime n = true
-          · rw [if_pos hhit] at h
-            cases h
-          · rw [if_neg hhit] at h
-            intro hp
-            exact hhit (isTablePrime_iff.mpr (mem_primeTable_of_prime hp htab))
-        · rw [if_neg htab] at h
-          split at h
-          · rename_i a hfind
-            intro hp
-            have := List.find?_some hfind
-            rw [Bool.not_eq_true'] at this
-            exact absurd (millerRabin_eq_true_of_prime hp) (by
-              rw [this]
-              exact Bool.false_ne_true)
-          · dsimp only at h
-            split at h
-            · rename_i f' herr
-              injection h with h
+        exact hhit (isTablePrime_iff.mpr (mem_primeTable_of_prime hp htab))
+    · rw [if_neg htab] at h
+      split at h
+      · rename_i a hfind
+        intro hp
+        have := List.find?_some hfind
+        rw [Bool.not_eq_true'] at this
+        exact absurd (millerRabin_eq_true_of_prime hp) (by
+          rw [this]
+          exact Bool.false_ne_true)
+      · dsimp only at h
+        split at h
+        · injection h with h
+          subst h
+          cases hstop
+        · split at h
+          · rename_i f' herr
+            injection h with h
+            subst h
+            rw [assembleGo_error_stop _ _ _ _ herr] at hstop
+            cases hstop
+          · split at h
+            · injection h with h
               subst h
-              rw [assembleGo_error_stop _ _ _ _ herr] at hstop
               cases hstop
-            · split at h
-              · injection h with h
-                subst h
-                cases hstop
-              · split at h <;> cases h
+            · split at h <;> cases h
 
 /-- A counted `.composite` failure is a verdict: the input is not prime. -/
 theorem Internal.primeCertCounted?_composite {n : Nat} {r : Rand} {fuel : Nat}

--- a/HexPrimality/Search.lean
+++ b/HexPrimality/Search.lean
@@ -562,8 +562,8 @@ set_option maxRecDepth 10000 in
 
 /-- Why certificate search stopped without a certificate. -/
 inductive PrimeCertStop where
-  /-- The input is provably composite (trial, table completeness, or a
-  Miller-Rabin witness); the failure is a verdict. -/
+  /-- The input is provably composite (the size check, table completeness, or
+  a Miller-Rabin witness); the failure is a verdict. -/
   | composite
   /-- The search budget ran out; no primality claim either way. -/
   | exhausted

--- a/conformance/HexIntFactor/Conformance.lean
+++ b/conformance/HexIntFactor/Conformance.lean
@@ -477,11 +477,12 @@ private def retainedCertInput : Nat := starvedInput * 1000037
       failure.stop == .incomplete && failure.attempts == 0
   | .ok _ => false)
 
--- A later stopped continuation retains the successful-part subtotal that the
--- public pair-returning API intentionally omits.
+-- Table children close at residual depth zero, so the later stopped
+-- continuation includes their witness work in the successful-part subtotal
+-- that the public pair-returning API intentionally omits.
 #guard (match factorPowerWithRoute? 2 128 .minus (Rand.ofSeed 1) (fuel := 3) with
   | .error failure =>
-      failure.stop == .incomplete && failure.attempts == 17
+      failure.stop == .incomplete && failure.attempts == 21
   | .ok _ => false)
 
 -- Degenerate split input uses the ordinary dispatcher, and the route tag makes

--- a/conformance/HexPrimality/Conformance.lean
+++ b/conformance/HexPrimality/Conformance.lean
@@ -110,6 +110,59 @@ open Hex.Nat
         | .error f => f.stop == .composite
         | .ok _ => false)
 
+-- Fixed verdict tiers run before recursive certificate fuel and do not consume
+-- attempts or random state. A prime beyond the table still needs construction.
+#guard (List.range 2).all fun fuel =>
+  match primeCert? 4 (Hex.Rand.ofSeed 0) fuel with
+  | .error failure =>
+      failure.stop == .composite && failure.attempts == 0 &&
+        failure.rand == Hex.Rand.ofSeed 0
+  | .ok _ => false
+#guard (List.range 2).all fun fuel =>
+  match primeCert? 97 (Hex.Rand.ofSeed 0) fuel with
+  | .ok (cert, r) =>
+      cert.raw.subject == 97 && checkPrime cert.raw && r == Hex.Rand.ofSeed 0
+  | .error _ => false
+#guard (List.range 2).all fun fuel =>
+  match primeCert? 2147483649 (Hex.Rand.ofSeed 0) fuel with
+  | .error failure =>
+      failure.stop == .composite && failure.attempts == 0 &&
+        failure.rand == Hex.Rand.ofSeed 0
+  | .ok _ => false
+#guard (match primeCert? 2147483647 (Hex.Rand.ofSeed 0) 0 with
+  | .error failure =>
+      failure.stop == .exhausted && failure.attempts == 0 &&
+        failure.rand == Hex.Rand.ofSeed 0
+  | .ok _ => false)
+#guard (match Internal.primeCertCounted? 2147483647
+    (Hex.Rand.ofSeed 0) 1 with
+  | .ok success =>
+      success.attempts == 7 &&
+        success.rand == ((Hex.Rand.ofSeed 0).words 7).2
+  | .error _ => false)
+
+-- The bounded decision exposes the same zero/one-fuel boundary.
+#guard (List.range 2).all fun fuel =>
+  match isPrime? 4 (Hex.Rand.ofSeed 0) fuel with
+  | .ok (verdict, r) => !verdict && r == Hex.Rand.ofSeed 0
+  | .error _ => false
+#guard (List.range 2).all fun fuel =>
+  match isPrime? 97 (Hex.Rand.ofSeed 0) fuel with
+  | .ok (verdict, r) => verdict && r == Hex.Rand.ofSeed 0
+  | .error _ => false
+#guard (List.range 2).all fun fuel =>
+  match isPrime? 2147483649 (Hex.Rand.ofSeed 0) fuel with
+  | .ok (verdict, r) => !verdict && r == Hex.Rand.ofSeed 0
+  | .error _ => false
+#guard (match isPrime? 2147483647 (Hex.Rand.ofSeed 0) 0 with
+  | .error failure =>
+      failure.attempts == 0 && failure.rand == Hex.Rand.ofSeed 0
+  | .ok _ => false)
+#guard (match isPrime? 2147483647 (Hex.Rand.ofSeed 0) 1 with
+  | .ok (verdict, r) =>
+      verdict && r == ((Hex.Rand.ofSeed 0).words 7).2
+  | .error _ => false)
+
 -- Counted compatibility forms retain successful randomized work without
 -- changing the ordinary pair-returning entry points.
 #guard (match Internal.rhoFactorCounted? 9 (Hex.Rand.ofSeed 2) 8 with
@@ -123,23 +176,39 @@ open Hex.Nat
         success.rand == ((Hex.Rand.ofSeed 3).words 8).2
   | .error _ => false)
 
--- Fuel two certifies an earlier child and finds its witness before a later
--- recursive child exhausts. The failure retains that successful work.
+-- Fuel one resolves table children and finds their witnesses before a later
+-- child needs construction. The failure retains that successful work.
 #guard (match Internal.primeCertCounted? 1000003
-    (Hex.Rand.ofSeed 3) 2 with
+    (Hex.Rand.ofSeed 3) 1 with
   | .error failure =>
       failure.stop == .exhausted && failure.attempts == 2 &&
         failure.rand == ((Hex.Rand.ofSeed 3).words 2).2
   | .ok _ => false)
 
--- A deeper child consumes its own randomized subtotal before exhaustion;
--- the parent retains both its earlier witness and that child subtotal.
+-- One more level constructs the remaining child and completes the parent.
+#guard (match Internal.primeCertCounted? 1000003
+    (Hex.Rand.ofSeed 3) 2 with
+  | .ok success =>
+      success.attempts == 8 &&
+        success.rand == ((Hex.Rand.ofSeed 3).words 8).2
+  | .error _ => false)
+
+-- At fuel two, a deeper child consumes its randomized subtotal before
+-- exhaustion; the parent retains both its earlier witness and that subtotal.
 #guard (match Internal.primeCertCounted? 1000000007
-    (Hex.Rand.ofSeed 3) 3 with
+    (Hex.Rand.ofSeed 3) 2 with
   | .error failure =>
       failure.stop == .exhausted && failure.attempts == 7 &&
         failure.rand == ((Hex.Rand.ofSeed 3).words 7).2
   | .ok _ => false)
+
+-- Fuel three constructs that child and completes the parent.
+#guard (match Internal.primeCertCounted? 1000000007
+    (Hex.Rand.ofSeed 3) 3 with
+  | .ok success =>
+      success.attempts == 16 &&
+        success.rand == ((Hex.Rand.ofSeed 3).words 16).2
+  | .error _ => false)
 
 -- This strong pseudoprime passes the fixed Miller--Rabin screen, then its
 -- first certificate witness search consumes all 32 candidates. The retained

--- a/conformance/HexPrimality/Conformance.lean
+++ b/conformance/HexPrimality/Conformance.lean
@@ -141,7 +141,8 @@ open Hex.Nat
         success.rand == ((Hex.Rand.ofSeed 0).words 7).2
   | .error _ => false)
 
--- The bounded decision exposes the same zero/one-fuel boundary.
+-- The bounded decision remains fuel-insensitive below the table bound and
+-- exposes the reordered verdict/construction boundary above its trial cutoff.
 #guard (List.range 2).all fun fuel =>
   match isPrime? 4 (Hex.Rand.ofSeed 0) fuel with
   | .ok (verdict, r) => !verdict && r == Hex.Rand.ofSeed 0


### PR DESCRIPTION
Closes #9781

## Summary

- run size, complete table, and fixed Miller--Rabin verdict tiers before certificate construction fuel
- define fuel as constructed-node depth and preserve attempt/Rand accounting across deterministic tiers
- re-derive low-fuel primality and downstream integer-factor conformance cases, including focused zero/one-fuel API guards
- document the exact fixed-front-end/recursive-construction boundary in the HexPrimality SPEC

## Public behavior

At explicit fuel zero, `primeCert?` can now return a small table certificate or a proved `.composite` verdict, and `isPrime?` can return `false` for composites decided by its fixed front end. Inputs that pass the fixed front end and require certificate construction still exhaust without consuming attempts or Rand state.

## Verification

- `lake build HexPrimality HexConformance`
- `lake build HexPrimality +HexPrimality.Conformance` (after second-opinion documentation refinements)

## Second opinion

Claude Opus found no soundness, termination, or accounting defect and independently reproduced the key low-fuel totals. Its SPEC wording concerns were addressed in f80d47f36.