### PR TITLE
fix: include meta imports in DAG checks

### DIFF
--- a/scripts/check_dag.py
+++ b/scripts/check_dag.py
@@ -19,12 +19,16 @@ from libgraph import (
 )
 
 
-IMPORT_RE = re.compile(r"^\s*(?:public\s+|private\s+)?import\s+(.+?)\s*$")
+IMPORT_RE = re.compile(
+    r"^\s*(?:(?:public|private)\s+)?(?:meta\s+)?import\s+(.+?)\s*$"
+)
 LEAN_EXE_ROOT_RE = re.compile(r"^\s*root\s*:=\s*`([A-Za-z0-9_.]+)\s*$")
 LEAN_GLOB_MODULE_RE = re.compile(r"`([A-Z][A-Za-z0-9_.]+)")
 LEAN_LIB_RE = re.compile(r"^lean_lib\s+([A-Za-z0-9_]+)\b")
 LEAN_EXE_RE = re.compile(r"^lean_exe\s+([A-Za-z0-9_]+)\b")
-QUALIFIED_IMPORT_RE = re.compile(r"^\s*(?:public\s+|private\s+)?import\s+([A-Za-z0-9_.]+)\s*$")
+QUALIFIED_IMPORT_RE = re.compile(
+    r"^\s*(?:(?:public|private)\s+)?(?:meta\s+)?import\s+([A-Za-z0-9_.]+)\s*$"
+)
 IMPORT_ALL_RE = re.compile(
     r"^\s*(?:(?:public|private|meta)\s+)*import\s+all\s+([A-Za-z0-9_.]+)\s*$"
 )

--- a/scripts/test_check_dag.py
+++ b/scripts/test_check_dag.py
@@ -8,9 +8,41 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from check_dag import check_correspondence_only, check_sealed_import_all
+from check_dag import (
+    check_correspondence_only,
+    check_sealed_import_all,
+    import_roots,
+    parse_imports,
+)
 from check_phase4 import check_headline_reports
 from libgraph import LibraryInfo, load_libraries
+
+
+class MetaImportTest(unittest.TestCase):
+    def test_meta_imports_are_edges(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "HexOwner.lean"
+            path.write_text(
+                "public meta import HexDependency.Tactic\n"
+                "meta import HexDependency.Runtime\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                parse_imports(path),
+                ["HexDependency.Tactic", "HexDependency.Runtime"],
+            )
+            self.assertEqual(
+                import_roots("public meta import HexDependency.Tactic"),
+                ["HexDependency"],
+            )
+            self.assertEqual(
+                import_roots("meta import HexDependency.Runtime"),
+                ["HexDependency"],
+            )
+            self.assertEqual(
+                import_roots("meta public import HexDependency.Invalid"), []
+            )
 
 
 class SealedImportAllTest(unittest.TestCase):


### PR DESCRIPTION
Closes #9425.

Teach both DAG import parsers to recognize Lean meta imports, including the in-use `public meta import` form. Add a focused regression test covering umbrella reachability and cross-library dependency-edge extraction.

Verification:
- `python3 -m unittest scripts/test_check_dag.py`
- `python3 scripts/check_dag.py`