### PR TITLE
perf(hex-primality): eliminate duplicated runtime search computations

### DIFF
--- a/HexPrimality/MillerRabin.lean
+++ b/HexPrimality/MillerRabin.lean
@@ -108,8 +108,8 @@ def millerRabin (n a : Nat) : Bool :=
   else if a % n = 0 then true
   else if 1 < Nat.gcd a n then false
   else
-    mrStrongTestCore n (oddSplit (n - 1)).1
-      (HexArith.powMod a (oddSplit (n - 1)).2 n)
+    let split := oddSplit (n - 1)
+    mrStrongTestCore n split.1 (HexArith.powMod a split.2 n)
 
 /-- The first 13 primes: sufficient witnesses for `n < 3.3 · 10^24` by
 Sorenson-Webster, a fact used only to decide what to try and never in a

--- a/HexPrimality/Search.lean
+++ b/HexPrimality/Search.lean
@@ -159,8 +159,10 @@ bounded wall-clock at every input size. The cap still covers factors to
 about `2^44`, past rho's documented remit of roughly `10^12`; beyond it
 the honest outcome is a clean `exhausted`, not an inner loop whose budget
 outlives the caller. Runtime only, so `Nat.sqrt` is fine here. -/
+private def rhoInnerFuelCap : Nat := 1 <<< 22
+
 private def rhoInnerFuel (n : Nat) : Nat :=
-  min (16 * (Nat.sqrt (Nat.sqrt n) + 2)) (1 <<< 22)
+  min (16 * (Nat.sqrt (Nat.sqrt n) + 2)) rhoInnerFuelCap
 
 /-- One accepted restart draw together with its advanced random state. -/
 private structure RhoDraw where
@@ -235,8 +237,7 @@ private def rhoTry (n innerFuel : Nat) : Nat → Nat → Rand →
   | 0, attempts, r => .error ⟨.exhausted, attempts, r⟩
   | tries + 1, attempts, r =>
       let draw := rhoDraw n r
-      match (brentGo n draw.c (min (rhoInnerFuel n) innerFuel)
-          (brentStart draw.start)).factor with
+      match (brentGo n draw.c innerFuel (brentStart draw.start)).factor with
       | some d =>
           if 1 < d then
             if d < n then
@@ -254,12 +255,14 @@ def rhoFactorCountedWith? (n : Nat) (r : Rand) (restarts innerFuel : Nat) :
     Except RhoFailure RhoSuccess :=
   if n < 4 then .error ⟨.invalidInput, 0, r⟩
   else if n % 2 = 0 then .ok ⟨2, 0, r⟩
-  else rhoTry n innerFuel restarts 0 r
+  else
+    let restartFuel := min (rhoInnerFuel n) innerFuel
+    rhoTry n restartFuel restarts 0 r
 
 /-- A counted rho search with the production per-restart cycle budget. -/
 def rhoFactorCounted? (n : Nat) (r : Rand) (fuel : Nat) :
     Except RhoFailure RhoSuccess :=
-  rhoFactorCountedWith? n r fuel (rhoInnerFuel n)
+  rhoFactorCountedWith? n r fuel rhoInnerFuelCap
 
 end Internal
 
@@ -370,8 +373,18 @@ private def divOut (p : Nat) : Nat → Nat → Nat × Nat
   | 0, m => (0, m)
   | fuel + 1, m =>
       if 1 < p ∧ m % p = 0 then
-        ((divOut p fuel (m / p)).1 + 1, (divOut p fuel (m / p)).2)
+        let divided := divOut p fuel (m / p)
+        (divided.1 + 1, divided.2)
       else (0, m)
+
+namespace Internal
+
+/-- Exercise one trial-division extraction directly. Used by conformance to
+guard the high-valuation route independently of the full prime-table walk. -/
+def trialExtractTrace (p m : Nat) : Nat × Nat :=
+  divOut p (m.log2 + 1) m
+
+end Internal
 
 private theorem divOut_prod (p : Nat) :
     ∀ (fuel m : Nat), p ^ (divOut p fuel m).1 * (divOut p fuel m).2 = m := by
@@ -397,8 +410,8 @@ private def trialGo : List Nat → List (Nat × Nat) → Nat →
   | [], acc, m => (acc, m)
   | p :: ps, acc, m =>
       if 1 < p ∧ m % p = 0 then
