### PR TITLE
doc(hex-primality-mathlib): give the bridge an owned SPEC

### DIFF
--- a/HexPrimality/SPEC/hex-primality.md
+++ b/HexPrimality/SPEC/hex-primality.md
@@ -4,10 +4,11 @@ Kernel-checkable primality: a Miller-Rabin compositeness witness, a
 Pocklington certificate and its cube-root variant, a stored initial
 segment with a kernel-reducible sieve behind it, and the `primality`
 tactic that produces `Hex.Nat.Prime n` for a literal `n`. Mathlib-free.
-The companion `hex-primality-mathlib` relates the predicate to
-`Nat.Prime`, supplies
-the `norm_num` interoperation, and is where a dependency on an external
-Lean primality library may live.
+The companion
+[hex-primality-mathlib](../../HexPrimalityMathlib/SPEC/hex-primality-mathlib.md)
+owns the `Nat.Prime` correspondence, transports, tactic registration, and
+opt-in `norm_num` policy. This SPEC remains the sole normative owner of the
+Mathlib-free search, certificate, checker, and core elaboration algorithms.
 
 This SPEC expands the "Better primality" entry in
 [future-work](../../SPEC/future-work.md). That entry's diagnosis is right -- the
@@ -1004,86 +1005,11 @@ python3 scripts/bench/primality_elab_sweep.py --samples 6 \
 above: it never calls the total `isPrime`, whose exact trial fallback is
 intentionally unbounded.
 
