### PR TITLE
perf(poly-fast): stop retaining product-tree levels

### DIFF
--- a/HexManual/Chapters/HexPolyFast.lean
+++ b/HexManual/Chapters/HexPolyFast.lean
@@ -221,6 +221,8 @@ from their represented leaf blocks.
 
 {docstring Hex.DensePoly.ProductTree.build}
 
+{docstring Hex.DensePoly.ProductTree.level?}
+
 {docstring Hex.DensePoly.ProductTree.root}
 
 {docstring Hex.DensePoly.ProductTree.nodeProduct?}

--- a/HexManual/Chapters/HexPolyFast.lean
+++ b/HexManual/Chapters/HexPolyFast.lean
@@ -214,9 +214,10 @@ sequence; a checked fallback preserves exact executable behavior.
 tag := "hex-poly-fast-multipoint"
 %%%
 
-{name}`Hex.DensePoly.ProductTree` stores a balanced tree of nonempty levels.
-Its observations expose the original leaves, the root product, and individual
-node products while hiding the internal level representation.
+{name}`Hex.DensePoly.ProductTree` caches the root of a balanced tree without
+retaining its intermediate levels. Its observations expose the original
+leaves, reconstruct levels on demand, and compute individual node products
+from their represented leaf blocks.
 
 {docstring Hex.DensePoly.ProductTree.build}
 

--- a/HexPolyFast/Multipoint.lean
+++ b/HexPolyFast/Multipoint.lean
@@ -235,8 +235,8 @@ theorem cachedNode_build_isSome (mul : MulPlan R) (points : Array R)
   simp [cachedNode, mulPlan, build, hone, hne]
   rfl
 
-/-- Rebuild the observational product-tree view. Constructing an evaluation
-plan does not eagerly build this redundant level representation. -/
+/-- Rebuild the observational leaf-and-root product-tree view. Constructing an
+evaluation plan does not eagerly recompute this redundant product tree. -/
 def treeView (plan : EvalPlan R) : ProductTree R :=
   ProductTree.build plan.mulPlan (plan.points.map pointFactor)
 

--- a/HexPolyFast/SPEC/hex-poly-fast.md
+++ b/HexPolyFast/SPEC/hex-poly-fast.md
@@ -414,8 +414,8 @@ leaf divisor. The empty tree succeeds with an empty result.
 `EvalPlan` stores the point sequence and one indexed point-product tree carrying
 the reciprocal plans needed by evaluation and interpolation. Reusing it for
 another polynomial does not rebuild products or reciprocals. `treeView`
-explicitly rebuilds the separate level-oriented `ProductTree` observation when
-that representation is needed:
+explicitly rebuilds the separate leaf-and-root `ProductTree` observation when
+it is needed; its balanced levels remain on-demand observations:
 
 ```lean
 def EvalPlan.build (mul : MulPlan R) (points : Array R) : EvalPlan R
@@ -427,13 +427,14 @@ theorem EvalPlan.get_eval (plan : EvalPlan R) (f) (i) (hi : i < plan.size) :
 ```
 
 The indexed point tree and general remainder tree deliberately remain separate.
-They share the count-balanced split and sibling-subtree capacity calculation,
-but their proof payloads differ: the point tree carries dependent point and
-product indices plus evaluation-at-root witnesses, while the general tree
-accepts arbitrary monic leaves and carries divisibility and well-formedness
-witnesses used by `RemainderSpec`. A common node representation would either
-lose those static invariants or require a more complicated abstraction without
-sharing their traversals.
+They share the count-balanced split and compute the same sibling-subtree
+capacity for linear point leaves, using point counts in the indexed tree and
+leaf-degree sums in the general tree. Their proof payloads differ: the point
+tree carries dependent point and product indices plus evaluation-at-root
+witnesses, while the general tree accepts arbitrary monic leaves and carries
+divisibility and well-formedness witnesses used by `RemainderSpec`. A common
+node representation would either lose those static invariants or require a
+more complicated abstraction without sharing their traversals.
 
 The cached remainder-tree path applies when `f.size <= plan.size`; this is the
 finite capacity determined when the plan is built. `EvalPlan.eval` remains

