### PR TITLE
chore(int-factor): certify Phase 7 readiness

### DIFF
--- a/HexArith/Nat/Prime.lean
+++ b/HexArith/Nat/Prime.lean
@@ -132,6 +132,16 @@ theorem dvd_mul {p a b : Nat} (hp : Hex.Nat.Prime p) :
     | inl ha => exact Nat.dvd_trans ha (Nat.dvd_mul_right a b)
     | inr hb => exact Nat.dvd_trans hb (Nat.dvd_mul_left b a)
 
+/-- A prime that divides a power divides its base. -/
+theorem dvd_of_dvd_pow {p a k : Nat} (hp : Hex.Nat.Prime p)
+    (h : p ∣ a ^ k) : p ∣ a := by
+  induction k with
+  | zero =>
+      exact absurd (Nat.dvd_one.mp h) hp.ne_one
+  | succ k ih =>
+      rw [Nat.pow_succ] at h
+      exact (hp.dvd_mul.mp h).elim ih id
+
 end Prime
 
 /-- Primality as a bounded search: for `p ≥ 2`, having only trivial divisors is

--- a/HexIntFactor/Cert.lean
+++ b/HexIntFactor/Cert.lean
@@ -98,24 +98,22 @@ theorem factorProduct_eq {bound : Nat} :
         rw [ih acc' r h, boundedPowMul_eq e.exponent acc acc' hp]
         simp [Nat.mul_assoc]
 
-/-- A successful factor-list fold preserves the bound on its accumulator. -/
-theorem factorProduct_le {bound : Nat} :
-    ∀ (l : List PrimePower) (acc r : Nat), acc ≤ bound →
-      factorProduct bound l acc = some r → r ≤ bound := by
-  intro l
-  induction l with
-  | nil =>
-      intro acc r hacc h
-      unfold factorProduct at h
-      injection h with h
-      simpa [h] using hacc
-  | cons e rest ih =>
-      intro acc r hacc h
-      unfold factorProduct at h
-      split at h
-      · cases h
-      next acc' hp =>
-        exact ih acc' r (boundedPowMul_le hacc hp) h
+namespace Internal
+
+/-- Characterize a successful factor-list fold followed by one bounded
+residual multiplication. This is the shared proof boundary for complete and
+partial factorization checkers. -/
+theorem factorProduct_parts {bound : Nat} {entries : List PrimePower}
+    {initial folded residual result : Nat}
+    (hfold : factorProduct bound entries initial = some folded)
+    (hresidual : boundedPowMul bound residual folded 1 = some result) :
+    folded = initial *
+        (entries.map fun e => e.prime ^ e.exponent).prod ∧
+      result = folded * residual := by
+  exact ⟨factorProduct_eq entries initial folded hfold,
+    by simpa using boundedPowMul_eq 1 folded result hresidual⟩
+
+end Internal
 
 theorem checkEntries_positive : ∀ {l : List PrimePower},
     checkEntries l = true → ∀ e ∈ l, 0 < e.exponent := by
@@ -216,7 +214,10 @@ theorem checkFactorization_sorted {F : Factorization}
     F.factors.Pairwise (fun a b => a.prime < b.prime) :=
   checkEntries_pairwise (checked_parts h).2.1
 
-private theorem prime_dvd_pow {p a : Nat} (hp : Prime p) :
+namespace Internal
+
+/-- A prime dividing a power divides its base. -/
+theorem prime_dvd_pow {p a : Nat} (hp : Prime p) :
     ∀ {k : Nat}, p ∣ a ^ k → p ∣ a := by
   intro k
   induction k with
@@ -230,6 +231,30 @@ private theorem prime_dvd_pow {p a : Nat} (hp : Prime p) :
       rcases (hp.dvd_mul).mp h with h | h
       · exact ih h
       · exact h
+
+/-- A prime dividing a product of certified prime powers is the base of one
+of the entries. Exponents need not be positive for this direction. -/
+theorem prime_mem_of_dvd_prod {q : Nat} (hq : Prime q) :
+    ∀ {entries : List PrimePower},
+      (∀ e ∈ entries, Prime e.prime) →
+      q ∣ (entries.map fun e => e.prime ^ e.exponent).prod →
+      ∃ e ∈ entries, e.prime = q := by
+  intro entries hprime hdvd
+  induction entries with
+  | nil =>
+      exact absurd (Nat.dvd_one.mp hdvd) hq.ne_one
+  | cons e rest ih =>
+      simp only [List.map_cons, List.prod_cons] at hdvd
+      rcases hq.dvd_mul.mp hdvd with he | hrest
+      · have hbase := prime_dvd_pow hq he
+        rcases (hprime e (by simp)).2 q hbase with hq1 | heq
+        · exact absurd hq1 hq.ne_one
+        · exact ⟨e, by simp, heq.symm⟩
+      · obtain ⟨e, he, heq⟩ := ih
+          (fun e he => hprime e (by simp [he])) hrest
+        exact ⟨e, by simp [he], heq⟩
+
+end Internal
 
 private theorem prime_eq_of_dvd {p q : Nat} (hp : Prime p) (hq : Prime q)
     (h : p ∣ q) : p = q := by
@@ -259,7 +284,7 @@ private theorem prime_dvd_product_iff {q : Nat} (hq : Prime q) :
       constructor
       · intro h
         rcases h with h | h
-        · have hd := prime_dvd_pow hq h
+        · have hd := Internal.prime_dvd_pow hq h
           exact ⟨e, List.mem_cons_self, (prime_eq_of_dvd hq he hd).symm⟩
         · obtain ⟨x, hx, heq⟩ := h
           exact ⟨x, List.mem_cons_of_mem e hx, heq⟩

--- a/HexIntFactor/Cert.lean
+++ b/HexIntFactor/Cert.lean
@@ -216,22 +216,6 @@ theorem checkFactorization_sorted {F : Factorization}
 
 namespace Internal
 
-/-- A prime dividing a power divides its base. -/
-theorem prime_dvd_pow {p a : Nat} (hp : Prime p) :
-    ∀ {k : Nat}, p ∣ a ^ k → p ∣ a := by
-  intro k
-  induction k with
-  | zero =>
-      intro h
-      rw [Nat.pow_zero] at h
-      exact absurd (Nat.dvd_one.mp h) hp.ne_one
-  | succ k ih =>
-      intro h
-      rw [Nat.pow_succ] at h
-      rcases (hp.dvd_mul).mp h with h | h
-      · exact ih h
-      · exact h
-
 /-- A prime dividing a product of certified prime powers is the base of one
 of the entries. Exponents need not be positive for this direction. -/
 theorem prime_mem_of_dvd_prod {q : Nat} (hq : Prime q) :
@@ -246,13 +230,25 @@ theorem prime_mem_of_dvd_prod {q : Nat} (hq : Prime q) :
   | cons e rest ih =>
       simp only [List.map_cons, List.prod_cons] at hdvd
       rcases hq.dvd_mul.mp hdvd with he | hrest