-The companion adds `Nat.Prime n` through that correspondence. Bare
-`primality` uses the certificate route directly. Pinned Mathlib's
-`Nat.Prime` `norm_num` extension was registered first, so ordinary imports
-retain Mathlib's trial-division behavior; the later Hex registration cannot
-transparently pre-empt it. A module explicitly opts into the supported Hex
-policy with `use_hex_primality_norm_num`. Under that policy, numerals below
-`2^24` use a guarded alias of Mathlib's trial extension and larger positive
-proofs use the same 512-bit/512-fuel/2-restart/32768-step Hex certificate
-policy as `primality`. After a fixed-tier composite verdict, negative proofs
-use a separate factor search with one restart and at most `2^16` Brent cycle
-steps. This fixed work cap applies throughout the supported input range, so a
-small odd factor remains discoverable at 512 bits without scaling adversarial
-exhaustion with input width. Certificate search starts at `Rand.ofSeed n` and
-the factor search resumes its returned state. The current root-composite
-preflight consumes no draws, so deterministic replay begins at that same seed;
-the parity preflight can return factor 2 without consuming the restart. A found
-factor is dynamically revalidated by `1 < d`, `d < n`, and
-`n % d = 0` before `deriveNotPrime` emits the proper-factor term. Exhaustion
-only declines the goal and never starts total trial division. Above 512 bits
-the opt-in extension declines both positive and negative goals; `norm_num`
-reports an unsolved goal rather than silently restoring Mathlib's total trial
-decision. The opt-in erasure is local to the module and does not persist when
-that module is imported.
-
-The negative policy is gated by a 10-second absolute fresh-module budget on
-the designated benchmark host. Six balanced samples per row gave these maximum
-raw candidate wall times; the raw bound includes Lake traversal, imports,
-compiled search, proper-factor validation, proof construction, and elaboration.
-
-| case | bits | outcome | maximum wall time |
-|---|---:|---|---:|
-| first certificate-tier composite | 25 | factor found | 3.137 s |
-| strong pseudoprime | 32 | factor found | 2.235 s |
-| balanced semiprime | 64 | factor found | 2.286 s |
-| `2^64 + 1` | 65 | factor found | 2.423 s |
-| even ceiling input | 512 | parity factor found | 2.131 s |
-| odd ceiling input with a 7-bit factor | 512 | factor found | 2.435 s |
-| balanced ceiling semiprime | 512 | exhausted | 3.318 s |
-
-The release contract is absolute-only: import-subtracted deltas remain in the
-record as diagnostics and need not resolve above the null envelope. The two
-null controls had robust spread/build ratios of 12.51% and 2.69%. All rows passed
-the absolute budget, and the designated-host protocol recorded no exceptions,
-violations, or exhausted sample pairs. The committed record is
-`reports/bench-results/hex-primality-negative-policy-issue-9803-chungus2.json`.
-It reproduces with:
-
-```bash
-python3 scripts/bench/primality_negative_sweep.py --samples 6 \
-  --shared-host --expected-host chungus2 --cpu 22 --timeout 30 \
-  --warm-timeout 600 --max-pair-retries 32 \
-  --output reports/bench-results/hex-primality-negative-policy-issue-9803-chungus2.json
-```
-
-`lake build HexPrimalityElabProbe` is the untimed build-only reproduction.
-
-The `2^24` boundary comes from fresh one-goal modules on the pinned
-toolchain. Each arm was a fresh importing module containing only one
-`Nat.Prime` example. The trial arm used the ordinary Mathlib registration;
-the certificate arm invoked the opt-in with the threshold temporarily set to
-zero. Representative wall times in seconds were:
-
-| numeral | trial division | certificate |
-|---:|---:|---:|
-| 100003 | 1.7 | 2.1 |
-| 300007 | 1.4 | 1.0 |
-| 1000003 | 1.6 | 1.7 |
-| 3000017 | 1.5 | 3.6 |
-| 10000019 | 3.1 | 3.4 |
-| 30000001 | 3.4 | 3.5 |
-| 33554467 | 2.4 | 1.7 |
-
-These are policy measurements rather than a Phase-4 performance verdict:
-they establish the crossover region while exposing that certificate search
-is input-dependent. Mathlib's generated trial proof also reaches the pinned
-default kernel recursion limit on the 31-bit Mersenne prime. Choosing the
-power-of-two boundary keeps the full 24-bit range on the simpler route and
-puts every 25-bit input on the bounded route. If certificate production or
-factor search exhausts, the guarded trial alias also declines at that tier;
-the opt-in never silently starts a large unbounded trial search.
+The companion consumes this positive-certificate policy without widening it.
+Its `Nat.Prime` registration and precedence rules, negative factor-search
+budget, decline behavior, and bridge proof-performance evidence are normative
+only in the
+[hex-primality-mathlib SPEC](../../HexPrimalityMathlib/SPEC/hex-primality-mathlib.md#natprime-elaboration-routes).
 
 ## Kernel exposure
 
@@ -1316,42 +1242,17 @@ to obtain in a separate checkout rather than a CI comparator.
 
 ## The Mathlib layer
 
-```lean
-theorem prime_iff {n : Nat} : Hex.Nat.Prime n ↔ Nat.Prime n
+The Mathlib-facing layer has its own
+[owned SPEC](../../HexPrimalityMathlib/SPEC/hex-primality-mathlib.md). That
+document is normative for correspondence and segment transports, instance and
+elaborator registration, the `Nat.Prime` tactic and `norm_num` routes, bridge
+failure and resource semantics, and bridge conformance and proof-performance
+evidence. It links back here for the Mathlib-free algorithms and their positive
+certificate policy instead of restating them.
 
-theorem primeTable_spec : ∀ n < primeTableBound, n ∈ primeTable ↔ Nat.Prime n
-theorem primesIn_spec (lo hi) : ∀ n, n ∈ primesIn lo hi ↔ lo ≤ n ∧ n < hi ∧ Nat.Prime n
-```
-
-`prime_iff` is the whole correspondence, and it is one lemma: the two
-predicates are the same definition modulo Mathlib's `Irreducible`
-packaging, and `Nat.prime_def_lt` or `Nat.prime_def` closes it.
-Everything else transports along it.
-
-**No `DecidablePred Nat.Prime` instance.** Mathlib already declares
-`Nat.decidablePrime` with its own `@[csimp]` runtime twin
-(`Mathlib/Data/Nat/Prime/Defs.lean:162`, `:334`), so a second global
-instance would be a duplicate and would risk instance-selection churn.
-An earlier draft of this SPEC proposed one. What the companion offers
-instead is the tactic and the explicitly opted-in `norm_num` policy, which
-is where the scale actually helps.
-
-The companion also carries the opt-in `norm_num` extensions and command,
-the `Nat.Prime` form of the `primality` tactic, and the universally
-quantified segment statements ("every prime in `[1, x]` satisfies `P`")
-in the form a Mathlib consumer would state them, over
-`Finset.filter Nat.Prime`.
-
-**Where a PrimeCert dependency would go.** If the toolchains are
-aligned, `hex-primality-mathlib` may depend on PrimeCert and re-export
-`pock%` / `prime_cert%` for numerals beyond what this library's search
-reaches, exactly as hex-rcf's SPEC allows a Mathlib-side tactic to
-consume Mathlib-side infrastructure. That is an accelerator, never a
-substitute: the Mathlib-free `checkPrime` and its soundness theorem
-remain the tree's primality story, because every Mathlib-free consumer
--- hex-mod-arith's `PrimeModulus`, hex-berlekamp-zassenhaus's prime
-selection, hex-gfq's field construction -- lives below the companion and
-cannot see it.
+Any future Mathlib-side primality dependency belongs to that companion as an
+accelerator over this checker. It cannot replace this Mathlib-free proof
+boundary because the core consumers live below the companion.
 
 ## Milestones
 

--- a/HexPrimality/SPEC/hex-primality.md
+++ b/HexPrimality/SPEC/hex-primality.md
@@ -973,8 +973,9 @@ fresh-module sweep also exercises the non-smooth 512-bit probable-prime input
 `11069588345001798189188705872711741673446310956174776680242876230365522527670481055399138994024099817696810905038323515123654848684366962778647276800762123`,
 which reaches bounded rho work in a recursive child and exhausts after 11
 attempts at fuel 512, and the 513-bit value `2^512`, which is rejected before
-search. Both core and companion routes have a 10-second absolute fresh-module
-wall-clock budget on the designated benchmark host. The harness compares the
+search. The core route has a 10-second absolute fresh-module wall-clock budget
+on the designated benchmark host; the companion route is gated identically
+under its own SPEC. The harness compares the
 largest raw candidate wall time in every substantive sample set against that
 budget and makes any failure invalidate `release_quality`; it does not use the
 reference-subtracted tactic delta for this contract. This single end-to-end
@@ -1291,8 +1292,9 @@ boundary because the core consumers live below the companion.
    soundness case, with the stored square-root witness replacing any
    in-checker integer square root.
 
-5. **The companion.** `prime_iff`, the transports, the explicit opt-in
-   `norm_num` policy, and the segment statements. Begins after milestone 1.
+5. **The companion.** The Mathlib-facing milestone is specified by the
+   [owned companion SPEC](../../HexPrimalityMathlib/SPEC/hex-primality-mathlib.md).
+   Begins after milestone 1.
 
 ## File organisation
 
@@ -1308,12 +1310,10 @@ HexPrimality/
   Search.lean       -- rhoFactor?, partialFactor, primeCert?, isPrime?, isPrime, nextPrime?
   Elab.lean         -- the primality tactic
 HexPrimality.lean
-HexPrimalityMathlib/
-  Prime.lean        -- prime_iff and the transports
-  NormNum.lean      -- Nat.Prime tactic reach and opt-in norm_num policy
-  Segment.lean      -- Finset-level segment statements
-HexPrimalityMathlib.lean
 ```
+
+The companion's source, conformance, probe, and SPEC layout is owned by its
+[file-organization section](../../HexPrimalityMathlib/SPEC/hex-primality-mathlib.md#file-organization).
 
 `libraries.yml` gains:
 

--- a/HexPrimalityMathlib/NormNum.lean
+++ b/HexPrimalityMathlib/NormNum.lean
@@ -13,11 +13,12 @@ The `Nat.Prime` reach of the `primality` tactic and an explicitly opted-in
 certificate-backed `norm_num` policy.
 
 By default this module does not alter which extension handles
-`Nat.Prime`: pinned Mathlib's trial-division extension was registered first
-and remains first. A module opts into Hex's policy with the command
+`Nat.Prime`: pinned Mathlib's registered trial-division extension remains the
+selected route. A module opts into Hex's policy with the command
 `use_hex_primality_norm_num`. The command locally erases Mathlib's original
-registration, exposing the two extensions registered here: trial division
-below `natPrimeCertThreshold`, then certificate search at and above it.
+registration, exposing two disjointly guarded extensions registered here:
+trial division below `natPrimeCertThreshold` and certificate search at and
+above it. Their relative registration order is immaterial.
 The erasure does not survive an import, so every importing module makes its
 own choice.
 
@@ -42,8 +43,8 @@ The certificate extension uses the same 512-bit input ceiling and 512
 recursive-fuel cap as the core and companion `primality` handlers.
 
 The tactic handler registers on the same `primality` syntax kind as the
-Mathlib-free elaborator; registration order makes this handler run first,
-and it defers every non-`Nat.Prime` goal shape back.
+Mathlib-free elaborator. Both handlers defer on the other's predicate head, so
+dispatch does not depend on registration order.
 -/
 
 namespace Hex.PrimalityTactic

--- a/HexPrimalityMathlib/SPEC/hex-primality-mathlib.md
+++ b/HexPrimalityMathlib/SPEC/hex-primality-mathlib.md
@@ -1,0 +1,264 @@
+# hex-primality-mathlib (depends on hex-primality + Mathlib)
+
+The Mathlib bridge for
+[hex-primality](../../HexPrimality/SPEC/hex-primality.md). It identifies
+`Hex.Nat.Prime` with Mathlib's `Nat.Prime`, transports the core decision,
+search, and initial-segment results, extends the bare `primality` tactic to
+`Nat.Prime` goals, and provides an explicit opt-in `Nat.Prime` `norm_num`
+policy.
+
+This is not a correspondence-only layer. Its elaborators choose registrations,
+dispatch between proof-producing routes, run bounded untrusted search, and
+reify terms for kernel checking. This SPEC therefore owns their success,
+decline, failure, resource, conformance, and proof-performance contracts.
+
+## Ownership boundary
+
+The core SPEC owns every Mathlib-free predicate, table, sieve, Miller--Rabin
+test, certificate type, certificate search, factor-search primitive, checker,
+and correctness theorem. In particular, this layer does not respecify
+`primeCert?`, `rhoFactorCountedWith?`, `checkPrime`, or the core elaboration
+policy. Their algorithms and bounds remain normative in
+[the core API and tactic sections](../../HexPrimality/SPEC/hex-primality.md#the-api).
+
+This SPEC owns only the Mathlib-facing correspondence and transport theorems,
+the `Nat.Prime` tactic handler, the opt-in `norm_num` registrations and command,
+the bridge-specific negative-result policy, and the evidence that those paths
+elaborate kernel-checked proofs within their accepted budgets. A future
+Mathlib-side primality dependency or additional elaborator also belongs here;
+it must remain an accelerator over the core checker rather than a replacement
+for the Mathlib-free proof boundary.
+
+## Correspondence and transports
+
+The whole predicate correspondence is:
+
+```lean
+theorem Hex.Nat.prime_iff {n : Nat} :
+    Hex.Nat.Prime n ↔ Nat.Prime n
+```
+
+The two predicates have the same divisor characterization after unfolding
+Mathlib's irreducibility packaging. Every bridge theorem transports a core
+result through this equivalence; it does not introduce a second primality
+argument.
+
+The certificate, decision, compositeness, and successful-search transports
+are:
+
+```lean
+theorem Hex.Nat.natPrime_of_checkPrime {c : PrimeCert}
+    (h : checkPrime c = true) : Nat.Prime c.subject
+
+theorem Hex.Nat.natPrime_of_checkPrimeAt {n : Nat} {c : PrimeCert}
+    (h : (c.subject == n && checkPrime c) = true) : Nat.Prime n
+
+theorem Hex.Nat.isPrime_iff_natPrime {n : Nat} :
+    isPrime n = true ↔ Nat.Prime n
+
+theorem Hex.Nat.millerRabin_refutes_natPrime {n a : Nat}
+    (h : millerRabin n a = false) : ¬ Nat.Prime n
+
+theorem Hex.Nat.nextPrime?_natPrime {n : Nat} {r : Rand}
+    {fuel p : Nat} {r' : Rand}
+    (h : nextPrime? n r fuel = .ok (p, r')) :
+    n < p ∧ Nat.Prime p ∧
+      ∀ q, n < q → q < p → ¬ Nat.Prime q
+```
+
+No `DecidablePred Nat.Prime` instance is declared. Mathlib's
+`Nat.decidablePrime` remains the selected global instance; the bridge adds
+proof transports and elaborator routes without creating instance-selection
+churn.
+
+## Initial-segment transports
+
+The committed table and range enumeration remain core data. This layer states
+their results in the forms used by Mathlib consumers:
+
+```lean
+theorem Hex.Nat.primeTable_spec :
+    ∀ n < primeTableBound, (n ∈ primeTable ↔ Nat.Prime n)
+
+theorem Hex.Nat.primesIn_spec (lo hi : Nat) :
+    ∀ n, n ∈ primesIn lo hi ↔ lo ≤ n ∧ n < hi ∧ Nat.Prime n
+
+theorem Hex.Nat.filter_prime_range [DecidablePred Nat.Prime]
+    {bound : Nat} (h : bound ≤ primeTableBound) :
+    (Finset.range bound).filter Nat.Prime =
+      (primeTable.toList.filter (fun p => p < bound)).toFinset
+
+theorem Hex.Nat.forall_prime_lt {P : Nat → Prop} {bound : Nat}
+    (hb : bound ≤ primeTableBound)
+    (h : ∀ p ∈ primeTable, p < bound → P p) :
+    ∀ p, p < bound → Nat.Prime p → P p
+```
+
+`filter_prime_range` exposes the complete table as a `Finset`; the
+quantified `forall_prime_lt` form lets a caller discharge a property by a
+decidable fold over the committed literal. Sieve generation, table
+verification, and the unrestricted `primesIn` algorithm stay in the core
+SPEC.
+
+## `Nat.Prime` elaboration routes
+
+### Bare `primality`
+
+After importing this library, bare `primality` closes a goal whose target is
+definitionally `Nat.Prime n` for a closed natural-number numeral `n`. It uses
+the core certificate route and emits `natPrime_of_checkPrimeAt` applied to the
+reified certificate and a single reducible Boolean equality. Compiled search
+is untrusted; the elaborator first self-checks the certificate and the kernel
+then replays `checkPrime`.
+
+The bridge registers its handler on the existing `primality` syntax kind.
+Later registration gives it first refusal. A goal with any other head is
+declined with `unsupportedSyntax`, after which the core handler continues to
+support `Hex.Nat.Prime`. The bridge does not replace the term form
+`primality n`, nor the tactic forms `primality n` and `primality h : n` that
+introduce a hypothesis: those forms retain their core result type
+`Hex.Nat.Prime n`.
+
+The handler shares the core's named `withinPrimalityBudget`, `primalityFuel`,
+and `primalitySearchBudget` definitions. The positive certificate input,
+recursive-fuel, rho-restart, and rho-step limits therefore have one executable
+and normative owner; their current values and evidence are specified in
+[the core tactic contract](../../HexPrimality/SPEC/hex-primality.md#the-tactic).
+The bridge must not copy those constants or silently widen them.
+
+### Default and opt-in `norm_num`
+
+An ordinary import leaves Mathlib's previously registered `Nat.Prime`
+extension first in precedence. Thus `norm_num` retains pinned Mathlib's
+trial-division behavior unless the current module contains:
+
+```lean
+use_hex_primality_norm_num
+```
+
+The command locally removes Mathlib's original registration. It exposes a
+guarded alias of that extension for numerals below
+`natPrimeCertThreshold = 2^24`, followed by the Hex certificate extension at
+and above the threshold. Attribute erasure does not cross an import boundary:
+each importing module must opt in independently.
+
+On the certificate tier, positive results use the same bounded search,
+compiled self-check, reification, and kernel replay as bare `primality`.
+Negative results are supported only after certificate search returns the
+fixed-tier `.composite` verdict. They use the separately bounded factor route
+below. Neither Hex extension invokes the total `isPrime` decision.
+
+## Negative-result policy
+
+For an admitted numeral `n`, certificate search starts from
+`Hex.Rand.ofSeed n`. If it returns `.composite`, factor search resumes the
+returned state with:
+
+```lean
+Hex.Nat.Internal.rhoFactorCountedWith? n failure.rand
+  natPrimeRhoRestartBudget natPrimeRhoStepBudget
+```
+
+where `natPrimeRhoRestartBudget = 1` and
+`natPrimeRhoStepBudget = 2^16` Brent cycle steps per restart throughout the
+supported input range. The current root-composite preflight consumes zero
+attempts and leaves the seeded state unchanged; conformance pins that fact for
+deterministic replay. The factor primitive's parity preflight may return
+factor `2` without consuming a restart.
+
+Every returned candidate `d` is revalidated as `1 < d`, `d < n`, and
+`n % d = 0`. Only then may Mathlib's `deriveNotPrime` construct an
+independently kernel-checked proper-factor proof. A Miller--Rabin verdict
+selects this branch but never appears as the emitted negative proof.
+
+If certificate search returns `.exhausted`, negative factor search does not
+run. If factor search exhausts or returns an invalid candidate, the certificate
+extension declines. The guarded trial alias also declines at and above
+`2^24`, so none of these outcomes starts total or unbounded trial division.
+Inputs outside the core elaboration ceiling decline before certificate or
+negative-factor search.
+
+## Success, decline, failure, and timeout semantics
+
+| entry point and condition | required outcome |
+|---|---|
+| bare `primality`, accepted prime numeral | close the goal with a reified, kernel-replayed certificate proof |
+| bare `primality`, composite numeral | report that the numeral is not prime, including a fixed-base Miller--Rabin witness when available |
+| bare `primality`, certificate exhaustion | report exact attempts, seed, selected fuel, and policy maxima; state that no total decision ran |
+| bare `primality`, over-budget numeral | reject before certificate search with the supported bit ceiling |
+| bare `primality`, open or non-numeral `Nat.Prime` target | report the closed-numeral requirement |
+| bridge handler, non-`Nat.Prime` target | decline so the core handler or another syntax handler can run |
+| default `norm_num` | preserve pinned Mathlib registration and behavior |
+| opted-in `norm_num`, numeral below `2^24` | delegate to the guarded Mathlib trial extension |
+| opted-in `norm_num`, certificate-tier prime | emit the checked positive certificate proof |
+| opted-in `norm_num`, certificate-tier composite with a valid factor | emit the independently checked proper-factor proof |
+| opted-in `norm_num`, unsupported shape, over-budget input, or bounded exhaustion | decline; if no other extension applies, leave an unsolved goal |
+
+An internal certificate self-check failure is never converted into a proof.
+Bare `primality` reports it as an internal error; the `norm_num` extension
+declines.
+
+The resource contract is a **10-second absolute wall-clock gate for a fresh
+importing module** on the designated benchmark host. It includes Lake
+traversal, imports, compiled search and self-check, term construction, and
+kernel replay. It is not an internal ten-second tactic timer and is not an
+import-subtracted delta. A benchmark timeout or an ordinary Lean resource
+interruption emits no proof; a row exceeding the absolute gate invalidates the
+performance evidence rather than changing elaborator semantics.
+
+## Conformance and proof-performance ownership
+
+The bridge owns `conformance/HexPrimalityMathlib/Conformance.lean` and
+`OptInConformance.lean`. Together they cover correspondence-facing tactic
+use, default registration, module-local opt-in precedence, both sides of the
+`2^24` threshold, positive and negative certificate-tier results,
+deterministic seed/state replay, parity without a restart, exact negative
+exhaustion, the input ceiling, ordinary failure diagnostics, import-boundary
+locality, and preservation of `Nat.decidablePrime`.
+
+Fresh importing modules under
+`bench/HexPrimalityMathlib/ProofProbe/` own proof-production evidence. The
+`Mathlib512`, `MathlibExhausted`, and `MathlibOverBudget` probes cover the
+shared positive policy; `MathlibBaseline` is their import control. The
+`Negative*` probes cover factor-found inputs at 25, 32, 64, 65, and 512 bits,
+both parity and odd-factor cases, plus balanced 512-bit exhaustion.
+
+The positive-route harness and evidence are shared with the core policy and
+are cited by the core SPEC. The bridge-specific negative harness is
+`scripts/bench/primality_negative_sweep.py`. Its designated-host record,
+`reports/bench-results/hex-primality-negative-policy-issue-9803-chungus2.json`,
+contains six balanced samples per row. Every substantive row passes the
+10-second absolute gate; the maximum observed candidate wall times range from
+2.131 seconds to 3.318 seconds. Import-subtracted values remain diagnostic and
+need not resolve above the null envelope.
+
+These probes are proof-performance evidence, not a claim that the layer is
+correspondence-only and exempt from review. Any change to registration,
+dispatch, thresholds, search budgets, reification, emitted proof shape, or
+imports must refresh the affected conformance and fresh-module evidence.
+
+## Review and attestation
+
+Phase-2 review treats `HexPrimality` and `HexPrimalityMathlib` as distinct
+libraries with distinct owned specifications. The core attestation is reviewed
+against `HexPrimality/SPEC/hex-primality.md`; the bridge attestation is reviewed
+against this file. A pair-level review or report must identify both SPEC owners
+rather than citing the core SPEC as authority for bridge registration,
+failure, resource, or evidence semantics.
+
+## File organization
+
+```text
+HexPrimalityMathlib/
+  Prime.lean       -- prime_iff and core-result transports
+  Segment.lean     -- table and range statements in Mathlib vocabulary
+  NormNum.lean     -- Nat.Prime tactic handler and opt-in norm_num policy
+  SPEC/
+    hex-primality-mathlib.md
+HexPrimalityMathlib.lean
+
+conformance/HexPrimalityMathlib/
+  Conformance.lean
+  OptInConformance.lean
+bench/HexPrimalityMathlib/ProofProbe/
+```

--- a/HexPrimalityMathlib/SPEC/hex-primality-mathlib.md
+++ b/HexPrimalityMathlib/SPEC/hex-primality-mathlib.md
@@ -2,7 +2,7 @@
 
 The Mathlib bridge for
 [hex-primality](../../HexPrimality/SPEC/hex-primality.md). It identifies
-`Hex.Nat.Prime` with Mathlib's `Nat.Prime`, transports the core decision,
+`Hex.Nat.Prime` with Mathlib's `Nat.Prime`, transports the total core decision,
 search, and initial-segment results, extends the bare `primality` tactic to
 `Nat.Prime` goals, and provides an explicit opt-in `Nat.Prime` `norm_num`
 policy.
@@ -71,6 +71,11 @@ No `DecidablePred Nat.Prime` instance is declared. Mathlib's
 proof transports and elaborator routes without creating instance-selection
 churn.
 
+The bounded `isPrime?` result has no separate Mathlib transport: no bridge API
+consumes its explicit `Rand` and fuel plumbing. Consumers that need the
+bounded verdict stay on the core API; the bridge transports only the total
+`isPrime` result and the proof-producing routes listed above.
+
 ## Initial-segment transports
 
 The committed table and range enumeration remain core data. This layer states
@@ -104,17 +109,18 @@ SPEC.
 
 ### Bare `primality`
 
-After importing this library, bare `primality` closes a goal whose target is
-definitionally `Nat.Prime n` for a closed natural-number numeral `n`. It uses
-the core certificate route and emits `natPrime_of_checkPrimeAt` applied to the
-reified certificate and a single reducible Boolean equality. Compiled search
-is untrusted; the elaborator first self-checks the certificate and the kernel
-then replays `checkPrime`.
+After importing this library, bare `primality` closes a goal whose target,
+after metavariable instantiation, is syntactically `Nat.Prime n` for a closed
+natural-number numeral `n`. It uses the core certificate route and emits
+`natPrime_of_checkPrimeAt` applied to the reified certificate and a single
+reducible Boolean equality. Compiled search is untrusted; the elaborator first
+self-checks the certificate and the kernel then replays `checkPrime`.
 
 The bridge registers its handler on the existing `primality` syntax kind.
-Later registration gives it first refusal. A goal with any other head is
-declined with `unsupportedSyntax`, after which the core handler continues to
-support `Hex.Nat.Prime`. The bridge does not replace the term form
+Both handlers defer on the other predicate's goal head, so dispatch does not
+depend on their registration order. A goal with any other head is declined
+with `unsupportedSyntax`, after which the core handler continues to support
+`Hex.Nat.Prime`. The bridge does not replace the term form
 `primality n`, nor the tactic forms `primality n` and `primality h : n` that
 introduce a hypothesis: those forms retain their core result type
 `Hex.Nat.Prime n`.
@@ -128,19 +134,43 @@ The bridge must not copy those constants or silently widen them.
 
 ### Default and opt-in `norm_num`
 
-An ordinary import leaves Mathlib's previously registered `Nat.Prime`
-extension first in precedence. Thus `norm_num` retains pinned Mathlib's
-trial-division behavior unless the current module contains:
+An ordinary import retains pinned Mathlib's registered `Nat.Prime` extension,
+as the default-registration conformance probe pins. Thus `norm_num` uses
+Mathlib's trial-division behavior unless the current module contains:
 
 ```lean
 use_hex_primality_norm_num
 ```
 
-The command locally removes Mathlib's original registration. It exposes a
-guarded alias of that extension for numerals below
-`natPrimeCertThreshold = 2^24`, followed by the Hex certificate extension at
-and above the threshold. Attribute erasure does not cross an import boundary:
+The command locally removes Mathlib's original registration. The two Hex
+extensions have disjoint threshold guards: the guarded Mathlib alias handles
+numerals below `natPrimeCertThreshold = 2^24`, while the certificate extension
+handles numerals at and above it. Their relative registration order is
+therefore immaterial. Attribute erasure does not cross an import boundary;
 each importing module must opt in independently.
+
+The threshold comes from fresh one-goal modules on the pinned toolchain. Each
+arm was a fresh importing module containing only one `Nat.Prime` example. The
+trial arm used the ordinary Mathlib registration; the certificate arm invoked
+the opt-in with the threshold temporarily set to zero. Representative wall
+times in seconds were:
+
+| numeral | trial division | certificate |
+|---:|---:|---:|
+| 100003 | 1.7 | 2.1 |
+| 300007 | 1.4 | 1.0 |
+| 1000003 | 1.6 | 1.7 |
+| 3000017 | 1.5 | 3.6 |
+| 10000019 | 3.1 | 3.4 |
+| 30000001 | 3.4 | 3.5 |
+| 33554467 | 2.4 | 1.7 |
+
+These are policy measurements rather than a Phase-4 performance verdict.
+They locate the crossover region while showing that certificate search is
+input-dependent. Mathlib's generated trial proof also exceeds the pinned
+default kernel recursion limit on the 31-bit Mersenne prime. The power-of-two
+boundary keeps every input of at most 24 bits on the simpler route and sends
+every 25-bit input to the bounded route.
 
 On the certificate tier, positive results use the same bounded search,
 compiled self-check, reification, and kernel replay as bare `primality`.
@@ -188,7 +218,7 @@ negative-factor search.
 | bare `primality`, over-budget numeral | reject before certificate search with the supported bit ceiling |
 | bare `primality`, open or non-numeral `Nat.Prime` target | report the closed-numeral requirement |
 | bridge handler, non-`Nat.Prime` target | decline so the core handler or another syntax handler can run |
-| default `norm_num` | preserve pinned Mathlib registration and behavior |
+| default `norm_num`, any numeral | preserve pinned Mathlib registration and its total trial-division behavior; no Hex bound applies |
 | opted-in `norm_num`, numeral below `2^24` | delegate to the guarded Mathlib trial extension |
 | opted-in `norm_num`, certificate-tier prime | emit the checked positive certificate proof |
 | opted-in `norm_num`, certificate-tier composite with a valid factor | emit the independently checked proper-factor proof |
@@ -198,8 +228,14 @@ An internal certificate self-check failure is never converted into a proof.
 Bare `primality` reports it as an internal error; the `norm_num` extension
 declines.
 
-The resource contract is a **10-second absolute wall-clock gate for a fresh
-importing module** on the designated benchmark host. It includes Lake
+Without the opt-in, the bounded Hex `norm_num` routes never run: the default
+route inherits Mathlib's total `minFac` cost on large inputs and its generated
+proof can exceed the pinned kernel recursion limit by 31 bits, as
+`Conformance.lean` pins. The bounded resource contract below applies to bare
+`primality` and to `norm_num` only after `use_hex_primality_norm_num`.
+
+That contract is a **10-second absolute wall-clock gate for a fresh importing
+module** on the designated benchmark host. It includes Lake
 traversal, imports, compiled search and self-check, term construction, and
 kernel replay. It is not an internal ten-second tactic timer and is not an
 import-subtracted delta. A benchmark timeout or an ordinary Lean resource
@@ -222,15 +258,38 @@ Fresh importing modules under
 shared positive policy; `MathlibBaseline` is their import control. The
 `Negative*` probes cover factor-found inputs at 25, 32, 64, 65, and 512 bits,
 both parity and odd-factor cases, plus balanced 512-bit exhaustion.
+`Negative64Null` is the elevated null control: it repeats balanced 64-bit
+negative proofs so host interference is visible above the import floor.
 
 The positive-route harness and evidence are shared with the core policy and
 are cited by the core SPEC. The bridge-specific negative harness is
 `scripts/bench/primality_negative_sweep.py`. Its designated-host record,
 `reports/bench-results/hex-primality-negative-policy-issue-9803-chungus2.json`,
 contains six balanced samples per row. Every substantive row passes the
-10-second absolute gate; the maximum observed candidate wall times range from
-2.131 seconds to 3.318 seconds. Import-subtracted values remain diagnostic and
-need not resolve above the null envelope.
+10-second absolute gate:
+
+| case | bits | outcome | maximum wall time |
+|---|---:|---|---:|
+| first certificate-tier composite | 25 | factor found | 3.137 s |
+| strong pseudoprime | 32 | factor found | 2.235 s |
+| balanced semiprime | 64 | factor found | 2.286 s |
+| `2^64 + 1` | 65 | factor found | 2.423 s |
+| even ceiling input | 512 | parity factor found | 2.131 s |
+| odd ceiling input with a 7-bit factor | 512 | factor found | 2.435 s |
+| balanced ceiling semiprime | 512 | exhausted | 3.318 s |
+
+Import-subtracted values remain diagnostic and need not resolve above the null
+envelope. The baseline and elevated null controls had robust spread/build
+ratios of 12.51% and 2.69%, respectively. The record reproduces with:
+
+```bash
+python3 scripts/bench/primality_negative_sweep.py --samples 6 \
+  --shared-host --expected-host chungus2 --cpu 22 --timeout 30 \
+  --warm-timeout 600 --max-pair-retries 32 \
+  --output reports/bench-results/hex-primality-negative-policy-issue-9803-chungus2.json
+```
+
+`lake build HexPrimalityElabProbe` is the untimed build-only reproduction.
 
 These probes are proof-performance evidence, not a claim that the layer is
 correspondence-only and exempt from review. Any change to registration,

--- a/PLAN/Phase2.md
+++ b/PLAN/Phase2.md
@@ -104,3 +104,10 @@ Record completion by bumping `libraries.yml[L].done_through` to `2`.
 The `status/hex-foo.scaffolding-reviewed` token is the separate
 *point-in-time attestation* of the review; `libraries.yml` is the
 mutable phase counter. Both are required at Phase 2 exit.
+
+Where a core library and its Mathlib bridge have separate owned SPECs, review
+and attest them as separate libraries against their respective paths. In
+particular, primality review uses `HexPrimality/SPEC/hex-primality.md` for
+`HexPrimality` and
+`HexPrimalityMathlib/SPEC/hex-primality-mathlib.md` for
+`HexPrimalityMathlib`; a pair-level report identifies both owners.

--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -573,7 +573,8 @@ for developments whose source-local move has not happened yet.
 
 - [hex-basic](https://github.com/leanprover/hex-basic) (released): small Mathlib-free standard-library shims, including kernel-reducible array and vector operations
 - [hex-arith](../../HexArith/SPEC/hex-arith.md): extended GCD, Barrett/Montgomery reduction, binomial coefficients, Fermat's little theorem
-- [hex-primality.md](../../HexPrimality/SPEC/hex-primality.md): Miller-Rabin compositeness witnesses, Pocklington certificates, a kernel-reducible sieve and stored initial segment, the `primality` tactic (the Mathlib companion is specified in the same file)
+- [hex-primality.md](../../HexPrimality/SPEC/hex-primality.md): Miller-Rabin compositeness witnesses, Pocklington certificates, a kernel-reducible sieve and stored initial segment, and the Mathlib-free `primality` tactic
+- [hex-primality-mathlib.md](../../HexPrimalityMathlib/SPEC/hex-primality-mathlib.md): `Nat.Prime` correspondence and segment transports, bare-tactic registration, and the opt-in `norm_num` proof policy
 - [hex-int-factor.md](hex-int-factor.md): integer factorization with complete prime-exponent certificates, the divisor-function API, multiplicative order and primitive roots (the Mathlib companion is specified in the same file)
 - [hex-matrix](https://github.com/leanprover/hex-matrix/blob/main/SPEC/hex-matrix.md) (released): dense matrices, arithmetic, elementary row/column operations, submatrix slicing, the Gram matrix
 - [hex-row-reduce](https://github.com/leanprover/hex-row-reduce/blob/main/SPEC/hex-row-reduce.md) (released): row reduction, rank, span, nullspace


### PR DESCRIPTION
Closes #9800

## Summary

- add an owned `HexPrimalityMathlib` SPEC for correspondence, transports, tactic and `norm_num` registration, bounded negative search, failure semantics, and proof-performance evidence
- keep the Mathlib-free algorithms and positive elaboration policy normative in the core SPEC, with reciprocal cross-links instead of duplicate bridge prose
- list both primality libraries separately and require Phase-2 attestation to identify both SPEC owners

## Verification

- `lake build HexPrimalityMathlib`
- `lake build HexPrimalityMathlib.Conformance HexPrimalityMathlib.OptInConformance`
- `lake build HexPrimalityElabProbe`
- `lake build HexManual`
- `python3 -m unittest scripts.bench.test_primality_policy_sweeps scripts.bench.test_primality_negative_sweep`
- `python3 scripts/check_phase4.py`
- `python3 scripts/check_phase7.py`
- `python3 scripts/status.py HexPrimality` and `HexPrimalityMathlib`
- SPEC relative-link and `git diff --check` checks