### PR TITLE
test(primality): complete Phase-3 conformance and oracle coverage

### DIFF
--- a/HexPrimality/SPEC/hex-primality.md
+++ b/HexPrimality/SPEC/hex-primality.md
@@ -1223,6 +1223,17 @@ but PARI plus python-flint already cover the verdict surface and the
 second opinion, so this SPEC uses that pair and adds no third
 dependency.
 
+**Mode: required.** The existing single-job oracle tail installs and preflights
+PARI/cypari2 and python-flint, diffs fresh deterministic emission against the
+committed snapshot, and fails if either the dependency or a comparison is
+unavailable. Fixtures are limited to results the oracle can recompute from the
+original input: verdicts, certificate-checker replay, and prime segments.
+Multiplicative-order laws, p−1 and Brent routes, exact search accounting and
+bounded failures, sieve representation, total fallback, and the term/tactic
+surface are covered by `HexPrimality.Conformance`; PARI cannot independently
+establish those implementation-level properties, so emitting them would add
+ceremony rather than independent evidence.
+
 ## Benchmarking
 
 Per [SPEC/benchmarking.md](../../SPEC/benchmarking.md), with drivers at

--- a/HexPrimality/SPEC/hex-primality.md
+++ b/HexPrimality/SPEC/hex-primality.md
@@ -555,6 +555,8 @@ structure PMinusOneAttempt where
   attempts : Nat
   rand     : Rand
 
+def pMinusOneStage1 (n base bound : Nat) : PMinusOneResult
+
 def pMinusOneStage1Counted (n base bound : Nat) (r : Rand) :
     PMinusOneAttempt
 
@@ -1205,17 +1207,16 @@ Cases that must be present:
   migrated view has the same contents in the same order. Current core
   conformance does not import that unreleased downstream consumer.
 
-**Oracle choice.** PARI's `isprime`, `nextprime`, and `primes`
-through cypari2 cover the verdict surface, and cypari2 is already
-installed by the CI dependency step. Current PARI exposes certificates
-through `primecert`, not through the result of `isprime(n, 1)`;
-`primecert(n,,1)` requests its N-1 certificate form. The oracle validates
-that object with `primecertisvalid`, translates the cases satisfying this
-checker's `m = 1` hypotheses, and commits accepted translations as
-`certcheck` fixtures. Agreement on all `isprime` verdicts remains required
-even when PARI chooses another certificate form. python-flint's
-`fmpz.is_prime` is the second opinion on the large cases and is likewise
-already installed.
+**Oracle choice.** PARI's `isprime`, `nextprime`, and `primes` through
+cypari2 independently cover verdicts, next-prime results, and segments.
+Certificate fixtures are replayed by a separate Python implementation of the
+checker; PARI supplies every small-leaf primality verdict and independently
+confirms the subject of every accepted certificate. The rejected certificates
+are hand-constructed clause tests, so their independent evidence is agreement
+with that replay rather than a PARI certificate format. python-flint's
+`fmpz.is_prime` is a required second opinion on every primality verdict used by
+the oracle, including certificate leaves. Both dependencies are already
+installed by the CI dependency step.
 
 sympy is installed by CI alongside `python-flint`, `cypari2`, and
 `conway-polynomials` (an earlier draft of this SPEC said otherwise),
@@ -1226,8 +1227,11 @@ dependency.
 **Mode: required.** The existing single-job oracle tail installs and preflights
 PARI/cypari2 and python-flint, diffs fresh deterministic emission against the
 committed snapshot, and fails if either the dependency or a comparison is
-unavailable. Fixtures are limited to results the oracle can recompute from the
-original input: verdicts, certificate-checker replay, and prime segments.
+unavailable. The all-oracle local sweep may record a missing dependency as a
+skip unless `HEX_REQUIRE_ORACLES=1` or `--require-oracles` selects this required
+profile. Fixtures are limited to results the oracle can recompute from the
+original input: verdicts, next-prime results, certificate-checker replay, and
+prime segments.
 Multiplicative-order laws, p−1 and Brent routes, exact search accounting and
 bounded failures, sieve representation, total fallback, and the term/tactic
 surface are covered by `HexPrimality.Conformance`; PARI cannot independently

--- a/conformance-fixtures/HexPrimality/primality.jsonl
+++ b/conformance-fixtures/HexPrimality/primality.jsonl
@@ -64,6 +64,14 @@
 {"kind":"result","lib":"HexPrimality","case":"isprime/cert/mersenne31","op":"isprime","value":true}
 {"kind":"isprime","lib":"HexPrimality","case":"isprime/cert/mersenne31-succ2","n":2147483649}
 {"kind":"result","lib":"HexPrimality","case":"isprime/cert/mersenne31-succ2","op":"isprime","value":false}
