### PR TITLE
fix: leave bench verify CPU headroom under the CI oracle pool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,6 +273,11 @@ jobs:
         id: conformance
         background: true
         env:
+          # Bench verify runs concurrently under a hard wallclock cap, so
+          # the oracle pool (and any emitter-internal parallelism) must
+          # leave it CPU headroom on the 4-vCPU runner.
+          HEX_ORACLE_JOBS: "2"
+          HEX_EMIT_JOBS: "2"
           # Missing comparator packages are release failures, not green skips.
           HEX_REQUIRE_ORACLES: "1"
         run: |


### PR DESCRIPTION
This PR pin the conformance-oracle worker pool to two workers in CI (and pre-cap emitter-internal parallelism identically): bench verify runs background-parallel with the oracle step under its 360-second hard wallclock cap, and the pool's nproc default can saturate the 4-vCPU runner and starve the cap race-dependently — observed as a bench-verify failure on an unrelated conformance-only change. Two workers keep most of the pooling win while leaving two vCPUs for the timing-sensitive verify.

🤖 Prepared with Claude Code