-      · have hbase := prime_dvd_pow hq he
+      · have hbase := hq.dvd_of_dvd_pow he
         rcases (hprime e (by simp)).2 q hbase with hq1 | heq
         · exact absurd hq1 hq.ne_one
         · exact ⟨e, by simp, heq.symm⟩
       · obtain ⟨e, he, heq⟩ := ih
           (fun e he => hprime e (by simp [he])) hrest
         exact ⟨e, by simp [he], heq⟩
+
+/-- The first prime in a strictly ordered list of prime powers does not divide
+the product represented by its tail. -/
+theorem not_dvd_tail_prod {entry : PrimePower} {rest : List PrimePower}
+    (hp : Prime entry.prime) (htail : ∀ e ∈ rest, Prime e.prime)
+    (hsorted : (entry :: rest).Pairwise fun a b => a.prime < b.prime) :
+    ¬entry.prime ∣ (rest.map fun e => e.prime ^ e.exponent).prod := by
+  intro hdvd
+  obtain ⟨e, he, heq⟩ := prime_mem_of_dvd_prod hp htail hdvd
+  have hlt := (List.pairwise_cons.mp hsorted).1 e he
+  rw [heq] at hlt
+  exact Nat.lt_irrefl _ hlt
 
 end Internal
 
@@ -284,7 +280,7 @@ private theorem prime_dvd_product_iff {q : Nat} (hq : Prime q) :
       constructor
       · intro h
         rcases h with h | h
-        · have hd := Internal.prime_dvd_pow hq h
+        · have hd := hq.dvd_of_dvd_pow h
           exact ⟨e, List.mem_cons_self, (prime_eq_of_dvd hq he hd).symm⟩
         · obtain ⟨x, hx, heq⟩ := h
           exact ⟨x, List.mem_cons_of_mem e hx, heq⟩

--- a/HexIntFactor/Cyclotomic.lean
+++ b/HexIntFactor/Cyclotomic.lean
@@ -94,7 +94,7 @@ theorem cyclotomicSplit?_prod {b n : Nat} {sign : Sign}
   cases sign with
   | minus =>
       unfold cyclotomicSplit? at h
-      rw [if_neg hb, if_neg hn] at h
+      rw [ite_eq_right hb, ite_eq_right hn] at h
       dsimp only at h
       split at h
       · rename_i hp
@@ -104,7 +104,7 @@ theorem cyclotomicSplit?_prod {b n : Nat} {sign : Sign}
       · cases h
   | plus =>
       unfold cyclotomicSplit? at h
-      rw [if_neg hb, if_neg hn] at h
+      rw [ite_eq_right hb, ite_eq_right hn] at h
       dsimp only at h
       split at h
       · rename_i hp

--- a/HexIntFactor/DivisorEnumeration.lean
+++ b/HexIntFactor/DivisorEnumeration.lean
@@ -64,18 +64,6 @@ private theorem mem_powers {p e acc x : Nat} :
   | zero => simp [powers]
   | succ e ih => simp [powers, ih, Nat.add_assoc]
 
-private theorem prime_dvd_pow {p a : Nat} (hp : Prime p) :
-    ∀ {k : Nat}, p ∣ a ^ k → p ∣ a := by
-  intro k
-  induction k with
-  | zero =>
-      intro h
-      exact absurd (Nat.dvd_one.mp h) hp.ne_one
-  | succ k ih =>
-      intro h
-      rw [Nat.pow_succ] at h
-      exact (hp.dvd_mul.mp h).elim ih id
-
 private theorem divisor_prime_power {p e d : Nat} (hp : Prime p)
     (hd : d ∣ p ^ e) : ∃ j, j ≤ e ∧ d = p ^ j := by
   induction e generalizing d with
@@ -91,7 +79,8 @@ private theorem divisor_prime_power {p e d : Nat} (hp : Prime p)
           have hdpos := Nat.pos_of_dvd_of_pos hd (Nat.pow_pos hp.pos)
           omega
         obtain ⟨q, hq, hqd⟩ := exists_prime_dvd hd2
-        have hqp : q ∣ p := prime_dvd_pow hq (Nat.dvd_trans hqd hd)
+        have hqp : q ∣ p :=
+          Internal.prime_dvd_pow hq (Nat.dvd_trans hqd hd)
         have hqpEq : q = p := by
           rcases hp.2 q hqp with hq1 | hqpEq
           · exact absurd hq1 hq.ne_one
@@ -115,26 +104,6 @@ private theorem mem_powers_one_iff {p e d : Nat} (hp : Prime p) :
     obtain ⟨j, hj, rfl⟩ := divisor_prime_power hp hd
     exact ⟨j, hj, by simp⟩
 
-private theorem prime_dvd_product {q : Nat} (hq : Prime q) :
-    ∀ (entries : List PrimePower),
-      (∀ e ∈ entries, Prime e.prime) →
-      q ∣ (entries.map fun e => e.prime ^ e.exponent).prod →
-      ∃ e ∈ entries, e.prime = q := by
-  intro entries hprime hdvd
-  induction entries with
-  | nil =>
-      exact absurd (Nat.dvd_one.mp hdvd) hq.ne_one
-  | cons e rest ih =>
-      simp only [List.map_cons, List.prod_cons] at hdvd
-      rcases hq.dvd_mul.mp hdvd with he | hr
-      · have he' := prime_dvd_pow hq he
-        rcases (hprime e (by simp)).2 q he' with heq | heq
-        · exact absurd heq hq.ne_one
-        · exact ⟨e, by simp, heq.symm⟩
-      · obtain ⟨x, hx, heq⟩ := ih
-          (fun x hx => hprime x (by simp [hx])) hr
-        exact ⟨x, by simp [hx], heq⟩
-
 /-- The first prime power in a strictly ordered prime-power list is coprime to
 the product represented by the tail. -/
 theorem head_coprime {entry : PrimePower} {rest : List PrimePower}
@@ -149,7 +118,7 @@ theorem head_coprime {entry : PrimePower} {rest : List PrimePower}
   have hnot : ¬entry.prime ∣
       (rest.map fun e => e.prime ^ e.exponent).prod := by
     intro hd
-    obtain ⟨e, he, heq⟩ := prime_dvd_product hp rest htail hd
+    obtain ⟨e, he, heq⟩ := Internal.prime_mem_of_dvd_prod hp htail hd
     have hlt := (List.pairwise_cons.mp hsorted).1 e he
     rw [heq] at hlt
     exact Nat.lt_irrefl _ hlt

--- a/HexIntFactor/DivisorEnumeration.lean
+++ b/HexIntFactor/DivisorEnumeration.lean
@@ -79,8 +79,7 @@ private theorem divisor_prime_power {p e d : Nat} (hp : Prime p)
           have hdpos := Nat.pos_of_dvd_of_pos hd (Nat.pow_pos hp.pos)
           omega
         obtain ⟨q, hq, hqd⟩ := exists_prime_dvd hd2