+{"kind":"nextprime","lib":"HexPrimality","case":"nextprime/edge/zero","n":0}
+{"kind":"result","lib":"HexPrimality","case":"nextprime/edge/zero","op":"nextprime","value":2}
+{"kind":"nextprime","lib":"HexPrimality","case":"nextprime/table/after-90","n":90}
+{"kind":"result","lib":"HexPrimality","case":"nextprime/table/after-90","op":"nextprime","value":97}
+{"kind":"nextprime","lib":"HexPrimality","case":"nextprime/trial/after-99991","n":99991}
+{"kind":"result","lib":"HexPrimality","case":"nextprime/trial/after-99991","op":"nextprime","value":100003}
+{"kind":"nextprime","lib":"HexPrimality","case":"nextprime/cert/after-10000000","n":10000000}
+{"kind":"result","lib":"HexPrimality","case":"nextprime/cert/after-10000000","op":"nextprime","value":10000019}
 {"kind":"certcheck","lib":"HexPrimality","case":"certcheck/accept/small","n":97,"cert":{"t":"small","n":97}}
 {"kind":"result","lib":"HexPrimality","case":"certcheck/accept/small","op":"certcheck","value":true}
 {"kind":"certcheck","lib":"HexPrimality","case":"certcheck/accept/pock1","n":7,"cert":{"t":"pock","n":7,"f":[[2,0,{"t":"small","n":3}]]}}

--- a/conformance-fixtures/HexPrimality/primality.jsonl
+++ b/conformance-fixtures/HexPrimality/primality.jsonl
@@ -108,6 +108,8 @@
 {"kind":"result","lib":"HexPrimality","case":"certcheck/reject/pock3-witness-high","op":"certcheck","value":false}
 {"kind":"certcheck","lib":"HexPrimality","case":"certcheck/reject/pock3-size","n":43,"cert":{"t":"pock3","n":43,"r":1,"s":5,"w":0,"f":[[3,0,{"t":"small","n":2}]]}}
 {"kind":"result","lib":"HexPrimality","case":"certcheck/reject/pock3-size","op":"certcheck","value":false}
+{"kind":"segment","lib":"HexPrimality","case":"segment/edge/empty","lo":10,"hi":10}
+{"kind":"result","lib":"HexPrimality","case":"segment/edge/empty","op":"segment","value":[]}
 {"kind":"segment","lib":"HexPrimality","case":"segment/basic/1-100","lo":1,"hi":101}
 {"kind":"result","lib":"HexPrimality","case":"segment/basic/1-100","op":"segment","value":[2,3,5,7,11,13,17,19,23,29,31,37,41,43,47,53,59,61,67,71,73,79,83,89,97]}
 {"kind":"segment","lib":"HexPrimality","case":"segment/table/1-10000","lo":1,"hi":10000}

--- a/conformance/HexPrimality/Conformance.lean
+++ b/conformance/HexPrimality/Conformance.lean
@@ -10,13 +10,14 @@ import HexPrimality
 Core conformance checks for the `hex-primality` decision, certificate, and
 segment surfaces.
 
-Oracle: PARI (via cypari2) recomputes `isprime` verdicts and `segment`
-listings and an independent Python reimplementation replays `certcheck`
-cases (`scripts/oracle/primality_pari.py`); python-flint is the second
-opinion on large verdicts.
+Oracle: PARI (via cypari2) recomputes `isprime`, `nextprime`, and `segment`
+results and an independent Python reimplementation replays `certcheck` cases
+(`scripts/oracle/primality_pari.py`); python-flint is the second opinion on
+every primality verdict used by the oracle.
 Mode: `required`
 Covered operations:
 - `Hex.Nat.orderOf`
+- `Hex.Nat.smoothBound` / `Hex.Nat.smoothBoundCap`
 - `Hex.Nat.isPrime` / `Hex.Nat.isPrime?`
 - `Hex.Nat.checkPrime` on `PrimeCert` values
 - `Hex.Nat.primeCert?`
@@ -24,6 +25,7 @@ Covered operations:
 - `Hex.Nat.rhoFactor?`, its counted internal form, and batched-Brent route
   instrumentation
 - trial-division extraction route instrumentation
+- sieve decoding through `Hex.Nat.bitsToList`
 - `Hex.Nat.millerRabin` / `Hex.Nat.isProbablePrime`
 - `Hex.Nat.sieve` and its residue-index mapping
 - `Hex.Nat.isTablePrime`
@@ -86,6 +88,8 @@ private def pMinusOneWhole :=
   pMinusOneStage1Counted 15 4 2 (Hex.Rand.ofSeed 13)
 
 #guard pMinusOneStage1 299 2 5 == .factor 13
+#guard pMinusOneStage1 25 2 2 == .noFactor
+-- Invalid inputs have the same public result without entering the gcd route.
 #guard pMinusOneStage1 3 2 5 == .noFactor
 #guard pMinusOneStage1 15 4 2 == .whole
 #guard pMinusOneFound.result == .factor 13
@@ -222,7 +226,11 @@ example {n base bound d : Nat} {r : Hex.Rand}
     (Hex.Rand.ofSeed 23) (defaultPrimeFuel 104929010073468929) with
   | .ok success =>
       match success.cert.raw with
