### PR TITLE
perf: parallelize the hex-roots fixture emitter

### DIFF
--- a/HexRoots/SPEC/hex-roots.md
+++ b/HexRoots/SPEC/hex-roots.md
@@ -883,9 +883,13 @@ polynomials rarely have clustered roots.
   - 50 degree-20 polynomials with deterministic seed `0xC0FFEE` and
     coefficients in `[−10, 10]`, cross-checked against the python-flint
     oracle (below), plus the six curated atom/cluster cases retained for
-    explicit simple/multiple-root coverage. Fresh emission of the full stream
-    takes about 5.2 minutes on `chungus2`; at degree 20 the all-atoms local
-    finisher supplies the speedup, while the size-gated soft front end is idle.
+    explicit simple/multiple-root coverage. The emitter computes cases in
+    parallel tasks and writes records in case order, so the stream stays
+    byte-identical to sequential emission; fresh emission of the full
+    stream takes about 11 seconds on `chungus2` (about 4.8 CPU-minutes,
+    `HEX_EMIT_JOBS` caps the outstanding tasks). At degree 20 the
+    all-atoms local finisher supplies the per-case speedup, while the
+    size-gated soft front end is idle.
 - *local* (developer-driven):
   - Adversarial families cross-checked against MPSolve: Mignotte
     `(n, a)` for `n ∈ {10, 20}` and `a ∈ {1000, 10⁶}`, the Wilkinson

--- a/conformance/HexRoots/EmitFixtures.lean
+++ b/conformance/HexRoots/EmitFixtures.lean
@@ -62,6 +62,7 @@ private def target : Int := 32
 private structure Case where
   id     : String
   coeffs : List Int
+deriving Inhabited
 
 /-- One step of the deterministic seed-`0xC0FFEE` coefficient stream. -/
 private def lcgNext (s : UInt64) : UInt64 :=
@@ -120,26 +121,49 @@ private def certValue {p : ZPoly} (rs : Array (Certified p)) : String :=
 /-- The `result.value` for a driver give-up. -/
 private def noneValue : String := "\"none\""
 
-/-- Emit the `poly` fixture and `isolateAll32` result for one case, returning
-    `true` when the driver returned `none`. -/
-private def emitCase (c : Case) : IO Bool := do
-  emitPolyFixture lib c.id c.coeffs
+/-- The expensive half of one case: the serialised `isolateAll32`
+outcome and the gave-up flag. Pure, so cases parallelise as tasks
+with the record stream still written in order by `main`. -/
+private def caseValue (c : Case) : String × Bool :=
   let p : ZPoly := DensePoly.ofCoeffs c.coeffs.toArray
-  let (value, gaveUp) :=
-    if h : 0 < p.degree?.getD 0 then
-      match isolateAll? p target #[Component.cauchy p h] with
-      | some rs => (certValue rs, false)
-      | none    => (noneValue, true)
-    else
-      (noneValue, true)
-  emitResult lib c.id "isolateAll32" value
-  pure gaveUp
+  if h : 0 < p.degree?.getD 0 then
+    match isolateAll? p target #[Component.cauchy p h] with
+    | some rs => (certValue rs, false)
+    | none    => (noneValue, true)
+  else
+    (noneValue, true)
 
 end Hex.RootsEmit
 
-open Hex.RootsEmit in
+open Hex.RootsEmit Hex.Conformance.Emit in
 def main : IO Unit := do
-  for c in cases do
-    if ← emitCase c then
+  -- The per-case isolation dominates the run (seconds per degree-20
+  -- case), so it is computed in parallel tasks while the records are
+  -- written strictly in case order, keeping the stream byte-identical
+  -- to sequential emission. The runtime's task pool bounds
+  -- concurrency at the hardware thread count; `HEX_EMIT_JOBS` caps
+  -- the number of outstanding tasks below that when set.
+  let jobs? := (← IO.getEnv "HEX_EMIT_JOBS").bind (·.toNat?)
+  let arr := (cases : List Case).toArray
+  let n := arr.size
+  let window := match jobs? with
+    | some j => min (max 1 j) n
+    | none => n
+  let mut tasks : Array (Option (Task (String × Bool))) := .replicate n none
+  let mut spawned := 0
+  while spawned < window do
+    let j := spawned
+    tasks := tasks.set! j (some (Task.spawn fun _ => caseValue arr[j]!))
+    spawned := spawned + 1
+  for i in [0:n] do
+    let c := arr[i]!
+    emitPolyFixture lib c.id c.coeffs
+    let (value, gaveUp) := (tasks[i]!.getD (Task.pure (noneValue, true))).get
+    emitResult lib c.id "isolateAll32" value
+    if gaveUp then
       IO.eprintln s!"hexroots_emit_fixtures: isolateAll? returned none for case {c.id}; \
         this is SPEC-noteworthy"
+    if spawned < n then
+      let j := spawned
+      tasks := tasks.set! j (some (Task.spawn fun _ => caseValue arr[j]!))
+      spawned := spawned + 1


### PR DESCRIPTION
This PR compute the hex-roots fixture cases in parallel while writing records strictly in case order, so the emitted stream stays byte-identical to the committed fixture (the acceptance test run_oracles.sh already enforces). The expensive per-case isolateAll? becomes a pure value computed via Task.spawn behind a bounded in-order window (HEX_EMIT_JOBS; unset, the runtime pool bounds execution at hardware threads), and the Hex.Conformance.Emit record helpers are untouched. Emission drops from 4m47s to 1m24s at four threads and 11s on a full pool; with the pooled oracle step (https://github.com/kim-em/hex-dev/pull/9907) this removes the step's dominant tuple and should bring the warm CI lap near fifteen minutes. The SPEC's fixture-set audit confirms the 56-case set is exactly the intended merge tier — no cases move — and its emission-practicality note is updated to match.

Closes https://github.com/kim-em/hex-dev/issues/9909.

🤖 Prepared with Claude Code