### PR TITLE
bench: warm persistent FLINT fixed comparisons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,10 @@ jobs:
         run: |
           python3 -m unittest scripts/test_check_phase7.py
           python3 scripts/check_phase7.py
-      - name: Lint benches are Mathlib-free (SPEC/benchmarking.md §Mathlib-free benches)
+      - name: Run bench source lints (SPEC/benchmarking.md)
         run: |
           python3 -m unittest scripts/ci/test_check_benches_mathlib_free.py
+          python3 -m unittest scripts/ci/test_check_persistent_flint_warmup.py
           python3 -m unittest scripts/bench/test_fresh_module_sweep.py
           python3 -m unittest scripts/bench/test_real_roots_mathlib_sweep.py
           python3 -m unittest scripts/bench/test_bz_mathlib_sweep.py
@@ -74,6 +75,7 @@ jobs:
           python3 -m unittest scripts/oracle/test_singular_mpoly_bench.py
           python3 -m unittest scripts/oracle/test_rcf_flint_bench.py
           python3 scripts/ci/check_benches_mathlib_free.py
+          python3 scripts/ci/check_persistent_flint_warmup.py
       - name: Verify conformance matrix invariant
         run: python3 scripts/conformance_targets.py --check
       - name: Validate committed PNT+ inventory (offline)

--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -565,8 +565,10 @@ Two integration patterns:
     timed region, then reuses the file descriptors across the
     auto-tuned inner-repeat batch. This amortises one driver startup
     across the measured calls in that child; driver state is not
-    shared across outer repeats. Document the protocol and lifetime
-    in the bench module docstring.
+    shared across outer repeats. Fixed registrations using the shared
+    `Hex.BenchOracle.Flint` driver are checked by
+    `scripts/ci/check_persistent_flint_warmup.py`. Document the protocol
+    and lifetime in the bench module docstring.
   - **Per-call process spawn is acceptable only as a last resort.**
     FFI is preferred when feasible; persistent-subprocess is the
     fallback when FFI isn't viable. Per-call process spawn (the

--- a/bench/HexBareiss/Bench.lean
+++ b/bench/HexBareiss/Bench.lean
@@ -176,34 +176,43 @@ headline report records raw and overhead-adjusted ratios at each rung
 and a trend across the ladder. The comparator is `informational` per
 `SPEC/Libraries/hex-bareiss.md §"External comparators"`: no
 gating-goal verdict is required; the ratios are recorded for
-orientation. -/
+orientation. Both arms discard one call and use the same 200 ms inner-batch
+floor, so driver startup and first-use effects are outside timing. -/
 