-      | .pock3 n _ _ _ _ => n == 104929010073468929 && checkPrime success.cert.raw
+      | .pock3 n r s _ factors =>
+          n == 104929010073468929 &&
+            certProduct (n - 1) factors == some (2 ^ 20) &&
+            2 ^ 20 * 2 ^ 20 < n && r == 397121 && s == 47716 &&
+            checkPrime success.cert.raw
       | _ => false
   | .error _ => false)
 
@@ -272,8 +280,11 @@ example {n base bound d : Nat} {r : Hex.Rand}
         success.rand == ((Hex.Rand.ofSeed 2).words 12).2
   | .error _ => false)
 
--- Exercise a deep trial-extraction route and pin its exact valuation and
--- cofactor. The source binding keeps this route linear independently of CSE.
+-- Trial extraction covers a typical mixed cofactor, a non-dividing edge, and
+-- a deep adversarial valuation. The source binding keeps the last route linear
+-- independently of CSE.
+#guard Hex.Nat.Internal.trialExtractTrace 3 (3 ^ 7 * 10) == (7, 10)
+#guard Hex.Nat.Internal.trialExtractTrace 0 17 == (0, 17)
 set_option maxRecDepth 10000 in
 #guard Hex.Nat.Internal.trialExtractTrace 2 (2 ^ 128) == (128, 1)
 
@@ -481,6 +492,8 @@ private def wideDrawBound : Nat := 2 ^ 80 + 123
 #guard isProbablePrime 97 = true
 #guard isProbablePrime 0 = false
 #guard isProbablePrime 3215031751 = false
+#guard isProbablePrime 2047 [2] = true
+#guard isProbablePrime 2047 [2, 3] = false
 #guard millerRabin 2047 2 = true
 #guard millerRabin 2047 3 = false
 
@@ -495,7 +508,7 @@ private def wideDrawBound : Nat := 2 ^ 80 + 123
 -- certificate tiers.
 #guard (match nextPrime? 90 (Hex.Rand.ofSeed 0) 8 with
   | .ok (p, _) =>
-      p == 97 && (List.range' 91 6).all fun q => isPrime q == false
+      p == 97 && (List.range' 91 6).all fun q => isPrimeTrial q == false
   | .error _ => false)
 #guard (match nextPrime? 99991 (Hex.Rand.ofSeed 0) 16 with
   | .ok (p, _) => p == 100003

--- a/conformance/HexPrimality/Conformance.lean
+++ b/conformance/HexPrimality/Conformance.lean
@@ -13,13 +13,14 @@ segment surfaces.
 Oracle: PARI (via cypari2) recomputes `isprime` verdicts and `segment`
 listings and an independent Python reimplementation replays `certcheck`
 cases (`scripts/oracle/primality_pari.py`); python-flint is the second
-opinion on large verdicts where available.
-Mode: `if_available`
+opinion on large verdicts.
+Mode: `required`
 Covered operations:
+- `Hex.Nat.orderOf`
 - `Hex.Nat.isPrime` / `Hex.Nat.isPrime?`
 - `Hex.Nat.checkPrime` on `PrimeCert` values
 - `Hex.Nat.primeCert?`
-- counted Pollard `p - 1` integration in certificate partial factorization
+- `Hex.Nat.pMinusOneStage1` and its counted, resumable form
 - `Hex.Nat.rhoFactor?`, its counted internal form, and batched-Brent route
   instrumentation
 - trial-division extraction route instrumentation
@@ -30,6 +31,8 @@ Covered operations:
 - `Hex.Nat.nextPrime?`
 - `primality` term and tactic forms
 Covered properties:
+- multiplicative order is positive exactly on the tested nontrivial coprime
+  inputs, reaches one, and is minimal
 - the total decision agrees with trial division on an initial segment
 - a `.composite` certificate-search verdict never contradicts `isPrime`
 - rho restart and certificate-witness draws span arbitrary-precision bounds
@@ -53,8 +56,28 @@ Covered edge cases:
 
 open Hex.Nat
 
--- The owner library pins all three terminal gcd outcomes at the shared
--- counted boundary. Each call costs one attempt and preserves `Rand`.
+-- Multiplicative order: a typical primitive root, both junk-value edges, and
+-- a base-2 pseudoprime whose proper order catches a Fermat-only implementation.
+#guard orderOf 3 7 == 6
+#guard orderOf 2 1 == 0
+#guard orderOf 6 9 == 0
+#guard orderOf 2 341 == 10
+#guard 2 ^ orderOf 2 341 % 341 == 1
+#guard (List.range (orderOf 2 341)).all fun k => k == 0 || 2 ^ k % 341 != 1
+
+-- The subject projection covers every public certificate constructor.
+#guard (PrimeCert.small 97).subject == 97
+#guard (PrimeCert.pock 101 []).subject == 101
+#guard (PrimeCert.pock3 103 0 0 0 []).subject == 103
+
+-- The depth and rho policies are executable API, not undocumented constants.
+#guard defaultPrimeFuel 0 == 1
+#guard defaultPrimeFuel 2 == 2
+#guard defaultPrimeFuel (2 ^ 128) == 129
+#guard defaultPrimeCertBudget == ⟨8, 1 <<< 22⟩
+
+-- Direct and counted p−1 calls pin all three terminal gcd outcomes. Each
+-- counted call costs one attempt and preserves `Rand`.
 private def pMinusOneFound :=
   pMinusOneStage1Counted 299 2 5 (Hex.Rand.ofSeed 11)
 private def pMinusOneMiss :=
@@ -62,6 +85,9 @@ private def pMinusOneMiss :=
 private def pMinusOneWhole :=
   pMinusOneStage1Counted 15 4 2 (Hex.Rand.ofSeed 13)
 
+#guard pMinusOneStage1 299 2 5 == .factor 13
+#guard pMinusOneStage1 3 2 5 == .noFactor
+#guard pMinusOneStage1 15 4 2 == .whole
 #guard pMinusOneFound.result == .factor 13
 #guard pMinusOneFound.attempts == 1
 #guard pMinusOneFound.rand == Hex.Rand.ofSeed 11
@@ -187,6 +213,19 @@ example {n base bound d : Nat} {r : Hex.Rand}
         success.rand == ((Hex.Rand.ofSeed 0).words 7).2
   | .error _ => false)
 
