### PR TITLE
perf(lll): certify comparator ladder evidence

### DIFF
--- a/libraries.yml
+++ b/libraries.yml
@@ -475,7 +475,7 @@ libraries:
   HexLLL:
     deps: [HexGramSchmidt, HexMatrix, HexBasic]
     mathlib: false
-    done_through: 3
+    done_through: 7
     status: active
     phase4:
       comparators:

--- a/reports/figures/hex-lll-comparator-harsh-cubic.svg
+++ b/reports/figures/hex-lll-comparator-harsh-cubic.svg
@@ -29,19 +29,19 @@ z
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 69.05 300.672
+    <path d="M 68.87 300.672
 L 507.6 300.672
-L 507.6 25.44
-L 69.05 25.44
+L 507.6 26.88
+L 68.87 26.88
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
-      <path d="M 88.984091 300.672
-L 88.984091 25.44
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 88.812273 300.672
+L 88.812273 26.88
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
@@ -50,12 +50,12 @@ L 0 3.5
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="88.984091" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="88.812273" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- 15 -->
-      <g transform="translate(82.621591 315.270437) scale(0.1 -0.1)">
+      <g transform="translate(82.449773 315.270437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531
 L 1825 531
@@ -104,18 +104,18 @@ z
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
-      <path d="M 128.852273 300.672
-L 128.852273 25.44
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 128.696818 300.672
+L 128.696818 26.88
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="128.852273" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="128.696818" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- 20 -->
-      <g transform="translate(122.489773 315.270437) scale(0.1 -0.1)">
+      <g transform="translate(122.334318 315.270437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531
 L 3431 531
@@ -170,18 +170,18 @@ z
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
-      <path d="M 168.720455 300.672
-L 168.720455 25.44
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 168.581364 300.672
+L 168.581364 26.88
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="168.720455" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="168.581364" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- 25 -->
-      <g transform="translate(162.357955 315.270437) scale(0.1 -0.1)">
+      <g transform="translate(162.218864 315.270437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
        <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
       </g>
@@ -189,18 +189,18 @@ L 168.720455 25.44
     </g>
     <g id="xtick_4">
      <g id="line2d_7">
-      <path d="M 208.588636 300.672
-L 208.588636 25.44
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 208.465909 300.672
+L 208.465909 26.88
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="208.588636" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="208.465909" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- 30 -->
-      <g transform="translate(202.226136 315.270437) scale(0.1 -0.1)">
+      <g transform="translate(202.103409 315.270437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516
 Q 3050 2419 3304 2112
@@ -242,18 +242,18 @@ z
     </g>
     <g id="xtick_5">
      <g id="line2d_9">
-      <path d="M 248.456818 300.672
-L 248.456818 25.44
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 248.350455 300.672
+L 248.350455 26.88
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="248.456818" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="248.350455" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- 35 -->
-      <g transform="translate(242.094318 315.270437) scale(0.1 -0.1)">
+      <g transform="translate(241.987955 315.270437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
        <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
       </g>
@@ -261,18 +261,18 @@ L 248.456818 25.44
     </g>
     <g id="xtick_6">
      <g id="line2d_11">
-      <path d="M 288.325 300.672
-L 288.325 25.44
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 288.235 300.672
+L 288.235 26.88
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="288.325" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="288.235" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- 40 -->
-      <g transform="translate(281.9625 315.270437) scale(0.1 -0.1)">
+      <g transform="translate(281.8725 315.270437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116
 L 825 1625
@@ -301,18 +301,18 @@ z
     </g>
     <g id="xtick_7">
      <g id="line2d_13">
-      <path d="M 328.193182 300.672
-L 328.193182 25.44
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 328.119545 300.672
+L 328.119545 26.88
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="328.193182" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="328.119545" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 45 -->
-      <g transform="translate(321.830682 315.270437) scale(0.1 -0.1)">
+      <g transform="translate(321.757045 315.270437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-34"/>
        <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
       </g>
@@ -320,18 +320,18 @@ L 328.193182 25.44
     </g>
     <g id="xtick_8">
      <g id="line2d_15">
-      <path d="M 368.061364 300.672
-L 368.061364 25.44
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 368.004091 300.672
+L 368.004091 26.88
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="368.061364" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="368.004091" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 50 -->
-      <g transform="translate(361.698864 315.270437) scale(0.1 -0.1)">
+      <g transform="translate(361.641591 315.270437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-35"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
       </g>
@@ -339,18 +339,18 @@ L 368.061364 25.44
     </g>
     <g id="xtick_9">
      <g id="line2d_17">
-      <path d="M 407.929545 300.672
-L 407.929545 25.44
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 407.888636 300.672
+L 407.888636 26.88
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="407.929545" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="407.888636" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 55 -->
-      <g transform="translate(401.567045 315.270437) scale(0.1 -0.1)">
+      <g transform="translate(401.526136 315.270437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-35"/>
        <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
       </g>
@@ -358,18 +358,18 @@ L 407.929545 25.44
     </g>
     <g id="xtick_10">
      <g id="line2d_19">
-      <path d="M 447.797727 300.672
-L 447.797727 25.44
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 447.773182 300.672
+L 447.773182 26.88
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="447.797727" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="447.773182" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 60 -->
-      <g transform="translate(441.435227 315.270437) scale(0.1 -0.1)">
+      <g transform="translate(441.410682 315.270437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584
 Q 1688 2584 1439 2293
@@ -409,18 +409,18 @@ z
     </g>
     <g id="xtick_11">
      <g id="line2d_21">
-      <path d="M 487.665909 300.672
-L 487.665909 25.44
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 487.657727 300.672
+L 487.657727 26.88
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="487.665909" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="487.657727" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 65 -->
-      <g transform="translate(481.303409 315.270437) scale(0.1 -0.1)">
+      <g transform="translate(481.295227 315.270437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-36"/>
        <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
       </g>
@@ -428,7 +428,7 @@ L 487.665909 25.44
     </g>
     <g id="text_12">
      <!-- harsh-cubic dimension n -->
-     <g transform="translate(226.98125 328.948562) scale(0.1 -0.1)">
+     <g transform="translate(226.89125 328.948562) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-68" d="M 3513 2113
 L 3513 0
@@ -771,9 +771,9 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_23">
-      <path d="M 69.05 282.140446
-L 507.6 282.140446
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 282.237402
+L 507.6 282.237402
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <defs>
@@ -782,12 +782,12 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2fc5dfffec" x="69.05" y="282.140446" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2fc5dfffec" x="68.87" y="282.237402" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 0.1 ms -->
-      <g transform="translate(28.01875 285.939665) scale(0.1 -0.1)">
+      <g transform="translate(27.83875 286.036621) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2e" d="M 684 794
 L 1344 794
@@ -808,18 +808,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_25">
-      <path d="M 69.05 220.920852
-L 507.6 220.920852
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 221.338106
+L 507.6 221.338106
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m2fc5dfffec" x="69.05" y="220.920852" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2fc5dfffec" x="68.87" y="221.338106" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 1 ms -->
-      <g transform="translate(37.559375 224.720071) scale(0.1 -0.1)">
+      <g transform="translate(37.379375 225.137325) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-6d" transform="translate(95.410156 0)"/>
@@ -829,18 +829,18 @@ L 507.6 220.920852
     </g>
     <g id="ytick_3">
      <g id="line2d_27">
-      <path d="M 69.05 159.701258
-L 507.6 159.701258
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 160.43881
+L 507.6 160.43881
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m2fc5dfffec" x="69.05" y="159.701258" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2fc5dfffec" x="68.87" y="160.43881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 10 ms -->
-      <g transform="translate(31.196875 163.500477) scale(0.1 -0.1)">
+      <g transform="translate(31.016875 164.238028) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
@@ -851,18 +851,18 @@ L 507.6 159.701258
     </g>
     <g id="ytick_4">
      <g id="line2d_29">
-      <path d="M 69.05 98.481664
-L 507.6 98.481664
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 99.539513
+L 507.6 99.539513
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m2fc5dfffec" x="69.05" y="98.481664" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2fc5dfffec" x="68.87" y="99.539513" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
       <!-- 100 ms -->
-      <g transform="translate(24.834375 102.280882) scale(0.1 -0.1)">
+      <g transform="translate(24.654375 103.338732) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -874,18 +874,18 @@ L 507.6 98.481664
     </g>
     <g id="ytick_5">
      <g id="line2d_31">
-      <path d="M 69.05 37.26207
-L 507.6 37.26207
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 38.640217
+L 507.6 38.640217
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m2fc5dfffec" x="69.05" y="37.26207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2fc5dfffec" x="68.87" y="38.640217" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
       <!-- 1 s -->
-      <g transform="translate(47.3 41.061288) scale(0.1 -0.1)">
+      <g transform="translate(47.12 42.439436) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-73" transform="translate(95.410156 0)"/>
@@ -894,9 +894,9 @@ L 507.6 37.26207
     </g>
     <g id="ytick_6">
      <g id="line2d_33">
-      <path d="M 69.05 300.56938
-L 507.6 300.56938
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 300.569917
+L 507.6 300.569917
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <defs>
@@ -905,445 +905,445 @@ L -2 0
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="300.56938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="300.569917" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_35">
-      <path d="M 69.05 295.721937
-L 507.6 295.721937
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 295.747835
+L 507.6 295.747835
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="295.721937" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="295.747835" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_37">
-      <path d="M 69.05 291.623481
-L 507.6 291.623481
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 291.670823
+L 507.6 291.670823
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="291.623481" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="291.670823" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_39">
-      <path d="M 69.05 288.073238
-L 507.6 288.073238
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 288.139154
+L 507.6 288.139154
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="288.073238" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="288.139154" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_41">
-      <path d="M 69.05 284.941701
-L 507.6 284.941701
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 285.024001
+L 507.6 285.024001
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="284.941701" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="285.024001" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_43">
-      <path d="M 69.05 263.711512
-L 507.6 263.711512
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 263.904887
+L 507.6 263.904887
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="263.711512" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="263.904887" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_45">
-      <path d="M 69.05 252.931277
-L 507.6 252.931277
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 253.181054
+L 507.6 253.181054
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="252.931277" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="253.181054" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_47">
-      <path d="M 69.05 245.282578
-L 507.6 245.282578
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 245.572373
+L 507.6 245.572373
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="245.282578" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="245.572373" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_49">
-      <path d="M 69.05 239.349786
-L 507.6 239.349786
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 239.670621
+L 507.6 239.670621
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="239.349786" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="239.670621" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_51">
-      <path d="M 69.05 234.502342
-L 507.6 234.502342
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 234.848539
+L 507.6 234.848539
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="234.502342" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="234.848539" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_53">
-      <path d="M 69.05 230.403887
-L 507.6 230.403887
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 230.771526
+L 507.6 230.771526
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="230.403887" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="230.771526" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_55">
-      <path d="M 69.05 226.853644
-L 507.6 226.853644
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 227.239858
+L 507.6 227.239858
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="226.853644" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="227.239858" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_57">
-      <path d="M 69.05 223.722107
-L 507.6 223.722107
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 224.124705
+L 507.6 224.124705
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="223.722107" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="224.124705" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_59">
-      <path d="M 69.05 202.491918
-L 507.6 202.491918
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 203.005591
+L 507.6 203.005591
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="202.491918" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="203.005591" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_61">
-      <path d="M 69.05 191.711682
-L 507.6 191.711682
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 192.281757
+L 507.6 192.281757
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="191.711682" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="192.281757" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_63">
-      <path d="M 69.05 184.062984
-L 507.6 184.062984
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 184.673076
+L 507.6 184.673076
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="184.062984" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="184.673076" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_65">
-      <path d="M 69.05 178.130192
-L 507.6 178.130192
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 178.771325
+L 507.6 178.771325
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="178.130192" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="178.771325" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_67">
-      <path d="M 69.05 173.282748
-L 507.6 173.282748
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 173.949242
+L 507.6 173.949242
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="173.282748" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="173.949242" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_69">
-      <path d="M 69.05 169.184293
-L 507.6 169.184293
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 169.87223
+L 507.6 169.87223
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="169.184293" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="169.87223" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_71">
-      <path d="M 69.05 165.63405
-L 507.6 165.63405
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 166.340561
+L 507.6 166.340561
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="165.63405" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="166.340561" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_73">
-      <path d="M 69.05 162.502513
-L 507.6 162.502513
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 163.225409
+L 507.6 163.225409
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="162.502513" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="163.225409" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_75">
-      <path d="M 69.05 141.272324
-L 507.6 141.272324
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 142.106295
+L 507.6 142.106295
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_76">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="141.272324" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="142.106295" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_77">
-      <path d="M 69.05 130.492088
-L 507.6 130.492088
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 131.382461
+L 507.6 131.382461
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_78">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="130.492088" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="131.382461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_79">
-      <path d="M 69.05 122.84339
-L 507.6 122.84339
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 123.77378
+L 507.6 123.77378
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_80">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="122.84339" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="123.77378" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_81">
-      <path d="M 69.05 116.910598
-L 507.6 116.910598
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 117.872028
+L 507.6 117.872028
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_82">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="116.910598" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="117.872028" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_83">
-      <path d="M 69.05 112.063154
-L 507.6 112.063154
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 113.049946
+L 507.6 113.049946
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_84">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="112.063154" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="113.049946" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_85">
-      <path d="M 69.05 107.964699
-L 507.6 107.964699
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 108.972934
+L 507.6 108.972934
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_86">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="107.964699" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="108.972934" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_87">
-      <path d="M 69.05 104.414455
-L 507.6 104.414455
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 105.441265
+L 507.6 105.441265
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_88">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="104.414455" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="105.441265" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_34">
      <g id="line2d_89">
-      <path d="M 69.05 101.282919
-L 507.6 101.282919
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 102.326112
+L 507.6 102.326112
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_90">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="101.282919" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="102.326112" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_35">
      <g id="line2d_91">
-      <path d="M 69.05 80.05273
-L 507.6 80.05273
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 81.206999
+L 507.6 81.206999
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_92">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="80.05273" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="81.206999" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_36">
      <g id="line2d_93">
-      <path d="M 69.05 69.272494
-L 507.6 69.272494
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 70.483165
+L 507.6 70.483165
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_94">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="69.272494" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="70.483165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_37">
      <g id="line2d_95">
-      <path d="M 69.05 61.623795
-L 507.6 61.623795
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 62.874484
+L 507.6 62.874484
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_96">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="61.623795" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="62.874484" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_38">
      <g id="line2d_97">
-      <path d="M 69.05 55.691004
-L 507.6 55.691004
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 56.972732
+L 507.6 56.972732
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_98">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="55.691004" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="56.972732" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_39">
      <g id="line2d_99">
-      <path d="M 69.05 50.84356
-L 507.6 50.84356
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 52.15065
+L 507.6 52.15065
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_100">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="50.84356" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="52.15065" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_40">
      <g id="line2d_101">
-      <path d="M 69.05 46.745105
-L 507.6 46.745105
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 48.073637
+L 507.6 48.073637
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_102">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="46.745105" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="48.073637" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_41">
      <g id="line2d_103">
