### PR TITLE
docs(mv-poly): resolve representation decision

### DIFF
--- a/libraries.yml
+++ b/libraries.yml
@@ -156,7 +156,7 @@ libraries:
   HexMvPoly:
     deps: [HexPoly, HexBasic]
     mathlib: false
-    done_through: 3
+    done_through: 4
     status: active
     phase4:
       comparators:
@@ -695,7 +695,7 @@ libraries:
   HexMvPolyMathlib:
     deps: [HexMvPoly, HexPolyMathlib]
     mathlib: true
-    done_through: 3
+    done_through: 4
     status: active
     proof_probes: [bench/HexMvPolyMathlib/ProofProbe]
     phase4:

--- a/reports/hex-mv-poly-mathlib-performance.md
+++ b/reports/hex-mv-poly-mathlib-performance.md
@@ -171,6 +171,34 @@ The native companion ratios are recorded separately in
 `reports/hex-mv-poly-performance.md`. They characterize compiled throughput
 but do not override the kernel-specific decision.
 
+### Representation decision
+
+The proof-track evidence here and the compiled evidence in
+`reports/hex-mv-poly-performance.md` support one representation decision while
+retaining distinct acceptance rules. The compiled suite is accepted against
+its declared complexity modes. This fresh-module suite decides whether to add
+a second, kernel-specialised representation: at least two workload families
+must have a conservative lower bound above 2× at the largest size fitting the
+budget.
+
+The committed release-quality sweep is complete and valid, but at the tested
+terminal rungs zero families clear the conservative threshold. The
+preregistered default for anything short of two passes is the existing single
+representation, so the resolved current decision is to retain `ExtTreeMap`.
+The unresolved threshold intervals do not leave the production choice
+unresolved; they mean that a positive case for the sorted form was not
+demonstrated.
+
+This decision does not establish that every sorted representation is slower.
+Mathlib `MvSparsePoly` is unavailable at the pinned revision, so the measured
+candidate is a canonical sorted-list proxy rather than upstream code. The
+terminal rungs are only the largest registered rungs, not the largest sizes
+that fit the 300-second per-module budget, so the sweep did not exercise the
+gate's strongest largest-size clause. Larger preregistered rungs, more
+samples, and preferably a quiescent host would be needed for a future positive
+replacement claim; they are not required to apply the current negative
+default.
+
 ## Profile
 
 Sampling profiles are not applicable. `HexMvPolyMathlib` has no compiled
@@ -190,24 +218,3 @@ complete pair attempts, retained six accepted samples for every pair, and
 reported no validity violation.
 
 ## Concerns