--- a/HexPolyFast/SPEC/hex-poly-fast.md
+++ b/HexPolyFast/SPEC/hex-poly-fast.md
@@ -396,10 +396,10 @@ operation and preserve its Bezout relation and monic-remainder convention.
 
 ## Product trees and multipoint operations
 
-`ProductTree` is an opaque balanced tree of nonempty levels. Its public
-observations are its leaf sequence, root product, and the product represented
-by each node. Construction accepts general polynomial leaves; a point plan
-uses leaves `x - C point`.
+`ProductTree` is an opaque balanced tree with a cached root. Its public
+observations are its leaf sequence, levels reconstructed on demand, root
+product, and the product represented by each node. Construction accepts
+general polynomial leaves; a point plan uses leaves `x - C point`.
 
 `RemainderTree` accepts an ordered array of proof-carrying nonzero monic
 leaves. Its root caches the caller-supplied reciprocal capacity; each proper
@@ -425,6 +425,15 @@ def EvalPlan.treeView (plan : EvalPlan R) : ProductTree R
 theorem EvalPlan.get_eval (plan : EvalPlan R) (f) (i) (hi : i < plan.size) :
     (plan.eval f)[i] = f.eval plan.points[i]
 ```
+
+The indexed point tree and general remainder tree deliberately remain separate.
+They share the count-balanced split and sibling-subtree capacity calculation,
+but their proof payloads differ: the point tree carries dependent point and
+product indices plus evaluation-at-root witnesses, while the general tree
+accepts arbitrary monic leaves and carries divisibility and well-formedness
+witnesses used by `RemainderSpec`. A common node representation would either
+lose those static invariants or require a more complicated abstraction without
+sharing their traversals.
 
 The cached remainder-tree path applies when `f.size <= plan.size`; this is the
 finite capacity determined when the plan is built. `EvalPlan.eval` remains

--- a/HexPolyFast/Tree.lean
+++ b/HexPolyFast/Tree.lean
@@ -184,7 +184,8 @@ def levelCount (tree : ProductTree R) : Nat :=
 /-- Lawful multiplication plan used to build the tree. -/
 def plan (tree : ProductTree R) : MulPlan R := tree.planData
 
-/-- A balanced level reconstructed from the leaves, from leaves upward. -/
+/-- A balanced level reconstructed from the leaves, from leaves upward. The
+empty tree has the singleton level `[1]`. -/
 def level? (tree : ProductTree R) (i : Nat) : Option (Array (DensePoly R)) :=
   if i < tree.levelCount then
     some (buildLevel tree.planData i tree.leafData.toList |>.toArray)

--- a/HexPolyFast/Tree.lean
+++ b/HexPolyFast/Tree.lean
@@ -14,10 +14,11 @@ set_option backward.proofsInPublic true
 /-!
 Balanced product trees.
 
-The representation is private: clients observe the original leaves, the
-balanced levels, and the root product through the accessors below. Adjacent
-nodes are multiplied with the supplied lawful plan; an unpaired final node is
-carried to the next level unchanged.
+The representation is private: clients observe the original leaves, balanced
+levels, and the root product through the accessors below. The root is cached;
+level observations are reconstructed on demand. Adjacent nodes are multiplied
+with the supplied lawful plan; an unpaired final node is carried to the next
+level unchanged.
 -/
 
 namespace Hex.DensePoly
@@ -119,69 +120,76 @@ private theorem plannedProduct_pairProducts (plan : MulPlan R) :
                 ih rest.length (by simp at hlen; omega) rest rfl,
                 DensePoly.mul_assoc_poly]
 
-/-- Build all nonempty balanced levels and return their root. Fuel is only a
-totality guard; construction supplies the leaf count. -/
-private def buildLevels (plan : MulPlan R) :
-    Nat → List (DensePoly R) → List (List (DensePoly R)) × DensePoly R
-  | 0, xs => ([xs], plannedProduct plan xs)
-  | _ + 1, [] => ([[1]], 1)
-  | _ + 1, [p] => ([[p]], p)
+/-- Build the root of a balanced product tree. Fuel is only a totality guard;
+construction supplies the leaf count. -/
+private def buildRoot (plan : MulPlan R) :
+    Nat → List (DensePoly R) → DensePoly R
+  | 0, xs => plannedProduct plan xs
+  | _ + 1, [] => 1
+  | _ + 1, [p] => p
   | fuel + 1, p :: q :: rest =>
       let current := p :: q :: rest
       let next := pairProducts plan current
-      let built := buildLevels plan fuel next
-      (current :: built.1, built.2)
+      buildRoot plan fuel next
 
-private theorem buildLevels_root (plan : MulPlan R) : ∀ fuel xs,
-    (buildLevels plan fuel xs).2 = plannedProduct plan xs := by
+private theorem buildRoot_eq (plan : MulPlan R) : ∀ fuel xs,
+    buildRoot plan fuel xs = plannedProduct plan xs := by
   intro fuel
   induction fuel with
   | zero => intro xs; rfl
   | succ fuel ih =>
       intro xs
       cases xs with
-      | nil => simp [buildLevels, plannedProduct, mulWith_eq]
+      | nil => simp [buildRoot, plannedProduct, mulWith_eq]
       | cons p rest =>
           cases rest with
           | nil =>
-              simp [buildLevels, plannedProduct, mulWith_eq,
+              simp [buildRoot, plannedProduct, mulWith_eq,
                 DensePoly.mul_comm_poly (1 : DensePoly R) p,
                 DensePoly.mul_one_right_poly]
           | cons q rest =>
-              rw [buildLevels]
-              dsimp only
+              rw [buildRoot]
               rw [ih, plannedProduct_pairProducts]
 
-/-- An opaque balanced product tree. -/
+/-- Reconstruct one balanced level from the leaves. The empty tree uses the
+singleton level `[1]`. -/
+private def buildLevel (plan : MulPlan R) :
+    Nat → List (DensePoly R) → List (DensePoly R)
+  | 0, [] => [1]
+  | 0, xs => xs
+  | level + 1, xs => pairProducts plan (buildLevel plan level xs)
+
+/-- An opaque balanced product tree with a cached root and on-demand levels. -/
 structure ProductTree (R : Type u) [DecidableEq R] [Lean.Grind.CommRing R] where
   private planData : MulPlan R
   private leafData : Array (DensePoly R)
-  private levelData : Array (Array (DensePoly R))
   private rootData : DensePoly R
 
 namespace ProductTree
 
-/-- Build a balanced product tree. The empty tree has root `1` and one
-singleton internal level containing that root. -/
+/-- Build a balanced product tree without retaining intermediate levels. The
+empty tree has root `1` and one singleton level containing that root. -/
 def build (plan : MulPlan R) (leaves : Array (DensePoly R)) : ProductTree R :=
-  let built := buildLevels plan leaves.size leaves.toList
   { planData := plan
     leafData := leaves
-    levelData := (built.1.map List.toArray).toArray
-    rootData := built.2 }
+    rootData := buildRoot plan leaves.size leaves.toList }
 
 /-- The leaf sequence in its original order. -/
 def leaves (tree : ProductTree R) : Array (DensePoly R) := tree.leafData
 
-/-- Number of stored nonempty levels. -/
-def levelCount (tree : ProductTree R) : Nat := tree.levelData.size
+/-- Number of nonempty balanced levels, including the leaf and root levels. -/
+def levelCount (tree : ProductTree R) : Nat :=
+  if tree.leafData.size ≤ 1 then 1 else Nat.log2 (tree.leafData.size - 1) + 2
 
 /-- Lawful multiplication plan used to build the tree. -/
 def plan (tree : ProductTree R) : MulPlan R := tree.planData
 
-/-- A stored balanced level, from leaves upward. -/
+/-- A balanced level reconstructed from the leaves, from leaves upward. -/
 def level? (tree : ProductTree R) (i : Nat) : Option (Array (DensePoly R)) :=
-  tree.levelData[i]?
+  if i < tree.levelCount then
+    some (buildLevel tree.planData i tree.leafData.toList |>.toArray)
+  else
+    none
 
 /-- The product represented by the root node. -/
 def root (tree : ProductTree R) : DensePoly R := tree.rootData
@@ -193,7 +201,7 @@ def nodeLeaves (tree : ProductTree R) (level index : Nat) : Array (DensePoly R) 
   let lo := index * width
   tree.leafData.extract lo (min tree.leafData.size (lo + width))
 
-/-- Product represented by a valid stored node. The observation is semantic:
+/-- Product represented by a valid balanced node. The observation is semantic:
 it folds exactly that node's leaf block, independently of the internal level
 layout. -/
 def nodeProduct? (tree : ProductTree R) (level index : Nat) : Option (DensePoly R) :=
@@ -227,7 +235,7 @@ theorem root_build (plan : MulPlan R) (leaves : Array (DensePoly R)) :
       leaves.toList.foldl (fun acc p => mulWith plan acc p) 1 := by
   unfold build root
   dsimp only
-  exact buildLevels_root plan leaves.size leaves.toList
+  exact buildRoot_eq plan leaves.size leaves.toList
 
 /-- The root is independent of the selected lawful multiplication kernel. -/
 theorem root_build_eq_foldl (plan : MulPlan R) (leaves : Array (DensePoly R)) :

--- a/conformance/HexPolyFast/Conformance.lean
+++ b/conformance/HexPolyFast/Conformance.lean
@@ -268,12 +268,19 @@ private def singletonTree : ProductTree Int :=
 #guard (tree.level? 1).map Array.size = some 3
 #guard (tree.level? 2).map Array.size = some 2
 #guard (tree.level? 3).map Array.size = some 1
+#guard tree.level? 1 = some #[treeLeaves.getD 0 0 * treeLeaves.getD 1 0,
+  treeLeaves.getD 2 0 * treeLeaves.getD 3 0, treeLeaves.getD 4 0]
+#guard tree.level? 3 = some #[tree.root]
 #guard tree.nodeProduct? 1 0 = some (treeLeaves.getD 0 0 * treeLeaves.getD 1 0)
 #guard tree.nodeProduct? 1 2 = some (treeLeaves.getD 4 0)
 #guard emptyTree.leaves = #[]
 #guard emptyTree.root = 1
+#guard emptyTree.levelCount = 1
+#guard emptyTree.level? 0 = some #[1]
 #guard singletonTree.leaves = #[a]
 #guard singletonTree.root = a
+#guard singletonTree.levelCount = 1
+#guard singletonTree.level? 0 = some #[a]
 
 private def evalPoints : Array Int := #[-3, 0, 2, 5, 9]
 private def evalPlan : EvalPlan Int := EvalPlan.build plan evalPoints


### PR DESCRIPTION
Closes #9745

## Summary

- retain only the original leaves and balanced root product in `ProductTree`
- reconstruct the observational level API on demand while preserving semantic node products
- document why proof-indexed point and general remainder trees remain separate
- extend conformance coverage for reconstructed, empty, singleton, and root levels

## Premise validation

Only `root` has production downstream consumers; `level?` is observational/conformance API and `nodeProduct?` is already specified as a semantic fold over its leaf block. The point and general remainder nodes share the count-balanced split and equivalent sibling-capacity arithmetic for linear point leaves, but their dependent proof payloads and traversals differ enough that a common representation would weaken invariants or add abstraction without code sharing.

## Benchmark

`Hex.PolyFastBench.runProductTree`, warm cache on `chungus2`, Lean 4.34.0-rc2, compared with the stored clean baseline at `53ef234e` (the ProductTree source and benchmark body are unchanged between that baseline and this branch base):

| leaves | baseline | candidate | delta |
|---:|---:|---:|---:|
| 256 | 513.263 us | 475.209 us | -7.4% |
| 1,024 | 4.874 ms | 4.899 ms | +0.5% |
| 4,096 | 48.132 ms | 48.515 ms | +0.8% |
| 16,384 | 473.481 ms | 468.598 ms | -1.0% |

Peak RSS across the ladder fell from 82,784 KiB to 66,188 KiB (-20.0%). The candidate remains consistent with the declared Karatsuba complexity. A separate cold three-trial ladder over 256--4,096 leaves was also consistent.

## Validation

- `lake build HexPolyFast.Tree`
- `lake build HexPolyFast.Conformance`
- `lake build HexPolyFast.Conformance HexManual.Chapters.HexPolyFast` after rebasing onto current `origin/main`
- `.lake/build/bin/hexpolyfast_bench verify Hex.PolyFastBench.runProductTree`
- full `lake build` before and after rebasing onto current `origin/main`
- no added `axiom`, `sorry`, or `native_decide`