-      <path d="M 69.05 43.194861
-L 507.6 43.194861
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 44.541969
+L 507.6 44.541969
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_104">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="43.194861" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="44.541969" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_42">
      <g id="line2d_105">
-      <path d="M 69.05 40.063325
-L 507.6 40.063325
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 41.426816
+L 507.6 41.426816
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_106">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="40.063325" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="41.426816" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="text_18">
      <!-- median wall time per call -->
-     <g transform="translate(18.754688 226.280219) rotate(-90) scale(0.1 -0.1)">
+     <g transform="translate(18.574688 227.000219) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-77" d="M 269 3500
 L 844 3500
@@ -1445,18 +1445,18 @@ z
     </g>
    </g>
    <g id="line2d_107">
-    <path d="M 88.984091 229.72593
-L 128.852273 202.140952
-L 168.720455 177.93389
-L 208.588636 154.692921
-L 248.456818 134.310055
-L 288.325 114.764589
-L 328.193182 97.706822
-L 368.061364 81.271362
-L 407.929545 65.965357
-L 447.797727 52.811598
-L 487.665909 39.787745
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 88.812273 230.097116
+L 128.696818 202.656462
+L 168.581364 178.57605
+L 208.465909 155.456676
+L 248.350455 135.180452
+L 288.235 115.737247
+L 328.119545 98.768725
+L 368.004091 82.419255
+L 407.888636 67.193331
+L 447.773182 54.108391
+L 487.657727 41.152678
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="m0fee27a2d2" d="M -3 3
 L 3 3
@@ -1465,33 +1465,33 @@ L -3 -3
 z
 " style="stroke: #1f77b4; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p2a4e53d04e)">
-     <use xlink:href="#m0fee27a2d2" x="88.984091" y="229.72593" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="128.852273" y="202.140952" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="168.720455" y="177.93389" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="208.588636" y="154.692921" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="248.456818" y="134.310055" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="288.325" y="114.764589" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="328.193182" y="97.706822" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="368.061364" y="81.271362" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="407.929545" y="65.965357" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="447.797727" y="52.811598" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="487.665909" y="39.787745" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+    <g clip-path="url(#p173c71c5e1)">
+     <use xlink:href="#m0fee27a2d2" x="88.812273" y="230.097116" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="128.696818" y="202.656462" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="168.581364" y="178.57605" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="208.465909" y="155.456676" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="248.350455" y="135.180452" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="288.235" y="115.737247" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="328.119545" y="98.768725" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="368.004091" y="82.419255" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="407.888636" y="67.193331" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="447.773182" y="54.108391" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="487.657727" y="41.152678" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
-    <path d="M 88.984091 239.65118
-L 128.852273 208.564928
-L 168.720455 183.714924
-L 208.588636 161.583353
-L 248.456818 142.136685
-L 288.325 123.505986
-L 328.193182 106.673302
-L 368.061364 91.336913
-L 407.929545 75.766954
-L 447.797727 63.338485
-L 487.665909 50.736376
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #ff7f0e; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 88.812273 239.970438
+L 128.696818 209.046828
+L 168.581364 184.326838
+L 208.465909 162.311058
+L 248.350455 142.966134
+L 288.235 124.43291
+L 328.119545 107.688294
+L 368.004091 92.432144
+L 407.888636 76.943646
+L 447.773182 64.580202
+L 487.657727 52.044027
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #ff7f0e; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="m2451d16133" d="M 0 3
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132
@@ -1505,32 +1505,32 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #ff7f0e"/>
     </defs>
-    <g clip-path="url(#p2a4e53d04e)">
-     <use xlink:href="#m2451d16133" x="88.984091" y="239.65118" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="128.852273" y="208.564928" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="168.720455" y="183.714924" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="208.588636" y="161.583353" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="248.456818" y="142.136685" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="288.325" y="123.505986" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="328.193182" y="106.673302" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="368.061364" y="91.336913" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="407.929545" y="75.766954" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="447.797727" y="63.338485" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="487.665909" y="50.736376" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+    <g clip-path="url(#p173c71c5e1)">
+     <use xlink:href="#m2451d16133" x="88.812273" y="239.970438" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="128.696818" y="209.046828" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="168.581364" y="184.326838" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="208.465909" y="162.311058" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="248.350455" y="142.966134" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="288.235" y="124.43291" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="328.119545" y="107.688294" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="368.004091" y="92.432144" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="407.888636" y="76.943646" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="447.773182" y="64.580202" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="487.657727" y="52.044027" style="fill: #ff7f0e; stroke: #ff7f0e"/>
     </g>
    </g>
    <g id="line2d_109">
-    <path d="M 128.852273 177.745919
-L 168.720455 157.726532
-L 208.588636 140.686597
-L 248.456818 124.124496
-L 288.325 107.114592
-L 328.193182 92.618523
-L 368.061364 77.016799
-L 407.929545 63.266663
-L 447.797727 49.823189
-L 487.665909 37.950545
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 128.696818 178.389062
+L 168.581364 158.474416
+L 208.465909 141.523633
+L 248.350455 125.048184
+L 288.235 108.127274
+L 328.119545 93.707048
+L 368.004091 78.186951
+L 407.888636 64.508756
+L 447.773182 51.135617
+L 487.657727 39.325091
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="ma559d3018c" d="M 0 -3.5
 L -3.5 3.5
@@ -1538,32 +1538,32 @@ L 3.5 3.5
 z
 " style="stroke: #2ca02c; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p2a4e53d04e)">
-     <use xlink:href="#ma559d3018c" x="128.852273" y="177.745919" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="168.720455" y="157.726532" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="208.588636" y="140.686597" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="248.456818" y="124.124496" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="288.325" y="107.114592" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="328.193182" y="92.618523" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="368.061364" y="77.016799" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="407.929545" y="63.266663" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="447.797727" y="49.823189" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="487.665909" y="37.950545" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+    <g clip-path="url(#p173c71c5e1)">
+     <use xlink:href="#ma559d3018c" x="128.696818" y="178.389062" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="168.581364" y="158.474416" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="208.465909" y="141.523633" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="248.350455" y="125.048184" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="288.235" y="108.127274" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="328.119545" y="93.707048" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="368.004091" y="78.186951" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="407.888636" y="64.508756" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="447.773182" y="51.135617" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="487.657727" y="39.325091" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_110">
-    <path d="M 88.984091 224.351887
-L 128.852273 198.954907
-L 168.720455 176.977558
-L 208.588636 165.97098
-L 248.456818 157.205121
-L 288.325 148.803072
-L 328.193182 140.704294
-L 368.061364 133.894587
-L 407.929545 127.685878
-L 447.797727 119.74932
-L 487.665909 112.68678
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 88.812273 224.75119
+L 128.696818 199.487085
+L 168.581364 177.624721
+L 208.465909 166.675729
+L 248.350455 157.955733
+L 288.235 149.597642
+L 328.119545 141.541237
+L 368.004091 134.767158
+L 407.888636 128.590933
+L 447.773182 120.695899
+L 487.657727 113.67031
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="m633b1844ca" d="M -0 4.596194
 L 4.596194 0
@@ -1572,33 +1572,33 @@ L -4.596194 -0
 z
 " style="stroke: #d62728; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p2a4e53d04e)">
-     <use xlink:href="#m633b1844ca" x="88.984091" y="224.351887" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="128.852273" y="198.954907" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="168.720455" y="176.977558" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="208.588636" y="165.97098" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="248.456818" y="157.205121" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="288.325" y="148.803072" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="328.193182" y="140.704294" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="368.061364" y="133.894587" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="407.929545" y="127.685878" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="447.797727" y="119.74932" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="487.665909" y="112.68678" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+    <g clip-path="url(#p173c71c5e1)">
+     <use xlink:href="#m633b1844ca" x="88.812273" y="224.75119" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="128.696818" y="199.487085" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="168.581364" y="177.624721" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="208.465909" y="166.675729" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="248.350455" y="157.955733" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="288.235" y="149.597642" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="328.119545" y="141.541237" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="368.004091" y="134.767158" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="407.888636" y="128.590933" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="447.773182" y="120.695899" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="487.657727" y="113.67031" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_111">
-    <path d="M 88.984091 288.161455
-L 128.852273 259.580185
-L 168.720455 243.219962
-L 208.588636 232.330735
-L 248.456818 222.376278
-L 288.325 215.218451
-L 328.193182 204.114006
-L 368.061364 197.404118
-L 407.929545 190.871847
-L 447.797727 183.861572
-L 487.665909 179.699978
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #9467bd; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 88.812273 288.226909
+L 128.696818 259.795175
+L 168.581364 243.520548
+L 208.465909 232.688293
+L 248.350455 222.785917
+L 288.235 215.66554
+L 328.119545 204.619193
+L 368.004091 197.94441
+L 407.888636 191.446316
+L 447.773182 184.472718
+L 487.657727 180.332897
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #9467bd; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="m25acbb3ce1" d="M -0 3.5
 L 3.5 -3.5
@@ -1606,43 +1606,43 @@ L -3.5 -3.5
 z
 " style="stroke: #9467bd; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p2a4e53d04e)">
-     <use xlink:href="#m25acbb3ce1" x="88.984091" y="288.161455" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="128.852273" y="259.580185" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="168.720455" y="243.219962" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="208.588636" y="232.330735" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="248.456818" y="222.376278" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="288.325" y="215.218451" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="328.193182" y="204.114006" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="368.061364" y="197.404118" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="407.929545" y="190.871847" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="447.797727" y="183.861572" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="487.665909" y="179.699978" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+    <g clip-path="url(#p173c71c5e1)">
+     <use xlink:href="#m25acbb3ce1" x="88.812273" y="288.226909" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="128.696818" y="259.795175" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="168.581364" y="243.520548" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="208.465909" y="232.688293" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="248.350455" y="222.785917" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="288.235" y="215.66554" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="328.119545" y="204.619193" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="368.004091" y="197.94441" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="407.888636" y="191.446316" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="447.773182" y="184.472718" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="487.657727" y="180.332897" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 69.05 300.672
-L 69.05 25.44
+    <path d="M 68.87 300.672
+L 68.87 26.88
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
     <path d="M 507.6 300.672
-L 507.6 25.44
+L 507.6 26.88
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_5">
-    <path d="M 69.05 300.672
+    <path d="M 68.87 300.672
 L 507.6 300.672
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_6">
-    <path d="M 69.05 25.44
-L 507.6 25.44
+    <path d="M 68.87 26.88
+L 507.6 26.88
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_19">
     <!-- HexLLL harsh-cubic comparator runtime -->
-    <g transform="translate(167.448438 19.44) scale(0.12 -0.12)">
+    <g transform="translate(167.358438 20.88) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-48" d="M 628 4666
 L 1259 4666
@@ -1725,17 +1725,17 @@ z
    </g>
    <g id="legend_1">
     <g id="line2d_112">
-     <path d="M 78.05 38.538437
-L 88.05 38.538437
-L 98.05 38.538437
+     <path d="M 77.87 39.978437
+L 87.87 39.978437
+L 97.87 39.978437
 " style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m0fee27a2d2" x="88.05" y="38.538437" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+      <use xlink:href="#m0fee27a2d2" x="87.87" y="39.978437" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
      <!-- Isabelle native -->
-     <g transform="translate(106.05 42.038437) scale(0.1 -0.1)">
+     <g transform="translate(105.87 43.478437) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-49" d="M 628 4666
 L 1259 4666
@@ -1773,17 +1773,17 @@ z
      </g>
     </g>
     <g id="line2d_113">
-     <path d="M 78.05 53.216562
-L 88.05 53.216562
-L 98.05 53.216562
+     <path d="M 77.87 54.656563
+L 87.87 54.656563
+L 97.87 54.656563
 " style="fill: none; stroke: #ff7f0e; stroke-width: 2; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m2451d16133" x="88.05" y="53.216562" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+      <use xlink:href="#m2451d16133" x="87.87" y="54.656563" style="fill: #ff7f0e; stroke: #ff7f0e"/>
      </g>
     </g>
     <g id="text_21">
      <!-- Lean native -->
-     <g transform="translate(106.05 56.716562) scale(0.1 -0.1)">
+     <g transform="translate(105.87 58.156563) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-4c"/>
       <use xlink:href="#DejaVuSans-65" transform="translate(53.962891 0)"/>
       <use xlink:href="#DejaVuSans-61" transform="translate(115.486328 0)"/>
@@ -1798,17 +1798,17 @@ L 98.05 53.216562
      </g>
     </g>
     <g id="line2d_114">
-     <path d="M 78.05 67.894687
-L 88.05 67.894687
-L 98.05 67.894687
+     <path d="M 77.87 69.334687
+L 87.87 69.334687
+L 97.87 69.334687
 " style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#ma559d3018c" x="88.05" y="67.894687" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+      <use xlink:href="#ma559d3018c" x="87.87" y="69.334687" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
      <!-- Isabelle certified (adjusted) -->
-     <g transform="translate(106.05 71.394687) scale(0.1 -0.1)">
+     <g transform="translate(105.87 72.834687) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-66" d="M 2375 4863
 L 2375 4384
@@ -1909,17 +1909,17 @@ z
      </g>
     </g>
     <g id="line2d_115">
-     <path d="M 78.05 82.572812
-L 88.05 82.572812
-L 98.05 82.572812
+     <path d="M 77.87 84.012812
+L 87.87 84.012812
+L 97.87 84.012812
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m633b1844ca" x="88.05" y="82.572812" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+      <use xlink:href="#m633b1844ca" x="87.87" y="84.012812" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_23">
      <!-- Lean certified -->
-     <g transform="translate(106.05 86.072812) scale(0.1 -0.1)">
+     <g transform="translate(105.87 87.512812) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-4c"/>
       <use xlink:href="#DejaVuSans-65" transform="translate(53.962891 0)"/>
       <use xlink:href="#DejaVuSans-61" transform="translate(115.486328 0)"/>
@@ -1937,17 +1937,17 @@ L 98.05 82.572812
      </g>
     </g>
     <g id="line2d_116">
-     <path d="M 78.05 97.250937
-L 88.05 97.250937
-L 98.05 97.250937
+     <path d="M 77.87 98.690937
+L 87.87 98.690937
+L 97.87 98.690937
 " style="fill: none; stroke: #9467bd; stroke-width: 2; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m25acbb3ce1" x="88.05" y="97.250937" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+      <use xlink:href="#m25acbb3ce1" x="87.87" y="98.690937" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
      <!-- fpLLL via fplll-ffi -->
-     <g transform="translate(106.05 100.750937) scale(0.1 -0.1)">
+     <g transform="translate(105.87 102.190937) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-66"/>
       <use xlink:href="#DejaVuSans-70" transform="translate(35.205078 0)"/>
       <use xlink:href="#DejaVuSans-4c" transform="translate(98.681641 0)"/>
@@ -2549,8 +2549,8 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p2a4e53d04e">
-   <rect x="69.05" y="25.44" width="438.55" height="275.232"/>
+  <clipPath id="p173c71c5e1">
+   <rect x="68.87" y="26.88" width="438.73" height="273.792"/>
   </clipPath>
  </defs>
 </svg>