-setup_fixed_benchmark runBareissDet16 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintBareissDet16 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runBareissDet24 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintBareissDet24 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runBareissDet32 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintBareissDet32 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runBareissDet48 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintBareissDet48 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runBareissDet64 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintBareissDet64 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runBareissDet96 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintBareissDet96 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runBareissDet128 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintBareissDet128 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runBareissDet192 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintBareissDet192 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runBareissDet256 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runBareissGenericDet256 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintBareissDet256 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runBareissDet320 where { repeats := 5, maxSecondsPerCall := 8.0 }
-setup_fixed_benchmark runFlintBareissDet320 where { repeats := 5, maxSecondsPerCall := 8.0 }
-setup_fixed_benchmark runBareissDet384 where { repeats := 5, maxSecondsPerCall := 12.0 }
-setup_fixed_benchmark runBareissGenericDet384 where { repeats := 5, maxSecondsPerCall := 12.0 }
-setup_fixed_benchmark runFlintBareissDet384 where { repeats := 5, maxSecondsPerCall := 12.0 }
-setup_fixed_benchmark runBareissDet512 where { repeats := 5, maxSecondsPerCall := 25.0 }
-setup_fixed_benchmark runFlintBareissDet512 where { repeats := 5, maxSecondsPerCall := 25.0 }
+def leanCompareConfig (maxSeconds : Float) : LeanBench.FixedBenchmarkConfig :=
+  { repeats := 5, maxSecondsPerCall := maxSeconds, minTotalSeconds := 0.2,
+    warmupFirstIter := true }
+
+def flintCompareConfig (maxSeconds : Float) : LeanBench.FixedBenchmarkConfig :=
+  { repeats := 5, maxSecondsPerCall := maxSeconds, minTotalSeconds := 0.2,
+    warmupFirstIter := true }
+
+setup_fixed_benchmark runBareissDet16 where leanCompareConfig 6.0
+setup_fixed_benchmark runFlintBareissDet16 where flintCompareConfig 6.0
+setup_fixed_benchmark runBareissDet24 where leanCompareConfig 6.0
+setup_fixed_benchmark runFlintBareissDet24 where flintCompareConfig 6.0
+setup_fixed_benchmark runBareissDet32 where leanCompareConfig 6.0
+setup_fixed_benchmark runFlintBareissDet32 where flintCompareConfig 6.0
+setup_fixed_benchmark runBareissDet48 where leanCompareConfig 6.0
+setup_fixed_benchmark runFlintBareissDet48 where flintCompareConfig 6.0
+setup_fixed_benchmark runBareissDet64 where leanCompareConfig 6.0
+setup_fixed_benchmark runFlintBareissDet64 where flintCompareConfig 6.0
+setup_fixed_benchmark runBareissDet96 where leanCompareConfig 6.0
+setup_fixed_benchmark runFlintBareissDet96 where flintCompareConfig 6.0
+setup_fixed_benchmark runBareissDet128 where leanCompareConfig 6.0
+setup_fixed_benchmark runFlintBareissDet128 where flintCompareConfig 6.0
+setup_fixed_benchmark runBareissDet192 where leanCompareConfig 6.0
+setup_fixed_benchmark runFlintBareissDet192 where flintCompareConfig 6.0
+setup_fixed_benchmark runBareissDet256 where leanCompareConfig 6.0
+setup_fixed_benchmark runBareissGenericDet256 where leanCompareConfig 6.0
+setup_fixed_benchmark runFlintBareissDet256 where flintCompareConfig 6.0
+setup_fixed_benchmark runBareissDet320 where leanCompareConfig 8.0
+setup_fixed_benchmark runFlintBareissDet320 where flintCompareConfig 8.0
+setup_fixed_benchmark runBareissDet384 where leanCompareConfig 12.0
+setup_fixed_benchmark runBareissGenericDet384 where leanCompareConfig 12.0
+setup_fixed_benchmark runFlintBareissDet384 where flintCompareConfig 12.0
+setup_fixed_benchmark runBareissDet512 where leanCompareConfig 25.0
+setup_fixed_benchmark runFlintBareissDet512 where flintCompareConfig 25.0
 
 end Hex.BareissBench
 

--- a/bench/HexPoly/Bench.lean
+++ b/bench/HexPoly/Bench.lean
@@ -765,102 +765,112 @@ same parameter inside the densified eligible range so the headline
 report can record raw and overhead-adjusted ratios at each rung and a
 trend across the ladder. The comparator is `informational` per
 `SPEC/Libraries/hex-poly.md §"External comparators"`: no gating-goal
-verdict is required, the ratios are recorded for orientation. -/
+verdict is required, the ratios are recorded for orientation. Both arms discard
+one call and use the same 200 ms inner-batch floor, so driver startup and
+first-use effects are outside timing. -/
 
-setup_fixed_benchmark runAddChecksum16384 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintAddChecksum16384 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runAddChecksum32768 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintAddChecksum32768 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runAddChecksum49152 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintAddChecksum49152 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runAddChecksum65536 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintAddChecksum65536 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runAddChecksum98304 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintAddChecksum98304 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runAddChecksum131072 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintAddChecksum131072 where { repeats := 5, maxSecondsPerCall := 6.0 }
+def leanCompareConfig : LeanBench.FixedBenchmarkConfig :=
+  { repeats := 5, maxSecondsPerCall := 6.0, minTotalSeconds := 0.2,
+    warmupFirstIter := true }
 
-setup_fixed_benchmark runSubChecksum16384 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintSubChecksum16384 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runSubChecksum32768 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintSubChecksum32768 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runSubChecksum49152 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintSubChecksum49152 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runSubChecksum65536 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintSubChecksum65536 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runSubChecksum98304 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintSubChecksum98304 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runSubChecksum131072 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintSubChecksum131072 where { repeats := 5, maxSecondsPerCall := 6.0 }
+def flintCompareConfig : LeanBench.FixedBenchmarkConfig :=
+  { repeats := 5, maxSecondsPerCall := 6.0, minTotalSeconds := 0.2,
+    warmupFirstIter := true }
 