-        trialGo ps ((p, (divOut p (m.log2 + 1) m).1) :: acc)
-          (divOut p (m.log2 + 1) m).2
+        let divided := divOut p (m.log2 + 1) m
+        trialGo ps ((p, divided.1) :: acc) divided.2
       else trialGo ps acc m
 
 private theorem trialGo_prod :
@@ -660,9 +673,11 @@ private def witnessGo (n q : Nat) :
     Nat → Nat → Rand → Except PrimeCertFailure (Counted Nat)
   | 0, attempts, r => .error ⟨.exhausted, attempts, r⟩
   | t + 1, attempts, r =>
-      if checkWitness n q (r.next.1.toNat % (n - 3) + 2) then
-        .ok ⟨r.next.1.toNat % (n - 3) + 2, attempts + 1, r.next.2⟩
-      else witnessGo n q t (attempts + 1) r.next.2
+      let draw := r.next
+      let candidate := draw.1.toNat % (n - 3) + 2
+      if checkWitness n q candidate then
+        .ok ⟨candidate, attempts + 1, draw.2⟩
+      else witnessGo n q t (attempts + 1) draw.2
 
 /-- Assemble the cube-root node for the factored part `F`: the cofactor
 decomposition `R = 2Fs + r` and the square-root witness for the
@@ -799,6 +814,7 @@ private theorem witnessGo_error_stop {n q : Nat} :
   | succ t ih =>
       intro attempts r f h
       unfold witnessGo at h
+      dsimp only at h
       split at h
       · cases h
       · exact ih _ _ h

--- a/HexPrimality/Search.lean
+++ b/HexPrimality/Search.lean
@@ -153,14 +153,15 @@ private def brentGo (n c : Nat) : Nat → BrentState → BrentResult
             batchCount := batchCount', steps := state.steps + 1,
             gcds := state.gcds }
 
-/-- Inner iteration budget for one Brent restart: scaled past the expected
-`n^(1/4)` cycle length for small `n`, capped at `2^22` so one restart is
-bounded wall-clock at every input size. The cap still covers factors to
-about `2^44`, past rho's documented remit of roughly `10^12`; beyond it
-the honest outcome is a clean `exhausted`, not an inner loop whose budget
-outlives the caller. Runtime only, so `Nat.sqrt` is fine here. -/
+/-- Absolute Brent cycle-step cap for one restart. It covers factors to about
+`2^44`, past rho's documented remit of roughly `10^12`. -/
 private def rhoInnerFuelCap : Nat := 1 <<< 22
 
+/-- Inner iteration budget for one Brent restart: scaled past the expected
+`n^(1/4)` cycle length for small `n`, capped so one restart is bounded
+wall-clock at every input size. Beyond the cap the honest outcome is a clean
+`exhausted`, not an inner loop whose budget outlives the caller. Runtime only,
+so `Nat.sqrt` is fine here. -/
 private def rhoInnerFuel (n : Nat) : Nat :=
   min (16 * (Nat.sqrt (Nat.sqrt n) + 2)) rhoInnerFuelCap
 
@@ -196,6 +197,11 @@ namespace Internal
 
 /-- Shared maximum rho restart allocation for current worklist consumers. -/
 def rhoRestartCap : Nat := 8
+
+/-- Effective Brent cycle budget for each restart: the caller's allocation
+capped by the input-scaled production budget. -/
+def rhoRestartFuel (n innerFuel : Nat) : Nat :=
+  min (rhoInnerFuel n) innerFuel
 
 /-- A validated rho factor together with the exact number of restarts and
 the generator state after those restarts. -/
@@ -256,7 +262,7 @@ def rhoFactorCountedWith? (n : Nat) (r : Rand) (restarts innerFuel : Nat) :
   if n < 4 then .error ⟨.invalidInput, 0, r⟩
   else if n % 2 = 0 then .ok ⟨2, 0, r⟩
   else
-    let restartFuel := min (rhoInnerFuel n) innerFuel
+    let restartFuel := rhoRestartFuel n innerFuel
     rhoTry n restartFuel restarts 0 r
 
 /-- A counted rho search with the production per-restart cycle budget. -/
@@ -686,10 +692,11 @@ proof term); the public wrapper's `checkPrime` validation decides
 acceptance. -/
 private def mkPock3 (n F : Nat) (entries : List (Nat × Nat × PrimeCert)) :
     PrimeCert :=