--- a/reports/figures/hex-lll-comparator-random-bounded.svg
+++ b/reports/figures/hex-lll-comparator-random-bounded.svg
@@ -29,19 +29,19 @@ z
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 69.05 300.672
+    <path d="M 68.87 300.672
 L 507.6 300.672
-L 507.6 25.44
-L 69.05 25.44
+L 507.6 26.88
+L 68.87 26.88
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
-      <path d="M 88.984091 300.672
-L 88.984091 25.44
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 88.812273 300.672
+L 88.812273 26.88
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
@@ -50,12 +50,12 @@ L 0 3.5
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="88.984091" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="88.812273" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- 30 -->
-      <g transform="translate(82.621591 315.270437) scale(0.1 -0.1)">
+      <g transform="translate(82.449773 315.270437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516
 Q 3050 2419 3304 2112
@@ -118,18 +118,18 @@ z
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
-      <path d="M 128.852273 300.672
-L 128.852273 25.44
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 128.696818 300.672
+L 128.696818 26.88
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="128.852273" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="128.696818" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- 45 -->
-      <g transform="translate(122.489773 315.270437) scale(0.1 -0.1)">
+      <g transform="translate(122.334318 315.270437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116
 L 825 1625
@@ -183,18 +183,18 @@ z
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
-      <path d="M 168.720455 300.672
-L 168.720455 25.44
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 168.581364 300.672
+L 168.581364 26.88
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="168.720455" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="168.581364" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- 60 -->
-      <g transform="translate(162.357955 315.270437) scale(0.1 -0.1)">
+      <g transform="translate(162.218864 315.270437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584
 Q 1688 2584 1439 2293
@@ -234,18 +234,18 @@ z
     </g>
     <g id="xtick_4">
      <g id="line2d_7">
-      <path d="M 208.588636 300.672
-L 208.588636 25.44
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 208.465909 300.672
+L 208.465909 26.88
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="208.588636" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="208.465909" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- 75 -->
-      <g transform="translate(202.226136 315.270437) scale(0.1 -0.1)">
+      <g transform="translate(202.103409 315.270437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-37" d="M 525 4666
 L 3525 4666
@@ -265,18 +265,18 @@ z
     </g>
     <g id="xtick_5">
      <g id="line2d_9">
-      <path d="M 248.456818 300.672
-L 248.456818 25.44
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 248.350455 300.672
+L 248.350455 26.88
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="248.456818" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="248.350455" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- 90 -->
-      <g transform="translate(242.094318 315.270437) scale(0.1 -0.1)">
+      <g transform="translate(241.987955 315.270437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-39" d="M 703 97
 L 703 672
@@ -316,18 +316,18 @@ z
     </g>
     <g id="xtick_6">
      <g id="line2d_11">
-      <path d="M 328.193182 300.672
-L 328.193182 25.44
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 328.119545 300.672
+L 328.119545 26.88
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="328.193182" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="328.119545" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- 120 -->
-      <g transform="translate(318.649432 315.270437) scale(0.1 -0.1)">
+      <g transform="translate(318.575795 315.270437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531
 L 1825 531
@@ -376,18 +376,18 @@ z
     </g>
     <g id="xtick_7">
      <g id="line2d_13">
-      <path d="M 407.929545 300.672
-L 407.929545 25.44
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 407.888636 300.672
+L 407.888636 26.88
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="407.929545" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="407.888636" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 150 -->
-      <g transform="translate(398.385795 315.270437) scale(0.1 -0.1)">
+      <g transform="translate(398.344886 315.270437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -396,18 +396,18 @@ L 407.929545 25.44
     </g>
     <g id="xtick_8">
      <g id="line2d_15">
-      <path d="M 487.665909 300.672
-L 487.665909 25.44
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 487.657727 300.672
+L 487.657727 26.88
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="487.665909" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="487.657727" y="300.672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 180 -->
-      <g transform="translate(478.122159 315.270437) scale(0.1 -0.1)">
+      <g transform="translate(478.113977 315.270437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216
 Q 1584 2216 1326 1975
@@ -457,7 +457,7 @@ z
     </g>
     <g id="text_9">
      <!-- random-bounded dimension n -->
-     <g transform="translate(212.885156 328.948562) scale(0.1 -0.1)">
+     <g transform="translate(212.795156 328.948562) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-72" d="M 2631 2963
 Q 2534 3019 2420 3045
@@ -763,9 +763,9 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_17">
-      <path d="M 69.05 297.671742
-L 507.6 297.671742
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 297.687439
+L 507.6 297.687439
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <defs>
@@ -774,12 +774,12 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2fc5dfffec" x="69.05" y="297.671742" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2fc5dfffec" x="68.87" y="297.687439" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 1 ms -->
-      <g transform="translate(37.559375 301.47096) scale(0.1 -0.1)">
+      <g transform="translate(37.379375 301.486658) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-6d" transform="translate(95.410156 0)"/>
@@ -789,18 +789,18 @@ L -3.5 0
     </g>
     <g id="ytick_2">
      <g id="line2d_19">
-      <path d="M 69.05 230.242654
-L 507.6 230.242654
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 230.611137
+L 507.6 230.611137
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m2fc5dfffec" x="69.05" y="230.242654" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2fc5dfffec" x="68.87" y="230.611137" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 10 ms -->
-      <g transform="translate(31.196875 234.041873) scale(0.1 -0.1)">
+      <g transform="translate(31.016875 234.410356) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
@@ -811,18 +811,18 @@ L 507.6 230.242654
     </g>
     <g id="ytick_3">
      <g id="line2d_21">
-      <path d="M 69.05 162.813567
-L 507.6 162.813567
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 163.534835
+L 507.6 163.534835
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m2fc5dfffec" x="69.05" y="162.813567" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2fc5dfffec" x="68.87" y="163.534835" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 100 ms -->
-      <g transform="translate(24.834375 166.612786) scale(0.1 -0.1)">
+      <g transform="translate(24.654375 167.334054) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -834,18 +834,18 @@ L 507.6 162.813567
     </g>
     <g id="ytick_4">
      <g id="line2d_23">
-      <path d="M 69.05 95.38448
-L 507.6 95.38448
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 96.458534
+L 507.6 96.458534
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m2fc5dfffec" x="69.05" y="95.38448" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2fc5dfffec" x="68.87" y="96.458534" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1 s -->
-      <g transform="translate(47.3 99.183698) scale(0.1 -0.1)">
+      <g transform="translate(47.12 100.257752) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-73" transform="translate(95.410156 0)"/>
@@ -854,18 +854,18 @@ L 507.6 95.38448
     </g>
     <g id="ytick_5">
      <g id="line2d_25">
-      <path d="M 69.05 27.955392
-L 507.6 27.955392
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 29.382232
+L 507.6 29.382232
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m2fc5dfffec" x="69.05" y="27.955392" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2fc5dfffec" x="68.87" y="29.382232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 10 s -->
-      <g transform="translate(40.9375 31.754611) scale(0.1 -0.1)">
+      <g transform="translate(40.7575 33.181451) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
@@ -875,9 +875,9 @@ L 507.6 27.955392
     </g>
     <g id="ytick_6">
      <g id="line2d_27">
-      <path d="M 69.05 277.373564
-L 507.6 277.373564
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 277.49546
+L 507.6 277.49546
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <defs>
@@ -886,385 +886,385 @@ L -2 0
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="277.373564" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="277.49546" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_29">
-      <path d="M 69.05 265.499891
-L 507.6 265.499891
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 265.68391
+L 507.6 265.68391
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="265.499891" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="265.68391" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_31">
-      <path d="M 69.05 257.075386
-L 507.6 257.075386
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 257.303481
+L 507.6 257.303481
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="257.075386" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="257.303481" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_33">
-      <path d="M 69.05 250.540832
-L 507.6 250.540832
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 250.803116
+L 507.6 250.803116
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="250.540832" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="250.803116" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_35">
-      <path d="M 69.05 245.201713
-L 507.6 245.201713
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 245.491931
+L 507.6 245.491931
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="245.201713" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="245.491931" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_37">
-      <path d="M 69.05 240.687552
-L 507.6 240.687552
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 241.001388
+L 507.6 241.001388
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="240.687552" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="241.001388" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_39">
-      <path d="M 69.05 236.777208
-L 507.6 236.777208
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 237.111502
+L 507.6 237.111502
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="236.777208" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="237.111502" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_41">
-      <path d="M 69.05 233.32804
-L 507.6 233.32804
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 233.68038
+L 507.6 233.68038
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="233.32804" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="233.68038" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_43">
-      <path d="M 69.05 209.944476
-L 507.6 209.944476
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 210.419158
+L 507.6 210.419158
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="209.944476" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="210.419158" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_45">
-      <path d="M 69.05 198.070804
-L 507.6 198.070804
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 198.607608
+L 507.6 198.607608
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="198.070804" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="198.607608" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_47">
-      <path d="M 69.05 189.646299
-L 507.6 189.646299
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 190.227179
+L 507.6 190.227179
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="189.646299" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="190.227179" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_49">
-      <path d="M 69.05 183.111745
-L 507.6 183.111745
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 183.726814
+L 507.6 183.726814
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="183.111745" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="183.726814" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_51">
-      <path d="M 69.05 177.772626
-L 507.6 177.772626
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 178.415629
+L 507.6 178.415629
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="177.772626" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="178.415629" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_53">
-      <path d="M 69.05 173.258465
-L 507.6 173.258465
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 173.925086
+L 507.6 173.925086
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="173.258465" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="173.925086" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_55">
-      <path d="M 69.05 169.348121
-L 507.6 169.348121
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 170.035201
+L 507.6 170.035201
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="169.348121" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="170.035201" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_57">
-      <path d="M 69.05 165.898953
-L 507.6 165.898953
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 166.604079
+L 507.6 166.604079
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="165.898953" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="166.604079" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_59">
-      <path d="M 69.05 142.515389
-L 507.6 142.515389
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 143.342857
+L 507.6 143.342857
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="142.515389" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="143.342857" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_61">
-      <path d="M 69.05 130.641716
-L 507.6 130.641716
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 131.531306
+L 507.6 131.531306
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="130.641716" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="131.531306" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_63">
-      <path d="M 69.05 122.217211
-L 507.6 122.217211
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 123.150878
+L 507.6 123.150878
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="122.217211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="123.150878" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_65">
-      <path d="M 69.05 115.682658
-L 507.6 115.682658
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 116.650513
+L 507.6 116.650513
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="115.682658" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="116.650513" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_67">
-      <path d="M 69.05 110.343538
-L 507.6 110.343538
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 111.339327
+L 507.6 111.339327
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="110.343538" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="111.339327" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_69">
-      <path d="M 69.05 105.829378
-L 507.6 105.829378
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 106.848784
+L 507.6 106.848784
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="105.829378" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="106.848784" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_71">
-      <path d="M 69.05 101.919033
-L 507.6 101.919033
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 102.958899
+L 507.6 102.958899
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="101.919033" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="102.958899" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_73">
-      <path d="M 69.05 98.469866
-L 507.6 98.469866
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 99.527777
+L 507.6 99.527777
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="98.469866" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="99.527777" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_75">
-      <path d="M 69.05 75.086302
-L 507.6 75.086302
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 76.266555
+L 507.6 76.266555
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_76">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="75.086302" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="76.266555" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_77">
-      <path d="M 69.05 63.212629
-L 507.6 63.212629
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 64.455005
+L 507.6 64.455005
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_78">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="63.212629" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="64.455005" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_79">
-      <path d="M 69.05 54.788124
-L 507.6 54.788124
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 56.074576
+L 507.6 56.074576
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_80">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="54.788124" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="56.074576" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_81">
-      <path d="M 69.05 48.25357
-L 507.6 48.25357
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 49.574211
+L 507.6 49.574211
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_82">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="48.25357" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="49.574211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_34">
      <g id="line2d_83">
-      <path d="M 69.05 42.914451
-L 507.6 42.914451
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 44.263026
+L 507.6 44.263026
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_84">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="42.914451" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="44.263026" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_35">
      <g id="line2d_85">
-      <path d="M 69.05 38.40029
-L 507.6 38.40029
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 39.772483
+L 507.6 39.772483
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_86">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="38.40029" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="39.772483" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_36">
      <g id="line2d_87">
-      <path d="M 69.05 34.489946
-L 507.6 34.489946
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 35.882597
+L 507.6 35.882597
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_88">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="34.489946" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="35.882597" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_37">
      <g id="line2d_89">
-      <path d="M 69.05 31.040778
-L 507.6 31.040778
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 68.87 32.451475
+L 507.6 32.451475
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_90">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="31.040778" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="68.87" y="32.451475" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="text_15">
      <!-- median wall time per call -->
-     <g transform="translate(18.754688 226.280219) rotate(-90) scale(0.1 -0.1)">
+     <g transform="translate(18.574688 227.000219) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-77" d="M 269 3500
 L 844 3500
@@ -1387,15 +1387,15 @@ z
     </g>
    </g>
    <g id="line2d_91">
-    <path d="M 88.984091 216.311329
-L 128.852273 176.587637
-L 168.720455 148.501507
-L 208.588636 125.227897
-L 248.456818 107.543849
-L 328.193182 77.622242
-L 407.929545 56.621137
-L 487.665909 37.950545
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 88.812273 216.7527
+L 128.696818 177.23684
+L 168.581364 149.297656
+L 208.465909 126.145812
+L 248.350455 108.554286
+L 328.119545 78.789227
+L 407.888636 57.897999
+L 487.657727 39.325091
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="m0fee27a2d2" d="M -3 3
 L 3 3
@@ -1404,27 +1404,27 @@ L -3 -3
 z
 " style="stroke: #1f77b4; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p2a4e53d04e)">
-     <use xlink:href="#m0fee27a2d2" x="88.984091" y="216.311329" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="128.852273" y="176.587637" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="168.720455" y="148.501507" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="208.588636" y="125.227897" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="248.456818" y="107.543849" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="328.193182" y="77.622242" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="407.929545" y="56.621137" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="487.665909" y="37.950545" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+    <g clip-path="url(#p173c71c5e1)">
+     <use xlink:href="#m0fee27a2d2" x="88.812273" y="216.7527" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="128.696818" y="177.23684" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="168.581364" y="149.297656" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="208.465909" y="126.145812" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="248.350455" y="108.554286" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="328.119545" y="78.789227" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="407.888636" y="57.897999" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="487.657727" y="39.325091" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_92">
-    <path d="M 88.984091 219.08579
-L 128.852273 182.549314
-L 168.720455 155.167362
-L 208.588636 131.885027
-L 248.456818 117.41336
-L 328.193182 89.448027
-L 407.929545 69.194648
-L 487.665909 52.284105
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #ff7f0e; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 88.812273 219.512645
+L 128.696818 183.167326
+L 168.581364 155.928635
+L 208.465909 132.768112
+L 248.350455 118.37216
+L 328.119545 90.55314
+L 407.888636 70.405726
+L 487.657727 53.583658
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #ff7f0e; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="m2451d16133" d="M 0 3
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132
@@ -1438,27 +1438,27 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #ff7f0e"/>
     </defs>