+-- Here `n - 1 = 2^20 * 100003 * 1000651`. With rho disabled, trial division
+-- supplies `F = 2^20` but leaves the table-coprime composite cofactor
+-- untouched. It is below the square-root Pocklington threshold and above the
+-- cube-root threshold, so search must construct a `pock3` node and the ordinary
+-- checker must replay it.
+#guard (match Internal.primeCertCountedWith? ⟨0, 0⟩ 104929010073468929
+    (Hex.Rand.ofSeed 23) (defaultPrimeFuel 104929010073468929) with
+  | .ok success =>
+      match success.cert.raw with
+      | .pock3 n _ _ _ _ => n == 104929010073468929 && checkPrime success.cert.raw
+      | _ => false
+  | .error _ => false)
+
 -- The bounded decision remains fuel-insensitive below the table bound and
 -- exposes the reordered verdict/construction boundary above its trial cutoff.
 #guard (List.range 2).all fun fuel =>
@@ -197,6 +236,11 @@ example {n base bound d : Nat} {r : Hex.Rand}
   match isPrime? 97 (Hex.Rand.ofSeed 0) fuel with
   | .ok (verdict, r) => verdict && r == Hex.Rand.ofSeed 0
   | .error _ => false
+-- This prime is above the table and below the trial threshold. The unchanged
+-- state distinguishes the exact trial route from certificate construction.
+#guard (match isPrime? 100003 (Hex.Rand.ofSeed 0) 0 with
+  | .ok (verdict, r) => verdict && r == Hex.Rand.ofSeed 0
+  | .error _ => false)
 #guard (List.range 2).all fun fuel =>
   match isPrime? 2147483649 (Hex.Rand.ofSeed 0) fuel with
   | .ok (verdict, r) => !verdict && r == Hex.Rand.ofSeed 0
@@ -212,6 +256,16 @@ example {n base bound d : Nat} {r : Hex.Rand}
 
 -- Counted compatibility forms retain successful randomized work without
 -- changing the ordinary pair-returning entry points.
+#guard (match Internal.rhoFactorCounted? 3 (Hex.Rand.ofSeed 2) 8 with
+  | .error failure =>
+      failure.stop == .invalidInput && failure.attempts == 0 &&
+        failure.rand == Hex.Rand.ofSeed 2
+  | .ok _ => false)
+#guard (match Internal.rhoFactorCounted? 8 (Hex.Rand.ofSeed 2) 8 with
+  | .ok success =>
+      success.factor == 2 && success.attempts == 0 &&
+        success.rand == Hex.Rand.ofSeed 2
+  | .error _ => false)
 #guard (match Internal.rhoFactorCounted? 9 (Hex.Rand.ofSeed 2) 8 with
   | .ok success =>
       success.factor == 3 && success.attempts == 4 &&
@@ -307,6 +361,14 @@ private def rhoBatchTrace : Hex.Nat.Internal.RhoTrace :=
 #guard (match rhoFactor? 100160063 (Hex.Rand.ofSeed 1) 8 with
   | .ok (d, _) => 1 < d && d < 100160063 && 100160063 % d == 0
   | .error _ => false)
+#guard (match rhoFactor? 3 (Hex.Rand.ofSeed 1) 8 with
+  | .error failure => failure.stop == .invalidInput
+  | .ok _ => false)
+#guard (match rhoFactor? 101 (Hex.Rand.ofSeed 1) 0 with
+  | .error failure =>
+      failure.stop == .exhausted && failure.attempts == 0 &&
+        failure.rand == Hex.Rand.ofSeed 1
+  | .ok _ => false)
 
 -- Collisions for 11 and 13 share the cycle-boundary batch, so the route
 -- returns their proper composite product rather than pretending it is prime.
@@ -408,8 +470,17 @@ private def wideDrawBound : Nat := 2 ^ 80 + 123
 #guard Hex.Nat.Internal.rhoRestartCap == 8
 
 -- Miller-Rabin filter behaviour on the adversarial families.