-        have hqp : q ∣ p :=
-          Internal.prime_dvd_pow hq (Nat.dvd_trans hqd hd)
+        have hqp : q ∣ p := hq.dvd_of_dvd_pow (Nat.dvd_trans hqd hd)
         have hqpEq : q = p := by
           rcases hp.2 q hqp with hq1 | hqpEq
           · exact absurd hq1 hq.ne_one
@@ -115,13 +114,7 @@ theorem head_coprime {entry : PrimePower} {rest : List PrimePower}
   have htail : ∀ e ∈ rest, Prime e.prime := by
     intro e he
     exact hprime e (by simp [he])
-  have hnot : ¬entry.prime ∣
-      (rest.map fun e => e.prime ^ e.exponent).prod := by
-    intro hd
-    obtain ⟨e, he, heq⟩ := Internal.prime_mem_of_dvd_prod hp htail hd
-    have hlt := (List.pairwise_cons.mp hsorted).1 e he
-    rw [heq] at hlt
-    exact Nat.lt_irrefl _ hlt
+  have hnot := Internal.not_dvd_tail_prod hp htail hsorted
   exact (hp.coprime_of_not_dvd hnot).pow_left _
 
 /-- Generated values are exactly the divisors of the represented product. -/

--- a/HexIntFactor/Divisors.lean
+++ b/HexIntFactor/Divisors.lean
@@ -626,51 +626,6 @@ private theorem squareEntries_decomp : ∀ entries : List PrimePower,
               (rest.map fun e => e.prime ^ e.exponent).prod := by
           rw [squareEntry_decomp, ih]
 
-private theorem prime_dvd_pow_factor {q a : Nat} (hq : Prime q) :
-    ∀ {k : Nat}, q ∣ a ^ k → q ∣ a := by
-  intro k
-  induction k with
-  | zero =>
-      intro h
-      exact absurd (Nat.dvd_one.mp h) hq.ne_one
-  | succ k ih =>
-      intro h
-      rw [Nat.pow_succ] at h
-      exact (hq.dvd_mul.mp h).elim ih id
-
-private theorem prime_dvd_power_product {q : Nat} (hq : Prime q) :
-    ∀ (entries : List PrimePower),
-      (∀ e ∈ entries, Prime e.prime) →
-      q ∣ (entries.map fun e => e.prime ^ e.exponent).prod →
-      ∃ e ∈ entries, e.prime = q := by
-  intro entries hprime hdvd
-  induction entries with
-  | nil => exact absurd (Nat.dvd_one.mp hdvd) hq.ne_one
-  | cons entry rest ih =>
-      simp only [List.map_cons, List.prod_cons] at hdvd
-      rcases hq.dvd_mul.mp hdvd with he | hrest
-      · have hbase := prime_dvd_pow_factor hq he
-        have hp := hprime entry (by simp)
-        rcases hp.2 q hbase with hq1 | heq
-        · exact absurd hq1 hq.ne_one
-        · exact ⟨entry, by simp, heq.symm⟩
-      · obtain ⟨e, he, heq⟩ := ih
-          (fun e he => hprime e (by simp [he])) hrest
-        exact ⟨e, by simp [he], heq⟩
-
-private theorem head_not_dvd_tail_product {entry : PrimePower}
-    {rest : List PrimePower}
-    (hprime : ∀ e ∈ entry :: rest, Prime e.prime)
-    (hsorted : (entry :: rest).Pairwise fun a b => a.prime < b.prime) :
-    ¬entry.prime ∣ (rest.map fun e => e.prime ^ e.exponent).prod := by
-  intro hdvd
-  obtain ⟨e, he, heq⟩ := prime_dvd_power_product
-    (hprime entry (by simp)) rest
-    (fun e he => hprime e (by simp [he])) hdvd
-  have hlt := (List.pairwise_cons.mp hsorted).1 e he
-  rw [heq] at hlt
-  exact Nat.lt_irrefl _ hlt
-
 private theorem squareRoot_dvd_primeProduct {p rest root : Nat}
     (hp : Prime p) (hnot : ¬p ∣ rest)
     (hrest : ∀ c, c ^ 2 ∣ rest → c ∣ root) :
@@ -732,7 +687,14 @@ private theorem squareRoot_dvd_entries : ∀ (entries : List PrimePower),
       simp only [List.map_cons, List.prod_cons] at hd ⊢
       apply squareRoot_dvd_primeProduct
         (hprime entry (by simp))
-        (head_not_dvd_tail_product hprime hsorted)
+        (by
+          intro hdvd
+          obtain ⟨e, he, heq⟩ := Internal.prime_mem_of_dvd_prod
+            (hprime entry (by simp))
+            (fun e he => hprime e (by simp [he])) hdvd
+          have hlt := (List.pairwise_cons.mp hsorted).1 e he
+          rw [heq] at hlt
+          exact Nat.lt_irrefl _ hlt)
         (fun c hc => ih
           (fun e he => hprime e (by simp [he]))
           (List.pairwise_cons.mp hsorted).2 c hc)

--- a/HexIntFactor/Divisors.lean
+++ b/HexIntFactor/Divisors.lean
@@ -687,14 +687,8 @@ private theorem squareRoot_dvd_entries : ∀ (entries : List PrimePower),
       simp only [List.map_cons, List.prod_cons] at hd ⊢
       apply squareRoot_dvd_primeProduct
         (hprime entry (by simp))
-        (by
-          intro hdvd
-          obtain ⟨e, he, heq⟩ := Internal.prime_mem_of_dvd_prod
-            (hprime entry (by simp))
-            (fun e he => hprime e (by simp [he])) hdvd
-          have hlt := (List.pairwise_cons.mp hsorted).1 e he
-          rw [heq] at hlt
-          exact Nat.lt_irrefl _ hlt)
+        (Internal.not_dvd_tail_prod (hprime entry (by simp))
+          (fun e he => hprime e (by simp [he])) hsorted)
         (fun c hc => ih
           (fun e he => hprime e (by simp [he]))
           (List.pairwise_cons.mp hsorted).2 c hc)

--- a/HexIntFactor/Factor.lean
+++ b/HexIntFactor/Factor.lean
@@ -31,6 +31,7 @@ deriving Repr, DecidableEq
 structure PartialSnapshot where
   /-- The retained partial factorization candidate. -/
   raw : PartialFactorization
+  /-- Successful replay of the retained partial factorization. -/
   valid : checkPartial raw = true
 deriving Repr
 

--- a/HexIntFactor/Order.lean
+++ b/HexIntFactor/Order.lean
@@ -48,7 +48,7 @@ structure CheckedOrderCert where
   valid : checkOrder raw = true
 
 /-- Characterisation of every condition replayed by the order checker. -/
-@[simp] theorem checkOrder_iff {c : OrderCert} : checkOrder c = true ↔
+theorem checkOrder_iff {c : OrderCert} : checkOrder c = true ↔
     1 < c.modulus ∧ 0 < c.order ∧ c.orderFac.subject = c.order ∧
       checkFactorization c.orderFac = true ∧
       HexArith.powModNat c.base c.order c.modulus = 1 % c.modulus ∧
