### PR TITLE
chore(hex-primality): certify pair through Phase 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,8 @@ jobs:
             hexmodarith_bench \
             hexmodular_bench \
             hexgf2_bench hexgfqring_bench hexgfqfield_bench hexgfq_bench \
-            hexhensel_bench hexintfactor_bench hexberlekamp_bench hexbz_bench \
+            hexhensel_bench hexprimality_bench hexintfactor_bench \
+            hexberlekamp_bench hexbz_bench \
             hexconway_bench hexdeterminant_bench hexmatrix_bench \
             hexhermite_bench hexsmith_bench \
             hexcharpoly_bench hexminpoly_bench \

--- a/HexPrimalityMathlib/SPEC/hex-primality-mathlib.md
+++ b/HexPrimalityMathlib/SPEC/hex-primality-mathlib.md
@@ -29,6 +29,22 @@ Mathlib-side primality dependency or additional elaborator also belongs here;
 it must remain an accelerator over the core checker rather than a replacement
 for the Mathlib-free proof boundary.
 
+## Headline correctness theorem
+
+The bridge's headline correctness theorem is
+`Hex.Nat.isPrime_iff_natPrime`:
+
+```lean
+theorem Hex.Nat.isPrime_iff_natPrime {n : Nat} :
+    isPrime n = true ↔ Nat.Prime n
+```
+
+It is the end-to-end post-condition for the public total decision API: the
+Mathlib-free computation returns `true` exactly when Mathlib's predicate
+holds. The proof-producing tactic route terminates at the separately exposed
+`Hex.Nat.natPrime_of_checkPrimeAt`, whose Boolean premise is the
+kernel-replayed certificate check emitted by the elaborator.
+
 ## Correspondence and transports
 
 The whole predicate correspondence is:
@@ -254,6 +270,18 @@ locality, and preservation of `Nat.decidablePrime`. The non-executable
 correspondence and segment theorem surfaces are instantiated against the exact
 inputs pinned by core conformance; bridge tests exercise their transport but
 do not rerun the core computation as nominally independent evidence.
+
+The correspondence and segment declarations (`prime_iff`, the direct result
+transports, `primeTable_spec`, `primesIn_spec`, `filter_prime_range`, and
+`forall_prime_lt`) are structural theorems, not executable or proof-producing
+operations in either Phase-4 evidence track. Their proof bodies are compiled
+once into the bridge and applying them runs neither certificate search nor a
+bridge elaborator. The small conformance examples that rewrite with
+`filter_prime_range` deliberately test the theorem's semantics; the ensuing
+`Finset` reduction is consumer proof work over core-owned committed data, not
+a bridge operation. The hypotheses cap this table-facing API at
+`primeTableBound`. A future bridge tactic that performs this reduction would
+be a new proof-track operation and would require matched fresh-module evidence.
 
 Fresh importing modules under
 `bench/HexPrimalityMathlib/ProofProbe/` own proof-production evidence. The

--- a/conformance/HexPrimalityMathlib/Conformance.lean
+++ b/conformance/HexPrimalityMathlib/Conformance.lean
@@ -12,7 +12,7 @@ import Mathlib.Tactic.IntervalCases
 
 Oracle: none; the bridge-local elaboration checks construct kernel-checked
 proofs. Transport examples cite concrete cases from `HexPrimality.Conformance`
-(whose PARI oracle mode is `if_available`) rather than recomputing those cases
+(whose PARI oracle mode is `required`) rather than recomputing those cases
 as nominally independent bridge evidence.
 Mode: always.
 

--- a/libraries.yml
+++ b/libraries.yml
@@ -854,7 +854,7 @@ libraries:
     deps: [HexPrimality]
     mathlib: true
     proof_probes: [bench/HexPrimalityMathlib/ProofProbe]
-    done_through: 2
+    done_through: 4
     status: active
     phase4:
       input_families:

--- a/reports/hex-primality-mathlib-performance.md
+++ b/reports/hex-primality-mathlib-performance.md
@@ -44,7 +44,11 @@ production elaborator's emitted `Eq.refl true` witness.
 
 Core certificate search is intentionally not timed a second time. Both public
 bridge entry points call the core-owned `primeCertCountedWith?` with the same
-seed, fuel, and `PrimeCertBudget`; the shared search evidence is
+seed, fuel, and `PrimeCertBudget`. Its Phase-4 performance owners are
+`Hex.PrimalityBench.runCertSearch` and `runCertSearch512` in the core headline
+report, together with the matched `search` rows in
+`reports/bench-results/hex-primality-core-proof-issue-9762-chungus2.json`.
+The shared policy-selection evidence for the seed, fuel, and budget is
 `reports/bench-results/hex-primality-fuel-issue-9784-chungus2.json` (SHA-256
 `0d772cb92479b0b8b8e0852491af42ec361bfb0cf02c729df79623001b8e7269`).
 The bridge's earlier complete policy evidence remains in