+#guard millerRabin 0 2 = false
+#guard millerRabin 2 2 = true
+#guard millerRabin 4 3 = false
+#guard millerRabin 7 7 = true
+#guard millerRabin 21 3 = false
+#guard millerRabin 97 5 = true
 #guard isProbablePrime 561 = false
 #guard isProbablePrime 1373653 = false
+#guard isProbablePrime 97 = true
+#guard isProbablePrime 0 = false
+#guard isProbablePrime 3215031751 = false
 #guard millerRabin 2047 2 = true
 #guard millerRabin 2047 3 = false
 
@@ -423,7 +494,8 @@ private def wideDrawBound : Nat := 2 ^ 80 + 123
 -- Next-prime success returns the least prime across the table, trial, and
 -- certificate tiers.
 #guard (match nextPrime? 90 (Hex.Rand.ofSeed 0) 8 with
-  | .ok (p, _) => p == 97
+  | .ok (p, _) =>
+      p == 97 && (List.range' 91 6).all fun q => isPrime q == false
   | .error _ => false)
 #guard (match nextPrime? 99991 (Hex.Rand.ofSeed 0) 16 with
   | .ok (p, _) => p == 100003
@@ -477,6 +549,8 @@ private def wideDrawBound : Nat := 2 ^ 80 + 123
 #guard numOfIndex (indexWidth 10000) ≥ 10000
 #guard (List.range (indexWidth 100)).all fun t =>
   t == 0 || ((sieve 100 10).testBit t == isPrimeTrial (numOfIndex t))
+#guard sieve 0 0 == 0
+#guard bitsToList (sieve 25 5) 25 == [5, 7, 11, 13, 17, 19, 23]
 
 -- Table bound edges, the largest entry, an above-bound prime, and empty
 -- segment behavior.

--- a/conformance/HexPrimality/EmitFixtures.lean
+++ b/conformance/HexPrimality/EmitFixtures.lean
@@ -12,10 +12,10 @@ Deterministic fixture emission for `hex-primality`.
 
 Every case is fixed data (no randomness beyond the reproducible seeds baked
 into `isPrime`), so repeated runs emit identical JSONL and CI can diff the
-stream against the committed snapshot. The oracle recomputes each `isprime`
-verdict and `segment` listing with PARI, replays each `certcheck` with an
-independent Python reimplementation of the checker, and cross-checks large
-verdicts with python-flint.
+stream against the committed snapshot. The oracle recomputes each `isprime`,
+`nextprime`, and `segment` result with PARI, replays each `certcheck` with an
+independent Python reimplementation of the checker, and cross-checks every
+primality verdict with python-flint.
 
 Only operations for which the driver can independently recompute the result
 are emitted. Multiplicative order, p−1 and rho route selection, search
@@ -34,6 +34,17 @@ open Hex.Conformance.Emit
 open Hex.Nat (PrimeCert)
 
 private def lib : String := "HexPrimality"
+
+private def quote (s : String) : String := "\"" ++ s ++ "\""
+
+private def emitNextPrimeFixture (case : String) (n : Nat) : IO Unit := do
+  let line := "{\"kind\":\"nextprime\",\"lib\":" ++ quote lib ++
+    ",\"case\":" ++ quote case ++ ",\"n\":" ++ toString n ++ "}\n"
+  match (← IO.getEnv "HEX_FIXTURE_OUTPUT") with
+  | none => IO.print line
+  | some path =>
+      let handle ← IO.FS.Handle.mk path IO.FS.Mode.append
+      handle.putStr line
 
 mutual
 
@@ -76,6 +87,15 @@ private def isPrimeCases : List (String × Nat) :=
     ("cert/10000019", 10000019), ("cert/99999989", 99999989),
     ("cert/mersenne31", 2147483647),
     ("cert/mersenne31-succ2", 2147483649) ]
+
+/-- The `nextPrime?` value surface: the bottom edge, an ordinary table result,
+the table/trial boundary, and a certificate-tier result. The generator state
+and bounded failures remain core-only route properties. -/
+private def nextPrimeCases : List (String × Nat × Nat) :=
+  [ ("edge/zero", 0, 4),
+    ("table/after-90", 90, 16),
+    ("trial/after-99991", 99991, 16),
+    ("cert/after-10000000", 10000000, 32) ]
 
 /-- The `certcheck` surface: accepted certificates one, two, and three
 levels deep plus the accepted cube-root node, and one rejected certificate
@@ -131,6 +151,12 @@ private def emitCase : IO Unit := do
   for (case, n) in isPrimeCases do
     emitIsPrimeFixture lib s!"isprime/{case}" (Int.ofNat n)
     emitResult lib s!"isprime/{case}" "isprime" (boolValue (Hex.Nat.isPrime n))