@@ -106,13 +106,8 @@ private theorem factorProduct_dvd {d : Nat} :
       have htailPrime : ∀ x ∈ rest, Prime x.prime := by
         intro x hx
         exact hprime x (by simp [hx])
-      have hnot : ¬e.prime ∣ (rest.map fun x => x.prime ^ x.exponent).prod := by
-        intro h
-        obtain ⟨x, hx, heq⟩ :=
-          Internal.prime_mem_of_dvd_prod (hprime e (by simp)) htailPrime h
-        have hlt := hsorted.1 x hx
-        rw [heq] at hlt
-        exact Nat.lt_irrefl _ hlt
+      have hnot := Internal.not_dvd_tail_prod (hprime e (by simp))
+        htailPrime (List.pairwise_cons.mpr hsorted)
       have hcop : Nat.Coprime (e.prime ^ e.exponent)
           (rest.map fun x => x.prime ^ x.exponent).prod :=
         ((hprime e (by simp)).coprime_of_not_dvd hnot).pow_left _

--- a/HexIntFactor/Order.lean
+++ b/HexIntFactor/Order.lean
@@ -6,7 +6,7 @@ Authors: Kim Morrison
 
 module
 
-public import HexIntFactor.Divisors
+public import HexIntFactor.Cert
 public import HexPrimality.Order
 
 public section
@@ -19,9 +19,13 @@ namespace Nat
 
 /-- A raw witness that `base` has exactly `order` modulo `modulus`. -/
 structure OrderCert where
+  /-- Residue whose multiplicative order is claimed. -/
   base : Nat
+  /-- Modulus for the residue computation. -/
   modulus : Nat
+  /-- Claimed least positive exponent sending `base` to one. -/
   order : Nat
+  /-- Complete prime factorization of `order`. -/
   orderFac : Factorization
 deriving Repr
 
@@ -38,11 +42,13 @@ def checkOrder (c : OrderCert) : Bool :=
 
 /-- Order data accepted by the checker. -/
 structure CheckedOrderCert where
+  /-- Untrusted order certificate payload. -/
   raw : OrderCert
+  /-- Successful replay of every order check. -/
   valid : checkOrder raw = true
 
 /-- Characterisation of every condition replayed by the order checker. -/
-theorem checkOrder_iff {c : OrderCert} : checkOrder c = true ↔
+@[simp] theorem checkOrder_iff {c : OrderCert} : checkOrder c = true ↔
     1 < c.modulus ∧ 0 < c.order ∧ c.orderFac.subject = c.order ∧
       checkFactorization c.orderFac = true ∧
       HexArith.powModNat c.base c.order c.modulus = 1 % c.modulus ∧
@@ -85,39 +91,6 @@ theorem checkOrder_pow_div_prime {c : OrderCert} (h : checkOrder c = true) :
         1 % c.modulus :=
   (checkOrder_iff.mp h).2.2.2.2.2
 
-private theorem prime_dvd_pow' {q a : Nat} (hq : Prime q) :
-    ∀ {k : Nat}, q ∣ a ^ k → q ∣ a := by
-  intro k
-  induction k with
-  | zero =>
-      intro h
-      simp only [Nat.pow_zero] at h
-      exact absurd (Nat.dvd_one.mp h) hq.ne_one
-  | succ k ih =>
-      intro h
-      rw [Nat.pow_succ] at h
-      exact (hq.dvd_mul.mp h).elim ih id
-
-private theorem prime_dvd_factorProduct {q : Nat} (hq : Prime q) :
-    ∀ {entries : List PrimePower},
-      (∀ e ∈ entries, Prime e.prime) →
-      q ∣ (entries.map fun e => e.prime ^ e.exponent).prod →
-      ∃ e ∈ entries, e.prime = q := by
-  intro entries hprime hdvd
-  induction entries with
-  | nil =>
-      simp only [List.map_nil, List.prod_nil] at hdvd
-      exact absurd (Nat.dvd_one.mp hdvd) hq.ne_one
-  | cons e rest ih =>
-      simp only [List.map_cons, List.prod_cons] at hdvd
-      rcases hq.dvd_mul.mp hdvd with he | hr
-      · have he' : q ∣ e.prime := prime_dvd_pow' hq he
-        rcases (hprime e (by simp)).2 q he' with heq | heq
-        · exact absurd heq hq.ne_one
-        · exact ⟨e, by simp, heq.symm⟩
-      · obtain ⟨x, hx, heq⟩ := ih (fun x hx => hprime x (by simp [hx])) hr
-        exact ⟨x, by simp [hx], heq⟩
-
 private theorem factorProduct_dvd {d : Nat} :
     ∀ {entries : List PrimePower},
       (∀ e ∈ entries, Prime e.prime) →
@@ -136,7 +109,7 @@ private theorem factorProduct_dvd {d : Nat} :
       have hnot : ¬e.prime ∣ (rest.map fun x => x.prime ^ x.exponent).prod := by
         intro h
         obtain ⟨x, hx, heq⟩ :=
-          prime_dvd_factorProduct (hprime e (by simp)) htailPrime h
+          Internal.prime_mem_of_dvd_prod (hprime e (by simp)) htailPrime h
         have hlt := hsorted.1 x hx
         rw [heq] at hlt
         exact Nat.lt_irrefl _ hlt
@@ -194,7 +167,7 @@ def isPrimitiveRoot {p : Nat} (_pc : CheckedPrimeCert p)
   checkOrder ⟨g, p, p - 1, F.raw⟩
 
 /-- The checker criterion is exact. -/
-theorem isPrimitiveRoot_iff {p : Nat} {pc : CheckedPrimeCert p}
+@[simp] theorem isPrimitiveRoot_iff {p : Nat} {pc : CheckedPrimeCert p}
     {F : CheckedFactorization (p - 1)} {g : Nat} :
     isPrimitiveRoot pc F g = true ↔ orderOf g p = p - 1 := by
   constructor
@@ -297,7 +270,7 @@ private theorem pow_one_add (x r : Nat) :
       obtain ⟨t, ht⟩ := ih
       refine ⟨t + r + t * x, ?_⟩
       rw [Nat.pow_succ, ht]
