### PR TITLE
perf: resolve informational comparator concerns

### DIFF
--- a/libraries.yml
+++ b/libraries.yml
@@ -114,7 +114,7 @@ libraries:
   HexPoly:
     deps: []
     mathlib: false
-    done_through: 3
+    done_through: 4
     status: active
     phase4:
       comparators:
@@ -259,7 +259,7 @@ libraries:
   HexBareiss:
     deps: [HexArith, HexDeterminant, HexMatrix]
     mathlib: false
-    done_through: 3
+    done_through: 4
     status: active
     phase4:
       comparators:
@@ -379,7 +379,7 @@ libraries:
   HexGF2:
     deps: [HexBasic]
     mathlib: false
-    done_through: 3
+    done_through: 4
     status: active
     phase4:
       comparators:

--- a/progress/20260831T061332Z_issue-9804.md
+++ b/progress/20260831T061332Z_issue-9804.md
@@ -1,0 +1,26 @@
+# Issue #9804 — informational comparator concern resolution
+
+Session: `issue-9804` (feature)
+
+## Result
+
+- Confirmed that the HexPoly/FLINT, HexBareiss/FLINT, and HexGF2/NTL
+  comparators are declared `informational` in both their library SPECs and
+  `libraries.yml`.
+- Retained the measured ratios and limitations in each comparator narrative,
+  classified the expected algorithm-class and protocol effects as non-gating,
+  and emptied the three live `## Concerns` sections.
+- Restored `done_through: 4` independently for HexPoly, HexBareiss, and HexGF2.
+
+## Local verification
+
+- `lake exe hexpoly_bench verify` (103/103)
+- `lake exe hexbareiss_bench verify` (27/27)
+- `lake exe hexgf2_bench verify` (147/147)
+- `python3 scripts/check_phase4.py`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+
+The FLINT checks used python-flint 0.9.0, matching CI. The NTL checks used NTL
+11.6.0 through the repository's persistent comparator driver. All requested
+verification passed; no work remains in this issue.

--- a/reports/hex-bareiss-performance.md
+++ b/reports/hex-bareiss-performance.md
@@ -104,8 +104,11 @@ once driver startup is subtracted, FLINT spends about 5% of Hex's wall time on
 the same determinant surface, widening as `n` grows. This is the structural gap
 named in advance by the `informational` rationale (FLINT uses multimodular
 reduction + CRT; Hex uses Bareiss fraction-free elimination). The comparator is
-`informational`, so the divergence is recorded for orientation rather than as a
-Phase-4 gate.
+`informational`, so this expected different-complexity-class divergence is
+recorded for optimization orientation rather than as a Phase-4 gate or an
+evidence defect. HexBareiss claims the specified fraction-free algorithm; a
+faster multimodular determinant would be a distinct optional surface, not a
+repair required by this report.
 
 ## Profile
 
@@ -125,17 +128,3 @@ The dominant inclusive costs all map to the registered `HexBareiss.Bench`
 target. No unattributed dominant cost was observed.
 
 ## Concerns