+  for (case, n, fuel) in nextPrimeCases do
+    let case := s!"nextprime/{case}"
+    emitNextPrimeFixture case n
+    match Hex.Nat.nextPrime? n (Hex.Rand.ofSeed n) fuel with
+    | .ok (p, _) => emitResult lib case "nextprime" (toString p)
+    | .error _ => throw <| IO.userError (case ++ ": bounded search exhausted")
   for (case, n, cert) in certCases do
     emitCertCheckFixture lib s!"certcheck/{case}" (Int.ofNat n) (certJson cert)
     emitResult lib s!"certcheck/{case}" "certcheck"

--- a/conformance/HexPrimality/EmitFixtures.lean
+++ b/conformance/HexPrimality/EmitFixtures.lean
@@ -15,7 +15,14 @@ into `isPrime`), so repeated runs emit identical JSONL and CI can diff the
 stream against the committed snapshot. The oracle recomputes each `isprime`
 verdict and `segment` listing with PARI, replays each `certcheck` with an
 independent Python reimplementation of the checker, and cross-checks large
-verdicts with python-flint where available.
+verdicts with python-flint.
+
+Only operations for which the driver can independently recompute the result
+are emitted. Multiplicative order, p−1 and rho route selection, search
+accounting and bounded failures, sieve bitsets, and elaborator behavior remain
+in `HexPrimality.Conformance`, where algebraic identities and route traces test
+them directly; emitting Lean's observations of those properties would create
+ceremonial fixtures rather than independent oracle evidence.
 
 The certificate serialization is
 `{"t":"small","n":N}` / `{"t":"pock","n":N,"f":[[a,e,child],…]}` /
@@ -115,7 +122,8 @@ segment straddling `primeTableBound` to check that the table and fallback
 agree across the boundary. The release-gated `hotPathCandidates` migration is
 tracked separately by issue #9849. -/
 private def segmentCases : List (String × Nat × Nat) :=
-  [ ("basic/1-100", 1, 101),
+  [ ("edge/empty", 10, 10),
+    ("basic/1-100", 1, 101),
     ("table/1-10000", 1, 10000),
     ("straddle/99950-100050", 99950, 100050) ]
 

--- a/libraries.yml
+++ b/libraries.yml
@@ -641,7 +641,7 @@ libraries:
   HexPrimality:
     deps: [HexArith, HexBasic]
     mathlib: false
-    done_through: 2
+    done_through: 3
     status: active
     phase4:
       comparators:

--- a/progress/2026-08-30T235946Z_01a05509.md
+++ b/progress/2026-08-30T235946Z_01a05509.md
@@ -10,7 +10,7 @@
 - Declared the PARI/cypari2 plus python-flint oracle required, made missing
   dependencies fail closed, documented non-emitted core-only properties, and
   added an independently checked empty-segment fixture.
-- Regenerated the deterministic fixture stream; all 59 result records have a
+- Regenerated the deterministic fixture stream; all 63 result records have a
   paired original-input fixture and pass the required oracle.
 - Advanced only `HexPrimality.done_through` from 2 to 3.
 - Verification: requested aggregate Lake build, full `HexConformance`, kernel
@@ -18,5 +18,9 @@
   conformance discovery, DAG/release/Phase-4 structural checks, Python syntax,
   and whitespace checks all pass. Existing repository deprecation/linter
   warnings are unchanged.
-- Publication, independent review, CI, conflict checks, and merge follow this
-  implementation checkpoint.
+- An independent Opus review prompted stronger Pocklington-3 parameter checks,
+  independent `nextPrime?` fixtures, genuine PARI evaluation of the empty
+  segment, explicit local-skip/required-CI oracle behavior, and several
+  route-coverage and SPEC corrections.
+- PR #9853 contains the implementation and review follow-up; its updated
+  revision passes the requested aggregate build and required oracle locally.

--- a/progress/2026-08-30T235946Z_01a05509.md
+++ b/progress/2026-08-30T235946Z_01a05509.md
@@ -1,0 +1,22 @@
+# Feature session 01a05509
+
+- Date: 2026-08-30 23:59 UTC
+- Issue: #9760 (`HexPrimality` Phase-3 conformance and oracle coverage)
+- Added explicit core coverage for multiplicative order, direct and counted
+  p−1, all Miller–Rabin front-end branches, bounded trial dispatch, rho result
+  shapes, sieve readback, least-next-prime behavior, and executable policy data.
+- Added an end-to-end zero-rho search case whose independently factored input
+  forces construction and checker replay of a Pocklington-3 certificate.
+- Declared the PARI/cypari2 plus python-flint oracle required, made missing
+  dependencies fail closed, documented non-emitted core-only properties, and
+  added an independently checked empty-segment fixture.
+- Regenerated the deterministic fixture stream; all 59 result records have a
+  paired original-input fixture and pass the required oracle.
+- Advanced only `HexPrimality.done_through` from 2 to 3.
+- Verification: requested aggregate Lake build, full `HexConformance`, kernel
+  probe, fixture regeneration/diff, required oracle, table regeneration,
+  conformance discovery, DAG/release/Phase-4 structural checks, Python syntax,
+  and whitespace checks all pass. Existing repository deprecation/linter
+  warnings are unchanged.
+- Publication, independent review, CI, conflict checks, and merge follow this
+  implementation checkpoint.

--- a/scripts/ci/run_oracles.sh
+++ b/scripts/ci/run_oracles.sh
@@ -105,6 +105,11 @@ for entry in "${ORACLES[@]}"; do
 
   oracle_args=()
   case "$oracle" in
+    *primality_pari.py)
+      if [ "${HEX_REQUIRE_ORACLES:-0}" = "1" ]; then
+        oracle_args=(--require-oracles)
+      fi
+      ;;
     *conway_luebeck.py)
       if [ "${HEX_REQUIRE_ORACLES:-0}" = "1" ]; then
         oracle_args=(--require-conway-polynomials)