-      simp only [Nat.add_mul, Nat.mul_add, Nat.one_mul, Nat.mul_one,
+      simp only [Nat.add_mul, Nat.mul_add, Nat.mul_one,
         Nat.succ_mul]
       ac_rfl
 
@@ -414,15 +387,16 @@ private theorem powTwoPower {a e : Nat} (he : 0 < e)
   have ha2 : Nat.Coprime a 2 := Nat.Coprime.coprime_dvd_right hdiv ha
   have hodd := mod_two_eq_one ha2
   rcases Nat.eq_or_lt_of_le (show 1 ≤ e by omega) with rfl | he1
-  · simpa [hodd]
+  · simp [hodd]
   rcases Nat.eq_or_lt_of_le (show 2 ≤ e by omega) with rfl | he2
   · have h8 := oddSquareEight hodd
     have hrepr := one_add_of_mod (by decide : 1 < 8) (by simpa using h8)
     obtain ⟨t, ht⟩ := hrepr
-    simp only [if_neg (by decide : (2 : Nat) ≠ 1), if_pos]
+    simp only [ite_eq_right (by decide : (2 : Nat) ≠ 1), ite_eq_left]
     rw [ht, show 8 * t = 4 * (2 * t) by omega, Nat.add_mul_mod_self_left]
   · obtain ⟨j, rfl⟩ : ∃ j, e = j + 3 := ⟨e - 3, by omega⟩
-    rw [if_neg (by omega : j + 3 ≠ 1), if_neg (by omega : j + 3 ≠ 2)]
+    rw [ite_eq_right (by omega : j + 3 ≠ 1),
+      ite_eq_right (by omega : j + 3 ≠ 2)]
     rw [show j + 3 - 2 = j + 1 by omega]
     have hmod : 1 < 2 ^ (j + 3) :=
       Nat.one_lt_pow (by omega) (by decide)
@@ -435,7 +409,7 @@ private theorem powPrimePower (e : PrimePower) (hp : Prime e.prime)
       1 % e.prime ^ e.exponent := by
   by_cases hp2 : e.prime = 2
   · rw [hp2] at ha ⊢
-    simpa only [carmichaelPrimePower, hp2, if_pos] using powTwoPower he ha
+    simpa only [carmichaelPrimePower, hp2, ite_eq_left] using powTwoPower he ha
   · obtain ⟨j, hj⟩ : ∃ j, e.exponent = j + 1 := ⟨e.exponent - 1, by omega⟩
     rw [hj] at ha ⊢
     simpa [carmichaelPrimePower, hp2, hj] using
@@ -482,7 +456,7 @@ theorem pow_carmichael {n : Nat} (F : CheckedFactorization n)
     (a : Nat) (ha : Nat.Coprime a n) :
     a ^ carmichael F % n = 1 % n := by
   by_cases hn : n = 1
-  · simpa only [hn, Nat.mod_one]
+  · simp only [hn, Nat.mod_one]
   have hnPos : 0 < n := F.pos
   have hnOne : 1 < n := by omega
   have hlocal : ∀ e ∈ F.raw.factors,

--- a/HexIntFactor/Partial.lean
+++ b/HexIntFactor/Partial.lean
@@ -74,8 +74,7 @@ theorem checkPartial_prod {F : PartialFactorization}
     (F.factors.map (fun e => e.prime ^ e.exponent)).prod * F.residual =
       F.subject := by
   obtain ⟨acc, hacc, hfinal⟩ := (checkedPartial_parts h).2.2
-  have hprod := factorProduct_eq F.factors 1 acc hacc
-  have hmul := boundedPowMul_eq 1 acc F.subject hfinal
+  obtain ⟨hprod, hmul⟩ := Internal.factorProduct_parts hacc hfinal
   simpa [hprod] using hmul.symm
 
 /-- Every prime power exposed by accepted partial data is genuinely prime. -/
@@ -104,7 +103,7 @@ theorem checkFactorization_of_checkPartial {F : PartialFactorization}
   obtain ⟨hsubject, hentries, acc, hproduct, hresidual⟩ :=
     checkedPartial_parts h
   have hacc : acc = F.subject := by
-    have heq := boundedPowMul_eq 1 acc F.subject hresidual
+    obtain ⟨_, heq⟩ := Internal.factorProduct_parts hproduct hresidual
     simpa [hr] using heq.symm
   simp only [checkFactorization, Bool.and_eq_true, decide_eq_true_eq]
   exact ⟨⟨hsubject, hentries⟩, hacc ▸ hproduct⟩

--- a/HexIntFactor/README.md
+++ b/HexIntFactor/README.md
@@ -1,0 +1,83 @@
+# hex-int-factor
+
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
+library for Lean 4. The aim is fast executable code, fully verified, built
+with spec-driven development.
+
+Certified natural-number factorization, divisor functions, multiplicative
+orders, and primitive roots for Lean 4, without Mathlib. It builds on
+[`hex-primality`](https://github.com/leanprover/hex-primality),
+[`hex-arith`](https://github.com/leanprover/hex-arith), and
+[`hex-basic`](https://github.com/leanprover/hex-basic). Correspondence with
+Mathlib's factorization and order APIs lives in
+[`hex-int-factor-mathlib`](https://github.com/leanprover/hex-int-factor-mathlib).
+
+# Quickstart
+
+```toml
+[[require]]
+name = "hex-int-factor"
+git = "https://github.com/leanprover/hex-int-factor.git"
+rev = "main"
+```
+
+```lean
+import HexIntFactor
+open Hex Hex.Nat
+set_option maxRecDepth 100000
+
+def twelve : CheckedFactorization 12 :=
+  ⟨⟨12, [⟨2, .small 2⟩, ⟨1, .small 3⟩]⟩, rfl, by decide⟩
+
+#guard checkFactorization twelve.raw
+#guard divisors twelve == #[1, 2, 3, 4, 6, 12]
+#guard totient twelve == 4
+#guard squarefreePart twelve == 3
+#guard squareDivisor twelve == 2
+```
+
+# Functionality
+
+- `factor?` searches for a complete checked factorization with explicit
+  randomness and a finite fuel budget. `factorPartial?` retains a checked
+  residual when complete search exhausts its budget.
+- `checkFactorization` and `checkPartial` replay untrusted factorization data.
+  Prime entries carry `hex-primality` certificates, and bounded products reject
+  oversized powers before constructing them.
+- `divisors`, `numDivisors`, `sigma`, `totient`, `radical`, `squarefreePart`,
+  `squareDivisor`, and `isSquarefree` compute from a `CheckedFactorization`.
+- `checkOrder`, `isPrimitiveRoot`, and `primitiveRoot?` use a complete
+  factorization of the proposed order. `carmichael` computes the Carmichael
+  exponent from a complete factorization.
+- `rhoSplit?`, `pMinusOneFactor`, and `ecmStage1` expose the individual split
+  routes. `factorPower?` adds a cyclotomic pre-split for `b ^ n ± 1`.
+
+# Verification
+
+Every accepted complete certificate has positive subject, canonical positive
+prime-power entries, exact product, complete prime support, and exact
+multiplicities:
+
+```lean
+theorem checkFactorization_prod {F : Factorization}
+    (h : checkFactorization F = true) :
+    (F.factors.map (fun e => e.prime ^ e.exponent)).prod = F.subject
+
+theorem checkFactorization_primeSupport {F : Factorization}
+    (h : checkFactorization F = true) {q : Nat} (hq : Prime q) :
+    q ∣ F.subject ↔ ∃ e ∈ F.factors, e.prime = q
+```
+
+Factor search is deliberately partial: zero, exhausted search, and internal
+checker rejection are distinct `FactorStop` cases, with the advanced random
+state and checked partial snapshot retained where available. Split algorithms
+are untrusted producers; only Lean-checked certificates cross the public
+correctness boundary. See the [SPEC](SPEC/hex-int-factor.md) for the route and
+fuel contracts.
+
+# Contributing
+
+Development happens in the
+[`hex-dev`](https://github.com/kim-em/hex-dev) monorepo, not in this published
+mirror. Contributions are welcome as pull requests to the `SPEC/` directory:
+describe the behavior you want and leave the implementation to the maintainer.

--- a/HexIntFactorMathlib/README.md
+++ b/HexIntFactorMathlib/README.md
@@ -1,0 +1,81 @@
+# hex-int-factor-mathlib
+
+Part of [`hex`](https://github.com/kim-em/hex-dev), a computer algebra
+library for Lean 4. The aim is fast executable code, fully verified, built
+with spec-driven development.
+
+The Mathlib correspondence layer for
+[`hex-int-factor`](https://github.com/leanprover/hex-int-factor). It identifies
+checked executable factorizations with `Nat.factorization`, divisor functions,
+squarefree decomposition, and Mathlib's multiplicative order. It also uses
+[`hex-primality-mathlib`](https://github.com/leanprover/hex-primality-mathlib)
+to transport the primality evidence carried by factor entries.
+
+# Quickstart
+
+```toml
+[[require]]
+name = "hex-int-factor-mathlib"
+git = "https://github.com/leanprover/hex-int-factor-mathlib.git"
+rev = "main"
+```
+
+```lean
+import HexIntFactorMathlib
+open Hex
+set_option maxRecDepth 100000
+
+def twelve : Hex.Nat.CheckedFactorization 12 :=
+  ⟨⟨12, [⟨2, .small 2⟩, ⟨1, .small 3⟩]⟩, rfl, by decide⟩
+
+example : Hex.Nat.totient twelve = Nat.totient 12 :=
+  Hex.Nat.totient_eq twelve
+
+example : (Hex.Nat.divisors twelve).toList.toFinset = Nat.divisors 12 :=
+  Hex.Nat.divisors_eq twelve
+```
+
+# Functionality
+
+- `factorization_entry`, `factorization_eq`, and
+  `CheckedFactorization.factorization_eq` identify checked multiplicities with
+  Mathlib's `Nat.factorization`.
+- `factors_eq` and `CheckedFactorization.primeFactorsList_eq` identify the
+  canonical expanded prime list.
+- `divisors_eq`, `divisors_list_eq`, `numDivisors_eq_card`, `totient_eq`,
+  `sigma_eq`, `primeFactors_eq`, and `radical_eq` transport executable divisor
+  data and arithmetic functions.
+- `isSquarefree_iff_squarefree`, `squarefreePart_mathlib`, and
+  `squareDivisor_mathlib` connect the executable square decomposition to
+  Mathlib's predicates and order-theoretic characterization.
+- `orderOf_unitOfCoprime`, `orderOf_natCast`, and `orderOf_eq` identify the
+  Mathlib-free natural order with Mathlib's `orderOf` on `ZMod` and its units.
+
+# Verification
+
+The bridge is correspondence-only. It performs no factor search, certificate
+replay, reification, or tactic execution; all transported values are computed
+by `hex-int-factor`.
+
+```lean
+theorem CheckedFactorization.factorization_eq {n : Nat}
+    (F : CheckedFactorization n) (p : Nat) :
+    n.factorization p =
+      (F.raw.factors.find? fun e => e.prime == p).elim 0 (·.exponent)
+
+theorem orderOf_eq {c : OrderCert} (h : checkOrder c = true) :
+    _root_.orderOf
+        (ZMod.unitOfCoprime c.base (coprime_of_checkOrder h)) = c.order
+```
+
+Use [`hex-int-factor`](https://github.com/leanprover/hex-int-factor) alone for
+computation. This package is for theorem statements and interoperability with
+Mathlib. See the [SPEC](SPEC/hex-int-factor-mathlib.md) for the complete
+correspondence boundary.
+
+# Contributing
+
+Development happens in the
+[`hex-dev`](https://github.com/kim-em/hex-dev) monorepo, not in this published
+mirror. Contributions are welcome as pull requests to the `SPEC/` directory:
+describe the behavior you want and leave the implementation to the maintainer.

--- a/HexIntFactorMathlib/SPEC/hex-int-factor-mathlib.md
+++ b/HexIntFactorMathlib/SPEC/hex-int-factor-mathlib.md
@@ -14,6 +14,24 @@ a tactic, or install a decision procedure. All transported values are computed
 by `HexIntFactor`; this layer supplies proofs that identify those values with
 their Mathlib counterparts.
 
+## Headline correctness theorem
+
+The bridge's headline correctness theorem is
+`Hex.Nat.CheckedFactorization.factorization_eq`:
+
+```lean
+theorem Hex.Nat.CheckedFactorization.factorization_eq {n : Nat}
+    (F : CheckedFactorization n) (p : Nat) :
+    n.factorization p =
+      (F.raw.factors.find? fun e => e.prime == p).elim 0 (·.exponent)
+```
+
+It is the end-to-end correspondence for the checked factorization API: every
+multiplicity computed from the certificate's canonical prime-power list is
+exactly Mathlib's `Nat.factorization` value for the certified subject. The
+divisor, arithmetic-function, square-decomposition, and order transports
+below build on this checked correspondence and the core correctness theorems.
+
 ## Factorization correspondences
 
 `HexIntFactorMathlib.Factorization` transports the core checker facts and

--- a/HexManual.lean
+++ b/HexManual.lean
@@ -36,6 +36,7 @@ import HexManual.Chapters.FactorTactics
 import HexManual.Chapters.HexTruncatedSeries
 import HexManual.Chapters.HexPolyFast
 import HexManual.Chapters.HexPrimality
+import HexManual.Chapters.HexIntFactor
 import HexManual.Chapters.HexModular
 import HexManual.Chapters.HexResultant
 import HexManual.Chapters.HexPolyZGcd
@@ -166,6 +167,8 @@ here to keep the reference chapters above focused on the released libraries.
 {include 2 HexManual.Chapters.HexPolyFast}
 
 {include 2 HexManual.Chapters.HexPrimality}
+
+{include 2 HexManual.Chapters.HexIntFactor}
 
 {include 2 HexManual.Chapters.HexModular}
 

--- a/HexManual/Chapters/HexIntFactor.lean
+++ b/HexManual/Chapters/HexIntFactor.lean
@@ -1,0 +1,250 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import VersoManual
+import HexIntFactor
+import HexIntFactorMathlib
+
+open Verso.Genre Manual
+open Verso.Genre.Manual.InlineLean
+
+set_option pp.rawOnError true
+
+#doc (Manual) "HexIntFactor: certified integer factorization" =>
+%%%
+tag := "hex-int-factor"
+%%%
+
+# Introduction
+%%%
+tag := "hex-int-factor-intro"
+%%%
+
+`HexIntFactor` factors natural numbers and turns the result into divisor,
+square-decomposition, multiplicative-order, and primitive-root data. Search is
+an explicitly bounded, untrusted producer. Its results become theorem inputs
+only after a small Boolean checker has replayed every prime certificate and
+the complete prime-power product.
+
+The executable library is Mathlib-free. It depends on `HexPrimality` for
+kernel-replayable primality certificates and modular-order infrastructure,
+and on `HexArith` and `HexBasic` for bounded arithmetic and explicit random
+state. The companion `HexIntFactorMathlib` proves correspondence with
+Mathlib's factorization, divisor, squarefree, and `ZMod` order APIs.
+
+# Complete certificates
+%%%
+tag := "hex-int-factor-certificates"
+%%%
+
+A {name}`Hex.Nat.PrimePower` stores an exponent and a
+`HexPrimality` certificate. Its base is the subject of that certificate, so
+the two cannot disagree. A {name}`Hex.Nat.Factorization` is raw data: its
+subject and factor list are trusted only after replay.
+
+{docstring Hex.Nat.PrimePower.prime}
+
+{docstring Hex.Nat.checkFactorization}
+
+{name}`Hex.Nat.CheckedFactorization` ties accepted raw data to the subject
+requested by its caller. The checker requires a positive subject, positive
+exponents, strictly ascending prime bases, successful primality replay, and an
+exact product. Product accumulation is bounded by the claimed subject, so an
+attacker-chosen exponent cannot first construct an arbitrarily large power.
+
+The checked facts are exposed as characterizing theorems rather than requiring
+callers to unfold the checker:
+
+{docstring Hex.Nat.checkFactorization_prod}
+
+{docstring Hex.Nat.checkFactorization_prime}
+
+{docstring Hex.Nat.checkFactorization_primeSupport}
+
+{docstring Hex.Nat.checkFactorization_multiplicity}
+
+The support theorem is complete because the checker proves both the product
+identity and primality of every listed base. Strict ordering additionally
+makes the representation canonical and makes each recorded exponent the exact
+multiplicity.
+
+# Checked arithmetic from a factorization
+%%%
+tag := "hex-int-factor-arithmetic"
+%%%
+
+Once a factorization is checked, divisor enumeration and the usual arithmetic
+functions require no further search. Divisors are returned in ascending order;
+the count and generalized divisor sum use prime-power product formulas rather
+than enumerating the entire list.
+
+{docstring Hex.Nat.divisors}
+
+{docstring Hex.Nat.numDivisors}
+
+{docstring Hex.Nat.sigma}
+
+{docstring Hex.Nat.totient}
+
+{docstring Hex.Nat.radical}
+
+The square decomposition writes the subject as a squarefree factor times the
+square of a greatest possible divisor.
+
+{docstring Hex.Nat.squarefreePart}
+
+{docstring Hex.Nat.squareDivisor}
+
+{docstring Hex.Nat.squarefreePart_mul_square}
+
+{docstring Hex.Nat.squareDivisor_spec}
+
+# Worked example
+%%%
+tag := "hex-int-factor-example"
+%%%
+
+The following block is elaborated with the manual. The certificate for
+`12 = 2² · 3` uses the small-prime certificates supplied by
+`HexPrimality`; ordinary kernel reduction checks the factorization before any
+arithmetic consumer can use it.
+
+```lean
+open Hex Hex.Nat
+
+namespace HexIntFactorChapter
+
+set_option maxRecDepth 100000
+
+def twelve : CheckedFactorization 12 :=
+  ⟨⟨12, [⟨2, .small 2⟩, ⟨1, .small 3⟩]⟩,
+    rfl, by decide⟩
+
+#guard checkFactorization twelve.raw
+#guard divisors twelve == #[1, 2, 3, 4, 6, 12]
+#guard sigma twelve 1 == 28
+#guard totient twelve == 4
+#guard radical twelve == 6
+#guard squarefreePart twelve == 3
+#guard squareDivisor twelve == 2
+
+end HexIntFactorChapter
+```
+
+# Search, fuel, and failure
+%%%
+tag := "hex-int-factor-search"
+%%%
+
+{docstring Hex.Nat.factor?}
+
+`factor?` first applies structural reductions and table trial division, then
+uses primality search, Brent rho, Pollard `p − 1`, and stage-one ECM as the
+input requires. Its `Hex.Rand` argument and returned random state make every
+random draw explicit. The default fuel scales with bit length but does not
+claim to make a partial search total.
+
+{docstring Hex.Nat.defaultFuel}
+
+The {name}`Hex.Nat.FactorStop` cases distinguish zero, ordinary exhaustion,
+and rejection of a producer's output by a checker. A
+{name}`Hex.Nat.FactorFailure` retains exact attempt accounting, the advanced
+random state, and either the last checked partial snapshot or the rejected raw
+candidate. This makes retry policy observable without treating exhaustion as
+a false mathematical result.
+
+{docstring Hex.Nat.factorPartial?}
+
+{docstring Hex.Nat.checkPartial}
+
+{docstring Hex.Nat.checkPartial_prod}
+
+A partial factorization certifies every listed prime power and the exact
+residual product, but makes no primality claim about the residual. Residual
+one promotes directly to a complete certificate without replaying the entire
+checker:
+
+{docstring Hex.Nat.checkFactorization_of_checkPartial}
+
+Specialized entry points expose the split routes for callers that need route
+control or diagnostics. `factorPower?` adds a checked cyclotomic pre-split for
+numbers of the form `b ^ n − 1` or `b ^ n + 1`; failed subproblems may fall
+back to generic search, while checker rejection is propagated.
+
+# Orders, primitive roots, and Carmichael exponents
+%%%
+tag := "hex-int-factor-orders"
+%%%
+
+An {name}`Hex.Nat.OrderCert` claims that a residue has a specified least
+positive order. Its factorization field must be a complete checked
+factorization of that order. The checker verifies the full power is one and
+that removing each distinct prime divisor from the exponent is not.
+
+{docstring Hex.Nat.checkOrder}
+
+{docstring Hex.Nat.checkOrder_iff}
+
+{docstring Hex.Nat.order_eq_of_checkOrder}
+
+For a certified prime `p`, {name}`Hex.Nat.isPrimitiveRoot` specializes this
+criterion to order `p − 1`; {name}`Hex.Nat.primitiveRoot?` performs a
+fuel-bounded ascending search and returns the checked order certificate with
+the generator.
+
+{docstring Hex.Nat.isPrimitiveRoot_iff}
+
+{docstring Hex.Nat.primitiveRoot?_spec}
+
+The Carmichael exponent is computed by taking the least common multiple of
+the prime-power exponents. Its correctness is stated both as a power law and
+as the divisibility bound on every multiplicative order.
+
+{docstring Hex.Nat.carmichael}
+
+{docstring Hex.Nat.pow_carmichael}
+
+{docstring Hex.Nat.orderOf_dvd_carmichael}
+
+# The Mathlib correspondence
+%%%
+tag := "hex-int-factor-mathlib"
+%%%
+
+`HexIntFactorMathlib` is correspondence-only: it neither searches for factors
+nor replays certificates. It identifies values already computed and checked
+by `HexIntFactor` with Mathlib's canonical definitions.
+
+{docstring Hex.Nat.CheckedFactorization.factorization_eq}
+
+{docstring Hex.Nat.CheckedFactorization.primeFactorsList_eq}
+
+{docstring Hex.Nat.divisors_eq}
+
+{docstring Hex.Nat.totient_eq}
+
+{docstring Hex.Nat.isSquarefree_iff_squarefree}
+
+For modular orders, the bridge first identifies the Mathlib-free natural
+order with the order of the corresponding unit in `ZMod n`, then specializes
+that equality to accepted order certificates.
+
+{docstring Hex.Nat.orderOf_unitOfCoprime}
+
+{docstring Hex.Nat.orderOf_eq}
+
+# Cross-references
+%%%
+tag := "hex-int-factor-cross-references"
+%%%
+
+* {ref "hex-primality"}[`HexPrimality`] supplies the primality certificates,
+  order computation, and shared rho and `p − 1` primitives.
+* {ref "hex-arith"}[`HexArith`] supplies bounded powers, modular arithmetic,
+  primality foundations, and exact gcd infrastructure.
+* `HexConway` can consume complete prime support for multiplicative-group
+  orders when its committed table grows beyond hand-maintained
+  factorizations.

--- a/HexManual/Chapters/HexIntFactor.lean
+++ b/HexManual/Chapters/HexIntFactor.lean
@@ -200,8 +200,9 @@ the generator.
 {docstring Hex.Nat.primitiveRoot?_spec}
 
 The Carmichael exponent is computed by taking the least common multiple of
-the prime-power exponents. Its correctness is stated both as a power law and
-as the divisibility bound on every multiplicative order.
+the Carmichael value of each certified prime power. Its correctness is stated
+both as a power law and as the divisibility bound on every multiplicative
+order.
 
 {docstring Hex.Nat.carmichael}
 

--- a/HexPrimality/Cert.lean
+++ b/HexPrimality/Cert.lean
@@ -381,21 +381,6 @@ private theorem checkChildren_forall :
 
 /-! Prime-power combination -/
 
-private theorem prime_dvd_pow {p a : Nat} (hp : Prime p) :
-    ∀ {k : Nat}, p ∣ a ^ k → p ∣ a := by
-  intro k
-  induction k with
-  | zero =>
-      intro h
-      rw [Nat.pow_zero] at h
-      exact absurd (Nat.dvd_one.mp h) (by have := hp.two_le; omega)
-  | succ k ih =>
-      intro h
-      rw [Nat.pow_succ] at h
-      rcases (hp.dvd_mul).mp h with h' | h'
-      · exact ih h'
-      · exact h'
-
 private theorem prime_eq_of_dvd {p q : Nat} (hp : Prime p) (hq : Prime q)
     (h : p ∣ q) : p = q := by
   rcases hq.2 p h with h1 | h1

--- a/bench/HexIntFactor/Bench.lean
+++ b/bench/HexIntFactor/Bench.lean
@@ -467,9 +467,9 @@ private theorem boundedPowMul_exact (q acc : Nat) (hq : 0 < q)
       have hle : q ≤ q ^ e * q := Nat.le_mul_of_pos_left q hpow
       have hmul : acc * q ≤ acc * q ^ (e + 1) := by
         simpa only [Nat.pow_succ] using Nat.mul_le_mul_left acc hle
-      rw [boundedPowMul, if_neg (Nat.ne_of_gt hacc),
-        if_neg (Nat.ne_of_gt hq),
-        if_pos ((Nat.le_div_iff_mul_le hq).2 hmul)]
+      rw [boundedPowMul, ite_eq_right (Nat.ne_of_gt hacc),
+        ite_eq_right (Nat.ne_of_gt hq),
+        ite_eq_left ((Nat.le_div_iff_mul_le hq).2 hmul)]
       simpa only [Nat.pow_succ, Nat.mul_assoc, Nat.mul_comm,
         Nat.mul_left_comm] using
         boundedPowMul_exact q (acc * q) hq (Nat.mul_pos hacc hq) e

--- a/libraries.yml
+++ b/libraries.yml
@@ -681,7 +681,7 @@ libraries:
   HexIntFactor:
     deps: [HexPrimality, HexArith, HexBasic]
     mathlib: false
-    done_through: 4
+    done_through: 7
     status: active
     proof_probes: [bench/HexIntFactor/ProofProbe]
     phase4:
@@ -881,7 +881,7 @@ libraries:
     deps: [HexIntFactor, HexPrimalityMathlib]
     mathlib: true
     correspondence_only: true
-    done_through: 3
+    done_through: 7
     status: active
   HexBerlekampZassenhausMathlib:
     deps: [HexBerlekampZassenhaus, HexBerlekampMathlib, HexHenselMathlib, HexPolyZMathlib, HexMatrixMathlib, HexLLLMathlib]

--- a/scripts/bench/proof_only_runtime_exemptions/hexarith-nat-prime-lean-3c739ff4-1bdbc090.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexarith-nat-prime-lean-3c739ff4-1bdbc090.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexArith/Nat/Prime.lean",
+ "baseline_blob": "3c739ff40939977910ea64afd72b1db3142c5444",
+ "current_blob": "1bdbc0907db62e7a03c7c3b4a2e078d0541b6bb0",
+ "reason": "Adds only the proof theorem Prime.dvd_of_dvd_pow so IntFactor can share its prime-power divisor argument and delete duplicate proofs. No executable definition or factorization-service runtime path changes."
+}


### PR DESCRIPTION
## Summary

- deduplicate factor-product and prime-support proof helpers, place the reusable prime-power lemma in HexArith, narrow the order module import, and clean IntFactor linter warnings
- add build-checked core and Mathlib-bridge READMEs plus a draft HexManual chapter covering certificates, APIs, search failure, fuel, and correspondence
- name the bridge headline correctness theorem and certify both IntFactor packages through local Phase 7

## Verification

- lake build HexIntFactor HexIntFactorMathlib HexConformance HexManual
- lake exe runLinter on all affected core modules and both public HexIntFactorMathlib modules
- lake exe hexintfactor_bench verify (40/40)
- copyright, file-line-count, DAG, released-manifest, manual-split, trust-surface, Phase 4, Phase 7, Mathlib-free bench, and conformance-matrix checks
- build-checked README quickstarts

The runtime implementation and benchmark registrations are unchanged; check_phase4 reports changed registrations: 0, so the committed IntFactor Phase-4 artifact remains representative. The leanprover split-repository links in the READMEs are intentional pre-release publication targets and must be revalidated when released.yml gains these packages.

## Independent review

A fresh Claude Opus review found no soundness defect. Follow-up commit 3b881105c moves the generic prime-power lemma upstream, removes the remaining duplicate, centralizes the ordered-tail proof, removes an anti-simp attribute, fixes Carmichael documentation, documents the retained partial proof field, and records the bridge headline theorem in its SPEC.

No released-repository publish or sync is performed here. Final directive closure remains with #9619.

Closes #9638