-setup_fixed_benchmark runMulChecksum128 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintMulChecksum128 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runMulChecksum192 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintMulChecksum192 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runMulChecksum256 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintMulChecksum256 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runMulChecksum320 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintMulChecksum320 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runMulChecksum384 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintMulChecksum384 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runMulChecksum448 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintMulChecksum448 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runMulChecksum512 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintMulChecksum512 where { repeats := 5, maxSecondsPerCall := 6.0 }
+setup_fixed_benchmark runAddChecksum16384 where leanCompareConfig
+setup_fixed_benchmark runFlintAddChecksum16384 where flintCompareConfig
+setup_fixed_benchmark runAddChecksum32768 where leanCompareConfig
+setup_fixed_benchmark runFlintAddChecksum32768 where flintCompareConfig
+setup_fixed_benchmark runAddChecksum49152 where leanCompareConfig
+setup_fixed_benchmark runFlintAddChecksum49152 where flintCompareConfig
+setup_fixed_benchmark runAddChecksum65536 where leanCompareConfig
+setup_fixed_benchmark runFlintAddChecksum65536 where flintCompareConfig
+setup_fixed_benchmark runAddChecksum98304 where leanCompareConfig
+setup_fixed_benchmark runFlintAddChecksum98304 where flintCompareConfig
+setup_fixed_benchmark runAddChecksum131072 where leanCompareConfig
+setup_fixed_benchmark runFlintAddChecksum131072 where flintCompareConfig
 
-setup_fixed_benchmark runDerivativeChecksum16384 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintDerivativeChecksum16384 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runDerivativeChecksum32768 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintDerivativeChecksum32768 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runDerivativeChecksum49152 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintDerivativeChecksum49152 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runDerivativeChecksum65536 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintDerivativeChecksum65536 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runDerivativeChecksum98304 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintDerivativeChecksum98304 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runDerivativeChecksum131072 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintDerivativeChecksum131072 where { repeats := 5, maxSecondsPerCall := 6.0 }
+setup_fixed_benchmark runSubChecksum16384 where leanCompareConfig
+setup_fixed_benchmark runFlintSubChecksum16384 where flintCompareConfig
+setup_fixed_benchmark runSubChecksum32768 where leanCompareConfig
+setup_fixed_benchmark runFlintSubChecksum32768 where flintCompareConfig
+setup_fixed_benchmark runSubChecksum49152 where leanCompareConfig
+setup_fixed_benchmark runFlintSubChecksum49152 where flintCompareConfig
+setup_fixed_benchmark runSubChecksum65536 where leanCompareConfig
+setup_fixed_benchmark runFlintSubChecksum65536 where flintCompareConfig
+setup_fixed_benchmark runSubChecksum98304 where leanCompareConfig
+setup_fixed_benchmark runFlintSubChecksum98304 where flintCompareConfig
+setup_fixed_benchmark runSubChecksum131072 where leanCompareConfig
+setup_fixed_benchmark runFlintSubChecksum131072 where flintCompareConfig
 
-setup_fixed_benchmark runComposeChecksum16 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintComposeChecksum16 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runComposeChecksum24 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintComposeChecksum24 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runComposeChecksum32 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintComposeChecksum32 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runComposeChecksum40 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintComposeChecksum40 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runComposeChecksum48 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintComposeChecksum48 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runComposeChecksum56 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintComposeChecksum56 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runComposeChecksum64 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintComposeChecksum64 where { repeats := 5, maxSecondsPerCall := 6.0 }
+setup_fixed_benchmark runMulChecksum128 where leanCompareConfig
+setup_fixed_benchmark runFlintMulChecksum128 where flintCompareConfig
+setup_fixed_benchmark runMulChecksum192 where leanCompareConfig
+setup_fixed_benchmark runFlintMulChecksum192 where flintCompareConfig
+setup_fixed_benchmark runMulChecksum256 where leanCompareConfig
+setup_fixed_benchmark runFlintMulChecksum256 where flintCompareConfig
+setup_fixed_benchmark runMulChecksum320 where leanCompareConfig
+setup_fixed_benchmark runFlintMulChecksum320 where flintCompareConfig
+setup_fixed_benchmark runMulChecksum384 where leanCompareConfig
+setup_fixed_benchmark runFlintMulChecksum384 where flintCompareConfig
+setup_fixed_benchmark runMulChecksum448 where leanCompareConfig
+setup_fixed_benchmark runFlintMulChecksum448 where flintCompareConfig
+setup_fixed_benchmark runMulChecksum512 where leanCompareConfig
+setup_fixed_benchmark runFlintMulChecksum512 where flintCompareConfig
 