-
-[Issue #9810](https://github.com/kim-em/hex-dev/issues/9810) tracks the
-unresolved proof-track gate described below.
-
-The implementation milestone is complete, but all five terminal threshold
-comparisons remain statistically unresolved: their point estimates are not
-evidence that the conservative 2× threshold was crossed. Under the
-preregistered rule, zero families pass and the production library therefore
-remains a single `ExtTreeMap` representation.
-
-The unavailable upstream `Mathlib MvSparsePoly` remains an explicit comparator
-limitation. The current sorted proof-probe adapter is evidence, not production
-API, and the measured result does not justify promoting it. The terminal
-construction-controlled rungs are the largest registered rungs, but they
-finish well below the 300-second per-module budget and therefore are not the
-largest sizes that fit that budget. This capture does not exercise the
-strongest clause of the positive gate and cannot justify a second
-representation. Under the standing rule that anything short of two
-conservative passes leaves the single representation in place, the default
-remains `ExtTreeMap`. A future positive decision needs preregistered larger
-rungs, more samples, and preferably a quiescent host.

--- a/reports/hex-mv-poly-performance.md
+++ b/reports/hex-mv-poly-performance.md
@@ -249,17 +249,37 @@ The five visualizations are:
 - [structural collisions](figures/hex-mv-poly-comparator-structural-collisions.svg)
 - [sum of squares](figures/hex-mv-poly-comparator-sum-of-squares-arithmetic.svg)
 
-Native ratios are informational rather than the representation gate. The
-release-quality kernel sweep measured construction-subtracted point ratios of
-5.216× for addition, 2.379× for cancellation, 2.890× for SOS, and 1.586× for
-structural collisions. The first three conservative intervals start at
-1.287×, 1.265×, and 1.477× respectively; addition and structural collisions
-are noise-limited. Collision-heavy multiplication has a 0.930× point estimate
-but its [0.359×, 2.329×] threshold interval remains unresolved. No family has
-a lower bound above 2×, so the predeclared two-family gate is not met. The
-decision and its robust null-envelope checks are recorded in
-[`hex-mv-poly-mathlib-performance.md`](hex-mv-poly-mathlib-performance.md):
-keep `ExtTreeMap` as the single production representation.
+### Representation decision
+
+The compiled ratios above and the proof-track measurements in
+[`hex-mv-poly-mathlib-performance.md`](hex-mv-poly-mathlib-performance.md)
+inform one representation decision, but have separate acceptance rules. The
+native suite must pass its declared complexity modes; its comparator ratios
+are informational and do not select the representation. The proof-track gate
+selects a second, kernel-specialised sorted representation only when at least
+two workload families have a conservative lower bound above 2× at the largest
+size fitting the budget.
+
+The complete release-quality proof sweep measured construction-subtracted
+point ratios of 5.216× for addition, 2.379× for cancellation, 2.890× for SOS,
+and 1.586× for structural collisions. The first three conservative intervals
+start at 1.287×, 1.265×, and 1.477× respectively; addition and structural
+collisions are noise-limited. Collision-heavy multiplication has a 0.930×
+point estimate but its [0.359×, 2.329×] threshold interval remains unresolved.
+At the tested terminal rungs, no family has a lower bound above 2×, so the
+predeclared two-family positive condition was not demonstrated. Under the
+preregistered rule that anything short of two passes leaves the existing
+representation standing, the resolved current decision is to retain
+`ExtTreeMap` as the single production representation.
+
+This is a negative replacement decision, not evidence that every sorted
+representation is slower. The candidate is a canonical sorted-list proxy
+because Mathlib `MvSparsePoly` is unavailable at the pinned revision, and the
+terminal rungs are only the largest registered rungs, not the largest sizes
+that fit the 300-second per-module budget. The sweep therefore did not
+exercise the gate's strongest largest-size clause. Those limitations constrain
+a future positive replacement claim but do not invalidate the current default
+decision.
 
 ## Profile
 
@@ -347,23 +367,3 @@ committed JSON exports, report tables, and five SVGs are therefore generated
 from the same corpus and are byte-identifiable by the hashes above.
 
 ## Concerns
-
-[Issue #9805](https://github.com/kim-em/hex-dev/issues/9805) tracks the
-unresolved representation experiment described below.
-
-The implementation milestone is complete. The representation experiment is
-not a positive performance result: all five terminal comparisons remain
-statistically unresolved. Under the predeclared gate, zero families pass.
-
-The Mathlib-native curve is explicitly a sorted-list proxy because
-`MvSparsePoly` is unavailable at the pinned revision, and CompPoly's fixed
-lexicographic comparator prevents exact comparator matching on every family.
-These are disclosed measurement limitations, not Hex implementation defects.
-
-The release-quality kernel gate does not justify a second representation.
-Within the single `ExtTreeMap` implementation, the addition profile identifies
-a promising optimization: a direct tree-cursor version of the existing
-ordered joint fold plus a linear tree builder. Such primitives belong in the
-reusable, Std-only `HexBasic/ExtTreeMap.lean` upstream-candidate layer.
-Coefficient combination and removal of zero coefficients remain `HexMvPoly`
-policy.


### PR DESCRIPTION
Closes #9805.

## Summary

- record the paired compiled/proof-track representation decision in both MvPoly performance reports
- retain ExtTreeMap because the tested terminal rungs demonstrate zero conservative passes against the preregistered two-family positive condition
- state explicitly that the largest registered rungs did not exercise the gate's strongest largest-size clause
- preserve the comparator and rung limitations as context without treating them as open production blockers
- re-promote HexMvPoly and HexMvPolyMathlib through Phase 4

## Dependency-gate rationale

HexMvPoly completed Phase 4 previously while HexPoly satisfied its Phase-4 gate. The current HexPoly rollback concerns separate comparator-report evidence and does not invalidate HexMvPoly's representation evidence. PLAN/Conventions.md's rollback rule therefore preserves the completed downstream dep-coupled phase rather than blocking this re-attestation.

## Verification

- lake exe hexmvpoly_bench verify
- lake build HexMvPolyMathlibProofProbe
- python3 scripts/check_phase4.py
- python3 scripts/check_dag.py
- git diff --check