--- a/reports/hex-primality-performance.md
+++ b/reports/hex-primality-performance.md
@@ -204,7 +204,8 @@ kernel-facing route; and Mathlib-free `primality` support through 512 bits with
 a 10 s fresh-module budget.  The SPEC records the derivations, boundary cases,
 and retained policy-selection evidence.
 
-Smoke wiring is reproduced with:
+The shared CI smoke gate includes this executable's `list` and `verify`
+commands. Its local reproduction is:
 
 ```sh
 lake build HexPrimality HexPrimalityKernelProbe


### PR DESCRIPTION
Closes #9767

## Summary

- certify `HexPrimalityMathlib` through Phase 4 after independently auditing the core and bridge packages
- retain `HexPrimality.done_through: 4`, because the core had already earned that counter
- add the missing core benchmark to the shared CI `list`/`verify` smoke gate
- name the bridge headline correctness theorem and make the performance ownership assignments explicit
- correct the bridge conformance header to identify the core PARI mode as `required`

## Phase 1–4 audit

- Phase 1: both libraries have their SPEC, umbrella/source layout, dependency coupling, and Mathlib/core split; `HexPrimalityMathlib` depends on the already-Phase-4 `HexPrimality`, whose dependencies `HexBasic` and `HexArith` are through Phase 7.
- Phase 2: separate, substantive `status/hex-primality.scaffolding-reviewed` and `status/hex-primality-mathlib.scaffolding-reviewed` tokens are present.
- Phase 3: core and bridge conformance are independently wired through `HexConformance`; core fixture emission is deterministic and its required PARI + python-flint path checks 63 cases; bridge tactic/elaboration, opt-in, diagnostics, transport, and kernel-checked proof behavior have ordinary evidence without duplicating core computation. Bridge Phase-3 evidence landed through issue #9761 / PR #9852 at `6f0af968ac2967d529e2e8914c3225f733ca569d`; that directive explicitly deferred the counter update to this final join issue.
- Phase 4: all registered core targets and all bridge proof-track families have complete assignments. Structural correspondence/transport theorems are explicitly classified as non-operations rather than silently omitted from an evidence track. The compiled record, core proof record, PrimeCert comparator, both profiles, bridge proof probes, fuel, elaborator-policy, and negative-policy artifacts match the SHA-256 values cited in the reports. Scientific records have passing verdicts, release-quality fresh-module provenance, complete samples, no exhausted pairs or validity exceptions, and the permitted Lean axiom set only. Both reports have `Concerns: None`.
- Headline correctness: the bridge SPEC now designates `Hex.Nat.isPrime_iff_natPrime`, with `Hex.Nat.natPrime_of_checkPrimeAt` named as the tactic-emission certificate boundary.
- Ownership: certificate search/checking and transported computation remain core-owned; the bridge owns elaborator registration/dispatch, certificate-expression reification context, transport, kernel replay, wrappers, bounded failures, and diagnostics. The bridge report cites core Phase-4 search targets separately from retained policy-selection evidence.
- Trust: scoped source/probe/conformance audit finds zero `sorry`, `axiom`, or `native_decide`; fixture production uses native Lean computation and accepted certificates terminate in Lean-checked replay.

Accepted evidence commits audited: core Phase 4 `f8c260f4973249498e3ef9c51260e76dc4fa025d`; bridge Phase 4 package `dfa95d458b34cd9e90e90ee04bbbf3331636be7c`; core conformance `22e2f31a0324a353f8aedffbea2becee0d62c0b4`; bridge conformance `6f0af968ac2967d529e2e8914c3225f733ca569d`.

## Verification

- `lake build HexPrimality HexPrimalityMathlib HexConformance HexPrimalityKernelProbe`
- `lake build HexPrimalityMathlibProofProbe`
- `lake exe hexprimality_bench list`
- `lake exe hexprimality_bench verify`
- `bash scripts/ci/check_bench_verify_budget.sh hexprimality_bench` (passes in 2.35 s locally, well below both budgets)
- fresh `hexprimality_emit_fixtures` output matches the committed JSONL; `primality_pari.py --require-oracles` checks 63 cases with zero failures using PARI and python-flint
- all three primality proof/policy sweep unit suites (24 tests)
- `python3 scripts/check_phase4.py --base origin/main`
- DAG unit tests and checker
- released-manifest and Phase-7 unit/checker suites
- conformance target invariant and prime-table regeneration check
- Mathlib-free bench/probe and persistent-FLINT lints (135 tests plus repository scans)
- copyright, Lean line-count, manual split, published trust-surface, and `git diff --check`

The reports' designated-host measurement commands and inputs were audited against their committed hashes and provenance. They were not rerun on this non-designated host or allowed to overwrite release-quality records.