-setup_fixed_benchmark runContent16384 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintContent16384 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runContent32768 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintContent32768 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runContent49152 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintContent49152 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runContent65536 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintContent65536 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runContent98304 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintContent98304 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runContent131072 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintContent131072 where { repeats := 5, maxSecondsPerCall := 6.0 }
+setup_fixed_benchmark runDerivativeChecksum16384 where leanCompareConfig
+setup_fixed_benchmark runFlintDerivativeChecksum16384 where flintCompareConfig
+setup_fixed_benchmark runDerivativeChecksum32768 where leanCompareConfig
+setup_fixed_benchmark runFlintDerivativeChecksum32768 where flintCompareConfig
+setup_fixed_benchmark runDerivativeChecksum49152 where leanCompareConfig
+setup_fixed_benchmark runFlintDerivativeChecksum49152 where flintCompareConfig
+setup_fixed_benchmark runDerivativeChecksum65536 where leanCompareConfig
+setup_fixed_benchmark runFlintDerivativeChecksum65536 where flintCompareConfig
+setup_fixed_benchmark runDerivativeChecksum98304 where leanCompareConfig
+setup_fixed_benchmark runFlintDerivativeChecksum98304 where flintCompareConfig
+setup_fixed_benchmark runDerivativeChecksum131072 where leanCompareConfig
+setup_fixed_benchmark runFlintDerivativeChecksum131072 where flintCompareConfig
 
-setup_fixed_benchmark runPrimitivePartChecksum16384 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintPrimitivePartChecksum16384 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runPrimitivePartChecksum32768 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintPrimitivePartChecksum32768 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runPrimitivePartChecksum49152 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintPrimitivePartChecksum49152 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runPrimitivePartChecksum65536 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintPrimitivePartChecksum65536 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runPrimitivePartChecksum98304 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintPrimitivePartChecksum98304 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runPrimitivePartChecksum131072 where { repeats := 5, maxSecondsPerCall := 6.0 }
-setup_fixed_benchmark runFlintPrimitivePartChecksum131072 where { repeats := 5, maxSecondsPerCall := 6.0 }
+setup_fixed_benchmark runComposeChecksum16 where leanCompareConfig
+setup_fixed_benchmark runFlintComposeChecksum16 where flintCompareConfig
+setup_fixed_benchmark runComposeChecksum24 where leanCompareConfig
+setup_fixed_benchmark runFlintComposeChecksum24 where flintCompareConfig
+setup_fixed_benchmark runComposeChecksum32 where leanCompareConfig
+setup_fixed_benchmark runFlintComposeChecksum32 where flintCompareConfig
+setup_fixed_benchmark runComposeChecksum40 where leanCompareConfig
+setup_fixed_benchmark runFlintComposeChecksum40 where flintCompareConfig
+setup_fixed_benchmark runComposeChecksum48 where leanCompareConfig
+setup_fixed_benchmark runFlintComposeChecksum48 where flintCompareConfig
+setup_fixed_benchmark runComposeChecksum56 where leanCompareConfig
+setup_fixed_benchmark runFlintComposeChecksum56 where flintCompareConfig
+setup_fixed_benchmark runComposeChecksum64 where leanCompareConfig
+setup_fixed_benchmark runFlintComposeChecksum64 where flintCompareConfig
+
+setup_fixed_benchmark runContent16384 where leanCompareConfig
+setup_fixed_benchmark runFlintContent16384 where flintCompareConfig
+setup_fixed_benchmark runContent32768 where leanCompareConfig
+setup_fixed_benchmark runFlintContent32768 where flintCompareConfig
+setup_fixed_benchmark runContent49152 where leanCompareConfig
+setup_fixed_benchmark runFlintContent49152 where flintCompareConfig
+setup_fixed_benchmark runContent65536 where leanCompareConfig
+setup_fixed_benchmark runFlintContent65536 where flintCompareConfig
+setup_fixed_benchmark runContent98304 where leanCompareConfig
+setup_fixed_benchmark runFlintContent98304 where flintCompareConfig
+setup_fixed_benchmark runContent131072 where leanCompareConfig
+setup_fixed_benchmark runFlintContent131072 where flintCompareConfig
+
+setup_fixed_benchmark runPrimitivePartChecksum16384 where leanCompareConfig
+setup_fixed_benchmark runFlintPrimitivePartChecksum16384 where flintCompareConfig
+setup_fixed_benchmark runPrimitivePartChecksum32768 where leanCompareConfig
+setup_fixed_benchmark runFlintPrimitivePartChecksum32768 where flintCompareConfig
+setup_fixed_benchmark runPrimitivePartChecksum49152 where leanCompareConfig
+setup_fixed_benchmark runFlintPrimitivePartChecksum49152 where flintCompareConfig
+setup_fixed_benchmark runPrimitivePartChecksum65536 where leanCompareConfig
+setup_fixed_benchmark runFlintPrimitivePartChecksum65536 where flintCompareConfig
+setup_fixed_benchmark runPrimitivePartChecksum98304 where leanCompareConfig
+setup_fixed_benchmark runFlintPrimitivePartChecksum98304 where flintCompareConfig
+setup_fixed_benchmark runPrimitivePartChecksum131072 where leanCompareConfig
+setup_fixed_benchmark runFlintPrimitivePartChecksum131072 where flintCompareConfig
 
 end Hex.PolyBench
 