--- a/scripts/oracle/common.py
+++ b/scripts/oracle/common.py
@@ -43,6 +43,8 @@ JSONL fixture record shape (one record per line):
                       "basis": [[int...]...]}``
 * ``prime``      — ``{"kind": "prime",      "lib": str, "case": str,
                       "p": int, "n": int}``
+* ``nextprime``  — ``{"kind": "nextprime",  "lib": str, "case": str,
+                      "n": nonnegative int}``
 * ``symmod``     — ``{"kind": "symmod",     "lib": str, "case": str,
                       "a": int, "m": nonnegative int}``
 * ``crt``        — ``{"kind": "crt",        "lib": str, "case": str,
@@ -131,6 +133,7 @@ VALID_FIXTURE_KINDS = frozenset(
         "ratrecon",
         "conway",
         "isprime",
+        "nextprime",
         "certcheck",
         "segment",
         "gfq_bridge",
@@ -632,6 +635,10 @@ def _validate_fixture(record: dict[str, Any]) -> None:
     elif kind == "isprime":
         if not _is_int(record.get("n")) or record["n"] < 0:
             raise FixtureError(f"isprime.n must be a nonnegative int: {record!r}")
+    elif kind == "nextprime":
+        _exact_keys(record, {"kind", "lib", "case", "n"}, kind)
+        if not _is_nat(record.get("n")):
+            raise FixtureError(f"nextprime.n must be a nonnegative int: {record!r}")
     elif kind == "segment":
         for key in ("lo", "hi"):
             if not _is_int(record.get(key)) or record[key] < 0:

--- a/scripts/oracle/primality_pari.py
+++ b/scripts/oracle/primality_pari.py
@@ -5,9 +5,10 @@ Reads a JSONL stream produced by `lake exe hexprimality_emit_fixtures`
 (or the committed sample at
 `conformance-fixtures/HexPrimality/primality.jsonl`) and re-checks each
 case: `isprime` verdicts against PARI's `isprime` (with python-flint's
-`is_prime` as a second opinion on large inputs),
-`segment` listings against PARI's `primes` over the interval, and
-`certcheck` verdicts against an independent Python reimplementation of
+`is_prime` as a second opinion on every verdict), `nextprime` values against
+PARI's `nextprime`, `segment` listings against PARI's `primes` over the
+interval, and `certcheck` verdicts against an independent Python
+reimplementation of
 the certificate checker, whose small-table leaf uses the table's proven
 semantics (prime and below `10^5`) with PARI supplying the primality.
 Route selection, multiplicative-order laws, search accounting, bounded
@@ -69,7 +70,12 @@ def _is_prime(pari, n: int) -> bool:
     verdict = bool(int(pari.isprime(n)))
     import flint  # type: ignore[import-not-found]
 