-  .pock3 n ((n - 1) / F % (2 * F)) ((n - 1) / F / (2 * F))
-    (Nat.sqrt ((n - 1) / F % (2 * F) * ((n - 1) / F % (2 * F)) -
-      8 * ((n - 1) / F / (2 * F))))
-    entries
+  let cofactor := (n - 1) / F
+  let window := 2 * F
+  let r := cofactor % window
+  let s := cofactor / window
+  .pock3 n r s (Nat.sqrt (r * r - 8 * s)) entries
 
 mutual
 
@@ -813,8 +820,7 @@ private theorem witnessGo_error_stop {n q : Nat} :
       rfl
   | succ t ih =>
       intro attempts r f h
-      unfold witnessGo at h
-      dsimp only at h
+      dsimp only [witnessGo] at h
       split at h
       · cases h
       · exact ih _ _ h

--- a/conformance/HexPrimality/Conformance.lean
+++ b/conformance/HexPrimality/Conformance.lean
@@ -169,8 +169,14 @@ open Hex.Nat
 -- Counted compatibility forms retain successful randomized work without
 -- changing the ordinary pair-returning entry points.
 #guard (match Internal.rhoFactorCounted? 9 (Hex.Rand.ofSeed 2) 8 with
-  | .ok success => success.factor == 3 && success.attempts == 4
+  | .ok success =>
+      success.factor == 3 && success.attempts == 4 &&
+        success.rand == ((Hex.Rand.ofSeed 2).words 12).2
   | .error _ => false)
+
+-- Trial extraction is linear in the valuation. A duplicated recursive call
+-- tree cannot complete this high-power route within conformance's budget.
+#guard Hex.Nat.Internal.trialExtractTrace 2 (2 ^ 128) == (128, 1)
 
 #guard (match Internal.primeCertCounted? 1000003
     (Hex.Rand.ofSeed 3) 16 with

--- a/conformance/HexPrimality/Conformance.lean
+++ b/conformance/HexPrimality/Conformance.lean
@@ -21,6 +21,7 @@ Covered operations:
 - `Hex.Nat.primeCert?`
 - `Hex.Nat.rhoFactor?`, its counted internal form, and batched-Brent route
   instrumentation
+- trial-division extraction route instrumentation
 - `Hex.Nat.millerRabin` / `Hex.Nat.isProbablePrime`
 - `Hex.Nat.sieve` and its residue-index mapping
 - `Hex.Nat.isTablePrime`
@@ -174,9 +175,15 @@ open Hex.Nat
         success.rand == ((Hex.Rand.ofSeed 2).words 12).2
   | .error _ => false)
 
--- Trial extraction is linear in the valuation. A duplicated recursive call
--- tree cannot complete this high-power route within conformance's budget.
+-- Exercise a deep trial-extraction route and pin its exact valuation and
+-- cofactor. The source binding keeps this route linear independently of CSE.
+set_option maxRecDepth 10000 in
 #guard Hex.Nat.Internal.trialExtractTrace 2 (2 ^ 128) == (128, 1)
+
+-- Pin the composition of caller allocation with the input-scaled Brent cap.
+#guard Hex.Nat.Internal.rhoRestartFuel 9 (1 <<< 22) == 48
+#guard Hex.Nat.Internal.rhoRestartFuel (2 ^ 200) (1 <<< 22) == (1 <<< 22)
+#guard Hex.Nat.Internal.rhoRestartFuel 9 4 == 4
 
 #guard (match Internal.primeCertCounted? 1000003
     (Hex.Rand.ofSeed 3) 16 with


### PR DESCRIPTION
Closes #9785.

## Summary
- bind Miller–Rabin odd splits, recursive trial divisions, witness draws, and certificate-assembly arithmetic once, removing reliance on compiler CSE
- compute and name the input-scaled Brent restart budget once before restart recursion
- add a deep prime-power extraction route guard, direct effective-budget guards, and fixed-seed rho state coverage
- audit the reviewed Miller–Rabin, p−1, and runtime-search routes; proof-only projection repetitions and kernel certificate checking remain outside this runtime scope

The deep extraction guard pins the compiled route result. Lean currently CSEs the old duplicate calls, so executable timing alone cannot distinguish the old source shape; the explicit binding is what makes linear source complexity independent of that optimizer pass.

## Verification
- `lake build HexPrimality.Search`
- `lake build HexPrimality.Conformance`
- `lake build HexPrimality HexConformance` (10,356 jobs, repeated after review changes)