-    <g clip-path="url(#p2a4e53d04e)">
-     <use xlink:href="#m2451d16133" x="88.984091" y="219.08579" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="128.852273" y="182.549314" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="168.720455" y="155.167362" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="208.588636" y="131.885027" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="248.456818" y="117.41336" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="328.193182" y="89.448027" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="407.929545" y="69.194648" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="487.665909" y="52.284105" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+    <g clip-path="url(#p173c71c5e1)">
+     <use xlink:href="#m2451d16133" x="88.812273" y="219.512645" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="128.696818" y="183.167326" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="168.581364" y="155.928635" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="208.465909" y="132.768112" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="248.350455" y="118.37216" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="328.119545" y="90.55314" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="407.888636" y="70.405726" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="487.657727" y="53.583658" style="fill: #ff7f0e; stroke: #ff7f0e"/>
     </g>
    </g>
    <g id="line2d_93">
-    <path d="M 88.984091 222.330218
-L 128.852273 189.915433
-L 168.720455 167.065018
-L 208.588636 147.206199
-L 248.456818 131.835183
-L 328.193182 106.259991
-L 407.929545 87.060884
-L 487.665909 70.549854
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 88.812273 222.740098
+L 128.696818 190.494906
+L 168.581364 167.764043
+L 208.465909 148.009124
+L 248.350455 132.718529
+L 328.119545 107.277145
+L 407.888636 88.178487
+L 487.657727 71.753841
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="ma559d3018c" d="M 0 -3.5
 L -3.5 3.5
@@ -1466,27 +1466,27 @@ L 3.5 3.5
 z
 " style="stroke: #2ca02c; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p2a4e53d04e)">
-     <use xlink:href="#ma559d3018c" x="88.984091" y="222.330218" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="128.852273" y="189.915433" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="168.720455" y="167.065018" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="208.588636" y="147.206199" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="248.456818" y="131.835183" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="328.193182" y="106.259991" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="407.929545" y="87.060884" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="487.665909" y="70.549854" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+    <g clip-path="url(#p173c71c5e1)">
+     <use xlink:href="#ma559d3018c" x="88.812273" y="222.740098" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="128.696818" y="190.494906" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="168.581364" y="167.764043" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="208.465909" y="148.009124" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="248.350455" y="132.718529" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="328.119545" y="107.277145" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="407.888636" y="88.178487" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="487.657727" y="71.753841" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
-    <path d="M 88.984091 256.162704
-L 128.852273 221.36211
-L 168.720455 196.040631
-L 208.588636 175.153545
-L 248.456818 159.497251
-L 328.193182 133.673366
-L 407.929545 112.393713
-L 487.665909 97.316331
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 88.812273 256.395574
+L 128.696818 221.777055
+L 168.581364 196.588057
+L 208.465909 175.810251
+L 248.350455 160.23587
+L 328.119545 134.547094
+L 407.888636 113.378776
+L 487.657727 98.380277
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="m633b1844ca" d="M -0 4.596194
 L 4.596194 0
@@ -1495,27 +1495,27 @@ L -4.596194 -0
 z
 " style="stroke: #d62728; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p2a4e53d04e)">