-    second = bool(flint.fmpz(n).is_prime())
+    try:
+        second = bool(flint.fmpz(n).is_prime())
+    except AttributeError as exc:
+        raise OracleMismatch(
+            "python-flint does not provide the required fmpz.is_prime API"
+        ) from exc
     if second != verdict:
         raise OracleMismatch(
             f"cypari2 and python-flint disagree on isprime({n}): "
@@ -79,8 +85,6 @@ def _is_prime(pari, n: int) -> bool:
 
 
 def _segment(pari, lo: int, hi: int) -> list[int]:
-    if hi <= lo:
-        return []
     vec = pari.primes([lo, hi - 1])
     return [int(p) for p in vec]
 
@@ -174,6 +178,20 @@ def check(
                 n = int(fixture["n"])
                 oracle_value = _is_prime(pari, n)
                 input_record: dict[str, Any] = {"n": n}
+            elif op == "nextprime":
+                if fixture["kind"] != "nextprime":
+                    raise OracleMismatch(
+                        f"{lib}/{case_id}: expected nextprime fixture, got "
+                        f"{fixture['kind']!r}"
+                    )
+                n = int(fixture["n"])
+                oracle_value = int(pari.nextprime(n + 1))
+                if not _is_prime(pari, oracle_value):
+                    raise OracleMismatch(
+                        f"{lib}/{case_id}: PARI nextprime returned nonprime "
+                        f"{oracle_value}"
+                    )
+                input_record = {"n": n}
             elif op == "segment":
                 if fixture["kind"] != "segment":
                     raise OracleMismatch(
@@ -249,6 +267,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--profile", default="ci")
     parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--require-oracles",
+        action="store_true",
+        help="fail instead of skipping when cypari2 or python-flint is missing",
+    )
     args = parser.parse_args(argv)
 
     if args.check:
@@ -256,17 +279,26 @@ def main(argv: list[str] | None = None) -> int:
     else:
         source = args.input  # may be None → stdin
 
+    require_oracles = (
+        args.require_oracles or os.environ.get("HEX_REQUIRE_ORACLES") == "1"
+    )
     try:
         import cypari2  # noqa: F401
         import flint  # noqa: F401
-    except ImportError:
-        # Both legs are required: the standard driver must never turn a
-        # missing PARI or python-flint dependency into a green skip.
+    except ImportError as exc:
+        if require_oracles:
+            print(
+                "FAIL: required oracles cypari2 and python-flint are not installed "
+                f"({exc.name})",
+                file=sys.stderr,
+            )
+            return 1
         print(
-            "FAIL: required oracles cypari2 and python-flint are not installed",
+            "SKIP: cypari2 and python-flint are not both installed "
+            f"({exc.name})",
             file=sys.stderr,
         )
-        return 1
+        return 0
 
     return check(
         source,

--- a/scripts/oracle/primality_pari.py
+++ b/scripts/oracle/primality_pari.py
@@ -5,11 +5,15 @@ Reads a JSONL stream produced by `lake exe hexprimality_emit_fixtures`
 (or the committed sample at
 `conformance-fixtures/HexPrimality/primality.jsonl`) and re-checks each
 case: `isprime` verdicts against PARI's `isprime` (with python-flint's
-`is_prime` as a second opinion on large inputs where available),
+`is_prime` as a second opinion on large inputs),
 `segment` listings against PARI's `primes` over the interval, and
 `certcheck` verdicts against an independent Python reimplementation of
 the certificate checker, whose small-table leaf uses the table's proven
 semantics (prime and below `10^5`) with PARI supplying the primality.
+Route selection, multiplicative-order laws, search accounting, bounded
+failure state, sieve representation, and elaborator behavior are deliberately
+not emitted: PARI cannot independently establish those implementation-level
+properties, so `HexPrimality.Conformance` checks them directly instead.
 On mismatch, writes a JSON failure record under `conformance-failures/`
 and exits non-zero so CI fails the job.
 
@@ -63,19 +67,14 @@ def _pari_version(pari) -> str:
 
 def _is_prime(pari, n: int) -> bool:
     verdict = bool(int(pari.isprime(n)))
-    try:  # python-flint second opinion, where available
-        import flint  # type: ignore[import-not-found]
+    import flint  # type: ignore[import-not-found]
 
-        second = bool(flint.fmpz(n).is_prime())
-        if second != verdict:
-            raise OracleMismatch(
-                f"cypari2 and python-flint disagree on isprime({n}): "
-                f"{verdict} vs {second}"
-            )
-    except ImportError:
-        pass
-    except AttributeError:
-        pass
+    second = bool(flint.fmpz(n).is_prime())
+    if second != verdict:
+        raise OracleMismatch(
+            f"cypari2 and python-flint disagree on isprime({n}): "
+            f"{verdict} vs {second}"
+        )
     return verdict
 
 
@@ -259,12 +258,15 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         import cypari2  # noqa: F401
+        import flint  # noqa: F401
     except ImportError:
-        # Mirror the SPEC's `if_available` mode: a missing oracle is a
-        # skip, not a failure. CI installs cypari2 before this script
-        # runs; a failure here in CI means install failed.
-        print("SKIP: cypari2 not installed", file=sys.stderr)
-        return 0
+        # Both legs are required: the standard driver must never turn a
+        # missing PARI or python-flint dependency into a green skip.
+        print(
+            "FAIL: required oracles cypari2 and python-flint are not installed",
+            file=sys.stderr,
+        )
+        return 1
 
     return check(
         source,


### PR DESCRIPTION
Closes #9760

## Summary

- complete typical, edge, and adversarial core conformance for the advertised primality operations and algebraic properties
- pin table/trial/Miller–Rabin/rho/p−1/certificate/Pocklington-3/order/sieve/fallback/failure routes and exercise the term/tactic importing surface
- make the PARI plus python-flint oracle required in CI, add independent `nextPrime?` coverage, document independently-oracleable fixture scope, and regenerate the deterministic 63-case fixture stream
- advance only `HexPrimality.done_through` from 2 to 3
- incorporate an independent Opus review by strengthening route assertions, preserving local oracle-sweep skips, and reconciling the SPEC with the implemented certificate oracle

## Verification

- `lake build HexPrimality HexConformance HexPrimalityKernelProbe`
- `lake build HexConformance hexprimality_emit_fixtures`
- fresh `lake exe hexprimality_emit_fixtures` output matches the committed fixture
- required PARI/python-flint oracle (63 cases, 0 failures)
- local missing-oracle path skips; `--require-oracles` fails closed
- Phase-3 structural checks: copyright, line counts, conformance target discovery, DAG, released manifest, Phase-4 schema, Python syntax, shell syntax, prime-table regeneration, fixture pairing/schema, and whitespace checks