--- a/scripts/ci/check_persistent_flint_warmup.py
+++ b/scripts/ci/check_persistent_flint_warmup.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Require fixed users of the persistent FLINT driver to warm each child.
+
+The shared ``Hex.BenchOracle.Flint`` process is lazy and cached only within one
+LeanBench child.  A fixed registration that reaches ``runOp`` (possibly through
+local adapter definitions or an imported bench helper) must therefore use a
+configuration with ``warmupFirstIter := true``.  Otherwise every outer child
+charges Python and python-flint startup to its first timed batch.
+
+This is deliberately a small source lint rather than a target-name allowlist:
+it follows Lean definition references from the driver call to registered fixed
+targets, so adding a new adapter does not silently evade the timing contract.
+"""
+
+from __future__ import annotations
+
+import bisect
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_DECL_PREFIX = (
+    r"(?:@\[[^\]]*\]\s*)*"
+    r"(?:(?:private|protected|noncomputable|unsafe|partial|local|scoped)\s+)*"
+)
+_DEF_RE = re.compile(
+    rf"(?m)^{_DECL_PREFIX}(?:def|abbrev)\s+([A-Za-z_][A-Za-z0-9_']*)\b"
+)
+_COMMAND_RE = re.compile(
+    rf"(?m)^(?:{_DECL_PREFIX}"
+    r"(?:def|abbrev|theorem|lemma|instance|structure|inductive|opaque)\b"
+    r"|initialize\b|setup_(?:fixed_)?benchmark\b|namespace\b|section\b"
+    r"|end\b|open\b|export\b|#(?:guard|check|eval)\b)"
+)
+_REGISTRATION_RE = re.compile(
+    r"(?m)^setup_fixed_benchmark\s+"
+    r"([A-Za-z_][A-Za-z0-9_'.]*(?:\.[A-Za-z_][A-Za-z0-9_']*)*)"
+    r"(?P<where>\s+where\b)?"
+)
+_IDENT_RE = re.compile(
+    r"[A-Za-z_][A-Za-z0-9_']*(?:\.[A-Za-z_][A-Za-z0-9_']*)*"
+)
+_DRIVER_CALL_RE = re.compile(
+    r"\bHex\.BenchOracle\.Flint\."
+    r"(?:runOp|runLine|sendRequest|sendRequestLine)\b"
+)
+_WARM_TRUE_RE = re.compile(r"\bwarmupFirstIter\s*:=\s*true\b")
+_WARM_FALSE_RE = re.compile(r"\bwarmupFirstIter\s*:=\s*false\b")
+_CONDITIONAL_RE = re.compile(r"\b(?:if|match)\b")
+
+
+@dataclass(frozen=True)
+class Definition:
+    path: Path
+    name: str
+    body: str
+
+
+@dataclass(frozen=True)
+class Registration:
+    path: Path
+    line: int
+    target: str
+    config: str
+
+
+def _without_comments(text: str) -> str:
+    """Remove nested Lean comments while retaining newlines and string text."""
+    out: list[str] = []
+    depth = 0
+    in_string = False
+    escaped = False
+    i = 0
+    while i < len(text):
+        if depth == 0 and in_string:
+            char = text[i]
+            out.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            i += 1
+        elif depth == 0 and text[i] == '"':
+            in_string = True
+            out.append(text[i])
+            i += 1
+        elif depth == 0 and text.startswith("--", i):
+            newline = text.find("\n", i)
+            if newline < 0:
+                break
+            out.append("\n")
+            i = newline + 1
+        elif text.startswith("/-", i):
+            depth += 1
+            i += 2
+        elif depth > 0 and text.startswith("-/", i):
+            depth -= 1
+            i += 2
+        elif depth > 0:
+            if text[i] == "\n":
+                out.append("\n")
+            i += 1
+        else:
+            out.append(text[i])
+            i += 1
+    return "".join(out)
+
+
+def _command_chunks(text: str) -> list[tuple[int, int]]:
+    starts = [match.start() for match in _COMMAND_RE.finditer(text)]
+    return [
+        (start, starts[index + 1] if index + 1 < len(starts) else len(text))
+        for index, start in enumerate(starts)
+    ]
+
+
+def _parse_source(path: Path) -> tuple[list[Definition], list[Registration]]:
+    text = _without_comments(path.read_text(encoding="utf-8"))
+    chunks = _command_chunks(text)
+    starts = [start for start, _ in chunks]
+    definitions: list[Definition] = []
+    registrations: list[Registration] = []
+
+    for match in _DEF_RE.finditer(text):
+        index = bisect.bisect_right(starts, match.start()) - 1
+        end = chunks[index][1] if index >= 0 else len(text)
+        definitions.append(Definition(path, match.group(1), text[match.start():end]))
+
+    for match in _REGISTRATION_RE.finditer(text):
+        index = bisect.bisect_right(starts, match.start()) - 1
+        end = chunks[index][1] if index >= 0 else len(text)
+        registrations.append(
+            Registration(
+                path=path,
+                line=text.count("\n", 0, match.start()) + 1,
+                target=match.group(1),
+                config=text[match.end():end] if match.group("where") else "",
+            )
+        )
+    return definitions, registrations
+
+
+def _terminal(identifier: str) -> str:
+    return identifier.rsplit(".", 1)[-1]
+
+
+def _persistent_definition_names(definitions: list[Definition]) -> set[str]:
+    persistent = {
+        definition.name
+        for definition in definitions
+        if _DRIVER_CALL_RE.search(definition.body)
+    }
+    changed = True
+    while changed:
+        changed = False
+        for definition in definitions:
+            if definition.name in persistent:
+                continue
+            references = {_terminal(token) for token in _IDENT_RE.findall(definition.body)}
+            if references & persistent:
+                persistent.add(definition.name)
+                changed = True
+    return persistent
+
+
+def _config_is_warm(
+    config: str,
+    path: Path,
+    definitions_by_name: dict[str, list[Definition]],
+    seen: set[str] | None = None,
+) -> bool:
+    if _WARM_FALSE_RE.search(config):
+        return False
+    if _WARM_TRUE_RE.search(config):
+        return not _CONDITIONAL_RE.search(config)
+    seen = set() if seen is None else seen
+    for token in _IDENT_RE.findall(config):
+        name = _terminal(token)
+        if name in seen:
+            continue
+        candidates = definitions_by_name.get(name, [])
+        local_candidates = [definition for definition in candidates if definition.path == path]
+        if local_candidates:
+            candidates = local_candidates
+        if candidates and all(
+            _config_is_warm(
+                definition.body, definition.path, definitions_by_name, seen | {name}
+            )
+            for definition in candidates
+        ):
+            return True
+    return False
+
+
+def check(repo_root: Path) -> tuple[list[Registration], list[Registration]]:
+    definitions: list[Definition] = []
+    registrations: list[Registration] = []
+    for path in sorted((repo_root / "bench").rglob("*.lean")):
+        parsed_definitions, parsed_registrations = _parse_source(path)
+        definitions.extend(parsed_definitions)
+        registrations.extend(parsed_registrations)
+
+    persistent_names = _persistent_definition_names(definitions)
+    definitions_by_name: dict[str, list[Definition]] = {}
+    for definition in definitions:
+        definitions_by_name.setdefault(definition.name, []).append(definition)
+
+    persistent_registrations = [
+        registration
+        for registration in registrations
+        if _terminal(registration.target) in persistent_names
+    ]
+    failures = [
+        registration
+        for registration in persistent_registrations
+        if not _config_is_warm(
+            registration.config, registration.path, definitions_by_name
+        )
+    ]
+    return persistent_registrations, failures
+
+
+def main() -> int:
+    registrations, failures = check(REPO_ROOT)
+    if not registrations:
+        print(
+            "Persistent FLINT fixed-benchmark warmup lint found no registrations; "
+            "check the driver-call and registration parsers.",
+            file=sys.stderr,
+        )
+        return 1
+    if failures:
+        print("Persistent FLINT fixed-benchmark warmup lint failed:", file=sys.stderr)
+        for registration in failures:
+            relative = registration.path.relative_to(REPO_ROOT)
+            print(
+                f"  {relative}:{registration.line}: `{registration.target}` "
+                "does not resolve to a config with `warmupFirstIter := true`",
+                file=sys.stderr,
+            )
+        print(
+            "Each outer LeanBench child must discard one driver call before its "
+            "timed inner batch; see SPEC/benchmarking.md §External comparators.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        "check_persistent_flint_warmup: OK "
+        f"({len(registrations)} fixed persistent-FLINT registration(s) checked)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/test_check_persistent_flint_warmup.py
+++ b/scripts/ci/test_check_persistent_flint_warmup.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Regression tests for the persistent FLINT fixed-benchmark warmup lint."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import check_persistent_flint_warmup as lint
+
+
+class PersistentFlintWarmupTests(unittest.TestCase):
+    def check_source(self, source: str) -> tuple[list[lint.Registration], list[lint.Registration]]:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            path = root / "bench" / "Sample" / "Bench.lean"
+            path.parent.mkdir(parents=True)
+            path.write_text(source, encoding="utf-8")
+            return lint.check(root)
+
+    def test_rejects_direct_cold_registration(self) -> None:
+        registrations, failures = self.check_source(
+            "def runFlint (_ : Unit) := Hex.BenchOracle.Flint.runOp \"x\" \"y\" #[]\n"
+            "setup_fixed_benchmark runFlint where { repeats := 5 }\n"
+        )
+        self.assertEqual(len(registrations), 1)
+        self.assertEqual(failures, registrations)
+
+    def test_rejects_registration_without_where_clause(self) -> None:
+        registrations, failures = self.check_source(
+            "def runFlint (_ : Unit) := Hex.BenchOracle.Flint.runOp \"x\" \"y\" #[]\n"
+            "setup_fixed_benchmark runFlint\n"
+        )
+        self.assertEqual(len(registrations), 1)
+        self.assertEqual(failures, registrations)
+
+    def test_follows_adapter_and_named_config(self) -> None:
+        registrations, failures = self.check_source(
+            "def callFlint := Hex.BenchOracle.Flint.runOp \"x\" \"y\" #[]\n"
+            "def runAdapter (_ : Unit) := callFlint\n"
+            "def compareConfig := { repeats := 5, warmupFirstIter := true }\n"
+            "setup_fixed_benchmark runAdapter where compareConfig\n"
+        )
+        self.assertEqual(len(registrations), 1)
+        self.assertEqual(failures, [])
+
+    def test_explicit_false_override_fails_closed(self) -> None:
+        registrations, failures = self.check_source(
+            "def runFlint (_ : Unit) := Hex.BenchOracle.Flint.runOp \"x\" \"y\" #[]\n"
+            "def warmConfig := { warmupFirstIter := true }\n"
+            "setup_fixed_benchmark runFlint where\n"
+            "  { warmConfig with warmupFirstIter := false }\n"
+        )
+        self.assertEqual(failures, registrations)
+
+    def test_comments_do_not_fake_driver_or_warmup(self) -> None:
+        registrations, failures = self.check_source(
+            "/- Hex.BenchOracle.Flint.runOp -/\n"
+            "def ordinary (_ : Unit) := pure 0\n"
+            "setup_fixed_benchmark ordinary where { repeats := 5 }\n"
+            "def runFlint (_ : Unit) := Hex.BenchOracle.Flint.runOp \"x\" \"y\" #[]\n"
+            "-- warmupFirstIter := true\n"
+            "setup_fixed_benchmark runFlint where { repeats := 5 }\n"
+        )
+        self.assertEqual(len(registrations), 1)
+        self.assertEqual(failures, registrations)
+
+    def test_follows_qualified_target_across_files(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            helper = root / "bench" / "SampleFlint.lean"
+            main = root / "bench" / "Sample" / "Bench.lean"
+            helper.parent.mkdir(parents=True)
+            main.parent.mkdir(parents=True)
+            helper.write_text(
+                "def runFlint (_ : Unit) := "
+                "Hex.BenchOracle.Flint.runOp \"x\" \"y\" #[]\n"
+                "def config := { warmupFirstIter := true }\n",
+                encoding="utf-8",
+            )
+            main.write_text(
+                "setup_fixed_benchmark Sample.runFlint where Sample.config\n",
+                encoding="utf-8",
+            )
+            registrations, failures = lint.check(root)
+            self.assertEqual(len(registrations), 1)
+            self.assertEqual(failures, [])
+
+    def test_same_named_warm_config_in_other_file_does_not_mask_cold_config(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cold = root / "bench" / "Cold" / "Bench.lean"
+            warm = root / "bench" / "Warm" / "Bench.lean"
+            cold.parent.mkdir(parents=True)
+            warm.parent.mkdir(parents=True)
+            cold.write_text(
+                "def runFlint (_ : Unit) := "
+                "Hex.BenchOracle.Flint.runOp \"x\" \"y\" #[]\n"
+                "def flintCompareConfig := { repeats := 5 }\n"
+                "setup_fixed_benchmark runFlint where flintCompareConfig\n",
+                encoding="utf-8",
+            )
+            warm.write_text(
+                "def flintCompareConfig := { warmupFirstIter := true }\n",
+                encoding="utf-8",
+            )
+            registrations, failures = lint.check(root)
+            self.assertEqual(failures, registrations)
+
+    def test_ambiguous_cross_file_config_fails_if_any_candidate_is_cold(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            target = root / "bench" / "Target" / "Bench.lean"
+            cold = root / "bench" / "ColdConfig.lean"
+            warm = root / "bench" / "WarmConfig.lean"
+            target.parent.mkdir(parents=True)
+            target.write_text(
+                "def runFlint (_ : Unit) := "
+                "Hex.BenchOracle.Flint.runOp \"x\" \"y\" #[]\n"
+                "setup_fixed_benchmark runFlint where Shared.config\n",
+                encoding="utf-8",
+            )
+            cold.write_text("def config := { repeats := 5 }\n", encoding="utf-8")
+            warm.write_text(
+                "def config := { warmupFirstIter := true }\n", encoding="utf-8"
+            )
+            registrations, failures = lint.check(root)
+            self.assertEqual(failures, registrations)
+
+    def test_conditional_warm_config_fails_closed(self) -> None:
+        registrations, failures = self.check_source(
+            "def runFlint (_ : Unit) := Hex.BenchOracle.Flint.runOp \"x\" \"y\" #[]\n"
+            "def config (external : Bool) := if external then "
+            "{ warmupFirstIter := true } else {}\n"
+            "setup_fixed_benchmark runFlint where config false\n"
+        )
+        self.assertEqual(failures, registrations)
+
+    def test_follows_abbrev_and_attributed_partial_adapter(self) -> None:
+        registrations, failures = self.check_source(
+            "abbrev callFlint := Hex.BenchOracle.Flint.runOp \"x\" \"y\" #[]\n"
+            "@[inline] partial def runAdapter (_ : Unit) := callFlint\n"
+            "abbrev config := { warmupFirstIter := true }\n"
+            "setup_fixed_benchmark runAdapter where config\n"
+        )
+        self.assertEqual(len(registrations), 1)
+        self.assertEqual(failures, [])
+
+    def test_repository_has_persistent_registrations(self) -> None:
+        registrations, failures = lint.check(lint.REPO_ROOT)
+        self.assertGreater(len(registrations), 0)
+        self.assertEqual(failures, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #9026

## Summary

- warm all 56 previously cold persistent-FLINT fixed registrations in HexPoly and HexBareiss
- give each Lean/FLINT pair a shared 200 ms inner-batch floor while discarding driver startup only on the persistent arm
- add a source-graph lint and focused regression tests covering all 306 current persistent-FLINT fixed registrations

## Validation

- `lake build hexpoly_bench hexbareiss_bench`
- affected `bench verify`: HexPoly 103/103; HexBareiss 27/27
- structural, released-manifest, trust-surface, Phase-4, Phase-7, bench-isolation, conformance-matrix, and PNT inventory checks
- `python3 -m unittest scripts/ci/test_check_persistent_flint_warmup.py`
- `python3 scripts/ci/check_persistent_flint_warmup.py`