-     <use xlink:href="#m633b1844ca" x="88.984091" y="256.162704" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="128.852273" y="221.36211" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="168.720455" y="196.040631" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="208.588636" y="175.153545" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="248.456818" y="159.497251" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="328.193182" y="133.673366" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="407.929545" y="112.393713" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="487.665909" y="97.316331" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+    <g clip-path="url(#p173c71c5e1)">
+     <use xlink:href="#m633b1844ca" x="88.812273" y="256.395574" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="128.696818" y="221.777055" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="168.581364" y="196.588057" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="208.465909" y="175.810251" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="248.350455" y="160.23587" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="328.119545" y="134.547094" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="407.888636" y="113.378776" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="487.657727" y="98.380277" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_95">
-    <path d="M 88.984091 288.161455
-L 128.852273 250.19273
-L 168.720455 224.547756
-L 208.588636 202.889919
-L 248.456818 187.917543
-L 328.193182 161.74507
-L 407.929545 142.630272
-L 487.665909 127.371703
-" clip-path="url(#p2a4e53d04e)" style="fill: none; stroke: #9467bd; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 88.812273 288.226909
+L 128.696818 250.456835
+L 168.581364 224.946034
+L 208.465909 203.40151
+L 248.350455 188.507469
+L 328.119545 162.471928
+L 407.888636 143.457138
+L 487.657727 128.278401
+" clip-path="url(#p173c71c5e1)" style="fill: none; stroke: #9467bd; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="m25acbb3ce1" d="M -0 3.5
 L 3.5 -3.5
@@ -1523,40 +1523,40 @@ L -3.5 -3.5
 z
 " style="stroke: #9467bd; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p2a4e53d04e)">
-     <use xlink:href="#m25acbb3ce1" x="88.984091" y="288.161455" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="128.852273" y="250.19273" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="168.720455" y="224.547756" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="208.588636" y="202.889919" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="248.456818" y="187.917543" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="328.193182" y="161.74507" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="407.929545" y="142.630272" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="487.665909" y="127.371703" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+    <g clip-path="url(#p173c71c5e1)">
+     <use xlink:href="#m25acbb3ce1" x="88.812273" y="288.226909" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="128.696818" y="250.456835" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="168.581364" y="224.946034" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="208.465909" y="203.40151" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="248.350455" y="188.507469" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="328.119545" y="162.471928" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="407.888636" y="143.457138" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="487.657727" y="128.278401" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 69.05 300.672
-L 69.05 25.44
+    <path d="M 68.87 300.672
+L 68.87 26.88
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
     <path d="M 507.6 300.672
-L 507.6 25.44
+L 507.6 26.88
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_5">
-    <path d="M 69.05 300.672
+    <path d="M 68.87 300.672
 L 507.6 300.672
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_6">
-    <path d="M 69.05 25.44
-L 507.6 25.44
+    <path d="M 68.87 26.88
+L 507.6 26.88
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_16">
     <!-- HexLLL random-bounded comparator runtime -->
-    <g transform="translate(150.533125 19.44) scale(0.12 -0.12)">
+    <g transform="translate(150.443125 20.88) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-48" d="M 628 4666
 L 1259 4666
@@ -1642,17 +1642,17 @@ z
    </g>
    <g id="legend_1">
     <g id="line2d_96">
-     <path d="M 78.05 38.538437
-L 88.05 38.538437
-L 98.05 38.538437
+     <path d="M 77.87 39.978437
+L 87.87 39.978437
+L 97.87 39.978437
 " style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m0fee27a2d2" x="88.05" y="38.538437" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+      <use xlink:href="#m0fee27a2d2" x="87.87" y="39.978437" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
      <!-- Isabelle native -->
-     <g transform="translate(106.05 42.038437) scale(0.1 -0.1)">
+     <g transform="translate(105.87 43.478437) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-49" d="M 628 4666
 L 1259 4666
@@ -1690,17 +1690,17 @@ z
      </g>
     </g>
     <g id="line2d_97">
-     <path d="M 78.05 53.216562
-L 88.05 53.216562
-L 98.05 53.216562
+     <path d="M 77.87 54.656563
+L 87.87 54.656563
+L 97.87 54.656563
 " style="fill: none; stroke: #ff7f0e; stroke-width: 2; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m2451d16133" x="88.05" y="53.216562" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+      <use xlink:href="#m2451d16133" x="87.87" y="54.656563" style="fill: #ff7f0e; stroke: #ff7f0e"/>
      </g>
     </g>
     <g id="text_18">
      <!-- Lean native -->
-     <g transform="translate(106.05 56.716562) scale(0.1 -0.1)">
+     <g transform="translate(105.87 58.156563) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-4c"/>
       <use xlink:href="#DejaVuSans-65" transform="translate(53.962891 0)"/>
       <use xlink:href="#DejaVuSans-61" transform="translate(115.486328 0)"/>
@@ -1715,17 +1715,17 @@ L 98.05 53.216562
      </g>
     </g>
     <g id="line2d_98">
-     <path d="M 78.05 67.894687
-L 88.05 67.894687
-L 98.05 67.894687
+     <path d="M 77.87 69.334687
+L 87.87 69.334687
+L 97.87 69.334687
 " style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#ma559d3018c" x="88.05" y="67.894687" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+      <use xlink:href="#ma559d3018c" x="87.87" y="69.334687" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
      <!-- Isabelle certified (adjusted) -->
-     <g transform="translate(106.05 71.394687) scale(0.1 -0.1)">
+     <g transform="translate(105.87 72.834687) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-66" d="M 2375 4863
 L 2375 4384
@@ -1826,17 +1826,17 @@ z
      </g>
     </g>
     <g id="line2d_99">
-     <path d="M 78.05 82.572812
-L 88.05 82.572812
-L 98.05 82.572812
+     <path d="M 77.87 84.012812
+L 87.87 84.012812
+L 97.87 84.012812
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m633b1844ca" x="88.05" y="82.572812" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+      <use xlink:href="#m633b1844ca" x="87.87" y="84.012812" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
      <!-- Lean certified -->
-     <g transform="translate(106.05 86.072812) scale(0.1 -0.1)">
+     <g transform="translate(105.87 87.512812) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-4c"/>
       <use xlink:href="#DejaVuSans-65" transform="translate(53.962891 0)"/>
       <use xlink:href="#DejaVuSans-61" transform="translate(115.486328 0)"/>
@@ -1854,17 +1854,17 @@ L 98.05 82.572812
      </g>
     </g>
     <g id="line2d_100">
-     <path d="M 78.05 97.250937
-L 88.05 97.250937
-L 98.05 97.250937
+     <path d="M 77.87 98.690937
+L 87.87 98.690937
+L 97.87 98.690937
 " style="fill: none; stroke: #9467bd; stroke-width: 2; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m25acbb3ce1" x="88.05" y="97.250937" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+      <use xlink:href="#m25acbb3ce1" x="87.87" y="98.690937" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
      <!-- fpLLL via fplll-ffi -->
-     <g transform="translate(106.05 100.750937) scale(0.1 -0.1)">
+     <g transform="translate(105.87 102.190937) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-66"/>
       <use xlink:href="#DejaVuSans-70" transform="translate(35.205078 0)"/>
       <use xlink:href="#DejaVuSans-4c" transform="translate(98.681641 0)"/>
@@ -2466,8 +2466,8 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p2a4e53d04e">
-   <rect x="69.05" y="25.44" width="438.55" height="275.232"/>
+  <clipPath id="p173c71c5e1">
+   <rect x="68.87" y="26.88" width="438.73" height="273.792"/>
   </clipPath>
  </defs>
 </svg>

--- a/reports/hex-lll-performance.md
+++ b/reports/hex-lll-performance.md
@@ -344,7 +344,7 @@ checksum.
 
 ## Comparator Ratios
 
-The current implemented gating comparator is `verified Isabelle LLL (AFP LLL_Basis_Reduction; Haskell extraction from Zenodo 2636367)`, declared in `SPEC/Libraries/hex-lll.md`. The persistent-subprocess harness for it was wired in HO-16 (#3676); the matching fpylll persistent driver was wired in HO-17 (#4186). The densified `random-bounded` and `harsh-cubic` ladders are the post-HO-18 fixed-benchmark schedules — `random-bounded` `n ∈ {30, 45, 60, 75, 90, 120, 150, 180}`, `harsh-cubic` `n ∈ {15, 20, 25, 30, 35, 40, 45, 50, 55}` — per the post-#3657 §"Headline reports" densification rule.
+The current implemented gating comparator is `verified Isabelle LLL (AFP LLL_Basis_Reduction; Haskell extraction from Zenodo 2636367)`, declared in `HexLLL/SPEC/hex-lll.md`. The persistent-subprocess harness for it was wired in HO-16 (#3676); the in-process fpLLL FFI was wired later for the production certified path. The densified `random-bounded` and `harsh-cubic` ladders are the post-HO-18 fixed-benchmark schedules — `random-bounded` `n ∈ {30, 45, 60, 75, 90, 120, 150, 180}`, `harsh-cubic` `n ∈ {15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65}` — per the post-#3657 §"Headline reports" densification rule.
 
 The certified external-dispatch SPEC also declares the gating comparator
 `verified Isabelle certified-LLL (JAR 2020 §7; svp_certified from the Zenodo 2636367 LLL_Basis_Reduction extraction, same archive as the native comparator)`.
@@ -352,70 +352,78 @@ The Hex certified path is now registered as fixed process-call targets:
 `runCertifiedFirstShortVectorRandomBounded{30,45,60,75,90,120,150,180}Checksum`
 and
 `runCertifiedFirstShortVectorHarshCubic{15,20,25,30,35,40,45,50,55,60,65}Checksum`.
-Each target sends a `CERT\t` request to the persistent fpylll driver, receives a
-flat `(B', U, V)` payload, and runs `ExternalReducer.certifyFlat`, so the measured
-path is fpLLL candidate production plus the Lean checker. Paired
+Each target obtains a flat `(B', U, V)` payload through the in-process
+`fplll-ffi` shim and runs `ExternalReducer.certifyFlat`, so the measured path is
+fpLLL candidate production plus the Lean checker. Paired
 `runCertifiedChecker*` targets cache the same candidate and re-run only
 `certCheck` after warmup, giving the checker's share of certified-path cost.
 
-Random-bounded certified ladder export:
-`reports/bench-results/hex-lll-certified-c3d2fecb.json`,
-SHA-256 `c4439a4e06c1f61ee76717ebcc8f170cb643ea095d6765230b84a55204c44e29`.
-The harsh-cubic certified ladder runs two rungs further (to `n = 65`) and is
-measured in its own carica sweep:
-`reports/bench-results/hex-lll-certified-harsh-extended-1e6679ff.json`,
-SHA-256 `ccaec1be0a5209f63387a8b2af0f093274f06d6518323f631093ad82288ee6cb`;
-its `15..55` result hashes match the c3d2fecb export exactly.
-Both runs used `HEX_FPLLL_FFI_LIB="$(scripts/oracle/setup_fplll_ffi.sh)"` so
-the certified-path cost is fpLLL candidate production through `fplll-ffi`
-plus Lean's checker. All certified-path and checker-only rows had
-repeat-stable hashes. Candidate rejection rate was `0 %` across both runs
-(`0 / 34` random-bounded+harsh-cubic-to-55, `0 / 22` harsh-cubic `15..65`):
-every full certified target and every checker-only cached payload accepted.
+The current clean consolidated sweeps were recorded on `carica` (Apple M2
+Ultra, macOS) with `scripts/dev/run_lll_bench.sh random-bounded RandomBounded`
+at commit `5d16cb58f92bd69590b2439b89c83894d3798e4b` and
+`scripts/dev/run_lll_bench.sh harsh-cubic HarshCubic` at commit
+`674302291e3c04dbd7e6b4252056ef33859c2e39`. The commands load the pinned
+native Isabelle, certified Isabelle, and `fplll-ffi` oracles, run every target
+whose name contains the family filter, and record three warm outer repeats.
+The exports and measured certified-Isabelle process floors are:
+
+- `reports/bench-results/hex-lll-random-bounded-5d16cb58.json`, SHA-256
+  `202772082eab1ad7ac2393c42446029d807261d62bd645f95d22c66f152a0314`;
+  floor `reports/bench-results/hex-lll-random-bounded-floor-5d16cb58.json`,
+  SHA-256 `3807c7c168f9906a4f83b59f01bdb47e8525c9275362a7df927563037aa16961`.
+- `reports/bench-results/hex-lll-harsh-cubic-67430229.json`, SHA-256
+  `d8dde9f79a477ab9e5834c6c9031d9fca182ff0a25f9e6f96cbb22f0e6b3e0ba`;
+  floor `reports/bench-results/hex-lll-harsh-cubic-floor-67430229.json`,
+  SHA-256 `2101e94e4dce5c7f4c8aaf643db9b1aadbd0be6104006a7f754d4d5560310b72`.
+
+Both exports record `git_dirty=false`. All certified-path and checker-only rows
+have repeat-stable hashes. A rejected candidate makes the fixed target fail;
+all 11,896 timed certified calls completed, so the measured rejection rate is
+`0 / 11,896 = 0 %`.
 
 Lean-certified-vs-Lean-native random-bounded ratios:
 
 | `n` | Lean native median | Lean certified median | certified/native | checker share |
 |---:|---:|---:|---:|---:|
-| 30 | 15.14 ms | 4.23 ms | 0.2794 | 64.4 % |
-| 45 | 55.53 ms | 14.11 ms | 0.2541 | 60.5 % |
-| 60 | 142.01 ms | 32.66 ms | 0.2300 | 63.1 % |
-| 75 | 296.58 ms | 65.59 ms | 0.2212 | 60.3 % |
-| 90 | 495.68 ms | 112.71 ms | 0.2274 | 61.3 % |
-| 120 | 1.39 s | 274.10 ms | 0.1972 | 63.0 % |
-| 150 | 2.65 s | 565.88 ms | 0.2135 | 63.5 % |
-| 180 | 4.76 s | 954.40 ms | 0.2005 | 64.4 % |
+| 30 | 14.64 ms | 4.13 ms | 0.2819 | 64.3 % |
+| 45 | 50.97 ms | 13.54 ms | 0.2657 | 61.7 % |
+| 60 | 129.84 ms | 32.15 ms | 0.2476 | 62.5 % |
+| 75 | 287.53 ms | 65.61 ms | 0.2282 | 58.5 % |
+| 90 | 471.31 ms | 111.99 ms | 0.2376 | 61.2 % |
+| 120 | 1.22 s | 270.50 ms | 0.2209 | 63.5 % |
+| 150 | 2.45 s | 559.43 ms | 0.2287 | 63.6 % |
+| 180 | 4.36 s | 936.16 ms | 0.2149 | 66.5 % |
 
-Random-bounded trend: Lean certified sits at about `0.20..0.28×` Lean
+Random-bounded trend: Lean certified sits at about `0.21..0.28×` Lean
 native. The checker is the dominant certified-path component, accounting for
-`60..64 %` of the measured full path. The input-size predictor routes the
-random-bounded checker rungs `n ≤ 120` to the exact integer checker
+`59..67 %` of the measured full path. The input-size predictor routes the
+random-bounded checker rungs `n ≤ 150` to the exact integer checker
 (the operand bit growth on this family stays below the 128-bit interval
-working precision); rungs `n ≥ 150` dispatch to the fixed-precision
-enclosure pass, which is where the small absolute speedup at the top of
-the ladder comes from.
+working precision); `n = 180` dispatches to the fixed-precision enclosure
+pass, which is where the small absolute speedup at the top of the ladder comes
+from.
 
 Lean-certified-vs-Lean-native harsh-cubic ratios:
 
 | `n` | Lean native median | Lean certified median | certified/native | checker share |
 |---:|---:|---:|---:|---:|
-| 15 | 515 µs | 832 µs | 1.6148 | 89.1 % |
-| 20 | 1.67 ms | 2.29 ms | 1.3698 | 92.0 % |
-| 25 | 4.15 ms | 5.19 ms | 1.2517 | 99.0 % |
-| 30 | 9.53 ms | 8.14 ms | 0.8538 | 85.5 % |
-| 35 | 19.65 ms | 11.13 ms | 0.5666 | 89.0 % |
-| 40 | 39.44 ms | 14.77 ms | 0.3745 | 91.2 % |
-| 45 | 75.83 ms | 19.95 ms | 0.2631 | 95.0 % |
-| 50 | 135.80 ms | 27.55 ms | 0.2029 | 87.4 % |
-| 55 | 234.28 ms | 35.53 ms | 0.1516 | 88.1 % |
-| 60 | 381.56 ms | 45.38 ms | 0.1189 | 91.2 % |
-| 65 | 621.32 ms | 56.10 ms | 0.0903 | 98.1 % |
+| 15 | 494 µs | 879 µs | 1.7779 | 88.5 % |
+| 20 | 1.59 ms | 2.28 ms | 1.4354 | 86.9 % |
+| 25 | 4.05 ms | 5.22 ms | 1.2884 | 93.4 % |
+| 30 | 9.32 ms | 7.90 ms | 0.8479 | 86.8 % |
+| 35 | 19.36 ms | 10.98 ms | 0.5674 | 89.8 % |
+| 40 | 39.02 ms | 15.07 ms | 0.3862 | 89.9 % |
+| 45 | 73.48 ms | 20.43 ms | 0.2780 | 89.0 % |
+| 50 | 130.83 ms | 26.40 ms | 0.2018 | 89.6 % |
+| 55 | 234.98 ms | 33.34 ms | 0.1419 | 90.6 % |
+| 60 | 375.02 ms | 44.94 ms | 0.1198 | 89.2 % |
+| 65 | 602.42 ms | 58.61 ms | 0.0973 | 85.7 % |
 
 Harsh-cubic trend: Lean certified crosses below Lean native at `n = 30` and
-drops to **`0.090×` Lean native at `n = 65`** — an 11.1× speedup over the
-native body (`0.15×`, 6.6× at `n = 55`; the certified curve is still widening
+drops to **`0.097×` Lean native at `n = 65`** — a 10.3× speedup over the
+native body (`0.14×`, 7.0× at `n = 55`; the certified curve is still widening
 its lead at the top of the ladder). Checker-only cost accounts for the large
-majority of the full certified path (`≈85..99 %`); the candidate-production
+majority of the full certified path (`≈86..93 %`); the candidate-production
 remainder is small on this family, and its measured share is within run noise
 at the small rungs where it is sub-millisecond.
 The dispatched checker routes harsh-cubic above `n ≈ 25` to the
@@ -435,78 +443,60 @@ same Zenodo 2636367 archive as the native comparator:
 `runIsabelleCertified*NormSq` fixed targets for the random-bounded and
 harsh-cubic ladders.
 
-The random-bounded certified-vs-Isabelle-certified ladder, and the
-harsh-cubic ladder through `n = 55`, were measured in one run on
-`carica` (Apple M2 Ultra, macOS) at commit `c3d2fecb`, with both engines
-hosted in the same process schedule so those gating ratios share a host and
-candidate set. The harsh-cubic Hex-certified column above `n = 55` (and, for
-the consolidated `15..65` curve plotted in the figure, the whole harsh-cubic
-Hex-certified series) comes from the later same-host dedicated sweep
-`hex-lll-certified-harsh-extended-1e6679ff.json`, whose `15..55` result
-hashes match this run exactly; the harsh-cubic Isabelle-certified column is
-this run, which already ran to `n = 65`:
+Each consolidated family sweep measures the Hex-certified and
+Isabelle-certified targets on the same host and at the same clean commit. The
+matching process-floor export comes from the immediately following command:
 
 ```sh
-HEX_LLL_ISABELLE_CERTIFIED_SVP="$(scripts/oracle/setup_lll_isabelle.sh certified)" \
-HEX_FPLLL_FFI_LIB="$(scripts/oracle/setup_fplll_ffi.sh)" \
-lake exe hexlll_bench run \
-  Hex.LLLBench.runCertifiedFirstShortVectorRandomBounded{30,45,60,75,90,120,150,180}Checksum \
-  Hex.LLLBench.runIsabelleCertifiedRandomBoundedNormSq{30,45,60,75,90,120,150,180} \
-  Hex.LLLBench.runCertifiedFirstShortVectorHarshCubic{15,20,25,30,35,40,45,50,55}Checksum \
-  Hex.LLLBench.runIsabelleCertifiedHarshCubicNormSq{15,20,25,30,35,40,45,50,55,60,65} \
-  --export-file reports/bench-results/hex-lll-certified-carica.json
+scripts/dev/run_lll_bench.sh random-bounded RandomBounded
+scripts/dev/run_lll_bench.sh harsh-cubic HarshCubic
 ```
 
-This export sources the random-bounded Lean-certified and both Isabelle-certified
-curves on the comparator plots. The harsh-cubic Lean-certified curve instead
-sources the dedicated `15..65` harsh-cubic sweep
-(`hex-lll-certified-harsh-extended-1e6679ff.json`), which extends that one series
-two rungs past this run; its `15..55` result hashes match this export exactly.
+The raw ratios below use the recorded wall times. The adjusted ratio subtracts
+the matching measured Isabelle-certified process floor (`20.561 ms` for
+random-bounded, `20.578 ms` for harsh-cubic) before dividing. A rung is
+eligible exactly when the floor is no more than 50% of its raw
+Isabelle-certified wall time and that time is below the 10-second ceiling.
 
 Certified-vs-Isabelle-certified random-bounded ratios:
 
-| `n` | Hex certified median | Isabelle certified median | Hex/Isabelle-certified | speedup |
-|---:|---:|---:|---:|---:|
-| 30 | 4.23 ms | 31.54 ms | 0.134 | 7.46× |
-| 45 | 14.11 ms | 57.66 ms | 0.245 | 4.09× |
-| 60 | 32.66 ms | 105.86 ms | 0.309 | 3.24× |
-| 75 | 65.59 ms | 187.17 ms | 0.350 | 2.85× |
-| 90 | 112.71 ms | 307.73 ms | 0.366 | 2.73× |
-| 120 | 274.10 ms | 697.89 ms | 0.393 | 2.55× |
-| 150 | 565.88 ms | 1.34 s | 0.424 | 2.36× |
-| 180 | 954.40 ms | 2.36 s | 0.404 | 2.48× |
+| `n` | Hex certified | Isabelle certified | raw ratio | adjusted ratio | adjusted speedup | status |
+|---:|---:|---:|---:|---:|---:|:---|
+| 30 | 4.13 ms | 33.66 ms | 0.1226 | 0.3150 | 3.18× | floor-dominated |
+| 45 | 13.54 ms | 60.20 ms | 0.2250 | 0.3417 | 2.93× | eligible |
+| 60 | 32.15 ms | 107.05 ms | 0.3004 | 0.3718 | 2.69× | eligible |
+| 75 | 65.61 ms | 190.96 ms | 0.3436 | 0.3851 | 2.60× | eligible |
+| 90 | 111.99 ms | 308.58 ms | 0.3629 | 0.3888 | 2.57× | eligible |
+| 120 | 270.50 ms | 710.34 ms | 0.3808 | 0.3921 | 2.55× | eligible |
+| 150 | 559.43 ms | 1.35 s | 0.4146 | 0.4210 | 2.38× | eligible |
+| 180 | 936.16 ms | 2.36 s | 0.3974 | 0.4009 | 2.49× | eligible |
 
 Certified-vs-Isabelle-certified harsh-cubic ratios:
 
-| `n` | Hex certified median | Isabelle certified median | Hex/Isabelle-certified | speedup |
-|---:|---:|---:|---:|---:|
-| 15 | 832 µs | 20.15 ms | 0.041 | 24.23× |
-| 20 | 2.29 ms | 24.03 ms | 0.095 | 10.51× |
-| 25 | 5.19 ms | 28.01 ms | 0.185 | 5.39× |
-| 30 | 8.14 ms | 38.24 ms | 0.213 | 4.70× |
-| 35 | 11.13 ms | 56.29 ms | 0.198 | 5.06× |
-| 40 | 14.77 ms | 90.02 ms | 0.164 | 6.10× |
-| 45 | 19.95 ms | 149.14 ms | 0.134 | 7.48× |
-| 50 | 27.55 ms | 243.26 ms | 0.113 | 8.83× |
-| 55 | 35.53 ms | 398.40 ms | 0.089 | 11.21× |
-| 60 | 45.38 ms | 628.55 ms | 0.072 | 13.85× |
-| 65 | 56.10 ms | 1.01 s | 0.055 | 18.08× |
+| `n` | Hex certified | Isabelle certified | raw ratio | adjusted ratio | adjusted speedup | status |
+|---:|---:|---:|---:|---:|---:|:---|
+| 15 | 879 µs | 23.00 ms | 0.0382 | 0.3628 | 2.76× | floor-dominated |
+| 20 | 2.28 ms | 25.65 ms | 0.0891 | 0.4504 | 2.22× | floor-dominated |
+| 25 | 5.22 ms | 31.35 ms | 0.1666 | 0.4848 | 2.06× | floor-dominated |
+| 30 | 7.90 ms | 41.02 ms | 0.1926 | 0.3864 | 2.59× | floor-dominated |
+| 35 | 10.98 ms | 58.70 ms | 0.1871 | 0.2882 | 3.47× | eligible |
+| 40 | 15.07 ms | 92.85 ms | 0.1623 | 0.2085 | 4.80× | eligible |
+| 45 | 20.43 ms | 145.25 ms | 0.1407 | 0.1639 | 6.10× | eligible |
+| 50 | 26.40 ms | 244.77 ms | 0.1078 | 0.1177 | 8.49× | eligible |
+| 55 | 33.34 ms | 396.61 ms | 0.0841 | 0.0887 | 11.28× | eligible |
+| 60 | 44.94 ms | 644.05 ms | 0.0698 | 0.0721 | 13.87× | eligible |
+| 65 | 58.61 ms | 995.02 ms | 0.0589 | 0.0601 | 16.63× | eligible |
 
-The Hex-certified column is the harsh-cubic `15..65` sweep
-(`hex-lll-certified-harsh-extended-1e6679ff.json`); the Isabelle-certified
-column is the carica export, which already ran to `n = 65`. Both certified
-ladders now share the full rung schedule.
-
-Gating verdict: **met at every shared rung.** Hex's certified path is faster
-than Isabelle's certified path across both families — by `2.36..7.46×` on
-random-bounded and `4.70..24.23×` on harsh-cubic, the harsh-cubic margin
-widest and still growing at the top rung (`18.08×` at `n = 65`). On
-random-bounded the margin is widest at small `n` (where Isabelle's per-request
-`fplll` subprocess fork dominates), narrows through the middle of the ladder,
-then plateaus at `~2.4×` on the top rungs. On harsh-cubic the margin widens
-above `n = 35` because the Hex enclosure checker scales `~n^2.8` while
-Isabelle's exact checker rides the `~n^4.6` slope of its exact integer
-Gram-Schmidt.
+Gating verdict: **met at every eligible rung.** The random-bounded adjusted
+ratio rises gently from `0.3417` at `n = 45` to about `0.40` on the upper
+rungs, then levels off: Hex remains `2.38..2.93×` faster across seven eligible
+points. The harsh-cubic adjusted ratio falls monotonically from `0.2882` at
+`n = 35` to `0.0601` at `n = 65`: Hex's lead grows from `3.47×` to `16.63×`
+across seven eligible points. The largest eligible rung therefore meets the
+declared gate for both families. The four bottom harsh-cubic rungs and bottom
+random-bounded rung remain in the table for completeness but do not support
+the verdict because the Isabelle per-request fork consumes more than half of
+their wall time.
 
 Architectural asymmetries for this ratio:
 
@@ -539,7 +529,7 @@ per-request `svp_certified` floor — the fixed fork + startup cost of one
 request, which Hex's in-process `fplll-ffi` path avoids. The floor is the
 committed `runIsabelleCertifiedProcessFloorNormSq` benchmark (a trivial 2×2
 request, so its median is the floor with negligible `n`-dependent work),
-measured in the **same run** as the harsh-cubic ladder (~19.9 ms on `carica`)
+measured in the **same run** as the harsh-cubic ladder (~20.6 ms on `carica`)
 so it is a true lower bound under every rung. The comparator drops rungs whose
 raw time is within 15% of the floor (*floor-dominated*: the subtracted value is
 within the floor's own measurement noise), so bottom rungs such as harsh-cubic
@@ -552,19 +542,34 @@ The harsh-cubic plot shows the same five series, and this is the family where
 the certified path's lead matters most. The exact `d`/`ν` reducer rides the
 `~n^5.6` slope of its Θ(n⁴)-bit Gram-determinant state, while the certified path
 — which only checks an fpLLL candidate — stays in a much lower complexity class.
-The Lean-certified curve now runs the full `15..65` schedule (from
-`hex-lll-certified-harsh-extended-1e6679ff.json`), matching the native and
-Isabelle-certified curves rung for rung; it widens its lead over exact native
-across the new top rungs (`0.090×` at `n = 65`).
+The clean consolidated export runs the full `15..65` schedule, matching the
+native and Isabelle-certified curves rung for rung; Lean certified widens its
+lead over exact native across the top rungs (`0.097×` at `n = 65`).
 
 ![Harsh-cubic comparator runtime plot](figures/hex-lll-comparator-harsh-cubic.svg)
 
 Here too the Isabelle-certified curve is adjusted down by its measured
 per-request `svp_certified` floor (the committed
-`runIsabelleCertifiedProcessFloorNormSq` benchmark, ~19.9 ms; see
+`runIsabelleCertifiedProcessFloorNormSq` benchmark, ~20.6 ms; see
 [§Per-call comparator overhead](#per-call-comparator-overhead)); as on the
 random-bounded figure, the ratio tables and scaling fits keep the raw
 medians.
+
+The figures were regenerated from the clean consolidated exports and their
+matching floor exports with:
+
+```sh
+python3 scripts/plots/hex-lll-comparator.py --family random-bounded \
+  --isabelle-floor reports/bench-results/hex-lll-random-bounded-floor-5d16cb58.json
+python3 scripts/plots/hex-lll-comparator.py --family harsh-cubic \
+  --isabelle-floor reports/bench-results/hex-lll-harsh-cubic-floor-67430229.json
+```
+
+The resulting SHA-256 digests are
+`61ff3d738f46655af42efc2377b8733c3f66174af281774dd955d1568deaf01f`
+for `hex-lll-comparator-random-bounded.svg` and
+`546b7c27ae5c668decef5dcbadcef764d6f364e8e7b54a9360b08e06c6ba7f4a`
+for `hex-lll-comparator-harsh-cubic.svg`.
 
 For the asymptotic scaling of these curves — fitted exponents and constant
 factors per method, with reproduction steps — see
@@ -578,24 +583,28 @@ class.
 
 ### Per-call comparator overhead
 
-Both gating and informational comparators are wired through the persistent-subprocess protocol described at the top of `HexLLL/Bench.lean`. The per-call protocol overhead, measured on the audit host, is:
+The external Isabelle and fpylll comparators use the persistent-subprocess
+protocol described at the top of `HexLLL/Bench.lean`; the production fpLLL
+path uses the in-process FFI described above. The per-call protocol overhead,
+measured on the audit host, is:
 
 - `Isabelle` (gating): **~9 µs** per steady-state request after the one-time GHC startup.
-- `Isabelle certified-LLL`: **~19.9 ms** per trivial end-to-end request through
-  persistent `svp_certified`; this includes the per-request `fplll` subprocess
-  and certificate/reducedness checks. This is now a committed, registered
-  measurement — `runIsabelleCertifiedProcessFloorNormSq` (a trivial 2×2
-  request), taken in the same run as the harsh-cubic Isabelle-certified ladder
-  — so the comparator plot subtracts a reproducible floor that is a true lower
-  bound under every rung, rather than a hardcoded constant; the earlier
-  audit-host figure was ~18.8 ms.
+- `Isabelle certified-LLL`: **20.561 ms** for random-bounded and **20.578 ms**
+  for harsh-cubic per trivial end-to-end request through persistent
+  `svp_certified`; this includes the per-request `fplll` subprocess and
+  certificate/reducedness checks. These are committed, registered
+  `runIsabelleCertifiedProcessFloorNormSq` measurements (a trivial 2×2
+  request), taken immediately after their matching family sweeps, so each plot
+  subtracts a reproducible floor rather than a hardcoded constant.
 - `fpLLL via fpylll` (informational): **~34 µs** per steady-state request after the one-time CPython + `import fpylll` startup.
 
-Both figures are below the 5 % overhead-to-measured-time floor that
-`SPEC/benchmarking.md` requires for honest ratios on the regenerated fixed
-comparator rungs. The process-call registrations set `minTotalSeconds := 1.0`,
-so each fixed child runs enough inner iterations to amortize its one-time
-GHC / CPython startup before reporting `total_nanos / inner_repeats`.
+The certified-Isabelle floor exceeds 5% on the lower and middle rungs, so the
+tables report both raw and adjusted ratios there and exclude rungs where it
+exceeds 50% from the gating verdict. The process-call registrations set
+`minTotalSeconds := 1.0`, so each fixed child runs enough inner iterations to
+amortize its one-time GHC startup before reporting
+`total_nanos / inner_repeats`; the separate per-request `fplll` fork remains
+and is removed only by the measured floor adjustment.
 
 ### Densified Lean + Isabelle sweep
 
@@ -716,7 +725,7 @@ Per the HO-18 issue body, the BZ family is reported for context only: its tiny m
 
 ### fpLLL via fplll-ffi (informational)
 
-`SPEC/Libraries/hex-lll.md` classifies the fpLLL comparator as informational
+`HexLLL/SPEC/hex-lll.md` classifies the fpLLL comparator as informational
 and renames it to `fpLLL via fplll-ffi`: the SPEC now requires fpLLL to be
 measured through the in-process `fplll-ffi` FFI shim into `libfplll` (the
 same reducer the certified external-dispatch path resolves at runtime), not
@@ -886,12 +895,4 @@ within ~1.2–2.5× of raw fpLLL. The generators are structurally validated by
 
 ## Concerns
 
-- [#9808](https://github.com/kim-em/hex-dev/issues/9808) tracks completion of
-  the verified-Isabelle comparison ladders.
-- **The verified Isabelle certified-LLL series has only one committed point
-  per family.** This is sufficient for the five-way plot legend and the
-  bottom/shared-rung fast-check verdict above, but it does not yet provide a
-  full-ladder certified-vs-certified trend. The native `verified Isabelle LLL`
-  gate is closed on both headline families: random-bounded `n = 180` is Lean
-  `4.76 s` vs Isabelle `7.55 s`, ratio `0.6304`, and harsh-cubic `n = 65` is
-  Lean `621.32 ms` vs Isabelle `950.08 ms`, ratio `0.6540`.
+None.

--- a/reports/hex-lll-performance.md
+++ b/reports/hex-lll-performance.md
@@ -92,7 +92,7 @@ Scientific run at commit `885431ee1d594b5f6a480cbcfa8f4389e3e3383d` on
 lake exe hexlll_bench run Hex.LLLBench.runSwapStepChecksum Hex.LLLBench.runSizeReduceChecksum Hex.LLLBench.runOfBasisRandomBoundedChecksum Hex.LLLBench.runOfBasisBzRecombinationChecksum Hex.LLLBench.runGramSchmidtCoeffChecksum Hex.LLLBench.runFirstShortVectorHarshCubicChecksum Hex.LLLBench.runPotential Hex.LLLBench.runOfBasisHarshCubicChecksum Hex.LLLBench.runFirstShortVectorRandomBoundedChecksum Hex.LLLBench.runSizeReduceColumnChecksum Hex.LLLBench.runFirstShortVectorBZRecombinationChecksum Hex.LLLBench.runFirstShortVectorHarshCubic15Checksum Hex.LLLBench.runFirstShortVectorRandomBounded30Checksum Hex.LLLBench.runFirstShortVectorBZRecombinationNormSq Hex.LLLBench.runFirstShortVectorRandomBoundedNormSq30 Hex.LLLBench.runFirstShortVectorRandomBoundedNormSq60 Hex.LLLBench.runFirstShortVectorRandomBoundedNormSq120 Hex.LLLBench.runFirstShortVectorRandomBoundedNormSq240 Hex.LLLBench.runFirstShortVectorHarshCubicNormSq15 Hex.LLLBench.runFirstShortVectorHarshCubicNormSq30 Hex.LLLBench.runFirstShortVectorHarshCubicNormSq45 --export-file reports/bench-results/hex-lll-885431e.json
 ```
 
-The run used deterministic inputs from `HexLLL/Bench.lean`; the
+The run used deterministic inputs from `bench/HexLLLBench/Inputs.lean`; the
 random-bounded family uses committed seed `8`. The harness recorded
 `885431e-dirty` because this worktree had an unrelated pre-existing
 `.claude/CLAUDE.md` modification. Export artefact:
@@ -314,7 +314,7 @@ PATH="$PWD/.venv-oracles/bin:$PATH" lake exe hexlll_bench run \
 ```
 
 The run used `fpylll 0.6.4`, `python-flint 0.8.0`, and deterministic benchmark
-inputs from `HexLLL/Bench.lean`; no random seeds are involved. The harness
+inputs from `bench/HexLLLBench/Inputs.lean`; no random seeds are involved. The harness
 recorded `594364a-dirty` because this worktree carried the benchmark
 registration/report edits plus a pre-existing local `.claude/CLAUDE.md`
 modification outside this evidence package. Export artefact:
@@ -344,9 +344,10 @@ checksum.
 
 ## Comparator Ratios
 
-The current implemented gating comparator is `verified Isabelle LLL (AFP LLL_Basis_Reduction; Haskell extraction from Zenodo 2636367)`, declared in `HexLLL/SPEC/hex-lll.md`. The persistent-subprocess harness for it was wired in HO-16 (#3676); the in-process fpLLL FFI was wired later for the production certified path. The densified `random-bounded` and `harsh-cubic` ladders are the post-HO-18 fixed-benchmark schedules — `random-bounded` `n ∈ {30, 45, 60, 75, 90, 120, 150, 180}`, `harsh-cubic` `n ∈ {15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65}` — per the post-#3657 §"Headline reports" densification rule.
+The current implemented gating comparator is `verified Isabelle LLL (AFP LLL_Basis_Reduction; Haskell extraction from Zenodo 2636367)`, declared in `libraries.yml` under `HexLLL.phase4.comparators`. The persistent-subprocess harness for it was wired in HO-16 (#3676); the in-process fpLLL FFI was wired later for the production certified path. The densified `random-bounded` and `harsh-cubic` ladders are the post-HO-18 fixed-benchmark schedules — `random-bounded` `n ∈ {30, 45, 60, 75, 90, 120, 150, 180}`, `harsh-cubic` `n ∈ {15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65}` — per the post-#3657 §"Headline reports" densification rule.
 
-The certified external-dispatch SPEC also declares the gating comparator
+The same `libraries.yml` block also declares the certified external-dispatch
+gating comparator
 `verified Isabelle certified-LLL (JAR 2020 §7; svp_certified from the Zenodo 2636367 LLL_Basis_Reduction extraction, same archive as the native comparator)`.
 The Hex certified path is now registered as fixed process-call targets:
 `runCertifiedFirstShortVectorRandomBounded{30,45,60,75,90,120,150,180}Checksum`
@@ -363,8 +364,9 @@ Ultra, macOS) with `scripts/dev/run_lll_bench.sh random-bounded RandomBounded`
 at commit `5d16cb58f92bd69590b2439b89c83894d3798e4b` and
 `scripts/dev/run_lll_bench.sh harsh-cubic HarshCubic` at commit
 `674302291e3c04dbd7e6b4252056ef33859c2e39`. The commands load the pinned
-native Isabelle, certified Isabelle, and `fplll-ffi` oracles, run every target
-whose name contains the family filter, and record three warm outer repeats.
+native Isabelle, certified Isabelle, and `fplll-ffi` oracles and run every
+target whose name contains the family filter. Each native, certified, and
+Isabelle target records three warm outer repeats; the fpLLL targets record five.
 The exports and measured certified-Isabelle process floors are:
 
 - `reports/bench-results/hex-lll-random-bounded-5d16cb58.json`, SHA-256
@@ -376,9 +378,12 @@ The exports and measured certified-Isabelle process floors are:
   floor `reports/bench-results/hex-lll-harsh-cubic-floor-67430229.json`,
   SHA-256 `2101e94e4dce5c7f4c8aaf643db9b1aadbd0be6104006a7f754d4d5560310b72`.
 
-Both exports record `git_dirty=false`. All certified-path and checker-only rows
-have repeat-stable hashes. A rejected candidate makes the fixed target fail;
-all 11,896 timed certified calls completed, so the measured rejection rate is
+Both family exports record `git_dirty=false`. The floor exports record
+`git_dirty=true` only because the preceding command has written its then-
+untracked family export; no source changes occur between the family and floor
+measurements. All certified-path and checker-only rows have repeat-stable
+hashes. A rejected candidate makes the fixed target fail; all 11,896 timed
+certified calls completed, so the measured rejection rate is
 `0 / 11,896 = 0 %`.
 
 Lean-certified-vs-Lean-native random-bounded ratios:
@@ -439,7 +444,7 @@ materialized comparison.
 The external `verified Isabelle certified-LLL` executable is now wired from the
 same Zenodo 2636367 archive as the native comparator:
 `scripts/oracle/setup_lll_isabelle.sh certified` builds
-`experiments/svp_certified`, and `HexLLL/Bench.lean` exposes persistent
+`experiments/svp_certified`, and `bench/HexLLLBench/Main.lean` exposes persistent
 `runIsabelleCertified*NormSq` fixed targets for the random-bounded and
 harsh-cubic ladders.
 
@@ -456,13 +461,16 @@ The raw ratios below use the recorded wall times. The adjusted ratio subtracts
 the matching measured Isabelle-certified process floor (`20.561 ms` for
 random-bounded, `20.578 ms` for harsh-cubic) before dividing. A rung is
 eligible exactly when the floor is no more than 50% of its raw
-Isabelle-certified wall time and that time is below the 10-second ceiling.
+Isabelle-certified wall time and that time is below the 10-second hard ceiling.
+The top two random-bounded rungs exceed the 1-second soft target because they
+are needed to show that the adjusted ratio levels off; both remain well below
+the hard ceiling.
 
 Certified-vs-Isabelle-certified random-bounded ratios:
 
 | `n` | Hex certified | Isabelle certified | raw ratio | adjusted ratio | adjusted speedup | status |
 |---:|---:|---:|---:|---:|---:|:---|
-| 30 | 4.13 ms | 33.66 ms | 0.1226 | 0.3150 | 3.18× | floor-dominated |
+| 30 | 4.13 ms | 33.66 ms | 0.1226 | 0.3150 | 3.18× | ineligible: floor > 50% |
 | 45 | 13.54 ms | 60.20 ms | 0.2250 | 0.3417 | 2.93× | eligible |
 | 60 | 32.15 ms | 107.05 ms | 0.3004 | 0.3718 | 2.69× | eligible |
 | 75 | 65.61 ms | 190.96 ms | 0.3436 | 0.3851 | 2.60× | eligible |
@@ -475,10 +483,10 @@ Certified-vs-Isabelle-certified harsh-cubic ratios:
 
 | `n` | Hex certified | Isabelle certified | raw ratio | adjusted ratio | adjusted speedup | status |
 |---:|---:|---:|---:|---:|---:|:---|
-| 15 | 879 µs | 23.00 ms | 0.0382 | 0.3628 | 2.76× | floor-dominated |
-| 20 | 2.28 ms | 25.65 ms | 0.0891 | 0.4504 | 2.22× | floor-dominated |
-| 25 | 5.22 ms | 31.35 ms | 0.1666 | 0.4848 | 2.06× | floor-dominated |
-| 30 | 7.90 ms | 41.02 ms | 0.1926 | 0.3864 | 2.59× | floor-dominated |
+| 15 | 879 µs | 23.00 ms | 0.0382 | 0.3628 | 2.76× | ineligible: floor > 50% |
+| 20 | 2.28 ms | 25.65 ms | 0.0891 | 0.4504 | 2.22× | ineligible: floor > 50% |
+| 25 | 5.22 ms | 31.35 ms | 0.1666 | 0.4848 | 2.06× | ineligible: floor > 50% |
+| 30 | 7.90 ms | 41.02 ms | 0.1926 | 0.3864 | 2.59× | ineligible: floor > 50% |
 | 35 | 10.98 ms | 58.70 ms | 0.1871 | 0.2882 | 3.47× | eligible |
 | 40 | 15.07 ms | 92.85 ms | 0.1623 | 0.2085 | 4.80× | eligible |
 | 45 | 20.43 ms | 145.25 ms | 0.1407 | 0.1639 | 6.10× | eligible |
@@ -529,7 +537,8 @@ per-request `svp_certified` floor — the fixed fork + startup cost of one
 request, which Hex's in-process `fplll-ffi` path avoids. The floor is the
 committed `runIsabelleCertifiedProcessFloorNormSq` benchmark (a trivial 2×2
 request, so its median is the floor with negligible `n`-dependent work),
-measured in the **same run** as the harsh-cubic ladder (~20.6 ms on `carica`)
+measured immediately after the random-bounded ladder in the same session
+(`20.561 ms` on `carica`)
 so it is a true lower bound under every rung. The comparator drops rungs whose
 raw time is within 15% of the floor (*floor-dominated*: the subtracted value is
 within the floor's own measurement noise), so bottom rungs such as harsh-cubic
@@ -573,7 +582,7 @@ for `hex-lll-comparator-harsh-cubic.svg`.
 
 For the asymptotic scaling of these curves — fitted exponents and constant
 factors per method, with reproduction steps — see
-[hex-lll-scaling.md](hex-lll-scaling.md). In brief: on random-bounded the
+[HexLLL/PERFORMANCE.md](../HexLLL/PERFORMANCE.md). In brief: on random-bounded the
 exact-native, certified, and fpLLL methods are all near-`n³` and differ by
 constant factors (Lean certified faster than exact native); on harsh-cubic the
 exact native reducer (`~n^5.6`) fans out from the certified path (`~n^2.79`) and
@@ -583,9 +592,9 @@ class.
 
 ### Per-call comparator overhead
 
-The external Isabelle and fpylll comparators use the persistent-subprocess
-protocol described at the top of `HexLLL/Bench.lean`; the production fpLLL
-path uses the in-process FFI described above. The per-call protocol overhead,
+The external Isabelle comparators use the persistent-subprocess protocol
+described at the top of `bench/HexLLLBench/Main.lean`; the production fpLLL path
+uses the in-process FFI described above. The per-call protocol overhead,
 measured on the audit host, is:
 
 - `Isabelle` (gating): **~9 µs** per steady-state request after the one-time GHC startup.
@@ -596,8 +605,6 @@ measured on the audit host, is:
   `runIsabelleCertifiedProcessFloorNormSq` measurements (a trivial 2×2
   request), taken immediately after their matching family sweeps, so each plot
   subtracts a reproducible floor rather than a hardcoded constant.
-- `fpLLL via fpylll` (informational): **~34 µs** per steady-state request after the one-time CPython + `import fpylll` startup.
-
 The certified-Isabelle floor exceeds 5% on the lower and middle rungs, so the
 tables report both raw and adjusted ratios there and exclude rungs where it
 exceeds 50% from the gating verdict. The process-call registrations set
@@ -606,116 +613,54 @@ amortize its one-time GHC startup before reporting
 `total_nanos / inner_repeats`; the separate per-request `fplll` fork remains
 and is removed only by the measured floor adjustment.
 
-### Densified Lean + Isabelle sweep
+### Verified Isabelle native gate
 
-Combined Lean + Isabelle sweep at commit `6fcd1185cee03cec228194857b3bab0816060158` on `carica` (Apple M2 Ultra, macOS), recorded from `2026-06-01T12:15:13Z` through `2026-06-01T12:51:25Z`. The harness recorded `6fcd118-dirty` because this worktree carried a pre-existing local `.claude/CLAUDE.md` modification outside this evidence package.
+The same clean consolidated exports and commands cited above contain the exact
+Lean native reducer (`runNativeFirstShortVector*NormSq`) and persistent
+`svp_verified` rows, so the native and certified Isabelle gates now share
+current, reachable evidence. The native comparator's measured steady-state
+protocol overhead is about `9 µs`, below 5% of every rung, so only the raw
+ratios are required.
 
-Sweep command:
+Random-bounded native-vs-Isabelle ratios:
 
-```sh
-lake exe hexlll_bench run \
-  Hex.LLLBench.runFirstShortVectorRandomBoundedNormSq30 \
-  Hex.LLLBench.runIsabelleRandomBoundedNormSq30 \
-  Hex.LLLBench.runFirstShortVectorRandomBoundedNormSq45 \
-  Hex.LLLBench.runIsabelleRandomBoundedNormSq45 \
-  Hex.LLLBench.runFirstShortVectorRandomBoundedNormSq60 \
-  Hex.LLLBench.runIsabelleRandomBoundedNormSq60 \
-  Hex.LLLBench.runFirstShortVectorRandomBoundedNormSq75 \
-  Hex.LLLBench.runIsabelleRandomBoundedNormSq75 \
-  Hex.LLLBench.runFirstShortVectorRandomBoundedNormSq90 \
-  Hex.LLLBench.runIsabelleRandomBoundedNormSq90 \
-  Hex.LLLBench.runFirstShortVectorRandomBoundedNormSq120 \
-  Hex.LLLBench.runIsabelleRandomBoundedNormSq120 \
-  Hex.LLLBench.runFirstShortVectorRandomBoundedNormSq150 \
-  Hex.LLLBench.runIsabelleRandomBoundedNormSq150 \
-  Hex.LLLBench.runFirstShortVectorRandomBoundedNormSq180 \
-  Hex.LLLBench.runIsabelleRandomBoundedNormSq180 \
-  Hex.LLLBench.runFirstShortVectorHarshCubicNormSq15 \
-  Hex.LLLBench.runIsabelleHarshCubicNormSq15 \
-  Hex.LLLBench.runFirstShortVectorHarshCubicNormSq20 \
-  Hex.LLLBench.runIsabelleHarshCubicNormSq20 \
-  Hex.LLLBench.runFirstShortVectorHarshCubicNormSq25 \
-  Hex.LLLBench.runIsabelleHarshCubicNormSq25 \
-  Hex.LLLBench.runFirstShortVectorHarshCubicNormSq30 \
-  Hex.LLLBench.runIsabelleHarshCubicNormSq30 \
-  Hex.LLLBench.runFirstShortVectorHarshCubicNormSq35 \
-  Hex.LLLBench.runIsabelleHarshCubicNormSq35 \
-  Hex.LLLBench.runFirstShortVectorHarshCubicNormSq40 \
-  Hex.LLLBench.runIsabelleHarshCubicNormSq40 \
-  Hex.LLLBench.runFirstShortVectorHarshCubicNormSq45 \
-  Hex.LLLBench.runIsabelleHarshCubicNormSq45 \
-  Hex.LLLBench.runFirstShortVectorHarshCubicNormSq50 \
-  Hex.LLLBench.runIsabelleHarshCubicNormSq50 \
-  Hex.LLLBench.runFirstShortVectorHarshCubicNormSq55 \
-  Hex.LLLBench.runIsabelleHarshCubicNormSq55 \
-  Hex.LLLBench.runFirstShortVectorBZRecombinationNormSq \
-  Hex.LLLBench.runIsabelleBZRecombinationNormSq \
-  --export-file reports/bench-results/hex-lll-densified-6fcd1185cee0.json
-```
+| `n` | Lean native | Isabelle native | Lean/Isabelle | speedup | status |
+|---:|---:|---:|---:|---:|:---|
+| 30 | 14.64 ms | 16.09 ms | 0.9096 | 1.10× | eligible |
+| 45 | 50.97 ms | 62.48 ms | 0.8158 | 1.23× | eligible |
+| 60 | 129.84 ms | 163.02 ms | 0.7964 | 1.26× | eligible |
+| 75 | 287.53 ms | 360.92 ms | 0.7967 | 1.26× | eligible |
+| 90 | 471.31 ms | 660.19 ms | 0.7139 | 1.40× | eligible |
+| 120 | 1.22 s | 1.83 s | 0.6678 | 1.50× | eligible |
+| 150 | 2.45 s | 3.76 s | 0.6509 | 1.54× | eligible |
+| 180 | 4.36 s | 7.11 s | 0.6130 | 1.63× | eligible |
 
-Export artefact: `reports/bench-results/hex-lll-densified-6fcd1185cee0.json`, SHA-256 `8917e96a952d7d2e40bdcea21d5399808dcd32fcec37114a06dd884e292effd9`.
+The ratio declines from `0.9096` at `n = 30` to `0.6130` at `n = 180`:
+Lean's lead grows across the ladder. The upper three rungs exceed the 1-second
+soft target but are retained to make that trend unambiguous and remain below
+the 10-second hard ceiling. At the largest eligible rung, Lean is 1.63× faster;
+the native gating goal is **met**.
 
-Comparator source: `scripts/oracle/setup_lll_isabelle.sh` downloads and verifies Zenodo record `2636367`, archive SHA-256 `5c975aeb2033540b8f9a05d2ffac87dca0f258e887a5807edefbe60178a547e0`, then runs `svp_verified`.
+Harsh-cubic native-vs-Isabelle ratios:
 
-### random-bounded ladder
+| `n` | Lean native | Isabelle native | Lean/Isabelle | speedup | status |
+|---:|---:|---:|---:|---:|:---|
+| 15 | 494 µs | 718 µs | 0.6885 | 1.45× | eligible |
+| 20 | 1.59 ms | 2.03 ms | 0.7854 | 1.27× | eligible |
+| 25 | 4.05 ms | 5.04 ms | 0.8046 | 1.24× | eligible |
+| 30 | 9.32 ms | 12.07 ms | 0.7717 | 1.30× | eligible |
+| 35 | 19.36 ms | 25.99 ms | 0.7450 | 1.34× | eligible |
+| 40 | 39.02 ms | 54.20 ms | 0.7198 | 1.39× | eligible |
+| 45 | 73.48 ms | 102.96 ms | 0.7137 | 1.40× | eligible |
+| 50 | 130.83 ms | 191.04 ms | 0.6848 | 1.46× | eligible |
+| 55 | 234.98 ms | 339.74 ms | 0.6917 | 1.45× | eligible |
+| 60 | 375.02 ms | 557.19 ms | 0.6730 | 1.49× | eligible |
+| 65 | 602.42 ms | 909.38 ms | 0.6625 | 1.51× | eligible |
 
-All three medians come from
-`reports/bench-results/hex-lll-random-bounded-schur.json`, a single
-Lean+Isabelle+fpylll sweep on `carica` (Apple M2 Ultra, macOS) with
-`warmupFirstIter := true`, all four post-#6330 perf fixes in
-(#6338, #6339, #6348, #6350), and the per-row Schur scaled-coefficient
-kernel.
-
-| `n` | Lean median | Isabelle median | fpylll median | Lean/Isabelle | speedup vs Isabelle | status |
-|---:|---:|---:|---:|---:|---:|:---|
-| 30 | 15.14 ms | 16.81 ms | 1.84 ms | 0.9007 | Lean 1.11× faster | eligible |
-| 45 | 55.53 ms | 64.85 ms | 4.83 ms | 0.8563 | Lean 1.17× faster | eligible |
-| 60 | 142.01 ms | 176.93 ms | 9.64 ms | 0.8026 | Lean 1.25× faster | eligible |
-| 75 | 296.58 ms | 383.34 ms | 19.41 ms | 0.7737 | Lean 1.29× faster | eligible |
-| 90 | 495.68 ms | 691.52 ms | 31.62 ms | 0.7168 | Lean 1.40× faster | eligible |
-| 120 | 1.39 s | 1.93 s | 76.61 ms | 0.7213 | Lean 1.39× faster | eligible |
-| 150 | 2.65 s | 3.98 s | 151.93 ms | 0.6639 | Lean 1.51× faster | eligible |
-| 180 | 4.76 s | 7.55 s | 268.23 ms | 0.6304 | Lean 1.59× faster | eligible |
-
-**Trend.** Across the eligible range `n = 30..180`, the Lean/Isabelle ratio moves from `0.9007` to `0.6304`: Lean's lead grows with `n`.
-
-**Gating-goal verdict (largest eligible rung `n = 180`).** Lean `4.76 s` vs Isabelle `7.55 s`; ratio `0.6304` (Lean 1.59× faster). Gating-goal verdict: **met**.
-
-### harsh-cubic ladder
-
-Lean and Isabelle medians come from
-`reports/bench-results/hex-lll-harsh-cubic-extended-schur-lean-isabelle.json`,
-a single sweep on `carica` (Apple M2 Ultra, macOS) with
-`warmupFirstIter := true`, all four post-#6330 perf fixes in
-(#6338, #6339, #6348, #6350), and the per-row Schur scaled-coefficient
-kernel. The fpylll comparator medians in the consolidated
-`reports/bench-results/hex-lll-harsh-cubic-extended-schur.json` are the
-unchanged fpylll series from the post-perf export.
-
-| `n` | Lean median | Isabelle median | fpylll median | Lean/Isabelle | speedup vs Isabelle | status |
-|---:|---:|---:|---:|---:|---:|:---|
-| 15 | 515 µs | 763 µs | 429 µs | 0.6743 | Lean 1.48× faster | eligible |
-| 20 | 1.67 ms | 2.17 ms | 829 µs | 0.7693 | Lean 1.30× faster | eligible |
-| 25 | 4.15 ms | 5.23 ms | 1.33 ms | 0.7931 | Lean 1.26× faster | eligible |
-| 30 | 9.53 ms | 12.40 ms | 1.99 ms | 0.7689 | Lean 1.30× faster | eligible |
-| 35 | 19.65 ms | 27.17 ms | 2.60 ms | 0.7230 | Lean 1.38× faster | eligible |
-| 40 | 39.44 ms | 56.52 ms | 3.59 ms | 0.6978 | Lean 1.43× faster | eligible |
-| 45 | 75.83 ms | 109.94 ms | 4.71 ms | 0.6897 | Lean 1.45× faster | eligible |
-| 50 | 135.80 ms | 199.09 ms | 5.75 ms | 0.6821 | Lean 1.47× faster | eligible |
-| 55 | 234.28 ms | 356.01 ms | 7.36 ms | 0.6581 | Lean 1.52× faster | eligible |
-| 60 | 381.56 ms | 597.68 ms | 9.21 ms | 0.6384 | Lean 1.57× faster | eligible |
-| 65 | 621.32 ms | 950.08 ms | 10.78 ms | 0.6540 | Lean 1.53× faster | eligible |
-
-**Trend.** Across the eligible range `n = 15..65`, the Lean/Isabelle ratio stays below `1.0` and moves from `0.6743` to `0.6540`; Lean is faster than Isabelle on every harsh-cubic rung.
-
-**Gating-goal verdict (largest eligible rung `n = 65`).** Lean `621.32 ms` vs Isabelle `950.08 ms`; ratio `0.6540` (Lean 1.53× faster). Gating-goal verdict: **met**.
-
-The four post-#6330 perf fixes (`swapStep` #6338, `stepScaledRows`
-#6339, `exactDiv` #6348, `setEntry` #6350) closed most of the
-previously-reported gap, and the Schur recurrence closes the remaining
-structural gap: the Lean/Isabelle ratio at `n = 65` moved from `1.90×`
-(post-warmupFirstIter, pre-perf-fix) to `1.14×` after the four point
-fixes, and now to `0.6540`.
+The ratio stays below `1.0` at every rung and settles from `0.6885` at
+`n = 15` to `0.6625` at `n = 65`; the small middle-rung rise reverses above
+`n = 25`. At the largest eligible rung, Lean is 1.51× faster, so the native
+gating goal is **met**.
 
 ### bz-recombination (context only)
 
@@ -725,84 +670,43 @@ Per the HO-18 issue body, the BZ family is reported for context only: its tiny m
 
 ### fpLLL via fplll-ffi (informational)
 
-`HexLLL/SPEC/hex-lll.md` classifies the fpLLL comparator as informational
-and renames it to `fpLLL via fplll-ffi`: the SPEC now requires fpLLL to be
-measured through the in-process `fplll-ffi` FFI shim into `libfplll` (the
-same reducer the certified external-dispatch path resolves at runtime), not
-through a Python `fpylll` subprocess whose interpreter and IPC overhead the
-runtime path never pays. The data in this section was collected before that
-rename, via the legacy `fpylll` persistent-subprocess wiring (`Hex.LLLBench.runFpylll*`
-targets); it is retained as transitional context and will be replaced by an
-`fplll-ffi` sweep when the shim is wired into `hexlll_bench`.
+`libraries.yml` classifies this comparator as informational and requires the
+in-process `fplll-ffi` shim into `libfplll`, the same reducer used by the
+certified dispatch. The current consolidated family exports contain its
+`runFpLLLFirstShortVector*Checksum` rows with five repeats and stable hashes.
+Because this is an in-process call, there is no process floor to subtract.
 
-The most recent informational fpLLL sweep is from worktree commit
-`594364a5d86cc9daaf26c53a8b6a137998b38a6e` on `carica` (Apple M2 Ultra,
-macOS), command:
+| random-bounded `n` | Lean native | fpLLL | fpLLL/Lean |
+|---:|---:|---:|---:|
+| 30 | 14.64 ms | 1.38 ms | 0.0945 |
+| 45 | 50.97 ms | 5.06 ms | 0.0993 |
+| 60 | 129.84 ms | 12.15 ms | 0.0936 |
+| 75 | 287.53 ms | 25.45 ms | 0.0885 |
+| 90 | 471.31 ms | 42.43 ms | 0.0900 |
+| 120 | 1.22 s | 103.72 ms | 0.0847 |
+| 150 | 2.45 s | 199.22 ms | 0.0815 |
+| 180 | 4.36 s | 335.44 ms | 0.0770 |
 
-```sh
-PATH="$PWD/.venv-oracles/bin:$PATH" lake exe hexlll_bench run \
-  Hex.LLLBench.runFpylllFirstShortVectorRandomBounded30Checksum \
-  Hex.LLLBench.runFpylllFirstShortVectorRandomBounded45Checksum \
-  Hex.LLLBench.runFpylllFirstShortVectorRandomBounded60Checksum \
-  Hex.LLLBench.runFpylllFirstShortVectorRandomBounded75Checksum \
-  Hex.LLLBench.runFpylllFirstShortVectorRandomBounded90Checksum \
-  Hex.LLLBench.runFpylllFirstShortVectorRandomBounded120Checksum \
-  Hex.LLLBench.runFpylllFirstShortVectorRandomBounded150Checksum \
-  Hex.LLLBench.runFpylllFirstShortVectorRandomBounded180Checksum \
-  --export-file reports/bench-results/hex-lll-fpylll-0c2d9a9e2d0a.json
-```
+The random-bounded ratio stays near a small constant and gently declines from
+`0.0945` to `0.0770`; fpLLL is about 10.1–13.0× faster than exact Lean native.
 
-Export artefact: `reports/bench-results/hex-lll-fpylll-0c2d9a9e2d0a.json`,
-SHA-256 `21fcd94e1dbf8e745ace1f14fbc31cb93be139c2c4119350f51e8ace332affd3`.
+| harsh-cubic `n` | Lean native | fpLLL | fpLLL/Lean |
+|---:|---:|---:|---:|
+| 15 | 494 µs | 80 µs | 0.1613 |
+| 20 | 1.59 ms | 234 µs | 0.1468 |
+| 25 | 4.05 ms | 432 µs | 0.1067 |
+| 30 | 9.32 ms | 651 µs | 0.0699 |
+| 35 | 19.36 ms | 947 µs | 0.0489 |
+| 40 | 39.02 ms | 1.24 ms | 0.0318 |
+| 45 | 73.48 ms | 1.88 ms | 0.0256 |
+| 50 | 130.83 ms | 2.42 ms | 0.0185 |
+| 55 | 234.98 ms | 3.10 ms | 0.0132 |
+| 60 | 375.02 ms | 4.03 ms | 0.0107 |
+| 65 | 602.42 ms | 4.71 ms | 0.0078 |
 
-- `random-bounded` `n = 30`: Lean median `18.403 ms`, fpLLL median `1.837 ms`, fpLLL relative median `0.100×` (raw); adjusted for ~34 µs protocol overhead, `0.098×`.
-- `random-bounded` `n = 45`: Lean median `69.406 ms`, fpLLL median `4.784 ms`, fpLLL relative median `0.069×` (raw); adjusted `0.068×`.
-- `random-bounded` `n = 60`: Lean median `179.295 ms`, fpLLL median `9.756 ms`, fpLLL relative median `0.054×` (raw); adjusted `0.054×`.
-- `random-bounded` `n = 75`: Lean median `371.360 ms`, fpLLL median `19.446 ms`, fpLLL relative median `0.052×` (raw); adjusted `0.052×`.
-- `random-bounded` `n = 90`: Lean median `650.187 ms`, fpLLL median `32.003 ms`, fpLLL relative median `0.049×` (raw); adjusted `0.049×`.
-- `random-bounded` `n = 120`: Lean median `1.839 s`, fpLLL median `76.952 ms`, fpLLL relative median `0.042×` (raw); adjusted `0.042×`.
-- `random-bounded` `n = 150`: Lean median `3.778 s`, fpLLL median `153.998 ms`, fpLLL relative median `0.041×` (raw); adjusted `0.041×`.
-- `random-bounded` `n = 180`: Lean median `6.939 s`, fpLLL median `271.702 ms`, fpLLL relative median `0.039×` (raw); adjusted `0.039×`.
-
-Harsh-cubic fpLLL sweep at worktree commit
-`594364a5d86cc9daaf26c53a8b6a137998b38a6e` on `carica`
-(Apple M2 Ultra, macOS), command:
-
-```sh
-PATH="$PWD/.venv-oracles/bin:$PATH" lake exe hexlll_bench run \
-  Hex.LLLBench.runFpylllFirstShortVectorHarshCubic15Checksum \
-  Hex.LLLBench.runFpylllFirstShortVectorHarshCubic20Checksum \
-  Hex.LLLBench.runFpylllFirstShortVectorHarshCubic25Checksum \
-  Hex.LLLBench.runFpylllFirstShortVectorHarshCubic30Checksum \
-  Hex.LLLBench.runFpylllFirstShortVectorHarshCubic35Checksum \
-  Hex.LLLBench.runFpylllFirstShortVectorHarshCubic40Checksum \
-  Hex.LLLBench.runFpylllFirstShortVectorHarshCubic45Checksum \
-  Hex.LLLBench.runFpylllFirstShortVectorHarshCubic50Checksum \
-  Hex.LLLBench.runFpylllFirstShortVectorHarshCubic55Checksum \
-  --export-file reports/bench-results/hex-lll-fpylll-harsh-cubic-4a69408a680d.json
-```
-
-The harness recorded `594364a-dirty` because this worktree carried the
-benchmark registration/report edits plus a pre-existing local `.claude/CLAUDE.md`
-modification outside this evidence package. Export artefact:
-`reports/bench-results/hex-lll-fpylll-harsh-cubic-4a69408a680d.json`,
-SHA-256 `572afe6866d80e4fd0f54519c3fbdf5bd6946cddcb919d8591e6642a1154aa0f`.
-
-- `harsh-cubic` `n = 15`: Lean median `898.791 us`, fpLLL median `423.473 us`, fpLLL relative median `0.471×` (raw); adjusted `0.433×`.
-- `harsh-cubic` `n = 20`: Lean median `3.191 ms`, fpLLL median `823.053 us`, fpLLL relative median `0.258×` (raw); adjusted `0.247×`.
-- `harsh-cubic` `n = 25`: Lean median `8.331 ms`, fpLLL median `1.291 ms`, fpLLL relative median `0.155×` (raw); adjusted `0.151×`.
-- `harsh-cubic` `n = 30`: Lean median `22.022 ms`, fpLLL median `1.961 ms`, fpLLL relative median `0.089×` (raw); adjusted `0.087×`.
-- `harsh-cubic` `n = 35`: Lean median `49.134 ms`, fpLLL median `2.598 ms`, fpLLL relative median `0.053×` (raw); adjusted `0.052×`.
-- `harsh-cubic` `n = 40`: Lean median `105.251 ms`, fpLLL median `3.530 ms`, fpLLL relative median `0.034×` (raw); adjusted `0.033×`.
-- `harsh-cubic` `n = 45`: Lean median `202.061 ms`, fpLLL median `4.678 ms`, fpLLL relative median `0.023×` (raw); adjusted `0.023×`.
-- `harsh-cubic` `n = 50`: Lean median `377.282 ms`, fpLLL median `5.913 ms`, fpLLL relative median `0.016×` (raw); adjusted `0.016×`.
-- `harsh-cubic` `n = 55`: Lean median `640.050 ms`, fpLLL median `7.356 ms`, fpLLL relative median `0.011×` (raw); adjusted `0.011×`.
-
-The regenerated fpLLL fixed-mode targets amortize CPython + `import fpylll`
-startup inside each measured child. Across both `random-bounded` and
-`harsh-cubic`, fpLLL is faster than Lean at every reported rung. Because
-fpylll is informational, these trends remain context rather than a gating
-performance signal for HexLLL.
+The harsh-cubic ratio falls throughout the ladder as exact integer operand
+growth drives Lean native away from fpLLL's floating-point path. That expected
+algorithm-class divergence is informational rather than a gating failure.
 
 ## Profile
 

--- a/scripts/plots/hex-lll-comparator.py
+++ b/scripts/plots/hex-lll-comparator.py
@@ -37,7 +37,7 @@ DEFAULT_ISABELLE_BOTTOM = (
 # checker, while the Isabelle-certified ladder is the full Lean+Isabelle
 # schedule (the Lean-certified export carries no Isabelle rows). Within
 # each series the rungs share a host and commit; the cross-series ratio
-# carries the cross-run caveat recorded in reports/hex-lll-scaling.md.
+# carries the cross-run caveat recorded in HexLLL/PERFORMANCE.md.
 DEFAULT_CERTIFIED = ROOT / "reports/bench-results/hex-lll-certified-c3d2fecb.json"
 # The harsh-cubic Lean-certified ladder runs to n = 65, two rungs past the
 # random-bounded certified run; its export is the dedicated 15–65 harsh-cubic


### PR DESCRIPTION
Closes #9808.

## Summary

- replace the stale single-point certified-Isabelle discussion with the clean, matched random-bounded and harsh-cubic ladder exports already committed in the repository
- report raw and process-floor-adjusted certified-vs-certified ratios, eligibility, seven-point trends, artifact and figure hashes, and regeneration commands
- source the native Isabelle and informational fpLLL tables from those same current, reachable exports, removing obsolete comparator evidence
- refresh both headline comparator figures, clear `## Concerns`, and re-promote HexLLL through Phase 7

## Verification

- `lake exe hexlll_bench verify` (all 291 benchmarks passed with the optional Isabelle and fplll providers configured)
- refreshed `reports/figures/hex-lll-comparator-{random-bounded,harsh-cubic}.svg`
- `python3 scripts/check_phase4.py`
- `python3 scripts/check_phase7.py`
- `python3 scripts/release/check_released_manifest.py`
- `python3 scripts/check_dag.py`
- `git diff --check`