-
-- [#9806](https://github.com/kim-em/hex-dev/issues/9806) tracks the expected
-  different-complexity-class finding's policy-correct reclassification.
-- The FLINT `fmpz_mat.det` comparator pulls steadily ahead of `runBareissDet`
-  across the ladder: raw ratio `0.973x → 0.062x` from `n = 128` to `n = 512`,
-  and within the eligible range the adjusted ratio drifts from `0.057x` to
-  `0.049x` — FLINT spends roughly 5% of Hex's wall time on the same surface, and
-  the gap widens with `n`. The comparator is `informational`, so this is
-  recorded for orientation rather than as a Phase-4 gate; the structural gap
-  matches the rationale (FLINT multimodular reduction + CRT versus Hex's
-  fraction-free Bareiss elimination over `Int`). A follow-up may file a narrow
-  issue against `Hex.Matrix.bareiss` if a faster determinant surface is wanted
-  (for instance, a multimodular CRT path layered over the existing Bareiss
-  kernel as a Tier-2 fast path).

--- a/reports/hex-gf2-performance.md
+++ b/reports/hex-gf2-performance.md
@@ -219,7 +219,13 @@ hex-marshaling buffer grows linearly, so the ratio decays as the
 fixed-cost portion of the marshaling protocol amortises. The
 asymptote sits at the marshaling-throughput ratio of the protocol
 itself, not at the underlying `add` kernel ratio; this surface is
-not a useful audit signal for the `GF2Poly.add` implementation.
+not a useful audit signal for the `GF2Poly.add` implementation. This
+is an expected, non-gating protocol limitation: the rows preserve the
+comparator's declared addition scope, but are a protocol-throughput
+anchor rather than algorithmic performance evidence. Because NTL is
+an `informational` comparator and the remaining packed operations
+provide substantive same-input comparisons, binary framing is not a
+Phase-4 repair requirement.
 
 ### NTL `GF2X` `mul` vs `runMulChecksum`
 
@@ -340,6 +346,14 @@ NTL's `GCD` uses subquadratic GCD variants (half-gcd) that Hex's
 Euclidean reduction does not; the gap accelerates more sharply with
 `n` than `div` / `rem` because Hex's gcd inner loop iterates the
 linear-time long-division cost across `O(n)` reduction steps.
+
+Taken together, the `mul` / `div` / `rem` / `gcd` trends are expected,
+non-gating informational-comparator behavior. They match the SPEC's
+predeclared algorithm-class difference: NTL uses tuned Karatsuba/FFT,
+fast division, and subquadratic GCD kernels, while HexGF2 supplies the
+verified schoolbook packed-word surface. The divergence remains useful
+optimization orientation, but does not identify a defect in the
+evidence for the algorithms HexGF2 claims.
 
 ### Within-Lean packed-vs-generic comparison (retained from prior report)
 
@@ -491,32 +505,3 @@ domain — and the dominant timed work maps to the registered packed-gcd
 target.
 
 ## Concerns
-
-- [#9807](https://github.com/kim-em/hex-dev/issues/9807) tracks both the
-  expected-trend reclassification and the marshalling-dominated addition
-  evidence below.
-- NTL `GF2X` `mul` / `div` / `rem` / `gcd` show a diverging trend
-  against Hex `GF2Poly` across the eligible upper rungs of each
-  ladder. At `n = 2048` (mul) and `n = 1024–1536` (div / rem / gcd)
-  NTL spends `0.04x – 0.001x` of Hex's wall time on the same surface
-  after subtracting the 24 ms driver-startup overhead; the gap
-  accelerates with `n`. NTL's Karatsuba/FFT-tuned inner loops and
-  subquadratic GCD beat Hex's schoolbook packed-word reduction by
-  roughly two to three orders of magnitude in the upper eligible
-  range. This is the structural gap `SPEC/Libraries/hex-gf2.md
-  §"External comparators"`'s `informational` rationale named in
-  advance ("NTL ships hand-tuned word-level inner loops for
-  GF(2)[x]; Hex's `GF2Poly` is the verified packed-word algorithmic
-  surface"). The comparator is `informational`, so the divergence
-  does not produce a gating-goal verdict, but is recorded here per
-  `SPEC/benchmarking.md §"Headline reports" §"Comparator ratios"`
-  ("a diverging trend … is itself an audit-found Concern even when
-  the highest-rung verdict happens to pass").
-- The NTL `add` surface measurements are dominated by the
-  hex-marshaling round-trip cost across the bench-driver protocol;
-  NTL `GF2X` addition is sub-millisecond at every reported rung but
-  the wall time includes parsing the hex-encoded operand bytes
-  (linear in `n`). The reported `add` rows are kept for completeness;
-  they are not an audit signal for `GF2Poly.add`'s implementation.
-  A follow-up HO could rewire the driver to accept raw binary frames
-  instead of hex if the `add` comparator becomes load-bearing later.

--- a/reports/hex-poly-performance.md
+++ b/reports/hex-poly-performance.md
@@ -179,8 +179,10 @@ because FLINT's algorithmic time is below the measurement floor at
 this density. This is the canonical
 `SPEC/benchmarking.md §"Comparator process overhead reported as
 algorithmic difference"` anti-pattern, recorded here in adjusted form
-rather than as a raw verdict; the comparator is `informational`, so
-no gating-goal verdict is required.
+rather than as a raw verdict. It is an expected, non-gating protocol
+limitation: the rows preserve the scope and measurement floor of the
+`informational` comparator, but do not support an algorithmic verdict
+and do not require comparator-protocol repair for Phase 4.
 
 ### FLINT `fmpz_poly.derivative` vs `runDerivativeChecksum`
 
@@ -221,10 +223,12 @@ follows the same monotone decline. Hex's `compose` uses Horner with
 schoolbook multiplication (`O(n⁴)` at the same dense composition
 inputs); FLINT composes via its own composition kernel and runs over
 ten times faster at `n = 64` (1.6 s vs 346 ms). This adverse trend
-is filed as the first Concern below — it does not change the
-`informational` classification, but it is the kind of structural gap
-the SPEC's `informational` rationale ("Hex schoolbook with declared
-Karatsuba crossover; FLINT FFT/Newton-style") was written to flag.
+is expected, non-gating informational-comparator behavior: it matches
+the different-complexity-class rationale in the SPEC (Hex Horner
+composition over schoolbook multiplication versus FLINT's faster
+composition kernels). It is retained as optimization orientation, not
+as evidence of a defect in HexPoly's declared schoolbook semantic
+foundation.
 
 ### FLINT `fmpz_poly.content` vs `runContent`
 
@@ -433,28 +437,3 @@ unattributable to a registered bench target, so no audit-found follow-up
 was filed from this rerun.
 
 ## Concerns
-
-- [#9804](https://github.com/kim-em/hex-dev/issues/9804) tracks resolution
-  and policy-correct classification of both findings below.
-- The FLINT `fmpz_poly.compose` comparator pulls steadily ahead of
-  `runComposeChecksum` across the eligible range: raw ratio
-  `0.505x → 0.210x` from `n = 40` to `n = 64`, adjusted ratio
-  `0.273x → 0.176x`. This is an adverse trend at the `n⁴` composition
-  surface. The comparator is `informational`, so this is recorded for
-  orientation rather than as a Phase-4 gate; the structural gap
-  matches `SPEC/Libraries/hex-poly.md §"External comparators"`'s
-  rationale (Hex schoolbook with declared Karatsuba crossover; FLINT
-  uses better-asymptotic composition kernels). A follow-up may file a
-  narrow HO against `DensePoly.compose` if a faster Hex composition
-  surface is wanted.
-- The `setup_fixed_benchmark` shape respawns the bench child per
-  repeat, so the FLINT median always includes one ~56 ms driver
-  startup. For the O(n²) `runMulChecksum` ladder this means no rung
-  is currently eligible — FLINT wall time sits near the startup floor
-  at every measured `n` and the adjusted ratios collapse to the
-  measurement floor. The headline ratios for `mul` are therefore
-  informational only; closing this gap would require either
-  amortising the persistent driver across measured inner repeats or
-  switching `fmpz_poly` to an FFI shim. Tracked here per
-  `SPEC/benchmarking.md §"Comparator process overhead reported as
-  algorithmic difference"`.


### PR DESCRIPTION
Closes #9804.

Reclassifies the Poly/FLINT, Bareiss/FLINT, and GF2/NTL findings as the expected non-gating informational-comparator behavior already declared by their SPECs and structured metadata. The full ratio and protocol-limit narratives remain in place, the live concern bodies are cleared, and each library is independently restored to Phase 4.

Verification:
- `lake exe hexpoly_bench verify` (103/103)
- `lake exe hexbareiss_bench verify` (27/27)
- `lake exe hexgf2_bench verify` (147/147)
- `python3 scripts/check_phase4.py`
- `python3 scripts/check_dag.py`
- `git diff --check`