### PR TITLE
chore: replace deprecated `if_pos`/`if_neg` with their `ite`/`dite` successors

### DIFF
--- a/HexArith/Barrett/Accumulator.lean
+++ b/HexArith/Barrett/Accumulator.lean
@@ -132,7 +132,7 @@ theorem accVal_accAddWord (lo hi q : UInt64) (hhi : hi.toNat + 1 < UInt64.word) 
   dsimp [accAddWord]
   by_cases hc : (UInt64.addCarry lo q false).2 = true
   · have hc' : (UInt64.addCarry lo q false).2 = true := hc
-    simp only [hc', if_true]
+    simp only [hc', ite_true]
     have hhi1 : (hi + 1).toNat = hi.toNat + 1 := by
       rw [UInt64.toNat_add]
       simp only [UInt64.toNat_one]
@@ -184,13 +184,13 @@ theorem accAddWord_eq_inline (lo hi q : UInt64) :
   · have hover : UInt64.word ≤ lo.toNat + q.toNat := by
       have h := (UInt64.addCarry_snd_eq_true lo q false).mp hc
       simpa using h
-    rw [hc, if_pos rfl, if_pos (hlt.mpr hover)]
+    rw [hc, ite_eq_left rfl, ite_eq_left (hlt.mpr hover)]
   · have hc' : (UInt64.addCarry lo q false).2 = false := by
       simpa using hc
     have hnover : ¬ UInt64.word ≤ lo.toNat + q.toNat := by
       intro h
       exact hc ((UInt64.addCarry_snd_eq_true lo q false).mpr (by simpa using h))
-    rw [hc', if_neg Bool.false_ne_true, if_neg (fun h => hnover (hlt.mp h)),
+    rw [hc', ite_eq_right Bool.false_ne_true, ite_eq_right (fun h => hnover (hlt.mp h)),
       UInt64.add_zero]
 
 /-! # Two-word reduction -/
@@ -410,18 +410,18 @@ theorem accFold_spec (ctx : BarrettCtx p) (ws : List UInt64) :
     have hgrow : (accAddWord lo hi q).2.toNat ≤ hi.toNat + 1 := by
       dsimp [accAddWord]
       by_cases hc : (UInt64.addCarry lo q false).2 = true
-      · rw [if_pos hc]
+      · rw [ite_eq_left hc]
         have hh : (hi + 1).toNat = hi.toNat + 1 := by
           rw [UInt64.toNat_add]; simp only [UInt64.toNat_one]
           exact Nat.mod_eq_of_lt hnw
         omega
-      · rw [if_neg hc]; omega
+      · rw [ite_eq_right hc]; omega
     rw [List.foldl_cons]
     by_cases hcase : count + 1 = barrettWindow
     · have hstep : accStep ctx (lo, hi, count) q =
           (accReduce ctx (radixResidue ctx) (accAddWord lo hi q).1 (accAddWord lo hi q).2,
             0, 0) := by
-        simp only [accStep]; rw [if_pos hcase]
+        simp only [accStep]; rw [ite_eq_left hcase]
       rw [hstep]
       have hres := ih (accReduce ctx (radixResidue ctx) (accAddWord lo hi q).1
         (accAddWord lo hi q).2) 0 0 (Nat.le_of_eq UInt64.toNat_zero) barrettWindow_pos
@@ -435,7 +435,7 @@ theorem accFold_spec (ctx : BarrettCtx p) (ws : List UInt64) :
       rw [hR, wordsSum_cons, Nat.mod_add_mod, Nat.add_assoc]
     · have hstep : accStep ctx (lo, hi, count) q =
           ((accAddWord lo hi q).1, (accAddWord lo hi q).2, count + 1) := by
-        simp only [accStep]; rw [if_neg hcase]
+        simp only [accStep]; rw [ite_eq_right hcase]
       rw [hstep]
       have hcount : count + 1 < barrettWindow := by omega
       have hhi : (accAddWord lo hi q).2.toNat ≤ count + 1 := by omega

--- a/HexArith/Montgomery/Context.lean
+++ b/HexArith/Montgomery/Context.lean
@@ -809,7 +809,7 @@ theorem powModNat_modulus_zero (a n : Nat) :
 theorem powModNat_eq (a n p : Nat) (hp : 0 < p) :
     powModNat a n p = a ^ n % p := by
   unfold powModNat
-  rw [if_neg (by omega)]
+  rw [ite_eq_right (by omega)]
   apply powModNatGo_eq a n p (bitLength n) 0 (1 % p) (a % p) hp
   · simpa using lt_two_pow_bitLength n
   · exact Nat.mod_lt _ hp

--- a/HexArith/Montgomery/Redc.lean
+++ b/HexArith/Montgomery/Redc.lean
@@ -280,7 +280,7 @@ theorem montgomeryReduce_sub_spec (ctx : MontCtx p) (Thi Tlo : UInt64)
                       exact hle
                     omega
                   simp [hlow_pair, hhi_pair, hge, hltNat]
-              · simp only [hlow_pair, hhi_pair, if_true, Bool.toNat_true]
+              · simp only [hlow_pair, hhi_pair, ite_true, Bool.toNat_true]
                 have hp_lt_lit : p.toNat < 2 ^ 64 := by
                   simpa [UInt64.word] using hp_lt
                 have hu_lt_lit : addHi.toNat + 2 ^ 64 < 2 * p.toNat := by
@@ -294,7 +294,7 @@ theorem montgomeryReduce_sub_spec (ctx : MontCtx p) (Thi Tlo : UInt64)
                       2 ^ 64 - p.toNat + addHi.toNat :=
                   Nat.mod_eq_of_lt hsub_lt
                 simp only [UInt64.toNat_sub, hsub_mod]
-                simp only [hnotlt, if_false, Nat.one_mul]
+                simp only [hnotlt, ite_false, Nat.one_mul]
                 rw [Nat.add_comm addHi.toNat (2 ^ 64)]
                 exact (Nat.sub_add_comm (Nat.le_of_lt hp_lt_lit)).symm
 

--- a/HexArith/Nat/Prime.lean
+++ b/HexArith/Nat/Prime.lean
@@ -393,8 +393,8 @@ private theorem binom_foldl (n : Nat) :
 theorem binom_eq_choose (n k : Nat) : binom n k = choose n k := by
   unfold binom
   by_cases h : n < k
-  · rw [if_pos h]; exact (choose_eq_zero_of_lt h).symm
-  · rw [if_neg h]
+  · rw [ite_eq_left h]; exact (choose_eq_zero_of_lt h).symm
+  · rw [ite_eq_right h]
     have hkn : k ≤ n := Nat.le_of_not_lt h
     rcases Nat.le_total k (n - k) with hle | hle
     · rw [Nat.min_eq_left hle]; exact binom_foldl n k hkn
@@ -718,14 +718,14 @@ private theorem no_divisor_of_isPrimeTrialAux {n fuel k : Nat}
   | zero =>
       rw [isPrimeTrialAux] at h
       by_cases hstop : n < k * k
-      · rw [if_pos hstop] at h
+      · rw [ite_eq_left hstop] at h
         intro d hkd hd hsq
         have hdk : d = k := by
           simp only [Nat.pow_zero] at hd
           omega
         subst d
         omega
-      · rw [if_neg hstop] at h
+      · rw [ite_eq_right hstop] at h
         intro d hkd hd _
         have hdk : d = k := by
           simp only [Nat.pow_zero] at hd
@@ -735,11 +735,11 @@ private theorem no_divisor_of_isPrimeTrialAux {n fuel k : Nat}
   | succ fuel ih =>
       rw [isPrimeTrialAux] at h
       by_cases hstop : n < k * k
-      · rw [if_pos hstop] at h
+      · rw [ite_eq_left hstop] at h
         intro d hkd _ hsq
         have hkk : k * k ≤ d * d := Nat.mul_le_mul hkd hkd
         omega
-      · rw [if_neg hstop, Bool.and_eq_true] at h
+      · rw [ite_eq_right hstop, Bool.and_eq_true] at h
         intro d hkd hd hsq
         have hpow : 2 ^ (fuel + 1) = 2 ^ fuel + 2 ^ fuel := by
           rw [Nat.pow_succ]
@@ -820,8 +820,8 @@ private theorem isPrimeTrialAux_of_prime {n : Nat} (hn : Prime n) :
       intro k hk2
       rw [isPrimeTrialAux]
       by_cases hstop : n < k * k
-      · rw [if_pos hstop]
-      · rw [if_neg hstop]
+      · rw [ite_eq_left hstop]
+      · rw [ite_eq_right hstop]
         apply decide_eq_true
         intro hmod
         have hdvd : k ∣ n := Nat.dvd_of_mod_eq_zero hmod
@@ -836,8 +836,8 @@ private theorem isPrimeTrialAux_of_prime {n : Nat} (hn : Prime n) :
       intro k hk2
       rw [isPrimeTrialAux]
       by_cases hstop : n < k * k
-      · rw [if_pos hstop]
-      · rw [if_neg hstop, Bool.and_eq_true]
+      · rw [ite_eq_left hstop]
+      · rw [ite_eq_right hstop, Bool.and_eq_true]
         exact ⟨ih k hk2,
           ih (k + 2 ^ fuel) (Nat.le_trans hk2 (Nat.le_add_right k _))⟩
 

--- a/HexBareiss/Bareiss.lean
+++ b/HexBareiss/Bareiss.lean
@@ -211,8 +211,8 @@ theorem findPivotAux_eq_zero_of_none [Zero R] [DecidableEq R]
             · exact hzero
             · have hzeroNat : ¬ M[start][col.val] = 0 := by
                 simpa using hzero
-              simp only [findPivotAux, hlt, dif_pos] at hfind
-              rw [if_neg (by simpa [getRow, Fin.getElem_fin] using hzero)] at hfind
+              simp only [findPivotAux, hlt, dite_eq_left] at hfind
+              rw [ite_eq_right (by simpa [getRow, Fin.getElem_fin] using hzero)] at hfind
               simp at hfind
           have hiFin : i = (⟨start, hlt⟩ : Fin n) := Fin.ext hi
           rw [hiFin]
@@ -222,14 +222,14 @@ theorem findPivotAux_eq_zero_of_none [Zero R] [DecidableEq R]
             · exact hzero
             · have hzeroNat : ¬ M[start][col.val] = 0 := by
                 simpa using hzero
-              simp only [findPivotAux, hlt, dif_pos] at hfind
-              rw [if_neg (by simpa [getRow, Fin.getElem_fin] using hzero)] at hfind
+              simp only [findPivotAux, hlt, dite_eq_left] at hfind
+              rw [ite_eq_right (by simpa [getRow, Fin.getElem_fin] using hzero)] at hfind
               simp at hfind
           have hnext : findPivotAux M col (start + 1) fuel = none := by
             have hentryNat : M[start][col.val] = 0 := by
               simpa using hentry
-            simp only [findPivotAux, hlt, dif_pos] at hfind
-            rw [if_pos (by simpa [getRow, Fin.getElem_fin] using hentry)] at hfind
+            simp only [findPivotAux, hlt, dite_eq_left] at hfind
+            rw [ite_eq_left (by simpa [getRow, Fin.getElem_fin] using hentry)] at hfind
             exact hfind
           have hstart' : start + 1 ≤ i.val := by omega
           have hfuel' : i.val < start + 1 + fuel := by omega
@@ -265,8 +265,8 @@ theorem findPivotAux_eq_none_of_zero [Zero R] [DecidableEq R]
           hzero ⟨start, hstart⟩ (Nat.le_refl _)
             (show (⟨start, hstart⟩ : Fin n).val < start + (fuel + 1) by
               simp)
-        simp only [findPivotAux, hstart, dif_pos]
-        rw [if_pos (by simpa [getRow, Fin.getElem_fin] using hentry)]
+        simp only [findPivotAux, hstart, dite_eq_left]
+        rw [ite_eq_left (by simpa [getRow, Fin.getElem_fin] using hentry)]
         apply ih
         intro i hle hlt
         exact hzero i (by omega) (by omega)
@@ -304,11 +304,11 @@ theorem findPivotAux_some_ne_zero [Zero R] [DecidableEq R]
   | succ fuel ih =>
       by_cases hlt : start < n
       · by_cases hzero : M[(⟨start, hlt⟩ : Fin n)][col] = 0
-        · simp only [findPivotAux, hlt, dif_pos] at hfind
-          rw [if_pos (by simpa [getRow, Fin.getElem_fin] using hzero)] at hfind
+        · simp only [findPivotAux, hlt, dite_eq_left] at hfind
+          rw [ite_eq_left (by simpa [getRow, Fin.getElem_fin] using hzero)] at hfind
           exact ih (start + 1) hfind
-        · simp only [findPivotAux, hlt, dif_pos] at hfind
-          rw [if_neg (by simpa [getRow, Fin.getElem_fin] using hzero)] at hfind
+        · simp only [findPivotAux, hlt, dite_eq_left] at hfind
+          rw [ite_eq_right (by simpa [getRow, Fin.getElem_fin] using hzero)] at hfind
           simp only [Option.some.injEq] at hfind
           subst hfind
           exact hzero
@@ -401,9 +401,9 @@ private theorem stepImplFold_ne [Zero R] [Sub R] [Mul R] (quot : R → R → R)
     intro A hne
     rw [List.foldl_cons, ih _ (fun t ht => hne t (List.mem_cons_of_mem _ ht))]
     by_cases hx : k < x.val
-    · rw [if_pos hx, Matrix.getElem_modifyEntries,
-        if_neg (fun hv => hne x List.mem_cons_self ((Fin.ext hv).symm))]
-    · rw [if_neg hx]
+    · rw [ite_eq_left hx, Matrix.getElem_modifyEntries,
+        ite_eq_right (fun hv => hne x List.mem_cons_self ((Fin.ext hv).symm))]
+    · rw [ite_eq_right hx]
 
 /-- The `stepMatrixWithImpl` fold updates every member row from its original
 entries. -/
@@ -435,8 +435,8 @@ private theorem stepImplFold_mem [Zero R] [Sub R] [Mul R] (quot : R → R → R)
     · rw [stepImplFold_ne quot k hk pivot prevPivot pivotRow r c xs _
         (fun t ht heq => (List.nodup_cons.mp hnd).1 (heq ▸ ht))]
       by_cases hx : k < r.val
-      · rw [if_pos hx, if_pos hx, Matrix.getElem_modifyEntries, if_pos rfl]
-      · rw [if_neg hx, if_neg hx]
+      · rw [ite_eq_left hx, ite_eq_left hx, Matrix.getElem_modifyEntries, ite_eq_left rfl]
+      · rw [ite_eq_right hx, ite_eq_right hx]
     · have hxr : x ≠ r := fun heq => (List.nodup_cons.mp hnd).1 (heq ▸ hr')
       have hrowr : ∀ cc : Fin n,
           (if k < x.val then
@@ -448,9 +448,9 @@ private theorem stepImplFold_mem [Zero R] [Sub R] [Mul R] (quot : R → R → R)
           else A)[r][cc] = A[r][cc] := by
         intro cc
         by_cases hx : k < x.val
-        · rw [if_pos hx, Matrix.getElem_modifyEntries,
-            if_neg (fun hv => hxr (Fin.ext hv.symm))]
-        · rw [if_neg hx]
+        · rw [ite_eq_left hx, Matrix.getElem_modifyEntries,
+            ite_eq_right (fun hv => hxr (Fin.ext hv.symm))]
+        · rw [ite_eq_right hx]
       rw [ih (List.nodup_cons.mp hnd).2 _ r hr']
       rw [show (if k < x.val then
             A.modifyEntries x.val fun j y =>
@@ -483,7 +483,7 @@ private theorem stepMatrixImpl_eq_ofFn [Zero R] [Sub R] [Mul R]
   rw [Matrix.getElem_ofFn]
   unfold stepMatrixWithImpl
   by_cases hk : k < n
-  · rw [dif_pos hk]
+  · rw [dite_eq_left hk]
     show (Fin.foldl n _ M)[i][j] = _
     rw [Fin.foldl_eq_finRange_foldl,
       stepImplFold_mem quot k hk pivot prevPivot (Matrix.getRow M ⟨k, hk⟩) j
@@ -491,7 +491,7 @@ private theorem stepMatrixImpl_eq_ofFn [Zero R] [Sub R] [Mul R]
     simp only [Matrix.getElem_pair_eq_nested, Matrix.getElem_eq_getRow]
     rw [show (Matrix.getRow M ⟨k, hk⟩)[j] = (Matrix.getRow M ⟨k, hk⟩)[j.val] from rfl]
     grind
-  · rw [dif_neg hk]
+  · rw [dite_eq_right hk]
     have hik : ¬ k < i.val := fun h => hk (Nat.lt_trans h i.isLt)
     simp only [Matrix.getElem_pair_eq_nested]
     grind
@@ -515,15 +515,15 @@ theorem stepMatrixWith_eq_ofFn [Zero R] [Sub R] [Mul R] (quot : R → R → R)
   rw [Matrix.getElem_ofFn]
   unfold stepMatrixWith
   by_cases hk : k < n
-  · rw [dif_pos hk, Matrix.getElem_mapRowsIdx]
+  · rw [dite_eq_left hk, Matrix.getElem_mapRowsIdx]
     by_cases hi : k < i.val
-    · simp only [hi, if_pos, Vector.getElem_finFoldl_modify, Matrix.getElem_pair_eq_nested,
+    · simp only [hi, ite_eq_left, Vector.getElem_finFoldl_modify, Matrix.getElem_pair_eq_nested,
         Matrix.getElem_eq_getRow, Matrix.getRow, Fin.getElem_fin]
       grind
     · simp only [hi, Matrix.getElem_pair_eq_nested, Matrix.getElem_eq_getRow,
         Matrix.getRow, Fin.getElem_fin]
       grind
-  · rw [dif_neg hk]
+  · rw [dite_eq_right hk]
     have hik : ¬ k < i.val := fun h => hk (Nat.lt_trans h i.isLt)
     simp only [Matrix.getElem_pair_eq_nested, Matrix.getElem_eq_getRow, Matrix.getRow,
       Fin.getElem_fin]
@@ -872,7 +872,7 @@ private theorem getEntry_swapRowsArray_matrixToRows [Zero R] (M : Matrix R n n)
       calc
         getEntry (swapRowsArray (matrixToRows M) rowA.val rowB.val) rowB.val j.val =
             getEntry (matrixToRows M) rowA.val j.val := by
-              simp only [swapRowsArray, hsame, if_false, getEntry,
+              simp only [swapRowsArray, hsame, ite_false, getEntry,
                 Array.set!_eq_setIfInBounds]
               exact congrArg (fun row : Array R => row.getD j.val 0)
                 (array_getD_setIfInBounds_same
@@ -891,7 +891,7 @@ private theorem getEntry_swapRowsArray_matrixToRows [Zero R] (M : Matrix R n n)
         calc
           getEntry (swapRowsArray (matrixToRows M) rowA.val rowB.val) rowA.val j.val =
               getEntry (matrixToRows M) rowB.val j.val := by
-                simp only [swapRowsArray, hsame, if_false, getEntry,
+                simp only [swapRowsArray, hsame, ite_false, getEntry,
                   Array.set!_eq_setIfInBounds]
                 exact congrArg (fun row : Array R => row.getD j.val 0)
                   ((array_getD_setIfInBounds_ne
@@ -914,7 +914,7 @@ private theorem getEntry_swapRowsArray_matrixToRows [Zero R] (M : Matrix R n n)
         calc
           getEntry (swapRowsArray (matrixToRows M) rowA.val rowB.val) i.val j.val =
               getEntry (matrixToRows M) i.val j.val := by
-                simp only [swapRowsArray, hsame, if_false, getEntry,
+                simp only [swapRowsArray, hsame, ite_false, getEntry,
                   Array.set!_eq_setIfInBounds]
                 exact congrArg (fun row : Array R => row.getD j.val 0)
                   ((array_getD_setIfInBounds_ne

--- a/HexBareissMathlib/Bareiss.lean
+++ b/HexBareissMathlib/Bareiss.lean
@@ -479,7 +479,7 @@ private theorem principalSubmatrix_rowSwap_eq_of_le {R : Type u}
     have hval : r.val = pivot.val := by simpa using congrArg Fin.val h
     omega
   rw [Hex.Matrix.getElem_principalSubmatrix, Hex.Matrix.getElem_principalSubmatrix]
-  simp only [Hex.Matrix.getElem_rowSwap, if_neg h_r_ne_pivot, if_neg h_r_ne_kFin]
+  simp only [Hex.Matrix.getElem_rowSwap, ite_eq_right h_r_ne_pivot, ite_eq_right h_r_ne_kFin]
 
 /-- Auxiliary: a row of `rowSwap M kFin pivot` with index `r` not equal to
 either swap target equals the corresponding row of `M`. -/
@@ -487,7 +487,7 @@ private theorem getElem_rowSwap_of_ne {R : Type u}
     (M : Hex.Matrix R n n) (kFin pivot r : Fin n) (c : Fin n)
     (hr_ne_kFin : r ≠ kFin) (hr_ne_pivot : r ≠ pivot) :
     (Hex.Matrix.rowSwap M kFin pivot)[r][c] = M[r][c] := by
-  rw [Hex.Matrix.getElem_rowSwap, if_neg hr_ne_pivot, if_neg hr_ne_kFin]
+  rw [Hex.Matrix.getElem_rowSwap, ite_eq_right hr_ne_pivot, ite_eq_right hr_ne_kFin]
 
 /-- Reading row `r` of `rowSwap M kFin pivot` returns row `swap_idx r` of `M`,
 where `swap_idx kFin pivot r = if r = pivot then kFin else if r = kFin then pivot else r`. -/
@@ -497,10 +497,10 @@ private theorem getElem_rowSwap_swap_eq {R : Type u}
       M[if r = pivot then kFin else if r = kFin then pivot else r][c] := by
   rw [Hex.Matrix.getElem_rowSwap]
   by_cases hrp : r = pivot
-  · simp only [if_pos hrp]
+  · simp only [ite_eq_left hrp]
   · by_cases hrk : r = kFin
-    · simp only [if_neg hrp, if_pos hrk]
-    · simp only [if_neg hrp, if_neg hrk]
+    · simp only [ite_eq_right hrp, ite_eq_left hrk]
+    · simp only [ite_eq_right hrp, ite_eq_right hrk]
 
 /-- Swapping source rows `kFin` and `pivot` (with `kFin.val = k` and
 `k + 1 ≤ pivot.val`) commutes with the bordered-minor construction at level
@@ -525,7 +525,7 @@ private theorem borderedMinor_rowSwap_source_row {R : Type u}
   rw [Hex.Matrix.getElem_ofFn, Hex.Matrix.getElem_ofFn]
   simp only [Hex.Matrix.getElem_pair_eq_nested]
   by_cases hrk : r.val < k
-  · simp only [dif_pos hrk]
+  · simp only [dite_eq_left hrk]
     have hr_lt : r.val < n := Nat.lt_trans hrk hk
     have h_r_ne_kFin : (⟨r.val, hr_lt⟩ : Fin n) ≠ kFin := by
       intro h
@@ -536,7 +536,7 @@ private theorem borderedMinor_rowSwap_source_row {R : Type u}
       have hval : r.val = pivot.val := by simpa using congrArg Fin.val h
       omega
     exact getElem_rowSwap_of_ne M kFin pivot ⟨r.val, hr_lt⟩ _ h_r_ne_kFin h_r_ne_pivot
-  · simp only [dif_neg hrk]
+  · simp only [dite_eq_right hrk]
     exact getElem_rowSwap_swap_eq M kFin pivot i _
 
 /-- Public regular swap-only step surface for the row-pivoted Bareiss proof.
@@ -593,16 +593,16 @@ theorem bareissPivotInvariant_regular_swap
     rw [borderedMinor_rowSwap_source_row source state.step hk kFin pivot hkF_val
       hp_ge i j]
     by_cases hip : i = pivot
-    · simp only [if_pos hip]
+    · simp only [ite_eq_left hip]
       -- Need: state.matrix[kFin][j] = det (borderedMinor source state.step _ kFin j).
       have hkFin_le : state.step ≤ kFin.val := Nat.le_of_eq hkF_val.symm
       exact hinv.trailing_eq hk kFin j hkFin_le hj
     · by_cases hik : i = kFin
-      · simp only [if_neg hip, if_pos hik]
+      · simp only [ite_eq_right hip, ite_eq_left hik]
         -- Need: state.matrix[pivot][j] = det (borderedMinor source state.step _ pivot j).
         have hp_step : state.step ≤ pivot.val := Nat.le_of_succ_le hp_ge
         exact hinv.trailing_eq hk pivot j hp_step hj
-      · simp only [if_neg hip, if_neg hik]
+      · simp only [ite_eq_right hip, ite_eq_right hik]
         exact hinv.trailing_eq hk i j hi hj
 
 private theorem bareissSign_succ {R : Type u} [CommRing R] (swaps : Nat) :
@@ -1157,7 +1157,7 @@ theorem failedBareissColumn_above_pivot
     (c : Fin n) (hc : k < c.val) :
     failedBareissColumn source k hk c = 0 := by
   show (if h : c.val ≤ k then _ else (0 : R)) = 0
-  rw [dif_neg (Nat.not_le_of_lt hc)]
+  rw [dite_eq_right (Nat.not_le_of_lt hc)]
 
 private theorem failedBareissTopBlock_apply_lt
     {R : Type u}
@@ -1167,7 +1167,7 @@ private theorem failedBareissTopBlock_apply_lt
       matrixEquiv source (⟨s.val, Nat.lt_trans s.isLt hk⟩ : Fin n)
         (⟨c.val, Nat.lt_trans hc hk⟩ : Fin n) := by
   show (if h : c.val < k then _ else _) = _
-  rw [dif_pos hc]
+  rw [dite_eq_left hc]
 
 private theorem failedBareissTopBlock_apply_last
     {R : Type u}
@@ -1177,7 +1177,7 @@ private theorem failedBareissTopBlock_apply_last
       matrixEquiv source (⟨s.val, Nat.lt_trans s.isLt hk⟩ : Fin n) ⟨k, hk⟩ := by
   show (if h : (Fin.last k : Fin (k + 1)).val < k then _ else _) = _
   simp only [Fin.val_last]
-  rw [dif_neg (Nat.lt_irrefl k)]
+  rw [dite_eq_right (Nat.lt_irrefl k)]
 
 private theorem failedBareissTopBlock_succAbove_last
     {R : Type u}
@@ -1204,7 +1204,7 @@ theorem failedBareissColumn_at_pivot
         Matrix.det ((failedBareissTopBlock source k hk).submatrix id
           (⟨(⟨k, hk⟩ : Fin n).val, Nat.lt_succ_of_le hc⟩ : Fin (k + 1)).succAbove)
       else 0) = _
-  rw [dif_pos (le_refl k)]
+  rw [dite_eq_left (le_refl k)]
   have hsign : (-1 : R) ^ (k + k) = 1 := by
     rw [← Nat.two_mul, pow_mul]; norm_num
   show (-1 : R) ^ (k + k) *
@@ -1233,12 +1233,12 @@ private theorem matrixEquiv_borderedMinor_apply_last
       (if hc : c'.val < k then (⟨c'.val, Nat.lt_trans hc hk⟩ : Fin n) else
         ⟨k, hk⟩) = _
   simp only [Fin.val_last]
-  rw [dif_neg (Nat.lt_irrefl k)]
+  rw [dite_eq_right (Nat.lt_irrefl k)]
   by_cases hcv : c'.val < k
-  · rw [dif_pos hcv]
+  · rw [dite_eq_left hcv]
   · have hc_eq : c'.val = k :=
       Nat.le_antisymm (Nat.le_of_lt_succ c'.isLt) (Nat.not_lt.mp hcv)
-    rw [dif_neg hcv]
+    rw [dite_eq_right hcv]
     show matrixEquiv source r (⟨k, hk⟩ : Fin n) =
       matrixEquiv source r (⟨c'.val, Nat.lt_of_le_of_lt
         (Nat.le_of_lt_succ c'.isLt) hk⟩ : Fin n)
@@ -1268,16 +1268,16 @@ private theorem submatrix_borderedMinor_succAbove_last_eq_topBlock
     failedBareissTopBlock source k hk s (c'.succAbove t)
   rw [Fin.succAbove_last]
   have hslt : (s.castSucc : Fin (k + 1)).val < k := s.isLt
-  rw [dif_pos hslt]
+  rw [dite_eq_left hslt]
   by_cases hctlt : (c'.succAbove t).val < k
-  · rw [dif_pos hctlt]
+  · rw [dite_eq_left hctlt]
     rw [failedBareissTopBlock_apply_lt source k hk s (c'.succAbove t) hctlt]
     rfl
   · have hctlt' : k ≤ (c'.succAbove t).val := Nat.not_lt.mp hctlt
     have hct_eq : (c'.succAbove t).val = k := by
       have := (c'.succAbove t).isLt
       omega
-    rw [dif_neg hctlt]
+    rw [dite_eq_right hctlt]
     have h_succAbove_eq : c'.succAbove t = Fin.last k := Fin.ext hct_eq
     rw [h_succAbove_eq, failedBareissTopBlock_apply_last source k hk s]
     rfl
@@ -1336,7 +1336,7 @@ private theorem failedBareissColumn_dot_row_eq_borderedMinor_det
           Matrix.det
             ((failedBareissTopBlock source k hk).submatrix id c'.succAbove) := by
     show (if hc : (φ c').val ≤ k then _ else (0 : R)) = _
-    rw [dif_pos hφc'_le, hφc'_eq_c', hφ_apply]
+    rw [dite_eq_left hφc'_le, hφc'_eq_c', hφ_apply]
   rw [hα_eq, matrixEquiv_borderedMinor_apply_last source k hk r c',
       submatrix_borderedMinor_succAbove_last_eq_topBlock source k hk r c']
   -- Now reduce both sides to a normal form.
@@ -1373,9 +1373,9 @@ private theorem matrixEquiv_borderedMinor_det_eq_zero_of_row_lt
       (if h : (⟨r.val, Nat.lt_succ_of_lt hr⟩ : Fin (k + 1)).val < k then _ else r) _ =
     matrixEquiv source
       (if h : (Fin.last k : Fin (k + 1)).val < k then _ else r) _
-  rw [dif_pos hr]
+  rw [dite_eq_left hr]
   simp only [Fin.val_last]
-  rw [dif_neg (Nat.lt_irrefl k)]
+  rw [dite_eq_right (Nat.lt_irrefl k)]
 
 /-- **Failed Bareiss column dependence.**
 

--- a/HexBasic/Rand.lean
+++ b/HexBasic/Rand.lean
@@ -101,10 +101,10 @@ private theorem Rand.natGo_lt {bound limit w : Nat} (hb : 0 < bound) :
       intro attempts r v r' h
       unfold Rand.natGo at h
       by_cases hc : (Rand.words r w).1 < limit
-      · simp only [hc, if_pos] at h
+      · simp only [hc, ite_eq_left] at h
         cases h
         exact Nat.mod_lt _ hb
-      · simp only [hc, if_neg, not_false_iff] at h
+      · simp only [hc, ite_eq_right, not_false_iff] at h
         exact ih (attempts + 1) (Rand.words r w).2 h
 
 /-- Range correctness: a successful bounded draw is below the bound. -/
@@ -112,9 +112,9 @@ theorem Rand.nat_lt {r : Rand} {bound fuel v : Nat} {r' : Rand}
     (h : Rand.nat r bound fuel = .ok (v, r')) : v < bound := by
   unfold Rand.nat at h
   by_cases hb : bound = 0
-  · rw [if_pos hb] at h
+  · rw [ite_eq_left hb] at h
     cases h
-  · rw [if_neg hb] at h
+  · rw [ite_eq_right hb] at h
     exact Rand.natGo_lt (Nat.pos_of_ne_zero hb) fuel 0 r h
 
 /-! Regression coverage: the canonical splitmix64 known-answer values (the

--- a/HexBerlekampMathlib/Irreducibility.lean
+++ b/HexBerlekampMathlib/Irreducibility.lean
@@ -210,7 +210,7 @@ theorem irreducible_dvd_frobeniusPolynomial_of_natDegree_dvd
   have : Module.Finite (ZMod p) (AdjoinRoot g) :=
     (AdjoinRoot.powerBasis hg_ne_zero).finite
   have : Finite (AdjoinRoot g) := Module.finite_of_finite (ZMod p)
-  letI : Fintype (AdjoinRoot g) := Fintype.ofFinite _
+  let : Fintype (AdjoinRoot g) := Fintype.ofFinite _
   have hcard : Fintype.card (AdjoinRoot g) = p ^ g.natDegree := by
     rw [← Nat.card_eq_fintype_card,
         ← FiniteField.pow_finrank_eq_natCard p (AdjoinRoot g),

--- a/HexBerlekampZassenhaus/BhksCandidates.lean
+++ b/HexBerlekampZassenhaus/BhksCandidates.lean
@@ -303,7 +303,7 @@ theorem normalizeCandidateFactor_eq_of_primitive_nonneg_leading
     ZPoly.primitivePart_eq_self_of_primitive g hprim
   rw [hpart]
   have hnot_neg : ¬ DensePoly.leadingCoeff g < 0 := Int.not_lt.mpr hsign
-  rw [if_neg hnot_neg]
+  rw [ite_eq_right hnot_neg]
 
 /-- Select the lifted factors marked by a nonempty zero-one indicator. -/
 def bhksIndicatorSelectedFactors
@@ -352,7 +352,7 @@ theorem bhksIndicatorSelectedFactors_eq_some_selectedArray_of_getD
   have hsizeBool : (indicator.size != liftedFactors.size) = false := by
     simp [hsize]
   rw [hsizeBool]
-  simp only [Bool.false_eq_true, if_false]
+  simp only [Bool.false_eq_true, ite_false]
   have hall :
       (List.range indicator.size).all
           (fun i => indicator.getD i 0 == 0 || indicator.getD i 0 == 1) = true := by
@@ -467,7 +467,7 @@ private theorem bhksIndicatorCandidate?_normalizeFactorSign
         else
           none) = some (candidate, quotient) at h
       by_cases hrecord : shouldRecordPolynomialFactor candidate'
-      · rw [if_pos hrecord] at h
+      · rw [ite_eq_left hrecord] at h
         cases hquot : exactQuotient? f candidate' with
         | none =>
             simp [hquot] at h
@@ -476,7 +476,7 @@ private theorem bhksIndicatorCandidate?_normalizeFactorSign
             rcases h with ⟨hcandidate, _hquotient⟩
             subst candidate
             exact normalizeFactorSign_idem candidate0
-      · rw [if_neg hrecord] at h
+      · rw [ite_eq_right hrecord] at h
         simp at h
 
 private theorem bhksIndicatorCandidate?_shouldRecord
@@ -505,7 +505,7 @@ private theorem bhksIndicatorCandidate?_shouldRecord
         else
           none) = some (candidate, quotient) at h
       by_cases hrecord : shouldRecordPolynomialFactor candidate'
-      · rw [if_pos hrecord] at h
+      · rw [ite_eq_left hrecord] at h
         cases hquot : exactQuotient? f candidate' with
         | none =>
             simp [hquot] at h
@@ -514,7 +514,7 @@ private theorem bhksIndicatorCandidate?_shouldRecord
             rcases h with ⟨hcandidate, _hquotient⟩
             subst candidate
             exact hrecord
-      · rw [if_neg hrecord] at h
+      · rw [ite_eq_right hrecord] at h
         simp at h
 
 /--
@@ -549,7 +549,7 @@ theorem bhksIndicatorCandidate?_dvd
         else
           none) = some (candidate, quotient) at h
       by_cases hrecord : shouldRecordPolynomialFactor candidate'
-      · rw [if_pos hrecord] at h
+      · rw [ite_eq_left hrecord] at h
         cases hquot : exactQuotient? f candidate' with
         | none =>
             simp [hquot] at h
@@ -562,7 +562,7 @@ theorem bhksIndicatorCandidate?_dvd
             refine ⟨quotient', ?_⟩
             rw [DensePoly.mul_comm_poly (S := Int)]
             exact hmul.symm
-      · rw [if_neg hrecord] at h
+      · rw [ite_eq_right hrecord] at h
         simp at h
 
 /-- If `normalizeCandidateFactor g` is nonzero, it is primitive: the inner
@@ -574,7 +574,7 @@ private theorem normalizeCandidateFactor_primitive
   unfold normalizeCandidateFactor at hne ⊢
   by_cases hlead :
       DensePoly.leadingCoeff (ZPoly.primitivePart g) < 0
-  · rw [if_pos hlead] at hne ⊢
+  · rw [ite_eq_left hlead] at hne ⊢
     have hprim_ne :
         (ZPoly.primitivePart g : ZPoly) ≠ 0 := by
       intro hzero
@@ -599,7 +599,7 @@ private theorem normalizeCandidateFactor_primitive
               (DensePoly.scale (-1 : Int) (ZPoly.primitivePart g)) from rfl,
         DensePoly.content_scale_neg_one (ZPoly.primitivePart g)]
     exact hprim_primitive
-  · rw [if_neg hlead] at hne ⊢
+  · rw [ite_eq_right hlead] at hne ⊢
     have hcontent_ne : ZPoly.content g ≠ 0 := by
       intro hzero
       apply hne
@@ -651,7 +651,7 @@ theorem bhksIndicatorCandidate?_primitive
         else
           none) = some (candidate, quotient) at h
       by_cases hrecord : shouldRecordPolynomialFactor candidate'
-      · rw [if_pos hrecord] at h
+      · rw [ite_eq_left hrecord] at h
         cases hquot : exactQuotient? f candidate' with
         | none =>
             simp [hquot] at h
@@ -673,11 +673,11 @@ theorem bhksIndicatorCandidate?_primitive
               have hlc :
                   ¬ DensePoly.leadingCoeff (0 : ZPoly) < 0 := by
                 simp
-              rw [if_neg hlc]
+              rw [ite_eq_right hlc]
             have hprim_cand0 : ZPoly.Primitive candidate0 :=
               normalizeCandidateFactor_primitive hcand0_ne
             exact normalizeFactorSign_primitive _ hprim_cand0
-      · rw [if_neg hrecord] at h
+      · rw [ite_eq_right hrecord] at h
         simp at h
 
 /-- A successful BHKS indicator candidate has positive degree: it is primitive
@@ -731,7 +731,7 @@ private theorem bhksIndicatorCandidate?_positive_degree
             rw [DensePoly.coeff_C]
             simp
         | succ n =>
-            rw [DensePoly.coeff_C, if_neg (Nat.succ_ne_zero n)]
+            rw [DensePoly.coeff_C, ite_eq_right (Nat.succ_ne_zero n)]
             exact DensePoly.coeff_eq_zero_of_size_le candidate (by omega)
       have hprim_C :
           DensePoly.content (DensePoly.C (candidate.coeff 0)) = 1 := by
@@ -769,7 +769,7 @@ private theorem bhksIndicatorCandidate?_positive_degree
   have hdeg_eq :
       (DensePoly.degree? candidate).getD 0 = candidate.size - 1 := by
     unfold DensePoly.degree?
-    rw [dif_neg hne_size]
+    rw [dite_eq_right hne_size]
     rfl
   show 0 < (DensePoly.degree? candidate).getD 0
   rw [hdeg_eq]
@@ -807,7 +807,7 @@ theorem bhksIndicatorCandidate?_eq_normalized_directLift
     else
       none) = some (candidate, quotient) at h
   by_cases hrecord : shouldRecordPolynomialFactor candidate'
-  · rw [if_pos hrecord] at h
+  · rw [ite_eq_left hrecord] at h
     cases hquot : exactQuotient? f candidate' with
     | none => simp [hquot] at h
     | some quotient' =>
@@ -815,7 +815,7 @@ theorem bhksIndicatorCandidate?_eq_normalized_directLift
         rcases h with ⟨hcandidate, _hquotient⟩
         subst candidate
         simp [candidate', candidate0, modulus, liftModulus]
-  · rw [if_neg hrecord] at h
+  · rw [ite_eq_right hrecord] at h
     simp at h
 
 /--
@@ -1088,7 +1088,7 @@ theorem bhksIndicatorAllOnes_eq_true_of_getD
         have hi : i < r := hlt i (List.mem_cons_self ..)
         have htail : ∀ j ∈ l, j < r :=
           fun j hj => hlt j (List.mem_cons_of_mem i hj)
-        rw [List.foldl_cons, if_pos (by simp [hones i hi]), ih _ htail]
+        rw [List.foldl_cons, ite_eq_left (by simp [hones i hi]), ih _ htail]
         simp [Nat.add_comm, Nat.add_left_comm]
   unfold bhksIndicatorAllOnes bhksIndicatorOneCount
   rw [hfold (List.range r) 0 (fun i hi => List.mem_range.mp hi)]
@@ -1275,9 +1275,9 @@ private theorem array_toList_getD {α : Type}
       rw [List.getD_eq_getElem?_getD]
       unfold Array.getD Array.size Array.getInternal
       by_cases hlt : i < data.length
-      · rw [dif_pos hlt]
+      · rw [dite_eq_left hlt]
         simp [List.getElem?_eq_getElem hlt]
-      · rw [dif_neg hlt]
+      · rw [dite_eq_right hlt]
         simp [List.getElem?_eq_none_iff.mpr (Nat.le_of_not_gt hlt)]
 
 private theorem bhksIndicatorCandidatesStep_fold_eq_some
@@ -1545,7 +1545,7 @@ theorem transformedCore_coeff (core : ZPoly) (degree n : Nat) :
         core.coeff n * DensePoly.leadingCoeff core ^ (degree - 1 - n)
       else if n = degree then 1 else 0 := by
   rcases Nat.lt_trichotomy n degree with h | h | h
-  · rw [if_pos h]
+  · rw [ite_eq_left h]
     change (transformedCoeffs core degree).getD n (0 : Int) = _
     unfold transformedCoeffs
     rw [array_getD_push_lt ((List.range degree).map
@@ -1555,9 +1555,9 @@ theorem transformedCore_coeff (core : ZPoly) (degree n : Nat) :
       List.getElem?_map, List.getElem?_range h]
     simp
   · subst h
-    rw [if_neg (Nat.lt_irrefl _), if_pos rfl]
+    rw [ite_eq_right (Nat.lt_irrefl _), ite_eq_left rfl]
     exact transformedCore_coeff_top core n
-  · rw [if_neg (by omega), if_neg (by omega)]
+  · rw [ite_eq_right (by omega), ite_eq_right (by omega)]
     exact DensePoly.coeff_eq_zero_of_size_le _ (by rw [transformedCore_size]; omega)
 
 /-- **Keystone for `toMonic` inverse recovery.** Dilating the monic transform
@@ -1585,12 +1585,12 @@ theorem dilate_transformedCore (core : ZPoly) (degree : Nat)
   rw [Hex.ZPoly.coeff_dilate, transformedCore_coeff, Hex.ZPoly.C_mul_eq_scale,
     DensePoly.coeff_scale_semiring]
   rcases Nat.lt_trichotomy n degree with h | h | h
-  · rw [if_pos h]
+  · rw [ite_eq_left h]
     have hexp : n + (degree - 1 - n) = degree - 1 := by omega
     rw [← Int.mul_assoc,
       Int.mul_comm (DensePoly.leadingCoeff core ^ n) (core.coeff n),
       Int.mul_assoc, ← int_pow_add, hexp, Int.mul_comm]
-  · rw [h, if_neg (Nat.lt_irrefl _), if_pos rfl, Int.mul_one]
+  · rw [h, ite_eq_right (Nat.lt_irrefl _), ite_eq_left rfl, Int.mul_one]
     have hcoeff : core.coeff degree = DensePoly.leadingCoeff core := by
       rw [DensePoly.leadingCoeff_eq_coeff_last core hsize_pos, hsize, Nat.add_sub_cancel]
     rw [hcoeff, ← Lean.Grind.Semiring.pow_succ]
@@ -1598,7 +1598,7 @@ theorem dilate_transformedCore (core : ZPoly) (degree : Nat)
     omega
   · have hz : core.coeff n = 0 :=
       DensePoly.coeff_eq_zero_of_size_le core (by omega)
-    rw [if_neg (by omega), if_neg (by omega), hz]
+    rw [ite_eq_right (by omega), ite_eq_right (by omega), hz]
     simp
 
 end ZPoly.ToMonicData

--- a/HexBerlekampZassenhaus/BhksRecover.lean
+++ b/HexBerlekampZassenhaus/BhksRecover.lean
@@ -227,8 +227,8 @@ private theorem bhksRecoverClassifiedWithAllOnes_fst (f : ZPoly) (d : LiftData) 
   by_cases hrows :
       1 ≤ (bhksLatticeBasis f d.p d.k d.liftedFactors).factorCount +
         (bhksLatticeBasis f d.p d.k d.liftedFactors).coeffWidth
-  · simp only [dif_pos hrows]
-  · simp only [dif_neg hrows]
+  · simp only [dite_eq_left hrows]
+  · simp only [dite_eq_right hrows]
 
 /--
 If the executable BHKS recovery guards all pass, `bhksRecover?` returns the
@@ -259,8 +259,8 @@ theorem bhksRecover?_eq_some_of_checks
   rw [bhksRecoverClassified]
   have hproductCheck : (Array.polyProduct candidates == f) = true := by
     simpa [beq_iff_eq] using hprod
-  simp only [dif_pos hrows, hnondeg, Bool.false_eq_true, if_false, hcand,
-    hproductCheck, if_true, BhksRecoveryResult.toOption]
+  simp only [dite_eq_left hrows, hnondeg, Bool.false_eq_true, ite_false, hcand,
+    hproductCheck, ite_true, BhksRecoveryResult.toOption]
 
 private def bhksIndicatorGuardLift : LiftData :=
   { p := 5

--- a/HexBerlekampZassenhaus/Certificate.lean
+++ b/HexBerlekampZassenhaus/Certificate.lean
@@ -339,10 +339,10 @@ theorem checkCertAtFactor_of_linear
   rcases hcheck with ⟨hmeta, htail⟩
   refine ⟨hmeta, ?_⟩
   by_cases hmonic : factor.leadingCoeff = 1
-  · rw [dif_pos hmonic] at htail ⊢
+  · rw [dite_eq_left hmonic] at htail ⊢
     exact Berlekamp.checkIrreducibilityCertificate_of_linearIncremental
       factor _ cert htail
-  · rw [dif_neg hmonic] at htail
+  · rw [dite_eq_right hmonic] at htail
     simp at htail
 
 /-- `checkFactorCertsLinear` implies `checkFactorCerts` once the block's prime

--- a/HexBerlekampZassenhaus/ChoosePrimeData.lean
+++ b/HexBerlekampZassenhaus/ChoosePrimeData.lean
@@ -556,14 +556,14 @@ private theorem improvePrimeData?_property
           | some score =>
               simp only
               by_cases hone : score.factorCount = 1
-              · simp only [hone, if_true]
+              · simp only [hone, ite_true]
                 exact hcandidate c score hscore
-              · simp only [hone, if_false]
+              · simp only [hone, ite_false]
                 by_cases hhalf : probeEarlyFactorFloor ≤ score.factorCount ∧
                     2 * score.factorCount ≤ first.factorCount
                 · simp only [hhalf]
                   exact hcandidate c score hscore
-                · simp only [hhalf, if_false]
+                · simp only [hhalf, ite_false]
                   apply ih (first := betterPrimeChoiceDataScore first score)
                     (extra := extra)
                   unfold betterPrimeChoiceDataScore
@@ -595,16 +595,16 @@ private theorem improvePrimeData?_p_le
           | some score =>
               simp only
               by_cases hone : score.factorCount = 1
-              · simp only [hone, if_true]
+              · simp only [hone, ite_true]
                 exact primeChoiceDataScore_p_le f c score
                   (hall c (by simp)) hscore
-              · simp only [hone, if_false]
+              · simp only [hone, ite_false]
                 by_cases hhalf : probeEarlyFactorFloor ≤ score.factorCount ∧
                     2 * score.factorCount ≤ first.factorCount
                 · simp only [hhalf]
                   exact primeChoiceDataScore_p_le f c score
                     (hall c (by simp)) hscore
-                · simp only [hhalf, if_false]
+                · simp only [hhalf, ite_false]
                   apply ih (first := betterPrimeChoiceDataScore first score)
                     (extra := extra)
                   · unfold betterPrimeChoiceDataScore
@@ -632,17 +632,17 @@ private theorem chooseAdaptiveFrom?_property
           simp only [hcurrent] at h
           have hproperty : P current := hcandidate c current hcurrent
           by_cases hone : current.factorCount = 1
-          · simp only [hone, if_true, Option.some.injEq] at h
+          · simp only [hone, ite_true, Option.some.injEq] at h
             rw [← h]
             exact hproperty
-          · simp only [hone, if_false] at h
+          · simp only [hone, ite_false] at h
             by_cases hprobe : shouldProbePrime f current = true
-            · simp only [hprobe, if_true, Option.some.injEq] at h
+            · simp only [hprobe, ite_true, Option.some.injEq] at h
               rw [← h]
               exact improvePrimeData?_property f P current hproperty hcandidate extra candidates
             · have hfalse : shouldProbePrime f current = false :=
                 Bool.eq_false_iff.mpr hprobe
-              simp only [hfalse, Bool.false_eq_true, if_false, Option.some.injEq] at h
+              simp only [hfalse, Bool.false_eq_true, ite_false, Option.some.injEq] at h
               rw [← h]
               exact hproperty
 
@@ -669,10 +669,10 @@ private theorem chooseAdaptiveFrom?_p_le
           have hcurrent_le : current.data.p ≤ 500 :=
             primeChoiceDataScore_p_le f c current (hall c (by simp)) hcurrent
           by_cases hone : current.factorCount = 1
-          · simp only [hone, if_true, Option.some.injEq] at h
+          · simp only [hone, ite_true, Option.some.injEq] at h
             rw [← h]
             exact hcurrent_le
-          · simp only [hone, if_false] at h
+          · simp only [hone, ite_false] at h
             split at h
             · simp only [Option.some.injEq] at h
               rw [← h]
@@ -969,7 +969,7 @@ private theorem chooseAdaptiveFrom?_ne_none_of_good
       | some score =>
           by_cases hone : score.factorCount = 1
           · simp [hone]
-          · simp only [hone, if_false]
+          · simp only [hone, ite_false]
             split <;> simp
       | none =>
           simp only

--- a/HexBerlekampZassenhaus/EisensteinCriterion.lean
+++ b/HexBerlekampZassenhaus/EisensteinCriterion.lean
@@ -63,8 +63,8 @@ private theorem C_zero : DensePoly.C (0 : Int) = (0 : ZPoly) := by
   intro n
   rw [DensePoly.coeff_C, DensePoly.coeff_zero]
   by_cases hn : n = 0
-  · rw [if_pos hn]
-  · rw [if_neg hn]
+  · rw [ite_eq_left hn]
+  · rw [ite_eq_right hn]
     rfl
 
 /-- `C` is additive on `ZPoly`. -/
@@ -75,8 +75,8 @@ private theorem C_add (a b : Int) :
   rw [DensePoly.coeff_add _ _ n (by decide), DensePoly.coeff_C,
     DensePoly.coeff_C, DensePoly.coeff_C]
   by_cases hn : n = 0
-  · rw [if_pos hn, if_pos hn, if_pos hn]
-  · rw [if_neg hn, if_neg hn, if_neg hn]
+  · rw [ite_eq_left hn, ite_eq_left hn, ite_eq_left hn]
+  · rw [ite_eq_right hn, ite_eq_right hn, ite_eq_right hn]
     rfl
 
 /-- `C` is multiplicative on `ZPoly`. -/
@@ -89,7 +89,7 @@ private theorem C_mul (a b : Int) :
     DensePoly.coeff_C, DensePoly.coeff_C]
   by_cases hn : n = 0
   · simp [hn]
-  · rw [if_neg hn, if_neg hn]
+  · rw [ite_eq_right hn, ite_eq_right hn]
     exact (Int.mul_zero a).symm
 
 /-- A dense polynomial of size zero is the zero polynomial. -/
@@ -194,11 +194,11 @@ private theorem eq_C_add_X_mul_divX (f : ZPoly) :
     DensePoly.coeff_C]
   match n with
   | 0 =>
-      rw [if_pos rfl, if_pos (by omega)]
+      rw [ite_eq_left rfl, ite_eq_left (by omega)]
       show f.coeff 0 = f.coeff 0 + 0
       omega
   | n + 1 =>
-      rw [if_neg (by omega), if_neg (by omega), coeff_divX]
+      rw [ite_eq_right (by omega), ite_eq_right (by omega), coeff_divX]
       have harith : n + 1 - 1 = n := by omega
       rw [harith]
       show f.coeff (n + 1) = 0 + f.coeff (n + 1)
@@ -250,10 +250,10 @@ private theorem translate_divX_unfold (s : Int) (f : ZPoly) :
   have hdivX : divX (DensePoly.C c) = 0 := by
     apply DensePoly.ext_coeff
     intro n
-    rw [coeff_divX, DensePoly.coeff_C, if_neg (by omega), DensePoly.coeff_zero]
+    rw [coeff_divX, DensePoly.coeff_C, ite_eq_right (by omega), DensePoly.coeff_zero]
     rfl
   have hcoeff : (DensePoly.C c : ZPoly).coeff 0 = c := by
-    rw [DensePoly.coeff_C, if_pos rfl]
+    rw [DensePoly.coeff_C, ite_eq_left rfl]
   rw [hdivX, translate_zero, DensePoly.zero_mul, hcoeff,
     DensePoly.add_comm_poly, DensePoly.add_zero_poly]
 
@@ -273,10 +273,10 @@ theorem translate_X (s : Int) : translate s X = X + DensePoly.C s := by
     rw [DensePoly.coeff_monomial, DensePoly.coeff_C]
     by_cases hn : n = 0
     · simp [hn]
-    · rw [if_neg (by omega), if_neg hn]
+    · rw [ite_eq_right (by omega), ite_eq_right hn]
   have hcoeff : (X : ZPoly).coeff 0 = 0 := by
     show (DensePoly.monomial 1 1 : ZPoly).coeff 0 = 0
-    rw [DensePoly.coeff_monomial, if_neg (by omega)]
+    rw [DensePoly.coeff_monomial, ite_eq_right (by omega)]
     rfl
   rw [hdivX, translate_one, hcoeff, C_zero, DensePoly.add_zero_poly,
     DensePoly.mul_comm_poly, DensePoly.mul_one_right_poly]
@@ -385,14 +385,14 @@ private theorem divX_X_mul (p : ZPoly) : divX (X * p) = p := by
   rw [coeff_divX]
   show (DensePoly.monomial 1 1 * p).coeff (n + 1) = p.coeff n
   rw [DensePoly.monomial_one_mul_poly_eq_shift, DensePoly.coeff_shift,
-    if_neg (by omega)]
+    ite_eq_right (by omega)]
   have harith : n + 1 - 1 = n := by omega
   rw [harith]
 
 private theorem coeff0_X_mul (p : ZPoly) : (X * p).coeff 0 = 0 := by
   show (DensePoly.monomial 1 1 * p).coeff 0 = 0
   rw [DensePoly.monomial_one_mul_poly_eq_shift, DensePoly.coeff_shift,
-    if_pos (by omega)]
+    ite_eq_left (by omega)]
   rfl
 
 private theorem translate_X_mul (s : Int) (p : ZPoly) :
@@ -512,8 +512,8 @@ private theorem size_X_add_C (s : Int) : (X + DensePoly.C s : ZPoly).size = 2 :=
   have hcoeff : (X + DensePoly.C s : ZPoly).coeff 1 ≠ 0 := by
     rw [DensePoly.coeff_add _ _ 1 (by decide)]
     show (DensePoly.monomial 1 1 : ZPoly).coeff 1 + (DensePoly.C s).coeff 1 ≠ 0
-    rw [DensePoly.coeff_monomial, if_pos rfl, DensePoly.coeff_C,
-      if_neg (by omega)]
+    rw [DensePoly.coeff_monomial, ite_eq_left rfl, DensePoly.coeff_C,
+      ite_eq_right (by omega)]
     decide
   have hgt : 1 < (X + DensePoly.C s : ZPoly).size := by
     rcases Nat.lt_or_ge 1 (X + DensePoly.C s : ZPoly).size with h | h
@@ -730,10 +730,10 @@ private theorem coeff_mul_zero_int (p q : ZPoly) :
   · have hterm : ∀ i, 0 < i → DensePoly.diagonalMulCoeffTerm p q 0 i = 0 := by
       intro i hi
       unfold DensePoly.diagonalMulCoeffTerm
-      rw [if_pos hi]
+      rw [ite_eq_left hi]
     rw [foldl_add_int_eq_first _ p.size hpos hterm]
     unfold DensePoly.diagonalMulCoeffTerm
-    rw [if_neg (by omega)]
+    rw [ite_eq_right (by omega)]
 
 /-- Below the leading coefficient, the product coefficient at the first
 `d`-unbroken index of `p` is congruent to `p_k · q₀` mod `d`. -/
@@ -743,15 +743,15 @@ private theorem coeff_mul_congr_first (p q : ZPoly) (k : Nat) (d : Int)
   rw [DensePoly.coeff_mul, DensePoly.mulCoeffSum_eq_diagonal]
   have hgk : DensePoly.diagonalMulCoeffTerm p q k k = p.coeff k * q.coeff 0 := by
     unfold DensePoly.diagonalMulCoeffTerm
-    rw [if_neg (by omega), Nat.sub_self]
+    rw [ite_eq_right (by omega), Nat.sub_self]
   rw [← hgk]
   apply foldl_add_int_dvd_sub d _ p.size k hk
   intro i hi hne
   unfold DensePoly.diagonalMulCoeffTerm
   by_cases hik : k < i
-  · rw [if_pos hik]
+  · rw [ite_eq_left hik]
     exact ⟨0, by rw [Int.mul_zero]⟩
-  · rw [if_neg hik]
+  · rw [ite_eq_right hik]
     exact int_dvd_mul_right (hmin i (by omega)) _
 
 /-- A constant integer factor of a primitive polynomial is a unit: it divides

--- a/HexBerlekampZassenhaus/FactorIrreducibility.lean
+++ b/HexBerlekampZassenhaus/FactorIrreducibility.lean
@@ -321,7 +321,7 @@ private theorem zpoly_C_mul_C (a b : Int) :
       DensePoly.coeff_C, DensePoly.coeff_C]
   by_cases hn : n = 0
   · simp [hn]
-  · rw [if_neg hn, if_neg hn]
+  · rw [ite_eq_right hn, ite_eq_right hn]
     exact (Int.mul_zero a).symm
 
 /-- Size of `DensePoly.C k` for nonzero `k` is exactly `1`. -/
@@ -894,9 +894,9 @@ theorem Irreducible_of_modP_irreducible_of_primitive_of_admissible
       intro g hdeg
       unfold DensePoly.degree? at hdeg
       by_cases hg_size : g.size = 0
-      · rw [dif_pos hg_size] at hdeg
+      · rw [dite_eq_left hg_size] at hdeg
         simp at hdeg
-      · rw [dif_neg hg_size] at hdeg
+      · rw [dite_eq_right hg_size] at hdeg
         injection hdeg with hdeg
         omega
     obtain ⟨_, hsplit⟩ := hirr
@@ -999,7 +999,7 @@ theorem zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible
     ZPoly.Irreducible (normalizeFactorSign f) := by
   unfold normalizeFactorSign
   by_cases hlc : DensePoly.leadingCoeff f < 0
-  · rw [if_pos hlc]
+  · rw [ite_eq_left hlc]
     -- Sign-flipped branch: `DensePoly.scale (-1) f`.
     have hmulzero : (-1 : Int) * (0 : Int) = 0 := by decide
     -- `scale (-1)` is an involution on `ZPoly`.
@@ -1019,7 +1019,7 @@ theorem zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible
           DensePoly.coeff_C, DensePoly.coeff_C]
       by_cases hn : n = 0
       · simp [hn]
-      · rw [if_neg hn, if_neg hn]; omega
+      · rw [ite_eq_right hn, ite_eq_right hn]; omega
     have hscale_C_neg_one : DensePoly.scale (-1 : Int) (DensePoly.C (-1 : Int)) =
         DensePoly.C (1 : Int) := by
       apply DensePoly.ext_coeff
@@ -1028,7 +1028,7 @@ theorem zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible
           DensePoly.coeff_C, DensePoly.coeff_C]
       by_cases hn : n = 0
       · simp [hn]
-      · rw [if_neg hn, if_neg hn]; omega
+      · rw [ite_eq_right hn, ite_eq_right hn]; omega
     have hscale_mul_left : ∀ a b : ZPoly,
         DensePoly.scale (-1 : Int) (a * b) = DensePoly.scale (-1 : Int) a * b := by
       intro a b
@@ -1078,7 +1078,7 @@ theorem zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible
           rw [hinvol, hscale_C_neg_one] at hcong
           exact hcong
       · exact Or.inr hb
-  · rw [if_neg hlc]
+  · rw [ite_eq_right hlc]
     exact hirr
 
 /-- Every factor emitted by the extracted `X`-power normalization array is
@@ -1256,9 +1256,9 @@ theorem extractXPower_core_primitive_of_ne_zero
       congrArg (fun p : ZPoly => p.coeff n) hshift.symm
     rw [hcoeff_eq, DensePoly.coeff_shift]
     by_cases hn : n < (ZPoly.extractXPower (ZPoly.primitivePart f)).power
-    · rw [if_pos hn]
+    · rw [ite_eq_left hn]
       exact ⟨0, by show (0 : Int) = _ * 0; rw [Int.mul_zero]⟩
-    · rw [if_neg hn]
+    · rw [ite_eq_right hn]
       exact DensePoly.content_dvd_coeff
         (ZPoly.extractXPower (ZPoly.primitivePart f)).core
         (n - (ZPoly.extractXPower (ZPoly.primitivePart f)).power)

--- a/HexBerlekampZassenhaus/FactorProduct.lean
+++ b/HexBerlekampZassenhaus/FactorProduct.lean
@@ -163,10 +163,10 @@ theorem factorTrialFactorsWithBound_polyProduct
       Array.polyProduct (factorTrialFactorsWithBound f B) = f := by
   unfold factorTrialFactorsWithBound
   by_cases hdeg : (normalizeForFactor f).squareFreeCore.degree?.getD 0 = 0
-  · simp only [hdeg, if_true]
+  · simp only [hdeg, ite_true]
     exact reassemblePolynomialFactors_product_eq_input f
       #[(normalizeForFactor f).squareFreeCore] (by simp [Array.polyProduct])
-  · simp only [hdeg, if_false]
+  · simp only [hdeg, ite_false]
     cases hquad : quadraticIntegerRootFactors? (normalizeForFactor f).squareFreeCore with
     | some coreFactors =>
         exact reassemblePolynomialFactors_product_eq_input f coreFactors
@@ -215,10 +215,10 @@ private theorem primitive_of_signedContentScalar_mul_eq
     rw [h1]
     have hnat : (signedContentScalar f).natAbs = (ZPoly.content f).natAbs := by
       unfold signedContentScalar
-      rw [if_neg hf]
+      rw [ite_eq_right hf]
       by_cases hl : DensePoly.leadingCoeff f < 0
-      · rw [if_pos hl, Int.natAbs_neg]
-      · rw [if_neg hl]
+      · rw [ite_eq_left hl, Int.natAbs_neg]
+      · rw [ite_eq_right hl]
     rw [hnat]
     exact Int.natAbs_of_nonneg hnonneg
   have key : ZPoly.content f = ZPoly.content f * ZPoly.content P := by
@@ -255,7 +255,7 @@ private theorem factorTrialWithBound_product_of_constant
     (hbranch : (normalizeForFactor f).squareFreeCore.degree?.getD 0 = 0) :
     Factorization.product (factorTrialWithBound f B) = f := by
   unfold factorTrialWithBound factorTrialFactorsWithBound
-  rw [if_pos hbranch]
+  rw [ite_eq_left hbranch]
   have hcore_one := squareFreeCore_eq_one_of_constant_of_ne_zero f hf hbranch
   rw [hcore_one]
   apply factorizationOfFactors_product_of_filtered_product
@@ -283,7 +283,7 @@ private theorem factorTrialWithBound_product_of_quadratic
     Factorization.product (factorTrialWithBound f B) = f := by
   apply factorTrialWithBound_product_of_all_recorded_normalized
   · unfold factorTrialFactorsWithBound
-    rw [if_neg hdeg, hquad]
+    rw [ite_eq_right hdeg, hquad]
     intro factor hmem
     refine reassemblePolynomialFactors_normalizeFactorSign_of_ne_zero f hf
       coreFactors ?_ factor hmem
@@ -291,7 +291,7 @@ private theorem factorTrialWithBound_product_of_quadratic
     exact quadraticIntegerRootFactors?_normalizeFactorSign
       (squareFreeCore_leadingCoeff_pos_of_ne_zero f hf) hquad c hc
   · unfold factorTrialFactorsWithBound
-    rw [if_neg hdeg, hquad]
+    rw [ite_eq_right hdeg, hquad]
     intro factor hmem
     refine reassemblePolynomialFactors_shouldRecord_of_ne_zero f hf
       coreFactors ?_ factor hmem
@@ -307,7 +307,7 @@ private theorem factorTrialWithBound_product_of_trial
     Factorization.product (factorTrialWithBound f B) = f := by
   apply factorTrialWithBound_product_of_all_recorded_normalized
   · unfold factorTrialFactorsWithBound
-    rw [if_neg hdeg, hquad]
+    rw [ite_eq_right hdeg, hquad]
     intro factor hmem
     refine reassemblePolynomialFactors_normalizeFactorSign_of_ne_zero f hf
       (exhaustiveIntegerTrialCoreFactorsWithBound
@@ -318,7 +318,7 @@ private theorem factorTrialWithBound_product_of_trial
       (normalizeForFactor f).squareFreeCore B
       (squareFreeCore_leadingCoeff_pos_of_ne_zero f hf) c hc
   · unfold factorTrialFactorsWithBound
-    rw [if_neg hdeg, hquad]
+    rw [ite_eq_right hdeg, hquad]
     intro factor hmem
     refine reassemblePolynomialFactors_shouldRecord_of_ne_zero f hf
       (exhaustiveIntegerTrialCoreFactorsWithBound
@@ -408,9 +408,9 @@ theorem factorize_product (f : ZPoly) :
             by_cases hlarge : proposalEligible
                 (normalizeForFactor f).squareFreeCore
                 modular.data.factorsModP.size
-            · simp only [if_pos hlarge]
+            · simp only [ite_eq_left hlarge]
               by_cases hcore : (normalizeForFactor f).squareFreeCore = f
-              · simp only [dif_pos hcore]
+              · simp only [dite_eq_left hcore]
                 generalize hproposal :
                     proposeFactorization f hcore modular = proposal
                 cases hresult : proposal.1 with
@@ -420,9 +420,9 @@ theorem factorize_product (f : ZPoly) :
                 | some result =>
                     simp only
                     exact result.product
-              · simp only [dif_neg hcore]
+              · simp only [dite_eq_right hcore]
                 exact hlattice run.trace modular
-            · simp only [if_neg hlarge]
+            · simp only [ite_eq_right hlarge]
               exact hlattice run.trace modular
   exact hproduct
 
@@ -464,7 +464,7 @@ theorem factorize_entries_primitive_of_ne_zero
     rw [List.toList_toArray, hentry_eq]
     unfold filteredNormalizedFactors
     rw [List.mem_filterMap]
-    exact ⟨raw, hraw_mem, by simp only [hrecord, if_true]⟩
+    exact ⟨raw, hraw_mem, by simp only [hrecord, ite_true]⟩
   exact hmem_filtered entry.1 hentry_in
 
 /-- Every recorded entry of a nonzero default factorization has positive
@@ -545,7 +545,7 @@ one factor of multiplicity one. -/
 theorem ZPoly.isIrreducible_X : ZPoly.isIrreducible ZPoly.X = true := by
   have hx0 : ZPoly.X ≠ (0 : ZPoly) := by decide
   have hxdeg : ZPoly.X.degree?.getD 0 ≠ 0 := by decide
-  rw [ZPoly.isIrreducible, if_neg hx0, if_neg hxdeg]
+  rw [ZPoly.isIrreducible, ite_eq_right hx0, ite_eq_right hxdeg]
   dsimp only
   let φ := ZPoly.factorize ZPoly.X
   have hscalar : φ.scalar = 1 := by

--- a/HexBerlekampZassenhaus/Factorization.lean
+++ b/HexBerlekampZassenhaus/Factorization.lean
@@ -834,8 +834,8 @@ private theorem bhksRecoverClassifiedWithAllOnes_snd (f : ZPoly) (d : LiftData) 
   by_cases hrows :
       1 ≤ (bhksLatticeBasis f d.p d.k d.liftedFactors).factorCount +
         (bhksLatticeBasis f d.p d.k d.liftedFactors).coeffWidth
-  · simp only [dif_pos hrows]
-  · simp only [dif_neg hrows]
+  · simp only [dite_eq_left hrows]
+  · simp only [dite_eq_right hrows]
 
 /-- Lattice-method recombination loop: `bhksRecoveryLoop` plus certificate-backed
 early termination. The split path is byte-identical to the fast loop;
@@ -930,8 +930,8 @@ private theorem latticeCoreLoop_unfold
           else latticeCoreLoop core B floor primeData (nextHenselPrecision k B) fuel) := by
   rw [latticeCoreLoop]
   by_cases hfl : k < floor
-  · rw [if_pos hfl, if_pos hfl]
-  · rw [if_neg hfl, if_neg hfl]
+  · rw [ite_eq_left hfl, ite_eq_left hfl]
+  · rw [ite_eq_right hfl, ite_eq_right hfl]
     simp only [bhksRecoverClassifiedWithAllOnes_fst, bhksRecoverClassifiedWithAllOnes_snd]
 
 /-- The certificate-aware lattice loop can only turn a fast-loop failure into
@@ -952,12 +952,12 @@ private theorem latticeCoreLoop_none_imp_bhksRecoveryLoop_none
       rw [latticeCoreLoop_unfold] at hnone
       rw [bhksRecoveryLoop]
       by_cases hfl : k < floor
-      · rw [if_pos hfl] at hnone ⊢
+      · rw [ite_eq_left hfl] at hnone ⊢
         by_cases hk : k ≥ B
         · simp [hk]
-        · rw [if_neg hk] at hnone ⊢
+        · rw [ite_eq_right hk] at hnone ⊢
           exact ih _ hnone
-      · rw [if_neg hfl] at hnone ⊢
+      · rw [ite_eq_right hfl] at hnone ⊢
         cases hclass :
             bhksRecoverClassified core
               (ZPoly.directLiftData core k primeData) with
@@ -968,25 +968,25 @@ private theorem latticeCoreLoop_none_imp_bhksRecoveryLoop_none
             rw [hclass] at hnone
             by_cases hk : k ≥ B
             · simp [hk]
-            · rw [if_neg hk] at hnone ⊢
+            · rw [ite_eq_right hk] at hnone ⊢
               exact ih _ hnone
         | productMismatch candidates =>
             rw [hclass] at hnone
             by_cases hk : k ≥ B
             · simp [hk]
-            · rw [if_neg hk] at hnone ⊢
+            · rw [ite_eq_right hk] at hnone ⊢
               exact ih _ hnone
         | degenerate =>
             rw [hclass] at hnone
             by_cases hones :
                 bhksSingleAllOnesPartition core
                   (ZPoly.directLiftData core k primeData) = true
-            · rw [if_pos hones] at hnone
+            · rw [ite_eq_left hones] at hnone
               simp at hnone
-            · rw [if_neg hones] at hnone
+            · rw [ite_eq_right hones] at hnone
               by_cases hk : k ≥ B
               · simp [hk]
-              · rw [if_neg hk] at hnone ⊢
+              · rw [ite_eq_right hk] at hnone ⊢
                 exact ih _ hnone
 
 /-- A successful fixed-precision recovery on the scheduled lattice path forces
@@ -1036,12 +1036,12 @@ private theorem latticeCoreLoop_some_spec
       rw [latticeCoreLoop_unfold] at h
       rw [bhksRecoveryLoop]
       by_cases hfl : k < floor
-      · rw [if_pos hfl] at h ⊢
+      · rw [ite_eq_left hfl] at h ⊢
         by_cases hk : k ≥ B
         · simp [hk] at h
-        · rw [if_neg hk] at h ⊢
+        · rw [ite_eq_right hk] at h ⊢
           exact ih _ cf h
-      · rw [if_neg hfl] at h ⊢
+      · rw [ite_eq_right hfl] at h ⊢
         cases hclass : bhksRecoverClassified core (ZPoly.directLiftData core k primeData) with
         | success factors =>
             rw [hclass] at h
@@ -1050,25 +1050,25 @@ private theorem latticeCoreLoop_some_spec
             rw [hclass] at h
             by_cases hk : k ≥ B
             · simp [hk] at h
-            · rw [if_neg hk] at h ⊢
+            · rw [ite_eq_right hk] at h ⊢
               exact ih _ cf h
         | productMismatch cands =>
             rw [hclass] at h
             by_cases hk : k ≥ B
             · simp [hk] at h
-            · rw [if_neg hk] at h ⊢
+            · rw [ite_eq_right hk] at h ⊢
               exact ih _ cf h
         | degenerate =>
             rw [hclass] at h
             by_cases hones :
                 bhksSingleAllOnesPartition core (ZPoly.directLiftData core k primeData) = true
-            · rw [if_pos hones] at h
+            · rw [ite_eq_left hones] at h
               exact Or.inr ⟨(Option.some.inj h).symm,
                 k, Nat.le_of_not_lt hfl, hones⟩
-            · rw [if_neg hones] at h
+            · rw [ite_eq_right hones] at h
               by_cases hk : k ≥ B
               · simp [hk] at h
-              · rw [if_neg hk] at h ⊢
+              · rw [ite_eq_right hk] at h ⊢
                 exact ih _ cf h
 
 /-- A successful `latticeCoreWithBound` call is either a
@@ -1409,10 +1409,10 @@ theorem routeClassical_plan
           proposalEligible (normalizeForFactor f).squareFreeCore
               plan.data.factorsModP.size ∧
             (normalizeForFactor f).squareFreeCore = f
-      · simp only [ClassicalInput.beforeProposal, if_pos hroute] at hmodular
+      · simp only [ClassicalInput.beforeProposal, ite_eq_left hroute] at hmodular
         cases Option.some.inj hmodular
         exact selected
-      · simp only [ClassicalInput.beforeProposal, if_neg hroute] at hmodular
+      · simp only [ClassicalInput.beforeProposal, ite_eq_right hroute] at hmodular
         rw [runClassicalPlan_modular] at hmodular
         cases Option.some.inj hmodular
         exact selected
@@ -1441,7 +1441,7 @@ theorem routeClassical_success
           simpa [hroute.2] using hroute.1
         simp [heligible] at h
       · simpa only [ClassicalInput.beforeProposal, ClassicalInput.run,
-          if_neg hroute] using h
+          ite_eq_right hroute] using h
 
 set_option maxHeartbeats 800000 in
 /-- Every factor returned by a planned CLD run comes from its successful
@@ -1466,9 +1466,9 @@ theorem runLatticePlan_mem_source
   | some cf =>
       simp only [hl] at hmem
       by_cases hp : Factorization.product (factorizationOfFactors f cf) = f
-      · rw [if_pos hp] at hmem
+      · rw [ite_eq_left hp] at hmem
         exact Or.inl ⟨cf, rfl, hmem⟩
-      · rw [if_neg hp] at hmem
+      · rw [ite_eq_right hp] at hmem
         exact Or.inr hmem
 
 /-- Every raw factor of the total selector comes from proposal replay,
@@ -1495,13 +1495,13 @@ theorem runFactor_mem_source (f : ZPoly) {raw : ZPoly}
   | some cf =>
       simp only [hcf] at hmem
       by_cases hp : Factorization.product (factorizationOfFactors f cf) = f
-      · rw [if_pos hp] at hmem
+      · rw [ite_eq_left hp] at hmem
         exact Or.inr (Or.inl
           ⟨cf,
             routeClassical_success f
               (by simpa [hrun] using hcf),
             hmem⟩)
-      · rw [if_neg hp] at hmem
+      · rw [ite_eq_right hp] at hmem
         exact Or.inr (Or.inr (Or.inr hmem))
   | none =>
       simp only [hcf] at hmem
@@ -1538,9 +1538,9 @@ theorem runFactor_mem_source (f : ZPoly) {raw : ZPoly}
           by_cases hlarge : proposalEligible
               (normalizeForFactor f).squareFreeCore
               modular.data.factorsModP.size
-          · simp only [if_pos hlarge] at hmem
+          · simp only [ite_eq_left hlarge] at hmem
             by_cases hcore : (normalizeForFactor f).squareFreeCore = f
-            · simp only [dif_pos hcore] at hmem
+            · simp only [dite_eq_left hcore] at hmem
               generalize hproposal :
                   proposeFactorization f hcore modular = proposal at hmem
               cases hresult : proposal.1 with
@@ -1552,11 +1552,11 @@ theorem runFactor_mem_source (f : ZPoly) {raw : ZPoly}
                   rcases fallbackSource hmem with hl | ht
                   · exact Or.inr (Or.inr (Or.inl hl))
                   · exact Or.inr (Or.inr (Or.inr ht))
-            · simp only [dif_neg hcore] at hmem
+            · simp only [dite_eq_right hcore] at hmem
               rcases fallbackSource hmem with hl | ht
               · exact Or.inr (Or.inr (Or.inl hl))
               · exact Or.inr (Or.inr (Or.inr ht))
-          · simp only [if_neg hlarge] at hmem
+          · simp only [ite_eq_right hlarge] at hmem
             rcases fallbackSource hmem with hl | ht
             · exact Or.inr (Or.inr (Or.inl hl))
             · exact Or.inr (Or.inr (Or.inr ht))
@@ -1610,11 +1610,11 @@ private theorem signedContentScalar_eq_zero_iff (f : ZPoly) :
     by_cases hf : f = 0
     · exact hf
     have hcontent_ne := content_ne_zero_of_zpoly_ne_zero f hf
-    rw [if_neg hf] at h
+    rw [ite_eq_right hf] at h
     by_cases hneg : DensePoly.leadingCoeff f < 0
-    · rw [if_pos hneg] at h
+    · rw [ite_eq_left hneg] at h
       exact absurd (Int.neg_eq_zero.mp h) hcontent_ne
-    · rw [if_neg hneg] at h
+    · rw [ite_eq_right hneg] at h
       exact absurd h hcontent_ne
   · intro hf
     simp [hf]

--- a/HexBerlekampZassenhaus/FactorizationResult.lean
+++ b/HexBerlekampZassenhaus/FactorizationResult.lean
@@ -264,7 +264,7 @@ follows by chaining this with the target `target = 2 * B + 1`.
 theorem le_pow_ceilLogP {p : Nat} (hp : 2 ≤ p) (target : Nat) :
     target ≤ p ^ ceilLogP p target := by
   unfold ceilLogP
-  rw [if_neg (by omega : ¬ p ≤ 1)]
+  rw [ite_eq_right (by omega : ¬ p ≤ 1)]
   have hlt2 : target < 2 ^ target := Nat.lt_two_pow_self
   have hle2 : (2 : Nat) ^ target ≤ 2 ^ (target + 1) :=
     Nat.pow_le_pow_right (by decide) (Nat.le_succ _)
@@ -313,7 +313,7 @@ theorem ceilLogP_le_of_le_pow {p : Nat} (hp : 2 ≤ p) (target a : Nat)
     (h : target ≤ p ^ a) :
     ceilLogP p target ≤ a := by
   unfold ceilLogP
-  rw [if_neg (by omega : ¬ p ≤ 1)]
+  rw [ite_eq_right (by omega : ¬ p ≤ 1)]
   have := ceilLogPAux_le p hp target a h (target + 1) 0 (Nat.zero_le a)
   simpa using this
 
@@ -538,8 +538,8 @@ private theorem splitInitialZeros_reassembles (coeffs : List Int) :
                   have hvalue :
                       (DensePoly.ofList core).coeff (n - power) =
                         coeffs.getD n 0 := by
-                    have key := hcoeff_n; rw [if_neg hn] at key; exact key
-                  simp only [hsucc, Nat.succ_sub_succ_eq_sub, if_false, List.getD_cons_succ]
+                    have key := hcoeff_n; rw [ite_eq_right hn] at key; exact key
+                  simp only [hsucc, Nat.succ_sub_succ_eq_sub, ite_false, List.getD_cons_succ]
                   exact hvalue
       · simp [hcoeff]
 
@@ -664,7 +664,7 @@ private theorem reassemblePolynomialFactors_mem
   | mk expanded residual =>
       simp only at hmem
       by_cases hres : residual = 1
-      · rw [if_pos hres] at hmem
+      · rw [ite_eq_left hres] at hmem
         rw [Array.toList_append, Array.toList_append] at hmem
         rcases List.mem_append.mp hmem with hxe | hcf
         · rcases List.mem_append.mp hxe with hx | hexp_mem
@@ -680,7 +680,7 @@ private theorem reassemblePolynomialFactors_mem
             exact expandRepeatedPartFactorArray_mem _ _ _ hexp_mem'
         · right
           exact hcf
-      · rw [if_neg hres] at hmem
+      · rw [ite_eq_right hres] at hmem
         rw [Array.toList_append] at hmem
         rcases List.mem_append.mp hmem with hprefix | hcf
         · exact Or.inl hprefix
@@ -725,7 +725,7 @@ theorem reassemblePolynomialFactors_mem_xPower_or_core_of_expansionComplete
   cases exp with
   | mk expanded residual =>
       simp only at hmem hcomplete
-      rw [if_pos hcomplete] at hmem
+      rw [ite_eq_left hcomplete] at hmem
       rw [Array.toList_append, Array.toList_append] at hmem
       rcases List.mem_append.mp hmem with hxe | hcore
       · rcases List.mem_append.mp hxe with hx | hexp_mem
@@ -754,12 +754,12 @@ private theorem polyProduct_reassemblePolynomialFactors
   | mk expanded residual =>
       simp only at hinv ⊢
       by_cases hres : residual = 1
-      · rw [if_pos hres]
+      · rw [ite_eq_left hres]
         rw [hres] at hinv
         rw [DensePoly.mul_one_right_poly (S := Int)] at hinv
         rw [ZPoly.polyProduct_append, ZPoly.polyProduct_append, polyProduct_xPowerFactorArray_mul,
           hinv]
-      · rw [if_neg hres]
+      · rw [ite_eq_right hres]
         rw [ZPoly.polyProduct_append, polyProduct_polynomialNormalizationPrefixFactors,
           polyProduct_xPowerFactorArray_mul, polyProduct_repeatedPartFactorArray_eq]
 
@@ -840,7 +840,7 @@ private theorem multListProduct_bumpFactorMultiplicity
   | cons entry entries ih =>
       unfold bumpFactorMultiplicity
       by_cases heq : entry.1 = g
-      · simp only [heq, if_true]
+      · simp only [heq, ite_true]
         rw [multListProduct_cons]
         show Factorization.polyPow g (entry.2 + 1) * multListProduct entries =
           g * multListProduct (entry :: entries)
@@ -848,7 +848,7 @@ private theorem multListProduct_bumpFactorMultiplicity
         rw [DensePoly.mul_comm_poly (S := Int)
               (Factorization.polyPow g entry.2) g]
         rw [DensePoly.mul_assoc_poly (S := Int)]
-      · simp only [heq, if_false]
+      · simp only [heq, ite_false]
         rw [multListProduct_cons, multListProduct_cons, ih, ← DensePoly.mul_assoc_poly (S := Int)]
         rw [DensePoly.mul_comm_poly (S := Int)
               (Factorization.polyPow entry.1 entry.2) g]
@@ -904,7 +904,7 @@ theorem normalizeFactorSign_ne_zero_of_ne_zero
     normalizeFactorSign f ≠ 0 := by
   unfold normalizeFactorSign
   by_cases hlead : DensePoly.leadingCoeff f < 0
-  · rw [if_pos hlead]
+  · rw [ite_eq_left hlead]
     intro hzero
     apply hf
     apply DensePoly.ext_coeff
@@ -916,7 +916,7 @@ theorem normalizeFactorSign_ne_zero_of_ne_zero
     rw [DensePoly.coeff_zero] at hcoeff
     rw [DensePoly.coeff_zero]
     omega
-  · rw [if_neg hlead]
+  · rw [ite_eq_right hlead]
     exact hf
 
 private theorem filteredNormalizedFactors_eq_map_normalizeFactorSign_of_no_units
@@ -1421,7 +1421,7 @@ theorem normalizeFactorSign_one :
     change ¬ DensePoly.leadingCoeff (DensePoly.C (1 : Int)) < 0
     simp [DensePoly.leadingCoeff,
       DensePoly.coeffs_C_of_ne_zero (by decide : (1 : Int) ≠ 0)]
-  rw [if_neg hnot]
+  rw [ite_eq_right hnot]
 
 /-- The `shouldRecordPolynomialFactor` filter rejects the unit `1`.  Exposed
 publicly so Mathlib-side per-branch umbrellas can contradict
@@ -1478,14 +1478,14 @@ theorem normalizeFactorSign_eq_self_of_leadingCoeff_nonneg (g : ZPoly)
     normalizeFactorSign g = g := by
   unfold normalizeFactorSign
   have hnot : ¬ DensePoly.leadingCoeff g < 0 := by omega
-  rw [if_neg hnot]
+  rw [ite_eq_right hnot]
 
 /-- Sign normalization produces a nonnegative leading coefficient. -/
 theorem normalizeFactorSign_leadingCoeff_nonneg (g : ZPoly) :
     0 ≤ DensePoly.leadingCoeff (normalizeFactorSign g) := by
   unfold normalizeFactorSign
   by_cases hlead : DensePoly.leadingCoeff g < 0
-  · rw [if_pos hlead]
+  · rw [ite_eq_left hlead]
     have hg_ne : g ≠ 0 := by
       intro hzero
       rw [hzero] at hlead
@@ -1493,7 +1493,7 @@ theorem normalizeFactorSign_leadingCoeff_nonneg (g : ZPoly) :
       omega
     rw [ZPoly.leadingCoeff_scale_of_nonzero (-1 : Int) g (by decide)]
     omega
-  · rw [if_neg hlead]
+  · rw [ite_eq_right hlead]
     omega
 
 /-- Sign normalization is idempotent. -/
@@ -1510,13 +1510,13 @@ theorem normalizeFactorSign_primitive (f : ZPoly)
     ZPoly.Primitive (normalizeFactorSign f) := by
   unfold normalizeFactorSign
   by_cases hlead : DensePoly.leadingCoeff f < 0
-  · rw [if_pos hlead]
+  · rw [ite_eq_left hlead]
     show ZPoly.content (DensePoly.scale (-1 : Int) f) = 1
     rw [show ZPoly.content (DensePoly.scale (-1 : Int) f)
           = DensePoly.content (DensePoly.scale (-1 : Int) f) from rfl,
         DensePoly.content_scale_neg_one f]
     exact h
-  · rw [if_neg hlead]
+  · rw [ite_eq_right hlead]
     exact h
 
 /-- Collected factor entries are fixed points of `normalizeFactorSign`. -/
@@ -1592,12 +1592,12 @@ private theorem shift_scale_int (k : Nat) (c : Int) (p : ZPoly) :
     (Int.mul_zero c)]
   rw [DensePoly.coeff_shift]
   by_cases hn : n < k
-  · rw [if_pos hn]
-    rw [if_pos hn]
+  · rw [ite_eq_left hn]
+    rw [ite_eq_left hn]
     change (0 : Int) = c * 0
     rw [Int.mul_zero]
-  · rw [if_neg hn]
-    rw [if_neg hn, DensePoly.coeff_scale (R := Int) c p (n - k) (Int.mul_zero c)]
+  · rw [ite_eq_right hn]
+    rw [ite_eq_right hn, DensePoly.coeff_scale (R := Int) c p (n - k) (Int.mul_zero c)]
 
 private theorem toRatPoly_mul_product (f g : ZPoly) :
     ZPoly.toRatPoly (f * g) = ZPoly.toRatPoly f * ZPoly.toRatPoly g := by
@@ -1671,7 +1671,7 @@ theorem exactQuotient?_eq_some_of_mul_eq_monic_of_pos_degree
   unfold exactQuotient?
   rw [hisZero_false]
   simp only [Bool.false_or, decide_eq_true_eq]
-  rw [if_neg hcandidate_ne_one]
+  rw [ite_eq_right hcandidate_ne_one]
   exact (ZPoly.divExact?_eq hcandidate_ne).2 hmul.symm
 
 /--
@@ -1721,7 +1721,7 @@ theorem exactQuotient?_eq_some_of_divMod_eq_of_shouldRecord
   unfold exactQuotient?
   rw [hisZero_false]
   simp only [Bool.false_or, decide_eq_true_eq]
-  rw [if_neg hcandidate_ne_one]
+  rw [ite_eq_right hcandidate_ne_one]
   exact (ZPoly.divExact?_eq hcandidate_ne).2 hmul.symm
 
 end Hex

--- a/HexBerlekampZassenhaus/IrreducibleDecide.lean
+++ b/HexBerlekampZassenhaus/IrreducibleDecide.lean
@@ -69,9 +69,9 @@ theorem eq_C_coeff_zero_of_size_one {f : ZPoly} (h : f.size = 1) :
   intro i
   rw [DensePoly.coeff_C]
   match i with
-  | 0 => rw [if_pos rfl]
+  | 0 => rw [ite_eq_left rfl]
   | i + 1 =>
-      rw [if_neg (by omega)]
+      rw [ite_eq_right (by omega)]
       exact DensePoly.coeff_eq_zero_of_size_le f (by omega)
 
 /-- A single-prime modular irreducibility witness for a `ZPoly` factor,

--- a/HexBerlekampZassenhaus/Lattice.lean
+++ b/HexBerlekampZassenhaus/Lattice.lean
@@ -394,15 +394,15 @@ theorem LiftModulus.centered_eq (m : LiftModulus) (z : Int) :
   unfold LiftModulus.centered centeredModNat
   by_cases hm : m.nat = 0
   · simp [hm]
-  · simp only [hm, if_false, m.int_eq, m.half_eq, Int.ofNat_eq_natCast]
+  · simp only [hm, ite_false, m.int_eq, m.half_eq, Int.ofNat_eq_natCast]
     have hne : ((m.nat : Nat) : Int) ≠ 0 := by omega
     have hnonneg : 0 ≤ z % ((m.nat : Nat) : Int) := Int.emod_nonneg z hne
     by_cases hhalf : 2 * (z % ((m.nat : Nat) : Int)).natAbs ≤ m.nat
     · have hle : z % ((m.nat : Nat) : Int) ≤ ((m.nat / 2 : Nat) : Int) := by omega
-      rw [if_pos hle, if_pos hhalf]
+      rw [ite_eq_left hle, ite_eq_left hhalf]
     · have hnle : ¬ z % ((m.nat : Nat) : Int) ≤ ((m.nat / 2 : Nat) : Int) := by omega
       have hnotneg : ¬ z % ((m.nat : Nat) : Int) < 0 := by omega
-      rw [if_neg hnle, if_neg hhalf, if_neg hnotneg]
+      rw [ite_eq_right hnle, ite_eq_right hhalf, ite_eq_right hnotneg]
 
 /-- Centred residue modulo `p^b`, the `mod^±` operation in the BHKS cut. -/
 @[expose]
@@ -553,7 +553,7 @@ theorem centeredModNat_emod_self (z : Int) (m : Nat) :
       show z % Int.ofNat m % Int.ofNat m = z % Int.ofNat m
       exact Int.emod_emod _ _
     unfold centeredModNat
-    rw [if_neg hm, if_neg hm, hmod]
+    rw [ite_eq_right hm, ite_eq_right hm, hmod]
 
 /-- `centeredModNat` chooses a representative congruent to the input modulo `m`. -/
 theorem self_sub_centeredModNat_dvd (z : Int) (m : Nat) :
@@ -589,7 +589,7 @@ theorem centeredResiduePow_add_pow_mul_psiCut
       centeredResiduePow p b (centeredResiduePow p a z) +
         ((p ^ b : Nat) : Int) * psiCut p a b z := by
   unfold psiCut
-  rw [if_neg hmod]
+  rw [ite_eq_right hmod]
   let xCentered := centeredResiduePow p a z
   let lower := centeredResiduePow p b xCentered
   have hdvd : ((p ^ b : Nat) : Int) ∣ xCentered - lower := by
@@ -637,7 +637,7 @@ theorem psiCut_eq_zero_of_natAbs_le
   have hbne : (p ^ b : Nat) ≠ 0 := Nat.ne_of_gt hbpos
   have hcentered_amb : centeredResiduePow p a z = y :=
     centeredResiduePow_eq_of_natAbs_le p a y z B hbound hsep_a hcongr
-  rw [if_neg hbne]
+  rw [ite_eq_right hbne]
   show (centeredResiduePow p a z - centeredResiduePow p b (centeredResiduePow p a z))
       / Int.ofNat (p ^ b) = 0
   rw [hcentered_amb]

--- a/HexBerlekampZassenhaus/Modular/PrimePlan.lean
+++ b/HexBerlekampZassenhaus/Modular/PrimePlan.lean
@@ -565,7 +565,7 @@ private theorem scoutBetterPattern_mem
       | succ fuel =>
           simp only [scoutBetterPattern] at h
           by_cases hpays : scoutPays core inc candidate.m (fuel + 1) = true
-          · rw [if_pos hpays] at h
+          · rw [ite_eq_left hpays] at h
             cases hpat :
                 probeDegreePattern? core.poly candidate inc.degrees.size with
             | none =>
@@ -577,11 +577,11 @@ private theorem scoutBetterPattern_mem
                 rw [hpat] at h
                 simp only at h
                 by_cases hcomplete : pattern.complete = true
-                · rw [if_pos hcomplete] at h
+                · rw [ite_eq_left hcomplete] at h
                   by_cases hbetter :
                       scoreBetter inc.score
                         (directDegreeScore core candidate.m pattern.separated) = true
-                  · rw [if_pos hbetter] at h
+                  · rw [ite_eq_left hbetter] at h
                     rcases ih fuel
                         ⟨candidate.m, pattern.separated,
                           directDegreeScore core candidate.m pattern.separated⟩
@@ -592,15 +592,15 @@ private theorem scoutBetterPattern_mem
                         rw [hc]
                         exact List.mem_cons_self)
                     · exact Or.inr (List.mem_cons_of_mem candidate hm)
-                  · rw [if_neg hbetter] at h
+                  · rw [ite_eq_right hbetter] at h
                     rcases ih fuel inc best scouted h with hb | hm
                     · exact Or.inl hb
                     · exact Or.inr (List.mem_cons_of_mem candidate hm)
-                · rw [if_neg hcomplete] at h
+                · rw [ite_eq_right hcomplete] at h
                   rcases ih fuel inc best scouted h with hb | hm
                   · exact Or.inl hb
                   · exact Or.inr (List.mem_cons_of_mem candidate hm)
-          · rw [if_neg hpays] at h
+          · rw [ite_eq_right hpays] at h
             exact Or.inl ⟨scouted, h, rfl⟩
 
 private theorem planOfScout_probes_mem

--- a/HexBerlekampZassenhaus/PrimeSelection.lean
+++ b/HexBerlekampZassenhaus/PrimeSelection.lean
@@ -615,7 +615,7 @@ private theorem berlekampFactorsModP_eq_of_isZero_false
   letI := ZMod64.primeModulusOfPrime c.prime
   intro hzero
   unfold berlekampFactorsModP
-  rw [dif_pos hzero]
+  rw [dite_eq_left hzero]
 
 /-- Reduce an integer coefficient to its canonical natural-number residue modulo `p` for the modular Horner evaluator. -/
 private def intCoeffModNat (z : Int) (p : Nat) : Nat :=

--- a/HexBerlekampZassenhaus/PrimitiveFactors.lean
+++ b/HexBerlekampZassenhaus/PrimitiveFactors.lean
@@ -66,7 +66,7 @@ theorem quadraticIntegerRootFactors?_degree_pos_of_primitive
   intro factor hmem
   unfold quadraticIntegerRootFactors? at hquad
   by_cases hdeg : core.degree?.getD 0 = 2
-  · simp only [hdeg, if_true] at hquad
+  · simp only [hdeg, ite_true] at hquad
     let roots := integerRootCandidates core
     let split := splitIntegerRootFactorsAux core roots roots.length
     obtain ⟨rs, _hsub, hshape⟩ :=
@@ -80,14 +80,14 @@ theorem quadraticIntegerRootFactors?_degree_pos_of_primitive
       exact linearFactorForRoot_degree_pos r
     by_cases hsize : split.1.size = 0
     · simp [roots, split, hsize] at hquad
-    · simp only [roots, split, hsize, if_false] at hquad
+    · simp only [roots, split, hsize, ite_false] at hquad
       by_cases hres_one : split.2 = 1
-      · rw [if_pos hres_one] at hquad
+      · rw [ite_eq_left hres_one] at hquad
         cases hquad
         exact hlinear_degree factor hmem
-      · rw [if_neg hres_one] at hquad
+      · rw [ite_eq_right hres_one] at hquad
         by_cases hres_deg : split.2.degree?.getD 0 ≤ 1
-        · rw [if_pos hres_deg] at hquad
+        · rw [ite_eq_left hres_deg] at hquad
           cases hquad
           rw [Array.toList_push] at hmem
           simp only [List.mem_append, List.mem_singleton] at hmem
@@ -196,9 +196,9 @@ theorem quadraticIntegerRootFactors?_degree_pos_of_primitive
             apply hres_one
             rw [hres_eq, hc_eq_one]
             rfl
-        · rw [if_neg hres_deg] at hquad
+        · rw [ite_eq_right hres_deg] at hquad
           contradiction
-  · rw [if_neg hdeg] at hquad
+  · rw [ite_eq_right hdeg] at hquad
     contradiction
 
 /-- Removing the maximal power of `X` from a nonzero primitive part leaves a nonzero factor. -/
@@ -972,11 +972,11 @@ private theorem reassemblePolynomialFactors_singleton_one_eq
   rw [expandRepeatedPartFactorArray_singleton_one]
   simp only
   by_cases hrp : d.repeatedPart = 1
-  · rw [if_pos hrp]
+  · rw [ite_eq_left hrp]
     unfold polynomialNormalizationPrefixFactors repeatedPartFactorArray
     rw [hrp]
     simp
-  · rw [if_neg hrp]
+  · rw [ite_eq_right hrp]
 
 private theorem squareFreeCore_ne_zero_of_ne_zero (f : ZPoly) (hf : f ≠ 0) :
     (normalizeForFactor f).squareFreeCore ≠ 0 := by
@@ -1024,7 +1024,7 @@ private theorem foldl_step_const_inner_pos (p q : ZPoly) (xs : List Nat) :
       have hj : 0 < j := hpos j List.mem_cons_self
       have hstep : DensePoly.mulCoeffStep p q 0 0 acc j = acc := by
         unfold DensePoly.mulCoeffStep
-        rw [if_neg (by omega)]
+        rw [ite_eq_right (by omega)]
       rw [hstep]
       exact ih (fun j' hj' => hpos j' (List.mem_cons_of_mem j hj')) acc
 
@@ -1040,7 +1040,7 @@ private theorem foldl_step_const_pos_i (p q : ZPoly) (i : Nat) (hi : 0 < i)
       rw [List.foldl_cons]
       have hstep : DensePoly.mulCoeffStep p q 0 i acc j = acc := by
         unfold DensePoly.mulCoeffStep
-        rw [if_neg (by omega)]
+        rw [ite_eq_right (by omega)]
       rw [hstep]; exact ih acc
 
 /-- The inner schoolbook fold for the constant coefficient at outer index `0`
@@ -1101,10 +1101,10 @@ private theorem mulCoeffSum_const (p q : ZPoly) :
       rw [List.range_succ_eq_map, List.foldl_cons, foldl_outer_const_pos p q _ hpos,
         foldl_step_const_inner p q q.size]
       by_cases hq : 0 < q.size
-      · rw [if_pos hq]
+      · rw [ite_eq_left hq]
         show (0 : Int) + p.coeff 0 * q.coeff 0 = p.coeff 0 * q.coeff 0
         rw [Int.zero_add]
-      · rw [if_neg hq]
+      · rw [ite_eq_right hq]
         have hq0 : q.coeff 0 = 0 := DensePoly.coeff_eq_zero_of_size_le q (by omega)
         show (0 : Int) = p.coeff 0 * q.coeff 0
         rw [hq0, Int.mul_zero]
@@ -1126,8 +1126,8 @@ private theorem splitInitialZeros_tail_getD_ne_zero (coeffs : List Int) :
   | cons c cs ih =>
       unfold ZPoly.splitInitialZeros
       by_cases hc : c = 0
-      · rw [if_pos hc]; simpa using ih
-      · rw [if_neg hc]; exact Or.inr (by simpa using hc)
+      · rw [ite_eq_left hc]; simpa using ih
+      · rw [ite_eq_right hc]; exact Or.inr (by simpa using hc)
 
 /-- The `X`-power-free square-free part extracted from a nonzero primitive part has a nonzero
 constant term: `extractXPower` strips the leading zero run, so the lowest stored

--- a/HexBerlekampZassenhaus/QuadraticFactors.lean
+++ b/HexBerlekampZassenhaus/QuadraticFactors.lean
@@ -123,7 +123,7 @@ theorem exhaustiveIntegerTrialCoreFactorsWithBound_factor_irreducible
       (if peel.2 = 1 then split.1 ++ peel.1 else (split.1 ++ peel.1).push peel.2).toList
     at hmem
   by_cases hres_one : peel.2 = 1
-  · rw [if_pos hres_one] at hmem
+  · rw [ite_eq_left hres_one] at hmem
     rw [Array.toList_append, List.mem_append] at hmem
     rcases hmem with hsplit_mem | hpeel_mem
     · exact splitIntegerRootFactorsAux_factor_irreducible
@@ -131,7 +131,7 @@ theorem exhaustiveIntegerTrialCoreFactorsWithBound_factor_irreducible
         (factors := split.1) (residual := split.2) rfl hsplit_mem
     · exact trialDivisionPeel_factor_irreducible hcore_ne hcore_prim hcore_sq
         hsplit2_dvd_core hsplit2_pos hbound rfl hpeel_mem
-  · rw [if_neg hres_one] at hmem
+  · rw [ite_eq_right hres_one] at hmem
     rw [Array.toList_push, List.mem_append] at hmem
     rcases hmem with hpref_mem | hres_mem
     · rw [Array.toList_append, List.mem_append] at hpref_mem
@@ -245,7 +245,7 @@ theorem quadraticIntegerRootFactors?_normalizeFactorSign
     ∀ factor ∈ factors.toList, normalizeFactorSign factor = factor := by
   unfold quadraticIntegerRootFactors? at hquad
   by_cases hdeg : core.degree?.getD 0 = 2
-  · simp only [hdeg, if_true] at hquad
+  · simp only [hdeg, ite_true] at hquad
     let roots := integerRootCandidates core
     let split := splitIntegerRootFactorsAux core roots roots.length
     have hsplit_norm :
@@ -255,14 +255,14 @@ theorem quadraticIntegerRootFactors?_normalizeFactorSign
           split.1 split.2 rfl
     by_cases hsize : split.1.size = 0
     · simp [roots, split, hsize] at hquad
-    · simp only [roots, split, hsize, if_false] at hquad
+    · simp only [roots, split, hsize, ite_false] at hquad
       by_cases hres_one : split.2 = 1
-      · rw [if_pos hres_one] at hquad
+      · rw [ite_eq_left hres_one] at hquad
         cases hquad
         exact hsplit_norm
-      · rw [if_neg hres_one] at hquad
+      · rw [ite_eq_right hres_one] at hquad
         by_cases hres_deg : split.2.degree?.getD 0 ≤ 1
-        · rw [if_pos hres_deg] at hquad
+        · rw [ite_eq_left hres_deg] at hquad
           cases hquad
           intro factor hmem
           rw [Array.toList_push] at hmem
@@ -322,7 +322,7 @@ theorem quadraticIntegerRootFactors?_shouldRecord
     ∀ factor ∈ factors.toList, shouldRecordPolynomialFactor factor = true := by
   unfold quadraticIntegerRootFactors? at hquad
   by_cases hdeg : core.degree?.getD 0 = 2
-  · simp only [hdeg, if_true] at hquad
+  · simp only [hdeg, ite_true] at hquad
     let roots := integerRootCandidates core
     let split := splitIntegerRootFactorsAux core roots roots.length
     have hsplit_record :
@@ -332,14 +332,14 @@ theorem quadraticIntegerRootFactors?_shouldRecord
           split.1 split.2 rfl
     by_cases hsize : split.1.size = 0
     · simp [roots, split, hsize] at hquad
-    · simp only [roots, split, hsize, if_false] at hquad
+    · simp only [roots, split, hsize, ite_false] at hquad
       by_cases hres_one : split.2 = 1
-      · rw [if_pos hres_one] at hquad
+      · rw [ite_eq_left hres_one] at hquad
         cases hquad
         exact hsplit_record
-      · rw [if_neg hres_one] at hquad
+      · rw [ite_eq_right hres_one] at hquad
         by_cases hres_deg : split.2.degree?.getD 0 ≤ 1
-        · rw [if_pos hres_deg] at hquad
+        · rw [ite_eq_left hres_deg] at hquad
           cases hquad
           intro factor hmem
           rw [Array.toList_push] at hmem
@@ -410,21 +410,21 @@ theorem quadraticIntegerRootFactors?_factor_irreducible_of_ne_residual
     ZPoly.Irreducible factor := by
   unfold quadraticIntegerRootFactors? at hquad
   by_cases hdeg : core.degree?.getD 0 = 2
-  · simp only [hdeg, if_true] at hquad
+  · simp only [hdeg, ite_true] at hquad
     let roots := integerRootCandidates core
     let split := splitIntegerRootFactorsAux core roots roots.length
     by_cases hsize : split.1.size = 0
     · simp [roots, split, hsize] at hquad
-    · simp only [roots, split, hsize, if_false] at hquad
+    · simp only [roots, split, hsize, ite_false] at hquad
       by_cases hres_one : split.2 = 1
-      · rw [if_pos hres_one] at hquad
+      · rw [ite_eq_left hres_one] at hquad
         cases hquad
         exact splitIntegerRootFactorsAux_factor_irreducible
           (target := core) (roots := roots) (fuel := roots.length)
           (factors := split.1) (residual := split.2) rfl hmem
-      · rw [if_neg hres_one] at hquad
+      · rw [ite_eq_right hres_one] at hquad
         by_cases hres_deg : split.2.degree?.getD 0 ≤ 1
-        · rw [if_pos hres_deg] at hquad
+        · rw [ite_eq_left hres_deg] at hquad
           cases hquad
           rw [Array.toList_push] at hmem
           simp only [List.mem_append, List.mem_singleton] at hmem
@@ -465,23 +465,23 @@ private theorem quadraticIntegerRootFactors?_residual_irreducible
     ZPoly.Irreducible factor := by
   unfold quadraticIntegerRootFactors? at hquad
   by_cases hdeg : core.degree?.getD 0 = 2
-  · simp only [hdeg, if_true] at hquad
+  · simp only [hdeg, ite_true] at hquad
     let roots := integerRootCandidates core
     let split := splitIntegerRootFactorsAux core roots roots.length
     by_cases hsize : split.1.size = 0
     · simp [roots, split, hsize] at hquad
-    · simp only [roots, split, hsize, if_false] at hquad
+    · simp only [roots, split, hsize, ite_false] at hquad
       by_cases hres_one : split.2 = 1
       · -- split.2 = 1: factor = 1 from hres. But hmem : factor ∈ split.1.toList,
         -- and every element of split.1 is irreducible.
-        rw [if_pos hres_one] at hquad
+        rw [ite_eq_left hres_one] at hquad
         cases hquad
         exact splitIntegerRootFactorsAux_factor_irreducible
           (target := core) (roots := roots) (fuel := roots.length)
           (factors := split.1) (residual := split.2) rfl hmem
-      · rw [if_neg hres_one] at hquad
+      · rw [ite_eq_right hres_one] at hquad
         by_cases hres_deg : split.2.degree?.getD 0 ≤ 1
-        · rw [if_pos hres_deg] at hquad
+        · rw [ite_eq_left hres_deg] at hquad
           cases hquad
           have hsplit_prod :
               split.2 * Array.polyProduct split.1 = core := by
@@ -704,7 +704,7 @@ theorem quadraticIntegerRootFactors?_product
     Array.polyProduct factors = core := by
   unfold quadraticIntegerRootFactors? at hquad
   by_cases hdeg : core.degree?.getD 0 = 2
-  · simp only [hdeg, if_true] at hquad
+  · simp only [hdeg, ite_true] at hquad
     let roots := integerRootCandidates core
     let split := splitIntegerRootFactorsAux core roots roots.length
     have hsplit_prod :
@@ -713,18 +713,18 @@ theorem quadraticIntegerRootFactors?_product
         splitIntegerRootFactorsAux_product core roots roots.length split.1 split.2 rfl
     by_cases hsize : split.1.size = 0
     · simp [roots, split, hsize] at hquad
-    · simp only [roots, split, hsize, if_false] at hquad
+    · simp only [roots, split, hsize, ite_false] at hquad
       by_cases hres_one : split.2 = 1
-      · rw [if_pos hres_one] at hquad
+      · rw [ite_eq_left hres_one] at hquad
         cases hquad
         simpa [hres_one, ZPoly.one_mul_zpoly] using hsplit_prod
-      · rw [if_neg hres_one] at hquad
+      · rw [ite_eq_right hres_one] at hquad
         by_cases hres_deg : split.2.degree?.getD 0 ≤ 1
-        · rw [if_pos hres_deg] at hquad
+        · rw [ite_eq_left hres_deg] at hquad
           cases hquad
           rw [polyProduct_push, DensePoly.mul_comm_poly (S := Int)]
           exact hsplit_prod
-        · rw [if_neg hres_deg] at hquad
+        · rw [ite_eq_right hres_deg] at hquad
           contradiction
   · simp [hdeg] at hquad
 
@@ -770,7 +770,7 @@ theorem quadraticIntegerRootFactors?_factor_size_eq_two
     factor.size = 2 := by
   unfold quadraticIntegerRootFactors? at hquad
   by_cases hdeg : core.degree?.getD 0 = 2
-  · simp only [hdeg, if_true] at hquad
+  · simp only [hdeg, ite_true] at hquad
     let roots := integerRootCandidates core
     let split := splitIntegerRootFactorsAux core roots roots.length
     obtain ⟨rs, _hsub, hshape⟩ :=
@@ -785,14 +785,14 @@ theorem quadraticIntegerRootFactors?_factor_size_eq_two
       exact linearFactorForRoot_size_eq_two r
     by_cases hsize : split.1.size = 0
     · simp [roots, split, hsize] at hquad
-    · simp only [roots, split, hsize, if_false] at hquad
+    · simp only [roots, split, hsize, ite_false] at hquad
       by_cases hres_one : split.2 = 1
-      · rw [if_pos hres_one] at hquad
+      · rw [ite_eq_left hres_one] at hquad
         cases hquad
         exact hsplit_size factor hmem
-      · rw [if_neg hres_one] at hquad
+      · rw [ite_eq_right hres_one] at hquad
         by_cases hres_deg : split.2.degree?.getD 0 ≤ 1
-        · rw [if_pos hres_deg] at hquad
+        · rw [ite_eq_left hres_deg] at hquad
           cases hquad
           rw [Array.toList_push] at hmem
           rcases List.mem_append.mp hmem with hsplit_mem | hres_mem
@@ -1099,7 +1099,7 @@ theorem quadraticIntegerRootFactors?_pairwise_not_associated
   have _ := hcore_primitive
   unfold quadraticIntegerRootFactors? at hquad
   by_cases hdeg : core.degree?.getD 0 = 2
-  · simp only [hdeg, if_true] at hquad
+  · simp only [hdeg, ite_true] at hquad
     let roots := integerRootCandidates core
     let split := splitIntegerRootFactorsAux core roots roots.length
     have hroots_nodup : roots.Nodup := integerRootCandidates_nodup core
@@ -1114,14 +1114,14 @@ theorem quadraticIntegerRootFactors?_pairwise_not_associated
       exact hrs_nodup.imp (fun hne => linearFactorForRoot_not_associated_of_ne hne)
     by_cases hsize : split.1.size = 0
     · simp [roots, split, hsize] at hquad
-    · simp only [roots, split, hsize, if_false] at hquad
+    · simp only [roots, split, hsize, ite_false] at hquad
       by_cases hres_one : split.2 = 1
-      · rw [if_pos hres_one] at hquad
+      · rw [ite_eq_left hres_one] at hquad
         cases hquad
         exact hLL
-      · rw [if_neg hres_one] at hquad
+      · rw [ite_eq_right hres_one] at hquad
         by_cases hres_deg : split.2.degree?.getD 0 ≤ 1
-        · rw [if_pos hres_deg] at hquad
+        · rw [ite_eq_left hres_deg] at hquad
           cases hquad
           rw [Array.toList_push]
           -- Residual leading-coefficient invariants.

--- a/HexBerlekampZassenhaus/QuadraticNormRecover.lean
+++ b/HexBerlekampZassenhaus/QuadraticNormRecover.lean
@@ -254,7 +254,7 @@ theorem check_of_certify? {f : ZPoly} {cert : QuadraticNormCertificate}
   | some proposal =>
       rw [hrec] at h
       by_cases hcheck : proposal.check f = true
-      · simp only [hcheck, if_true] at h
+      · simp only [hcheck, ite_true] at h
         rw [← Option.some.inj h]
         exact hcheck
       · simp only [Bool.not_eq_true] at hcheck

--- a/HexBerlekampZassenhaus/Recombination.lean
+++ b/HexBerlekampZassenhaus/Recombination.lean
@@ -468,14 +468,14 @@ private theorem bhksRecoveryCoreWithBound_unfold
   rw [bhksRecoveryCoreWithBound, bhksRecoveryThreshold_eq, bhksRecoveryLoop]
   simp only [hrec]
   by_cases hf : k < bhksRecoveryFloor core
-  · rw [if_pos hf]
+  · rw [ite_eq_left hf]
     have hfloor : ¬ k ≥ bhksRecoveryFloor core := Nat.not_le.mpr hf
     cases bhksRecoverClassified core (ZPoly.directLiftData core k primeData) <;>
-      simp only [hfloor, if_false]
-  · rw [if_neg hf]
+      simp only [hfloor, ite_false]
+  · rw [ite_eq_right hf]
     have hfloor : k ≥ bhksRecoveryFloor core := Nat.le_of_not_lt hf
     cases bhksRecoverClassified core (ZPoly.directLiftData core k primeData) <;>
-      simp only [hfloor, if_true]
+      simp only [hfloor, ite_true]
 
 /-- Finite list of Hensel precisions inspected by the fast BHKS recovery loop. -/
 def henselPrecisionSchedule (B : Nat) : Nat → Nat → List Nat
@@ -544,15 +544,15 @@ private theorem henselPrecisionSchedule_mem_cap
         rw [henselPrecisionSchedule]
         simp only [List.mem_cons]
         right
-        rw [if_neg (by omega : ¬ k ≥ B)]
+        rw [ite_eq_right (by omega : ¬ k ≥ B)]
         unfold nextHenselPrecision
         have hpow : k * 2 ^ (fuel + 1) = 2 * k * 2 ^ fuel := by
           rw [Nat.pow_succ', ← Nat.mul_assoc, Nat.mul_comm k 2]
         by_cases h2 : 2 * k < B
-        · rw [if_pos h2]
+        · rw [ite_eq_left h2]
           refine ih (2 * k) (by omega) (by omega) ?_
           omega
-        · rw [if_neg h2]
+        · rw [ite_eq_right h2]
           refine ih B (by omega) (Nat.le_refl _) ?_
           have hge1 : 1 ≤ 2 ^ fuel := Nat.one_le_two_pow
           calc B = B * 1 := (Nat.mul_one B).symm
@@ -765,7 +765,7 @@ theorem bhksRecoveryCoreWithBound_eq_some_of_recovery_on_schedule_of_no_prior_re
           · subst target
             rw [bhksRecover?] at hrecover
             simp [hclass, BhksRecoveryResult.toOption] at hrecover
-            simp only [ge_iff_le, hfloor, if_true]
+            simp only [ge_iff_le, hfloor, ite_true]
             exact congrArg some hrecover
           · have hstart_mem :
                 start ∈ henselPrecisionSchedule B start (fuel + 1) := by

--- a/HexBerlekampZassenhaus/RecombinationFactors.lean
+++ b/HexBerlekampZassenhaus/RecombinationFactors.lean
@@ -148,7 +148,7 @@ private theorem normalizeForFactor_reassembles_signedContentScalar
       exact Int.mul_pos hcontent_pos hA_pos
     have hf_not_neg : ¬ DensePoly.leadingCoeff f < 0 := by omega
     unfold signedContentScalar
-    rw [if_neg hf, if_neg hf_not_neg, hε, Int.mul_one]
+    rw [ite_eq_right hf, ite_eq_right hf_not_neg, hε, Int.mul_one]
   · -- ε = -1
     have hcontent_neg : ZPoly.content f * (-1 : Int) < 0 := by
       have hrw : ZPoly.content f * (-1 : Int) = -(ZPoly.content f) := by
@@ -158,7 +158,7 @@ private theorem normalizeForFactor_reassembles_signedContentScalar
       rw [h_f_leading, hε]
       exact Int.mul_neg_of_neg_of_pos hcontent_neg hA_pos
     unfold signedContentScalar
-    rw [if_neg hf, if_pos hf_neg, hε, Int.mul_neg_one]
+    rw [ite_eq_right hf, ite_eq_left hf_neg, hε, Int.mul_neg_one]
 
 private theorem shift_mul_left_zpoly (k : Nat) (a b : ZPoly) :
     DensePoly.shift k (a * b) = DensePoly.shift k a * b := by
@@ -577,7 +577,7 @@ theorem recombinationSearchModAux_isSome_of_step
     (recombinationSearchModAux target modulus localFactors (fuel + 1)).isSome = true := by
   obtain ⟨restFactors, hrest⟩ := Option.isSome_iff_exists.mp hsearch_rest
   unfold recombinationSearchModAux
-  rw [if_neg htarget_ne_one]
+  rw [ite_eq_right htarget_ne_one]
   refine firstSome_isSome_of_mem (y := candidate :: restFactors) hsplit ?_
   show (let candidate' := normalizeFactorSign <|
             ZPoly.primitivePart <|
@@ -594,7 +594,7 @@ theorem recombinationSearchModAux_isSome_of_step
             ZPoly.primitivePart <|
               centeredLiftPoly (Array.polyProduct selected.toArray) modulus) = candidate
         from hcandidate_def.symm]
-  rw [if_pos hrecord]
+  rw [ite_eq_left hrecord]
   simp only [hquot, hrest]
 
 /-- Companion to `recombinationSearchModAux_isSome_of_step` at the
@@ -660,7 +660,7 @@ theorem recombinationSearchModAux_eq_some_of_step_of_prefix_none
     recombinationSearchModAux target modulus localFactors (fuel + 1) =
       some (candidate :: restFactors) := by
   unfold recombinationSearchModAux
-  rw [if_neg htarget_ne_one, hsplits]
+  rw [ite_eq_right htarget_ne_one, hsplits]
   refine firstSome_eq_some_of_append pre suffix (selected, rest) _ _ hprefix ?_
   show (let candidate' :=
           normalizeFactorSign <|
@@ -678,7 +678,7 @@ theorem recombinationSearchModAux_eq_some_of_step_of_prefix_none
             ZPoly.primitivePart <|
               centeredLiftPoly (Array.polyProduct selected.toArray) modulus) = candidate
         from hcandidate_def.symm]
-  rw [if_pos hrecord]
+  rw [ite_eq_left hrecord]
   simp only [hquot, hsearch_rest]
 
 /--
@@ -743,7 +743,7 @@ private theorem bhksRecoverClassified_success_product
   rw [bhksRecoverClassified] at hrecover
   by_cases hrows : 1 ≤ (bhksLatticeBasis f d.p d.k d.liftedFactors).factorCount +
       (bhksLatticeBasis f d.p d.k d.liftedFactors).coeffWidth
-  · rw [dif_pos hrows] at hrecover
+  · rw [dite_eq_left hrows] at hrecover
     by_cases hdeg :
         bhksDegenerateIndicatorPartition
           (bhksProjectedRows (bhksLatticeBasis f d.p d.k d.liftedFactors) hrows)
@@ -751,7 +751,7 @@ private theorem bhksRecoverClassified_success_product
             (bhksProjectedRows (bhksLatticeBasis f d.p d.k d.liftedFactors)
               hrows)) = true
     · simp [hdeg] at hrecover
-    · simp only [hdeg, Bool.false_eq_true, if_false] at hrecover
+    · simp only [hdeg, Bool.false_eq_true, ite_false] at hrecover
       cases hcand : bhksIndicatorCandidates? f d
           (bhksEquivalenceClassIndicators
             (bhksProjectedRows (bhksLatticeBasis f d.p d.k d.liftedFactors)
@@ -760,11 +760,11 @@ private theorem bhksRecoverClassified_success_product
       | some cands =>
           simp only [hcand] at hrecover
           by_cases hprod : Array.polyProduct cands == f
-          · simp only [hprod, if_true] at hrecover
+          · simp only [hprod, ite_true] at hrecover
             cases hrecover
             simpa [beq_iff_eq] using hprod
           · simp [hprod] at hrecover
-  · rw [dif_neg hrows] at hrecover
+  · rw [dite_eq_right hrows] at hrecover
     simp at hrecover
 
 private theorem bhksRecoverClassified_success_all_of_candidates
@@ -780,23 +780,23 @@ private theorem bhksRecoverClassified_success_all_of_candidates
   rw [bhksRecoverClassified] at hrecover
   by_cases hrows : 1 ≤ (bhksLatticeBasis f d.p d.k d.liftedFactors).factorCount +
       (bhksLatticeBasis f d.p d.k d.liftedFactors).coeffWidth
-  · rw [dif_pos hrows] at hrecover
+  · rw [dite_eq_left hrows] at hrecover
     let projected :=
       bhksProjectedRows (bhksLatticeBasis f d.p d.k d.liftedFactors) hrows
     let indicators := bhksEquivalenceClassIndicators projected
     by_cases hdeg : bhksDegenerateIndicatorPartition projected indicators = true
     · simp [projected, indicators, hdeg] at hrecover
-    · simp only [projected, indicators, hdeg, Bool.false_eq_true, if_false] at hrecover
+    · simp only [projected, indicators, hdeg, Bool.false_eq_true, ite_false] at hrecover
       cases hcand : bhksIndicatorCandidates? f d indicators with
       | none => simp [projected, indicators, hcand] at hrecover
       | some cands =>
           simp only [projected, indicators, hcand] at hrecover
           by_cases hprod : Array.polyProduct cands == f
-          · simp only [hprod, if_true] at hrecover
+          · simp only [hprod, ite_true] at hrecover
             cases hrecover
             exact hall hcand
           · simp [hprod] at hrecover
-  · rw [dif_neg hrows] at hrecover
+  · rw [dite_eq_right hrows] at hrecover
     simp at hrecover
 
 private theorem bhksRecoverClassified_success_normalizeFactorSign
@@ -827,23 +827,23 @@ private theorem bhksRecoverClassified_success_dvd
   rw [bhksRecoverClassified] at hrecover
   by_cases hrows : 1 ≤ (bhksLatticeBasis f d.p d.k d.liftedFactors).factorCount +
       (bhksLatticeBasis f d.p d.k d.liftedFactors).coeffWidth
-  · rw [dif_pos hrows] at hrecover
+  · rw [dite_eq_left hrows] at hrecover
     let projected :=
       bhksProjectedRows (bhksLatticeBasis f d.p d.k d.liftedFactors) hrows
     let indicators := bhksEquivalenceClassIndicators projected
     by_cases hdeg : bhksDegenerateIndicatorPartition projected indicators = true
     · simp [projected, indicators, hdeg] at hrecover
-    · simp only [projected, indicators, hdeg, Bool.false_eq_true, if_false] at hrecover
+    · simp only [projected, indicators, hdeg, Bool.false_eq_true, ite_false] at hrecover
       cases hcand : bhksIndicatorCandidates? f d indicators with
       | none => simp [projected, indicators, hcand] at hrecover
       | some cands =>
           simp only [projected, indicators, hcand] at hrecover
           by_cases hprod : Array.polyProduct cands == f
-          · simp only [hprod, if_true] at hrecover
+          · simp only [hprod, ite_true] at hrecover
             cases hrecover
             exact bhksIndicatorCandidates?_dvd hcand
           · simp [hprod] at hrecover
-  · rw [dif_neg hrows] at hrecover
+  · rw [dite_eq_right hrows] at hrecover
     simp at hrecover
 
 /-- A successful BHKS recovery call preserves the polynomial product: when
@@ -933,7 +933,7 @@ private theorem bhksRecoverClassified_success_indicatorCandidates
   rw [bhksRecoverClassified] at hrecover
   by_cases hrows : 1 ≤ (bhksLatticeBasis f d.p d.k d.liftedFactors).factorCount +
       (bhksLatticeBasis f d.p d.k d.liftedFactors).coeffWidth
-  · rw [dif_pos hrows] at hrecover
+  · rw [dite_eq_left hrows] at hrecover
     by_cases hdeg :
         bhksDegenerateIndicatorPartition
           (bhksProjectedRows (bhksLatticeBasis f d.p d.k d.liftedFactors) hrows)
@@ -941,7 +941,7 @@ private theorem bhksRecoverClassified_success_indicatorCandidates
             (bhksProjectedRows (bhksLatticeBasis f d.p d.k d.liftedFactors)
               hrows)) = true
     · simp [hdeg] at hrecover
-    · simp only [hdeg, Bool.false_eq_true, if_false] at hrecover
+    · simp only [hdeg, Bool.false_eq_true, ite_false] at hrecover
       cases hcand : bhksIndicatorCandidates? f d
           (bhksEquivalenceClassIndicators
             (bhksProjectedRows (bhksLatticeBasis f d.p d.k d.liftedFactors)
@@ -950,11 +950,11 @@ private theorem bhksRecoverClassified_success_indicatorCandidates
       | some cands =>
           simp only [hcand] at hrecover
           by_cases hprod : Array.polyProduct cands == f
-          · simp only [hprod, if_true] at hrecover
+          · simp only [hprod, ite_true] at hrecover
             cases hrecover
             exact ⟨hrows, hcand, by simpa using hdeg⟩
           · simp [hprod] at hrecover
-  · rw [dif_neg hrows] at hrecover
+  · rw [dite_eq_right hrows] at hrecover
     simp at hrecover
 
 /-- A successful fast-recombination loop is witnessed by a concrete precision

--- a/HexBerlekampZassenhaus/TrialFactorization.lean
+++ b/HexBerlekampZassenhaus/TrialFactorization.lean
@@ -463,10 +463,10 @@ private theorem mem_trialDivisionCandidatesOfDegree {B d : Nat} {p : ZPoly}
       (DensePoly.ofCoeffs coeffs.toArray).degree?.getD 0 = d ∧
         0 < DensePoly.leadingCoeff (DensePoly.ofCoeffs coeffs.toArray) ∧
         shouldRecordPolynomialFactor (DensePoly.ofCoeffs coeffs.toArray) = true
-  · rw [if_pos hcheck] at heq
+  · rw [ite_eq_left hcheck] at heq
     cases heq
     exact hcheck
-  · rw [if_neg hcheck] at heq
+  · rw [ite_eq_right hcheck] at heq
     contradiction
 
 /-- Each candidate emitted by `trialDivisionCandidatesUpTo B maxDeg` has
@@ -580,7 +580,7 @@ private theorem mem_trialDivisionCandidatesOfDegree_of_bounded
           0 < DensePoly.leadingCoeff (DensePoly.ofCoeffs p.toArray) ∧
           shouldRecordPolynomialFactor (DensePoly.ofCoeffs p.toArray) = true := by
       simpa [hp] using And.intro hdeg (And.intro hlc hrecord)
-    rw [if_pos hcheck]
+    rw [ite_eq_left hcheck]
     simp [hp]
 
 /-- Bounded positive-leading recorded polynomials with degree in
@@ -1037,12 +1037,12 @@ theorem exhaustiveIntegerTrialCoreFactorsWithBound_polyProduct
       (if peel.2 = 1 then split.1 ++ peel.1
         else (split.1 ++ peel.1).push peel.2) = core
   by_cases hres_one : peel.2 = 1
-  · rw [if_pos hres_one]
+  · rw [ite_eq_left hres_one]
     rw [hres_one, ZPoly.one_mul_zpoly] at hpeel_prod
     rw [ZPoly.polyProduct_append, hpeel_prod,
         DensePoly.mul_comm_poly (S := Int)]
     exact hsplit_prod
-  · rw [if_neg hres_one]
+  · rw [ite_eq_right hres_one]
     rw [polyProduct_push, ZPoly.polyProduct_append,
         DensePoly.mul_assoc_poly (S := Int),
         DensePoly.mul_comm_poly (S := Int) (Array.polyProduct peel.1) peel.2,
@@ -1122,7 +1122,7 @@ theorem exhaustiveIntegerTrialCoreFactorsWithBound_normalizeFactorSign
     obtain ⟨_, hlc, _⟩ := mem_trialDivisionCandidatesUpTo hc
     unfold normalizeFactorSign
     have hnot_neg : ¬ DensePoly.leadingCoeff c < 0 := by omega
-    rw [if_neg hnot_neg]
+    rw [ite_eq_right hnot_neg]
   have hcand_pos :
       ∀ c ∈ candidates, 0 < DensePoly.leadingCoeff c :=
     fun c hc => (mem_trialDivisionCandidatesUpTo hc).2.1
@@ -1139,12 +1139,12 @@ theorem exhaustiveIntegerTrialCoreFactorsWithBound_normalizeFactorSign
     normalizeFactorSign factor = factor
   intro factor hmem
   by_cases hres_one : peel.2 = 1
-  · rw [if_pos hres_one] at hmem
+  · rw [ite_eq_left hres_one] at hmem
     rw [Array.toList_append] at hmem
     rcases List.mem_append.mp hmem with hlin | hpeel
     · exact hsplit_norm factor hlin
     · exact hpeel_norm factor hpeel
-  · rw [if_neg hres_one] at hmem
+  · rw [ite_eq_right hres_one] at hmem
     rw [Array.toList_push, Array.toList_append] at hmem
     rcases List.mem_append.mp hmem with hpref | hres
     · rcases List.mem_append.mp hpref with hlin | hpeel
@@ -1156,7 +1156,7 @@ theorem exhaustiveIntegerTrialCoreFactorsWithBound_normalizeFactorSign
       rw [hfactor_eq]
       unfold normalizeFactorSign
       have hnot_neg : ¬ DensePoly.leadingCoeff peel.2 < 0 := by omega
-      rw [if_neg hnot_neg]
+      rw [ite_eq_right hnot_neg]
 
 /-- Each factor emitted by the standalone integer trial-division algorithm
 satisfies `shouldRecordPolynomialFactor`, provided `core` has positive
@@ -1244,12 +1244,12 @@ theorem exhaustiveIntegerTrialCoreFactorsWithBound_shouldRecord
     shouldRecordPolynomialFactor factor = true
   intro factor hmem
   by_cases hres_one : peel.2 = 1
-  · rw [if_pos hres_one] at hmem
+  · rw [ite_eq_left hres_one] at hmem
     rw [Array.toList_append] at hmem
     rcases List.mem_append.mp hmem with hlin | hpeel
     · exact hsplit_record factor hlin
     · exact hpeel_record factor hpeel
-  · rw [if_neg hres_one] at hmem
+  · rw [ite_eq_right hres_one] at hmem
     rw [Array.toList_push, Array.toList_append] at hmem
     rcases List.mem_append.mp hmem with hpref | hres
     · rcases List.mem_append.mp hpref with hlin | hpeel
@@ -2288,11 +2288,11 @@ theorem exhaustiveIntegerTrialCoreFactorsWithBound_degree_pos
       (if peel.2 = 1 then split.1 ++ peel.1
         else (split.1 ++ peel.1).push peel.2).toList at hmem
   by_cases hres_one : peel.2 = 1
-  · rw [if_pos hres_one, Array.toList_append, List.mem_append] at hmem
+  · rw [ite_eq_left hres_one, Array.toList_append, List.mem_append] at hmem
     rcases hmem with h1 | h2
     · exact hsplit_deg factor h1
     · exact hpeel_deg factor h2
-  · rw [if_neg hres_one, Array.toList_push, Array.toList_append] at hmem
+  · rw [ite_eq_right hres_one, Array.toList_push, Array.toList_append] at hmem
     rcases List.mem_append.mp hmem with hpref | hres
     · rcases List.mem_append.mp hpref with h1 | h2
       · exact hsplit_deg factor h1

--- a/HexBerlekampZassenhausMathlib/BadVector.lean
+++ b/HexBerlekampZassenhausMathlib/BadVector.lean
@@ -741,8 +741,8 @@ theorem coord_cast_eq_zero_of_liftedFactor_dvd_cldCombination
           (Int.castRingHom (ZMod (p ^ a)))) :
     ((v[Fin.castAdd (f.degree?.getD 0) i₀] : ℤ) : ZMod (p ^ a)) = 0 := by
   classical
-  letI : Fact (1 < p ^ a) := ⟨hk⟩
-  haveI : Nontrivial (ZMod (p ^ a)) := inferInstance
+  let : Fact (1 < p ^ a) := ⟨hk⟩
+  have : Nontrivial (ZMod (p ^ a)) := inferInstance
   let φ := Int.castRingHom (ZMod (p ^ a))
   let q₀ := (HexPolyZMathlib.toPolynomial
     (liftedFactors.getD i₀.val 1)).map φ
@@ -893,7 +893,7 @@ theorem isCoprime_cldQuotientMod
         (Hex.cldQuotientMod f q p a)).map
           (Int.castRingHom (ZMod (p ^ a)))) := by
   classical
-  letI : Fact (1 < p ^ a) := ⟨hk⟩
+  let : Fact (1 < p ^ a) := ⟨hk⟩
   let φ := Int.castRingHom (ZMod (p ^ a))
   let Q := (HexPolyZMathlib.toPolynomial q).map φ
   let H := (HexPolyZMathlib.toPolynomial h).map φ

--- a/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
+++ b/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
@@ -544,7 +544,7 @@ theorem cldQuotientMod_congr_mul_derivative
       (g * Hex.cldQuotientMod input g p k)
       (input * Hex.DensePoly.derivative g) (p ^ k) := by
   have hpk_pos : 0 < p ^ k := by omega
-  haveI : Fact (1 < p ^ k) := ⟨hk⟩
+  have : Fact (1 < p ^ k) := ⟨hk⟩
   -- Executable quotient / remainder of the monic division underlying `cldQuotientMod`.
   set num : Hex.ZPoly :=
     Hex.ZPoly.reduceModPow (input * Hex.DensePoly.derivative g) p k with hnum

--- a/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
+++ b/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
@@ -724,13 +724,13 @@ private theorem C_dvd_toPolynomial_sub_of_congr
 theorem two_mul_natAbs_centeredModNat_le (z : Int) (m : Nat) (hm : 0 < m) :
     2 * (Hex.centeredModNat z m).natAbs ≤ m := by
   unfold Hex.centeredModNat
-  rw [if_neg hm.ne']
+  rw [ite_eq_right hm.ne']
   have h1 : 0 ≤ z % (m : Int) := Int.emod_nonneg z (by exact_mod_cast hm.ne')
   have h2 : z % (m : Int) < (m : Int) := Int.emod_lt_of_pos z (by exact_mod_cast hm)
   simp only [Int.ofNat_eq_natCast]
   by_cases hc : 2 * (z % (m : Int)).natAbs ≤ m
-  · rw [if_pos hc]; exact hc
-  · rw [if_neg hc, if_neg (by omega : ¬ z % (m : Int) < 0)]
+  · rw [ite_eq_left hc]; exact hc
+  · rw [ite_eq_right hc, ite_eq_right (by omega : ¬ z % (m : Int) < 0)]
     omega
 
 /-- The high-bit cut residue `Psi^a_b` lands in the centred range modulo `p^b`. -/
@@ -1415,7 +1415,7 @@ theorem periodAdjustedRowCoeffs_castAdd (L : Hex.BhksLatticeBasis)
   unfold periodAdjustedRowCoeffs
   simp only [Fin.getElem_fin, Vector.getElem_ofFn]
   rw [
-    dif_pos (show (Fin.castAdd L.coeffWidth i).val < L.factorCount from i.isLt)]
+    dite_eq_left (show (Fin.castAdd L.coeffWidth i).val < L.factorCount from i.isLt)]
   congr 1
 
 /-- The tail entries of the selection coefficients are the negated period
@@ -1426,7 +1426,7 @@ theorem periodAdjustedRowCoeffs_natAdd (L : Hex.BhksLatticeBasis)
   unfold periodAdjustedRowCoeffs
   simp only [Fin.getElem_fin, Vector.getElem_ofFn]
   rw [
-    dif_neg (by simp only [Fin.val_natAdd]; omega)]
+    dite_eq_right (by simp only [Fin.val_natAdd]; omega)]
   congr 2
   apply Fin.ext
   simp only [Fin.val_natAdd]
@@ -1474,8 +1474,8 @@ theorem periodAdjustedVector_project_of_blockForm
     intro j _
     rw [hentry]
     unfold Hex.bhksLatticeEntry
-    rw [dif_neg (by simp only [Fin.val_natAdd]; omega),
-      dif_pos (show (⟨i.val, Nat.lt_add_right L.coeffWidth i.isLt⟩ :
+    rw [dite_eq_right (by simp only [Fin.val_natAdd]; omega),
+      dite_eq_left (show (⟨i.val, Nat.lt_add_right L.coeffWidth i.isLt⟩ :
           Fin (L.factorCount + L.coeffWidth)).val < L.factorCount from i.isLt),
       zero_mul]
   rw [hsnd, add_zero]
@@ -1488,17 +1488,17 @@ theorem periodAdjustedVector_project_of_blockForm
     intro i'
     rw [hentry, periodAdjustedRowCoeffs_castAdd]
     unfold Hex.bhksLatticeEntry
-    rw [dif_pos (show (Fin.castAdd L.coeffWidth i').val < L.factorCount from i'.isLt),
-      dif_pos (show (⟨i.val, Nat.lt_add_right L.coeffWidth i.isLt⟩ :
+    rw [dite_eq_left (show (Fin.castAdd L.coeffWidth i').val < L.factorCount from i'.isLt),
+      dite_eq_left (show (⟨i.val, Nat.lt_add_right L.coeffWidth i.isLt⟩ :
           Fin (L.factorCount + L.coeffWidth)).val < L.factorCount from i.isLt)]
     by_cases h : i' = i
     · subst h; simp
-    · rw [if_neg h,
-        if_neg (by simp only [Fin.val_castAdd]; exact fun hv => h (Fin.ext hv))]
+    · rw [ite_eq_right h,
+        ite_eq_right (by simp only [Fin.val_castAdd]; exact fun hv => h (Fin.ext hv))]
   rw [Finset.sum_congr rfl (fun i' _ => hfst i'), Finset.sum_eq_single i]
-  · rw [if_pos rfl, one_mul]
+  · rw [ite_eq_left rfl, one_mul]
   · intro i' _ hne
-    rw [if_neg hne, zero_mul]
+    rw [ite_eq_right hne, zero_mul]
   · intro h
     exact absurd (Finset.mem_univ i) h
 
@@ -1540,8 +1540,8 @@ theorem periodAdjustedVector_coeff_of_blockForm
         ⟨L.factorCount + j.val, Nat.add_lt_add_left j.isLt L.factorCount⟩
         = (L.cldRows.getD i'.val #[]).getD j.val 0 := by
       unfold Hex.bhksLatticeEntry
-      rw [dif_pos (show (Fin.castAdd L.coeffWidth i').val < L.factorCount from i'.isLt),
-        dif_neg (by
+      rw [dite_eq_left (show (Fin.castAdd L.coeffWidth i').val < L.factorCount from i'.isLt),
+        dite_eq_right (by
           show ¬ (⟨L.factorCount + j.val,
             Nat.add_lt_add_left j.isLt L.factorCount⟩ :
             Fin (L.factorCount + L.coeffWidth)).val < L.factorCount
@@ -1562,8 +1562,8 @@ theorem periodAdjustedVector_coeff_of_blockForm
           ⟨L.factorCount + j.val, Nat.add_lt_add_left j.isLt L.factorCount⟩
           = Int.ofNat (L.p ^ (L.precision - L.cutThresholds.getD j.val 0)) := by
         unfold Hex.bhksLatticeEntry
-        rw [dif_neg (by simp only [Fin.val_natAdd]; omega),
-          dif_neg (by
+        rw [dite_eq_right (by simp only [Fin.val_natAdd]; omega),
+          dite_eq_right (by
             show ¬ (⟨L.factorCount + j.val,
               Nat.add_lt_add_left j.isLt L.factorCount⟩ :
               Fin (L.factorCount + L.coeffWidth)).val < L.factorCount
@@ -1576,14 +1576,14 @@ theorem periodAdjustedVector_coeff_of_blockForm
           L.cutThresholds L.cldRows (Fin.natAdd L.factorCount j')
           ⟨L.factorCount + j.val, Nat.add_lt_add_left j.isLt L.factorCount⟩ = 0 := by
         unfold Hex.bhksLatticeEntry
-        rw [dif_neg (by simp only [Fin.val_natAdd]; omega),
-          dif_neg (by
+        rw [dite_eq_right (by simp only [Fin.val_natAdd]; omega),
+          dite_eq_right (by
             show ¬ (⟨L.factorCount + j.val,
               Nat.add_lt_add_left j.isLt L.factorCount⟩ :
               Fin (L.factorCount + L.coeffWidth)).val < L.factorCount
             simp only []; omega)]
         simp only [Fin.val_natAdd, Nat.add_sub_cancel_left]
-        rw [if_neg (by
+        rw [ite_eq_right (by
           intro hcontra
           exact hne (Fin.ext hcontra.symm))]
       rw [hoff, zero_mul]
@@ -1736,7 +1736,7 @@ def recoveredShortVector
     · rw [Finset.sum_filter]
       refine Finset.sum_congr rfl (fun i _ => ?_)
       by_cases hi : i ∈ S
-      · rw [indicatorVector_apply_mem S hi, one_mul, if_pos hi]
+      · rw [indicatorVector_apply_mem S hi, one_mul, ite_eq_left hi]
         have hLcld : (L.cldRows.getD i.val #[]).getD j.val 0
             = (Hex.cldCoeffs D.f D.p D.a (L.liftedFactors.getD i.val 1)).getD j.val 0 := by
           congr 1
@@ -1745,7 +1745,7 @@ def recoveredShortVector
           simp [Array.getD, hsz]
         rw [hLcld,
           Hex.cldCoeffs_getD_of_lt D.f D.p D.a (L.liftedFactors.getD i.val 1) j.val hjlt]
-      · rw [indicatorVector_apply_not_mem S hi, zero_mul, if_neg hi]
+      · rw [indicatorVector_apply_not_mem S hi, zero_mul, ite_eq_right hi]
     · rw [Int.ofNat_eq_natCast, Nat.cast_pow]
       ring
   refine

--- a/HexBerlekampZassenhausMathlib/Classical/CombinationIterator.lean
+++ b/HexBerlekampZassenhausMathlib/Classical/CombinationIterator.lean
@@ -131,8 +131,8 @@ theorem filter_split_mem_subsetsOfSizeWithComplement
   | cons x xs ih =>
       cases hx : P x with
       | false =>
-          simp only [List.filter_cons, hx, Bool.false_eq_true, if_false,
-            Bool.not_false, if_true]
+          simp only [List.filter_cons, hx, Bool.false_eq_true, ite_false,
+            Bool.not_false, ite_true]
           cases hlen : (xs.filter P).length with
           | zero =>
               have hfilter : xs.filter P = [] :=
@@ -158,8 +158,8 @@ theorem filter_split_mem_subsetsOfSizeWithComplement
               exact Or.inr ⟨(xs.filter P, xs.filter fun x => !P x), by
                 simpa [hlen] using ih, rfl⟩
       | true =>
-          simp only [List.filter_cons, hx, if_true, Bool.not_true,
-            Bool.false_eq_true, if_false, List.length_cons,
+          simp only [List.filter_cons, hx, ite_true, Bool.not_true,
+            Bool.false_eq_true, ite_false, List.length_cons,
             Hex.subsetsOfSizeWithComplement, List.mem_append, List.mem_map]
           exact Or.inl
             ⟨(xs.filter P, xs.filter fun x => !P x), ih, rfl⟩

--- a/HexBerlekampZassenhausMathlib/Classical/Factorization.lean
+++ b/HexBerlekampZassenhausMathlib/Classical/Factorization.lean
@@ -660,7 +660,7 @@ theorem factorDirectCoreOfPlan_factored
       omega
     rw [hk, pow_zero] at hrecover
     omega
-  letI := modular.data.bounds
+  let := modular.data.bounds
   have hadm :
       Hex.leadingCoeffAdmissible core.poly modular.data.p :=
     Hex.isGoodPrime_leadingCoeffAdmissible core.poly modular.data.p

--- a/HexBerlekampZassenhausMathlib/Classical/Factorization.lean
+++ b/HexBerlekampZassenhausMathlib/Classical/Factorization.lean
@@ -426,14 +426,14 @@ theorem searchDirectAux_factored
         state hrun
       simp only [Hex.searchDirectAux] at hrun
       by_cases hone : target = 1
-      · rw [if_pos hone] at hrun
+      · rw [ite_eq_left hone] at hrun
         cases hrun
         refine
           { product := by simpa using hone.symm
             irreducible := by simp
             normalized := by simp
             degreePos := by simp }
-      · rw [if_neg hone] at hrun
+      · rw [ite_eq_right hone] at hrun
         cases localFactors with
         | nil => simp at hrun
         | cons head tail =>

--- a/HexBerlekampZassenhausMathlib/Classical/Recovery.lean
+++ b/HexBerlekampZassenhausMathlib/Classical/Recovery.lean
@@ -128,7 +128,7 @@ theorem directScaledProduct_congr_of_modP_support
       (Hex.DensePoly.scale
         (Hex.DensePoly.leadingCoeff cofactor) factor)
       (d.p ^ d.k) := by
-  letI := data.bounds
+  let := data.bounds
   let k := Hex.precisionForCoeffBound B data.p
   let d := Hex.ZPoly.directLiftData core B data
   let T : LiftedFactorSubset d :=
@@ -205,7 +205,7 @@ theorem directCandidate_eq_of_modP_support
           (Hex.ZPoly.monicTarget core data.p
             (Hex.precisionForCoeffBound B data.p))
           (Hex.precisionForCoeffBound B data.p) data) S) = factor := by
-  letI := data.bounds
+  let := data.bounds
   let k := Hex.precisionForCoeffBound B data.p
   let d := Hex.ZPoly.directLiftData core B data
   let T : LiftedFactorSubset d :=

--- a/HexBerlekampZassenhausMathlib/Classical/SearchCompleteness.lean
+++ b/HexBerlekampZassenhausMathlib/Classical/SearchCompleteness.lean
@@ -494,7 +494,7 @@ theorem tryDirectSplit_trueSupport
           (Hex.directSelectedFactors d selected) =
         factor := hcand
   rw [hpre]
-  simp only [if_true]
+  simp only [ite_true]
   rw [hcand_prepared, hrecord, hquot]
   rfl
 

--- a/HexBerlekampZassenhausMathlib/Classical/SupportPartition.lean
+++ b/HexBerlekampZassenhausMathlib/Classical/SupportPartition.lean
@@ -58,7 +58,7 @@ theorem modPFactorSubset_disjoint_of_modPFactorization
       ¬ Associated (HexPolyZMathlib.toPolynomial f)
         (HexPolyZMathlib.toPolynomial g)) :
     Disjoint S T := by
-  letI := data.bounds
+  let := data.bounds
   have hcore_modP_nz :
       (@Hex.ZPoly.modP data.p data.bounds core).isZero = false :=
     Hex.isGoodPrime_modP_isZero_false core data.p hval.good
@@ -137,8 +137,8 @@ theorem directSupportCandidate_map_associated
       ((HexPolyZMathlib.toPolynomial
         (liftedFactorProduct d T)).map
           (Int.castRingHom (ZMod data.p))) := by
-  letI := data.bounds
-  letI : Fact (_root_.Nat.Prime data.p) :=
+  let := data.bounds
+  let : Fact (_root_.Nat.Prime data.p) :=
     ⟨natPrime_of_hexNatPrime hprime⟩
   let d := Hex.ZPoly.directLiftData core B data
   let T := liftedSubsetOfModPSubset data d
@@ -245,8 +245,8 @@ theorem modPSubset_subset_of_product_dvd
           (modPFactorProduct data T)) :
     S ⊆ T := by
   classical
-  letI := data.bounds
-  letI : Fact (_root_.Nat.Prime data.p) :=
+  let := data.bounds
+  let : Fact (_root_.Nat.Prime data.p) :=
     ⟨natPrime_of_hexNatPrime hval.prime⟩
   have hinj :=
     toMathlibPolynomial_modPFactor_injective_of_modPFactorization
@@ -288,7 +288,7 @@ theorem directSupport_subset_of_dvd
     (hrecover : directSupportCandidate core B data S = factor)
     (hdvd : factor ∣ directSupportCandidate core B data T) :
     S ⊆ T := by
-  letI := data.bounds
+  let := data.bounds
   have hcand_dvd :
       (HexPolyZMathlib.toPolynomial
         (directSupportCandidate core B data S)).map
@@ -496,7 +496,7 @@ theorem directSupportPartition_initial
     (hgcd : Int.gcd (Hex.DensePoly.leadingCoeff core)
       (Int.ofNat (data.p ^ Hex.precisionForCoeffBound B data.p)) = 1) :
     DirectSupportPartition core B data Finset.univ core := by
-  letI := data.bounds
+  let := data.bounds
   have hpart :=
     modPSubsetPartitionHypotheses_of_modPFactorization
       core data hcore_degree_pos hval
@@ -601,8 +601,8 @@ theorem DirectSupportPartition.factorDvdCandidate
       directSupportCandidate core B data T ∣ target) :
     factor ∣ directSupportCandidate core B data T := by
   classical
-  letI := data.bounds
-  letI : Fact (_root_.Nat.Prime data.p) :=
+  let := data.bounds
+  let : Fact (_root_.Nat.Prime data.p) :=
     ⟨natPrime_of_hexNatPrime hval.prime⟩
   let cast := Int.castRingHom (ZMod data.p)
   let candidate := directSupportCandidate core B data T

--- a/HexBerlekampZassenhausMathlib/FactorIrreducibility.lean
+++ b/HexBerlekampZassenhausMathlib/FactorIrreducibility.lean
@@ -44,7 +44,7 @@ theorem factorClassicalFactors_factor_irreducible
     Hex.classicalInput] at hcf
   by_cases hdeg :
       (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 = 0
-  · rw [if_pos hdeg] at hcf
+  · rw [ite_eq_left hdeg] at hcf
     obtain rfl := Option.some.inj hcf
     have hcomplete :=
       Hex.reassemblyExpansionComplete_constant_of_ne_zero f hf hdeg
@@ -62,7 +62,7 @@ theorem factorClassicalFactors_factor_irreducible
       rw [hraw_one, Hex.normalizeFactorSign_one,
         Hex.shouldRecordPolynomialFactor_one] at hrec
       exact absurd hrec (by decide)
-  · rw [if_neg hdeg] at hcf
+  · rw [ite_eq_right hdeg] at hcf
     cases hquad :
         Hex.quadraticIntegerRootFactors?
           (Hex.normalizeForFactor f).squareFreeCore with

--- a/HexBerlekampZassenhausMathlib/FactorSoundness.lean
+++ b/HexBerlekampZassenhausMathlib/FactorSoundness.lean
@@ -199,12 +199,12 @@ theorem _root_.Hex.ZPoly.isIrreducible_iff (f : Hex.ZPoly) :
   rw [Hex.ZPoly.isIrreducible]
   by_cases hf0 : f = 0
   · subst hf0
-    rw [if_pos rfl]
+    rw [ite_eq_left rfl]
     exact ⟨fun h => absurd h (by decide), fun h => absurd rfl h.not_zero⟩
-  · rw [if_neg hf0]
+  · rw [ite_eq_right hf0]
     by_cases hdeg : f.degree?.getD 0 = 0
     · -- constant arm
-      rw [if_pos hdeg]
+      rw [ite_eq_left hdeg]
       have hsize_pos : 0 < f.size := Hex.ZPoly.size_pos_of_ne_zero f hf0
       have hsize1 : f.size = 1 := by
         have hdeg_eq : f.degree?.getD 0 = f.size - 1 := by
@@ -224,7 +224,7 @@ theorem _root_.Hex.ZPoly.isIrreducible_iff (f : Hex.ZPoly) :
         rw [hfC] at h
         exact Hex.ZPoly.isNatPrime_natAbs_of_irreducible_C hk_ne h
     · -- positive-degree arm
-      rw [if_neg hdeg]
+      rw [ite_eq_right hdeg]
       set φ := Hex.ZPoly.factorize f with hφ_def
       have hprod : Hex.Factorization.product φ = f := Hex.factorize_product f
       have hfp1 : ∀ q : Hex.ZPoly, Hex.Factorization.factorPower q 1 = q := fun q => by
@@ -273,14 +273,16 @@ theorem _root_.Hex.ZPoly.isIrreducible_iff (f : Hex.ZPoly) :
         have hCs_g : Hex.DensePoly.C s * g = f := by
           rw [hg_def, hs_def, Hex.normalizeFactorSign]
           by_cases hlc : Hex.DensePoly.leadingCoeff f < 0
-          · rw [if_pos hlc, if_pos hlc, Hex.ZPoly.C_mul_eq_scale, Hex.scale_neg_one_neg_one]
-          · rw [if_neg hlc, if_neg hlc, Hex.ZPoly.C_mul_eq_scale, Hex.densePoly_int_scale_one]
+          · rw [ite_eq_left hlc, ite_eq_left hlc, Hex.ZPoly.C_mul_eq_scale,
+              Hex.scale_neg_one_neg_one]
+          · rw [ite_eq_right hlc, ite_eq_right hlc, Hex.ZPoly.C_mul_eq_scale,
+              Hex.densePoly_int_scale_one]
         have hg_deg : 0 < g.degree?.getD 0 := by
           have : g.size = f.size := by
             rw [hg_def, Hex.normalizeFactorSign]
             by_cases hlc : Hex.DensePoly.leadingCoeff f < 0
-            · rw [if_pos hlc]; exact Hex.ZPoly.scale_size_of_ne_zero (-1) f (by norm_num)
-            · rw [if_neg hlc]
+            · rw [ite_eq_left hlc]; exact Hex.ZPoly.scale_size_of_ne_zero (-1) f (by norm_num)
+            · rw [ite_eq_right hlc]
           have hfsz : 0 < f.size := Hex.ZPoly.size_pos_of_ne_zero f hf0
           have hgeq : g.degree?.getD 0 = g.size - 1 := by
             unfold Hex.DensePoly.degree?; simp [Nat.ne_of_gt (this ▸ hfsz)]

--- a/HexBerlekampZassenhausMathlib/Factorization.lean
+++ b/HexBerlekampZassenhausMathlib/Factorization.lean
@@ -107,7 +107,7 @@ private theorem polynomialIrreducible_toPolynomial_normalizeFactorSign_of_zpolyI
     (Hex.ZPoly.Irreducible_iff_polynomialIrreducible f).mp hirr
   unfold Hex.normalizeFactorSign
   by_cases hlc : Hex.DensePoly.leadingCoeff f < 0
-  · rw [if_pos hlc]
+  · rw [ite_eq_left hlc]
     have hzero_mul : (-1 : Int) * (0 : Int) = 0 := by simp
     have heq :
         HexPolyZMathlib.toPolynomial (Hex.DensePoly.scale (-1 : Int) f) =
@@ -121,7 +121,7 @@ private theorem polynomialIrreducible_toPolynomial_normalizeFactorSign_of_zpolyI
     exact
       (Associated.neg_right (Associated.refl (HexPolyZMathlib.toPolynomial f))).irreducible
         hirr_poly
-  · rw [if_neg hlc]
+  · rw [ite_eq_right hlc]
     exact hirr_poly
 
 /-- `Hex.ZPoly.Irreducible` is preserved by `Hex.normalizeFactorSign`.
@@ -247,7 +247,7 @@ theorem normalize_toPolynomial_of_normalizeFactorSign_id
     rw [not_le] at hneg
     apply hne
     unfold Hex.normalizeFactorSign at h
-    rw [if_pos hneg] at h
+    rw [ite_eq_left hneg] at h
     apply Hex.DensePoly.ext_coeff
     intro n
     have hzero_mul : (-1 : Int) * (Zero.zero : Int) = (Zero.zero : Int) :=
@@ -264,7 +264,7 @@ theorem normalize_toPolynomial_of_normalizeFactorSign_id
   have hlc_poly : 0 ≤ (HexPolyZMathlib.toPolynomial f).leadingCoeff := by
     rw [HexPolyMathlib.leadingCoeff_toPolynomial]
     exact hlc_nonneg
-  rw [normalize_apply, Polynomial.coe_normUnit, Int.normUnit_eq, if_pos hlc_poly,
+  rw [normalize_apply, Polynomial.coe_normUnit, Int.normUnit_eq, ite_eq_left hlc_poly,
     Units.val_one, Polynomial.C_1, mul_one]
 
 /--
@@ -286,11 +286,11 @@ theorem zpoly_eq_of_toPolynomial_associated_of_primitive_pos_leading
   have hq_ne : q ≠ 0 := Hex.ZPoly.ne_zero_of_primitive q hq_primitive
   have hp_norm_sign : Hex.normalizeFactorSign p = p := by
     unfold Hex.normalizeFactorSign
-    rw [if_neg]
+    rw [ite_eq_right]
     omega
   have hq_norm_sign : Hex.normalizeFactorSign q = q := by
     unfold Hex.normalizeFactorSign
-    rw [if_neg]
+    rw [ite_eq_right]
     omega
   have hp_norm :
       normalize (HexPolyZMathlib.toPolynomial p) =
@@ -600,10 +600,10 @@ theorem leadingCoeff_normalizeFactorSign_nonneg (f : Hex.ZPoly) :
     0 ≤ Hex.DensePoly.leadingCoeff (Hex.normalizeFactorSign f) := by
   unfold Hex.normalizeFactorSign
   by_cases h : Hex.DensePoly.leadingCoeff f < 0
-  · rw [if_pos h]
+  · rw [ite_eq_left h]
     rw [Hex.ZPoly.leadingCoeff_scale_of_nonzero (-1 : Int) f (by decide)]
     omega
-  · rw [if_neg h]
+  · rw [ite_eq_right h]
     omega
 
 end

--- a/HexBerlekampZassenhausMathlib/ForwardHenselTransport.lean
+++ b/HexBerlekampZassenhausMathlib/ForwardHenselTransport.lean
@@ -124,8 +124,8 @@ theorem representsMonicTarget_of_represents
     (hrep : RepresentsIntegerFactorModP primeData factor S) :
     RepresentsIntegerFactorModP primeData
       (Hex.ZPoly.monicTarget factor primeData.p k) S := by
-  letI := primeData.bounds
-  letI : Hex.ZMod64.PrimeModulus primeData.p :=
+  let := primeData.bounds
+  let : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
   have hp : 1 < primeData.p := hprime.one_lt
   have htarget_monic :
@@ -193,9 +193,9 @@ theorem henselLiftData_represents_lifted_of_modP
     RepresentsIntegerFactorAtLift core (Hex.henselLiftData core B primeData) factor
       (liftedSubsetOfModPSubset primeData (Hex.henselLiftData core B primeData)
         (henselLiftData_liftedFactors_size_eq core B primeData) S) := by
-  letI := primeData.bounds
-  haveI hprime_fact : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
-  letI : Hex.ZMod64.PrimeModulus primeData.p :=
+  let := primeData.bounds
+  have hprime_fact : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
+  let : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime
       (by
         constructor
@@ -279,7 +279,7 @@ theorem henselLiftData_represents_lifted_of_modP
     rw [show liftedS = liftedSubsetOfModPSubset primeData d hsize S from rfl,
       h1, h2, h3, h4]
   -- Derive `hdeg` from `hg1` and monicness via `Monic.natDegree_map`.
-  haveI : Nontrivial (ZMod primeData.p) := inferInstance
+  have : Nontrivial (ZMod primeData.p) := inferInstance
   have hdeg : g.natDegree = g'.natDegree := by
     have hg_map_natDeg :
         (g.map (Int.castRingHom (ZMod primeData.p))).natDegree = g.natDegree :=
@@ -422,9 +422,9 @@ theorem henselLiftData_liftedSubset_congr_of_modP
         (liftedSubsetOfModPSubset primeData (Hex.henselLiftData target B primeData)
           (henselLiftData_liftedFactors_size_eq target B primeData) S))
       factor (primeData.p ^ B) := by
-  letI := primeData.bounds
-  haveI hprime_fact : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
-  letI : Hex.ZMod64.PrimeModulus primeData.p :=
+  let := primeData.bounds
+  have hprime_fact : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
+  let : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime
       (by
         constructor
@@ -506,7 +506,7 @@ theorem henselLiftData_liftedSubset_congr_of_modP
         (HexPolyZMathlib.toPolynomial factor).map (Int.castRingHom (ZMod primeData.p))
     rw [show liftedS = liftedSubsetOfModPSubset primeData d hsize S from rfl,
       h1, h2, h3, h4]
-  haveI : Nontrivial (ZMod primeData.p) := inferInstance
+  have : Nontrivial (ZMod primeData.p) := inferInstance
   have hdeg : g.natDegree = g'.natDegree := by
     have hg_map_natDeg :
         (g.map (Int.castRingHom (ZMod primeData.p))).natDegree = g.natDegree :=
@@ -626,7 +626,7 @@ theorem directLiftData_subset_congr_monicTarget
         (Hex.precisionForCoeffBound B primeData.p))
       ((Hex.ZPoly.directLiftData core B primeData).p ^
         (Hex.ZPoly.directLiftData core B primeData).k) := by
-  letI := primeData.bounds
+  let := primeData.bounds
   set precision := Hex.precisionForCoeffBound B primeData.p with hprecision_def
   set target := Hex.ZPoly.monicTarget core primeData.p precision with htarget_def
   set monicFactor := Hex.ZPoly.monicTarget factor primeData.p precision with hfactor_def

--- a/HexBerlekampZassenhausMathlib/ForwardHenselTransport.lean
+++ b/HexBerlekampZassenhausMathlib/ForwardHenselTransport.lean
@@ -911,20 +911,20 @@ theorem bhksIndicatorCandidate?_reduceModPow_eq_of_monic
         (Hex.centeredModNat z m) % (Int.ofNat m) = z % (Int.ofNat m) := by
     intro z m hm
     unfold Hex.centeredModNat
-    rw [if_neg hm]
+    rw [ite_eq_right hm]
     set r := z % (Int.ofNat m) with hr_def
     have hrmod : r % (Int.ofNat m) = r := by
       rw [hr_def, Int.emod_emod_of_dvd _ (dvd_refl _)]
     by_cases hc1 : 2 * r.natAbs ≤ m
-    · rw [if_pos hc1]; exact hrmod
-    · rw [if_neg hc1]
+    · rw [ite_eq_left hc1]; exact hrmod
+    · rw [ite_eq_right hc1]
       by_cases hc2 : r < 0
-      · rw [if_pos hc2]
+      · rw [ite_eq_left hc2]
         have hrwadd : (r + Int.ofNat m) % Int.ofNat m = r % Int.ofNat m := by
           rw [show r + Int.ofNat m = r + 1 * Int.ofNat m by ring,
             Int.add_mul_emod_self_right]
         rw [hrwadd, hrmod]
-      · rw [if_neg hc2]
+      · rw [ite_eq_right hc2]
         have hrwsub : (r - Int.ofNat m) % Int.ofNat m = r % Int.ofNat m := by
           rw [show r - Int.ofNat m = r + (-1) * Int.ofNat m by ring,
             Int.add_mul_emod_self_right]
@@ -1264,9 +1264,9 @@ private theorem size_normalizeFactorSign_eq (f : Hex.ZPoly) :
     (Hex.normalizeFactorSign f).size = f.size := by
   unfold Hex.normalizeFactorSign
   by_cases hneg : Hex.DensePoly.leadingCoeff f < 0
-  · rw [if_pos hneg]
+  · rw [ite_eq_left hneg]
     exact Hex.ZPoly.scale_size_of_ne_zero (-1 : Int) f (by decide)
-  · rw [if_neg hneg]
+  · rw [ite_eq_right hneg]
 
 /-- `Hex.ZPoly.primitivePart` preserves stored size on nonzero inputs.
 

--- a/HexBerlekampZassenhausMathlib/Hensel/DirectLift.lean
+++ b/HexBerlekampZassenhausMathlib/Hensel/DirectLift.lean
@@ -154,7 +154,7 @@ theorem directLiftFacts
     (hgcd : Int.gcd (Hex.DensePoly.leadingCoeff core)
       (Int.ofNat (data.p ^ Hex.precisionForCoeffBound B data.p)) = 1) :
     DirectLiftFacts core B data := by
-  letI := data.bounds
+  let := data.bounds
   set k := Hex.precisionForCoeffBound B data.p with hk
   set target := Hex.ZPoly.monicTarget core data.p k with htarget
   have hp : 1 < data.p := hval.prime.one_lt

--- a/HexBerlekampZassenhausMathlib/Hensel/LiftedFactors.lean
+++ b/HexBerlekampZassenhausMathlib/Hensel/LiftedFactors.lean
@@ -118,7 +118,7 @@ theorem henselLiftData_liftedFactors_size_eq
     (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData) :
     (Hex.henselLiftData core B primeData).liftedFactors.size =
       primeData.factorsModP.size := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   show (Hex.ZPoly.multifactorLiftQuadratic primeData.p B core
         (primeData.factorsModP.map Hex.FpPoly.liftToZ)).size
       = primeData.factorsModP.size
@@ -162,7 +162,7 @@ theorem henselLiftData_liftedFactor_monic
     ∀ i : Fin (Hex.henselLiftData core B primeData).liftedFactors.size,
       Hex.DensePoly.Monic
         (Hex.henselLiftData core B primeData).liftedFactors[i] := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   intro i
   exact Hex.ZPoly.multifactorLiftQuadratic_each_monic
     primeData.p B core
@@ -207,7 +207,7 @@ theorem henselLiftData_liftedFactor_monic_of_choosePrimeData
     ∀ i : Fin (Hex.henselLiftData core B primeData).liftedFactors.size,
       Hex.DensePoly.Monic
         (Hex.henselLiftData core B primeData).liftedFactors[i] := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   have hinv :
       Hex.ZPoly.QuadraticMultifactorLiftInvariant
         primeData.p B core
@@ -254,7 +254,7 @@ theorem henselLiftData_liftedFactor_injective
     (hfactorsModP_nodup : primeData.factorsModP.toList.Nodup) :
     Function.Injective
       (liftedFactor (Hex.henselLiftData core B primeData)) := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   -- The lifted-factor array equals the multifactor output by definition of
   -- `Hex.henselLiftData`. We name a local abbreviation for the multifactor output
   -- to thread index reasoning through both views.

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -197,7 +197,7 @@ theorem reassembly_complete
       by_contra hlt
       have hlt' : Hex.DensePoly.leadingCoeff q < 0 := lt_of_not_ge hlt
       unfold Hex.normalizeFactorSign at hq_norm
-      rw [if_pos hlt'] at hq_norm
+      rw [ite_eq_left hlt'] at hq_norm
       apply hq_ne
       apply Hex.DensePoly.ext_coeff
       intro n
@@ -320,7 +320,7 @@ theorem factorTrialFactorsWithBound_factor_irreducible
     IntReductionMod.normalizeForFactor_squareFreeCore_primitive_of_ne_zero f hf
   simp only [Hex.factorTrialFactorsWithBound] at hmem
   by_cases hdeg : (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 = 0
-  · rw [if_pos hdeg] at hmem
+  · rw [ite_eq_left hdeg] at hmem
     have hcomplete := Hex.reassemblyExpansionComplete_constant_of_ne_zero f hf hdeg
     rcases Hex.reassemblePolynomialFactors_mem_xPower_or_core_of_expansionComplete
         _ _ raw hcomplete hmem with hx | hcore
@@ -332,7 +332,7 @@ theorem factorTrialFactorsWithBound_factor_irreducible
         rw [hraw_core, Hex.squareFreeCore_eq_one_of_constant_of_ne_zero f hf hdeg]
       rw [hraw_one, Hex.normalizeFactorSign_one, Hex.shouldRecordPolynomialFactor_one] at hrec
       exact absurd hrec (by decide)
-  · rw [if_neg hdeg] at hmem
+  · rw [ite_eq_right hdeg] at hmem
     cases hquad :
         Hex.quadraticIntegerRootFactors? (Hex.normalizeForFactor f).squareFreeCore with
     | some coreFactors =>

--- a/HexBerlekampZassenhausMathlib/IntReductionMod/Descent.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod/Descent.lean
@@ -881,7 +881,7 @@ theorem normalizeForFactor_repeatedPart_toPolynomial_normalize
     rw [HexPolyMathlib.leadingCoeff_toPolynomial]
     unfold Hex.normalizeForFactor
     exact Hex.ZPoly.leadingCoeff_repeatedPart_nonneg _
-  rw [normalize_apply, Polynomial.coe_normUnit, Int.normUnit_eq, if_pos hlc_nonneg,
+  rw [normalize_apply, Polynomial.coe_normUnit, Int.normUnit_eq, ite_eq_left hlc_nonneg,
     Units.val_one, Polynomial.C_1, mul_one]
 
 /-! # Squarefree transport for the primitive square-free part
@@ -1015,7 +1015,7 @@ theorem isCoprime_toPolynomial_map_intCast_derivative_of_squareFreeRat
     rw [HexPolyMathlib.coeff_toPolynomial, Polynomial.coeff_C]
     by_cases hn : n = 0
     · simp [hn]
-    · rw [if_neg hn]
+    · rw [ite_eq_right hn]
       exact Hex.DensePoly.coeff_eq_zero_of_size_le G (by
         cases n with
         | zero => exact absurd rfl hn
@@ -1325,7 +1325,7 @@ theorem Polynomial.gcd_derivative_associated_divRadical_of_charZero
               have hsep : (q : Polynomial K).Separable :=
                 PerfectField.separable_of_irreducible hq.irreducible
               have hcop : IsCoprime q (Polynomial.derivative q) := hsep
-              exact hq.not_unit (hcop.isUnit_of_dvd' dvd_rfl hq_dvd_deriv)
+              exact hq.not_isUnit (hcop.isUnit_of_dvd' dvd_rfl hq_dvd_deriv)
           have hm_le_k : m ≤ k := Nat.lt_succ_iff.mp hm_lt
           exact hm_assoc.dvd.trans (pow_dvd_pow q hm_le_k)
         exact associated_of_dvd_dvd hg_dvd_qk hqk_dvd_g

--- a/HexBerlekampZassenhausMathlib/IntReductionMod/Descent.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod/Descent.lean
@@ -118,7 +118,7 @@ theorem irreducible_of_isPrimitive_of_irreducible_map_intCast_zmod
       (Int.castRingHom (ZMod p)) f.leadingCoeff ≠ 0)
     (hirr : Irreducible (f.map (Int.castRingHom (ZMod p)))) :
     Irreducible f := by
-  haveI : IsDomain (ZMod p) := inferInstance
+  have : IsDomain (ZMod p) := inferInstance
   set φ : ℤ →+* ZMod p := Int.castRingHom (ZMod p) with hφ_def
   refine ⟨?_, ?_⟩
   · intro hunit
@@ -268,7 +268,7 @@ theorem Hex_ZPoly_Irreducible_of_primeChoice_fModP
         (@HexBerlekampMathlib.toMathlibPolynomial primeData.p
           primeData.bounds primeData.fModP)) :
     Hex.ZPoly.Irreducible core := by
-  letI := primeData.bounds
+  let := primeData.bounds
   refine Hex_ZPoly_Irreducible_of_irreducible_modP
     (p := primeData.p) (core := core) hprim hlc_map_ne ?_
   simpa [hfModP_eq] using hirr_fModP
@@ -301,7 +301,7 @@ theorem squareFreeCore_irreducible_of_small_mod_singleton
         (@HexBerlekampMathlib.toMathlibPolynomial primeData.p
           primeData.bounds primeData.fModP)) :
     Hex.ZPoly.Irreducible core := by
-  haveI : Fact (Nat.Prime primeData.p) := ⟨hprime⟩
+  have : Fact (Nat.Prime primeData.p) := ⟨hprime⟩
   exact Hex_ZPoly_Irreducible_of_primeChoice_fModP
     (primeData := primeData)
     (core := core)
@@ -529,20 +529,20 @@ theorem irreducible_of_smallMod_form
           (@Hex.monicModularImage primeData.p primeData.bounds
             (@Hex.ZPoly.modP primeData.p primeData.bounds core)))) = true) :
     Hex.ZPoly.Irreducible core := by
-  letI := primeData.bounds
+  let := primeData.bounds
   have hprime : _root_.Nat.Prime primeData.p := by
     refine _root_.Nat.prime_def_lt.mpr ⟨hprime_hex.two_le, ?_⟩
     intro m hmlt hmdvd
     rcases hprime_hex.right m hmdvd with h | h
     · exact h
     · exact absurd h (Nat.ne_of_lt hmlt)
-  haveI : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
-  letI : Hex.ZMod64.PrimeModulus primeData.p := Hex.ZMod64.primeModulusOfPrime hprime_hex
+  have : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
+  let : Hex.ZMod64.PrimeModulus primeData.p := Hex.ZMod64.primeModulusOfPrime hprime_hex
   have hformCopy := hform
   obtain ⟨_, hzero, hfactors_eq⟩ := hformCopy
   let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime_hex
-  letI := hfield
+  let := hfield
   -- Translate factorsModP.size ≤ 1 into bfact.factors.length ≤ 1.
   have hfactors_len_le :
       (@Hex.Berlekamp.berlekampFactor primeData.p primeData.bounds
@@ -664,7 +664,7 @@ theorem irreducible_of_smallMod
       (Int.castRingHom (ZMod primeData.p))
         (HexPolyZMathlib.toPolynomial core).leadingCoeff ≠ 0) :
     Hex.ZPoly.Irreducible core := by
-  letI := primeData.bounds
+  let := primeData.bounds
   have hsquareFree : Hex.squareFreeModP core primeData.p :=
     Hex.isGoodPrime_squareFreeModP core primeData.p hgood
   have hsquareFree_modP :
@@ -681,7 +681,7 @@ theorem irreducible_of_smallMod
     rcases hprime_hex.right m hmdvd with h | h
     · exact h
     · exact absurd h (Nat.ne_of_lt hmlt)
-  haveI : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
+  have : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
   have hsquareFree_monic :
       Hex.gcdIsUnit
         (Hex.DensePoly.gcd
@@ -715,7 +715,7 @@ theorem squarefree_toMathlibPolynomial_monicModPImage_of_goodPrime
       (@HexBerlekampMathlib.toMathlibPolynomial primeData.p primeData.bounds
         (@monicModPImage primeData.p primeData.bounds
           (@Hex.ZPoly.modP primeData.p primeData.bounds core))) := by
-  letI := primeData.bounds
+  let := primeData.bounds
   have hsquareFree : Hex.squareFreeModP core primeData.p :=
     Hex.isGoodPrime_squareFreeModP core primeData.p hgood
   have hsquareFree_modP :
@@ -732,7 +732,7 @@ theorem squarefree_toMathlibPolynomial_monicModPImage_of_goodPrime
     rcases hprime_hex.right m hmdvd with h | h
     · exact h
     · exact absurd h (Nat.ne_of_lt hmlt)
-  haveI : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
+  have : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
   have hsquareFree_monic :
       Hex.gcdIsUnit
         (Hex.DensePoly.gcd
@@ -1160,7 +1160,7 @@ theorem choosePrimeData?_leadingCoeff_castRingHom_ne_zero
     (hselected : Hex.choosePrimeData? f = some primeData) :
     (Int.castRingHom (ZMod primeData.p))
         (HexPolyZMathlib.toPolynomial f).leadingCoeff ≠ 0 := by
-  letI := primeData.bounds
+  let := primeData.bounds
   exact
     leadingCoeff_castRingHom_ne_zero_of_isGoodPrime f
       (Hex.choosePrimeData?_isGoodPrime f primeData hselected)
@@ -1220,7 +1220,7 @@ the result without needing coprimality of `x` and `y`.
 private lemma dvd_gcd_mul_gcd_of_dvd_mul {α : Type*} [EuclideanDomain α]
     [DecidableEq α] {g x y : α} (h : g ∣ x * y) :
     g ∣ EuclideanDomain.gcd g x * EuclideanDomain.gcd g y := by
-  letI : GCDMonoid α := EuclideanDomain.gcdMonoid α
+  let : GCDMonoid α := EuclideanDomain.gcdMonoid α
   show g ∣ gcd g x * gcd g y
   have h1 : g ∣ gcd g x * y := dvd_gcd_mul_of_dvd_mul h
   rw [mul_comm] at h1

--- a/HexBerlekampZassenhausMathlib/IntReductionMod/Transport.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod/Transport.lean
@@ -552,7 +552,7 @@ private theorem List.nodup_of_prod_squarefree
       · subst hx
         rw [Multiset.count_replicate_self]
         omega
-      · rw [Multiset.count_replicate, if_neg (Ne.symm hx)]
+      · rw [Multiset.count_replicate, ite_eq_right (Ne.symm hx)]
         exact Nat.zero_le _
     have hdvd_prod := Multiset.prod_dvd_prod_of_le hle
     rw [Multiset.prod_replicate, Multiset.prod_coe] at hdvd_prod
@@ -971,7 +971,7 @@ theorem reassemblyExpansionComplete_of_irreducible_squarefree_cover_of_norm
       by_contra hlt
       have hlt' : Hex.DensePoly.leadingCoeff q < 0 := lt_of_not_ge hlt
       unfold Hex.normalizeFactorSign at hq_norm
-      rw [if_pos hlt'] at hq_norm
+      rw [ite_eq_left hlt'] at hq_norm
       apply hq_ne
       apply Hex.DensePoly.ext_coeff
       intro n
@@ -1279,7 +1279,7 @@ theorem reassemblyExpansionComplete_quadraticIntegerRootFactors_of_ne_zero
       by_contra hlt
       have hlt' : Hex.DensePoly.leadingCoeff q < 0 := lt_of_not_ge hlt
       unfold Hex.normalizeFactorSign at hq_norm
-      rw [if_pos hlt'] at hq_norm
+      rw [ite_eq_left hlt'] at hq_norm
       apply hq_ne
       apply Hex.DensePoly.ext_coeff
       intro n

--- a/HexBerlekampZassenhausMathlib/IrreducibilityCertificate.lean
+++ b/HexBerlekampZassenhausMathlib/IrreducibilityCertificate.lean
@@ -315,7 +315,7 @@ theorem checkIrreducibleCert_sound
           simp only [Hex.PrimeFactorData.checkCertAtFactor, Bool.and_eq_true] at hp
           obtain ⟨_, hif⟩ := hp
           have hmonic' : Hex.DensePoly.leadingCoeff primeData.factorPolys[i] = 1 := hmonic
-          rw [dif_pos hmonic'] at hif
+          rw [dite_eq_left hmonic'] at hif
           exact hif
         have hrabin :=
           Hex.Berlekamp.checkIrreducibilityCertificate_rabinTest

--- a/HexBerlekampZassenhausMathlib/IrreducibilityCertificate.lean
+++ b/HexBerlekampZassenhausMathlib/IrreducibilityCertificate.lean
@@ -104,7 +104,7 @@ private theorem natDegree_toMathlibPolynomial_factorPolys_eq
     letI := primeData.bounds
     (HexBerlekampMathlib.toMathlibPolynomial primeData.factorPolys[i]).natDegree =
       primeData.factorDegrees[i] := by
-  letI := primeData.bounds
+  let := primeData.bounds
   have hpair :=
     checkCertAtFactor_of_checkFactorCerts primeData hcheck i hi_deg hi_polys hi_certs
   have hdegree :
@@ -219,8 +219,8 @@ theorem checkIrreducibleCert_sound
           exact List.mem_of_mem_drop hmem_drop
       -- Extract `Nat.Prime primeData.p` from hypothesis
       have hp_prime : Nat.Prime primeData.p := hprime primeData hpd_mem
-      haveI : Fact (Nat.Prime primeData.p) := ⟨hp_prime⟩
-      letI := primeData.bounds
+      have : Fact (Nat.Prime primeData.p) := ⟨hp_prime⟩
+      let := primeData.bounds
       -- Extract checkForPolynomial fact
       have hcheckPoly := Hex.checkIrreducibleCert_prime_data f cert hcert primeData hpd_mem
       have hgood := Hex.checkIrreducibleCert_isGoodPrime f cert hcert primeData hpd_mem
@@ -254,7 +254,7 @@ theorem checkIrreducibleCert_sound
       -- Then c.leadingCoeff mod p ≠ 0 (using p prime → ZMod p domain)
       have hc_lc_map_ne :
           (Int.castRingHom (ZMod primeData.p)) c.leadingCoeff ≠ 0 := by
-        haveI : IsDomain (ZMod primeData.p) := inferInstance
+        have : IsDomain (ZMod primeData.p) := inferInstance
         intro heq
         apply hF_lc_map_ne
         have : F.leadingCoeff = c.leadingCoeff * d.leadingCoeff := by
@@ -275,7 +275,7 @@ theorem checkIrreducibleCert_sound
         map_intCast_zmod_toPolynomial_eq_factorPolys_product f primeData hcheckPoly
       rw [hF_modP_eq] at hc_modP_dvd_F_modP
       -- Construct Hex.ZMod64.PrimeModulus from Mathlib primality
-      haveI hpm : Hex.ZMod64.PrimeModulus primeData.p :=
+      have hpm : Hex.ZMod64.PrimeModulus primeData.p :=
         Hex.ZMod64.primeModulusOfPrime
           ⟨hp_prime.two_le, fun m hdvd => hp_prime.eq_one_or_self_of_dvd m hdvd⟩
       -- Each factor in factorPolys is irreducible (via Rabin)

--- a/HexBerlekampZassenhausMathlib/Lattice/CutProjection.lean
+++ b/HexBerlekampZassenhausMathlib/Lattice/CutProjection.lean
@@ -69,8 +69,8 @@ private theorem mem_foldl_push_if_of_mem_init {α β : Type*}
       intro init hx
       simp only [List.foldl_cons]
       by_cases hp : p a
-      · rw [if_pos hp]; exact ih _ (Array.mem_push.mpr (Or.inl hx))
-      · rw [if_neg hp]; exact ih _ hx
+      · rw [ite_eq_left hp]; exact ih _ (Array.mem_push.mpr (Or.inl hx))
+      · rw [ite_eq_right hp]; exact ih _ hx
 
 /-- A passing element `g i₀` of the conditional-push fold appears in the result. -/
 private theorem mem_foldl_push_if {α β : Type*}
@@ -84,12 +84,12 @@ private theorem mem_foldl_push_if {α β : Type*}
       intro init h
       simp only [List.foldl_cons]
       rcases List.mem_cons.mp h with rfl | hmem
-      · rw [if_pos hp₀]
+      · rw [ite_eq_left hp₀]
         exact mem_foldl_push_if_of_mem_init p g (g i₀) as _
           (Array.mem_push.mpr (Or.inr rfl))
       · by_cases hp : p a
-        · rw [if_pos hp]; exact ih _ hmem
-        · rw [if_neg hp]; exact ih _ hmem
+        · rw [ite_eq_left hp]; exact ih _ hmem
+        · rw [ite_eq_right hp]; exact ih _ hmem
 
 /-- Every element produced by a conditional-push fold either came from the
 initial accumulator or is the image of a passing source element. -/
@@ -108,11 +108,11 @@ private theorem mem_foldl_push_if_imp {α β : Type*}
       simp only [List.foldl_cons] at hx
       rcases ih _ x hx with hxinit | ⟨i, hi, hpi, hix⟩
       · by_cases hpa : p a
-        · rw [if_pos hpa] at hxinit
+        · rw [ite_eq_left hpa] at hxinit
           rcases Array.mem_push.mp hxinit with hxold | hax
           · exact Or.inl hxold
           · exact Or.inr ⟨a, by simp, hpa, hax.symm⟩
-        · rw [if_neg hpa] at hxinit
+        · rw [ite_eq_right hpa] at hxinit
           exact Or.inl hxinit
       · exact Or.inr ⟨i, List.mem_cons_of_mem a hi, hpi, hix⟩
 
@@ -127,7 +127,7 @@ private theorem bhksProjectIndicator_getD {r n : Nat}
   have hjrn : j.val < r + n := Nat.lt_of_lt_of_le j.isLt (Nat.le_add_right r n)
   rw [array_getD_of_lt _ _ hjlt]
   simp only [Hex.bhksProjectIndicator, List.getElem_toArray, List.getElem_map,
-    List.getElem_range, dif_pos hjrn]
+    List.getElem_range, dite_eq_left hjrn]
   rfl
 
 /-- A retained prefix row, projected to its first block, is a generator of the

--- a/HexBerlekampZassenhausMathlib/Lattice/DirectAdequacy.lean
+++ b/HexBerlekampZassenhausMathlib/Lattice/DirectAdequacy.lean
@@ -201,7 +201,7 @@ theorem directLiftedFactor_core_congr
               (Hex.ZPoly.directLiftData core B data)) \ {i})))
       ((Hex.ZPoly.directLiftData core B data).p ^
         (Hex.ZPoly.directLiftData core B data).k) := by
-  letI := data.bounds
+  let := data.bounds
   let d := Hex.ZPoly.directLiftData core B data
   have hp_eq : d.p = data.p := by
     simp [d, Hex.ZPoly.directLiftData]
@@ -276,7 +276,7 @@ theorem directLiftedFactors_isCoprime
             ((Hex.ZPoly.directLiftData core B data).p ^
               (Hex.ZPoly.directLiftData core B data).k)))) := by
   classical
-  letI := data.bounds
+  let := data.bounds
   let k := Hex.precisionForCoeffBound B data.p
   let target := Hex.ZPoly.monicTarget core data.p k
   let d := Hex.ZPoly.directLiftData core B data
@@ -330,7 +330,7 @@ theorem directLiftedFactors_isCoprime
         ((HexPolyZMathlib.toPolynomial (liftedFactor d j)).map
           (Int.castRingHom (ZMod data.p))) :=
     hcomp.of_isCoprime_of_dvd_right hjdvd
-  haveI : Fact (_root_.Nat.Prime data.p) :=
+  have : Fact (_root_.Nat.Prime data.p) :=
     ⟨natPrime_of_hexNatPrime hval.prime⟩
   have hpow := HexHenselMathlib.coprime_mod_p_lifts
     (HexPolyZMathlib.toPolynomial (liftedFactor d i))
@@ -359,7 +359,7 @@ theorem directLiftedFactor_map_irreducible
       ((HexPolyZMathlib.toPolynomial
         (liftedFactor (Hex.ZPoly.directLiftData core B data) i)).map
           (Int.castRingHom (ZMod data.p))) := by
-  letI := data.bounds
+  let := data.bounds
   let d := Hex.ZPoly.directLiftData core B data
   let hsize : d.liftedFactors.size = data.factorsModP.size :=
     henselLiftData_liftedFactors_size_eq
@@ -418,7 +418,7 @@ theorem directLiftedFactor_natDegree_le_core
       ((Hex.ZPoly.directLiftData core B data).liftedFactors.getD i.val 1)).natDegree ≤
         (HexPolyZMathlib.toPolynomial core).natDegree := by
   classical
-  letI := data.bounds
+  let := data.bounds
   let d := Hex.ZPoly.directLiftData core B data
   let q := HexPolyZMathlib.toPolynomial (liftedFactor d i)
   let h := liftedFactorProduct d
@@ -470,7 +470,7 @@ theorem directLiftedFactor_natDegree_le_core
       rwa [HexPolyMathlib.natDegree_toPolynomial]
     rw [hzero, Polynomial.natDegree_zero] at hcore_degree_map
     omega
-  haveI : Fact (_root_.Nat.Prime data.p) :=
+  have : Fact (_root_.Nat.Prime data.p) :=
     ⟨natPrime_of_hexNatPrime hval.prime⟩
   have hq_monic : q.Monic :=
     HexHenselMathlib.toPolynomial_monic_of_dense_monic _
@@ -524,7 +524,7 @@ theorem directLiftedFactor_isCoprime_cldQuotient
               ((Hex.ZPoly.directLiftData core B data).p ^
                 (Hex.ZPoly.directLiftData core B data).k)))) := by
   classical
-  letI := data.bounds
+  let := data.bounds
   let d := Hex.ZPoly.directLiftData core B data
   let q := HexPolyZMathlib.toPolynomial (liftedFactor d i)
   let complement :=
@@ -574,7 +574,7 @@ theorem directLiftedFactor_isCoprime_cldQuotient
   have hp : _root_.Nat.Prime d.p := by
     rw [hp_eq]
     exact natPrime_of_hexNatPrime hval.prime
-  letI : Fact (_root_.Nat.Prime d.p) := ⟨hp⟩
+  let : Fact (_root_.Nat.Prime d.p) := ⟨hp⟩
   have hirr :=
     directLiftedFactor_map_irreducible_at_liftPrime
       core B data hval facts i
@@ -781,7 +781,7 @@ theorem directAdequacy
     (hB_floor : Hex.bhksRecoveryFloor core ≤ B)
     (_hB_ne : B ≠ 0) :
     DirectAdequacy core B data := by
-  letI := data.bounds
+  let := data.bounds
   have hcore_ne : core ≠ 0 :=
     zpoly_ne_zero_of_pos_lc hcore_lc_pos
   have hcore_size : 0 < core.size :=
@@ -1011,7 +1011,7 @@ theorem directCutProjection
           (Hex.ZPoly.directLiftData core B data).liftedFactors) hrows)
       (directTrueSupports core B data) := by
   classical
-  letI := data.bounds
+  let := data.bounds
   let d := Hex.ZPoly.directLiftData core B data
   let A := directAdequacy core B data hcore_lc_pos hcore_pos
     hcore_prim hcore_sqfree hval hB_floor hB_ne
@@ -1116,7 +1116,7 @@ theorem directProjectedSpan_eq
             (Hex.ZPoly.directLiftData core B data).liftedFactors) hrows) =
       BHKS.trueSupportSpanInt (directTrueSupports core B data) := by
   classical
-  letI := data.bounds
+  let := data.bounds
   let d := Hex.ZPoly.directLiftData core B data
   have hcore_ne : core ≠ 0 :=
     zpoly_ne_zero_of_pos_lc hcore_lc_pos

--- a/HexBerlekampZassenhausMathlib/Lattice/DirectRecovery.lean
+++ b/HexBerlekampZassenhausMathlib/Lattice/DirectRecovery.lean
@@ -412,7 +412,7 @@ theorem recoveredClassFactors_polyProduct
         rw [HexPolyMathlib.leadingCoeff_toPolynomial]
         exact le_of_lt R.certificate.leadingCoeff_pos
       rw [normalize_apply, Polynomial.coe_normUnit, Int.normUnit_eq,
-        if_pos hlc, Units.val_one, Polynomial.C_1, mul_one]
+        ite_eq_left hlc, Units.val_one, Polynomial.C_1, mul_one]
     have heq :
         HexPolyZMathlib.toPolynomial R.certificate.factor = q := by
       rw [← hp_norm, ← hq_norm]
@@ -443,7 +443,7 @@ theorem recoveredClassFactors_polyProduct
       rw [HexPolyMathlib.leadingCoeff_toPolynomial]
       exact le_of_lt hcore_lc_pos
     rw [normalize_apply, Polynomial.coe_normUnit, Int.normUnit_eq,
-      if_pos hlc, Units.val_one, Polynomial.C_1, mul_one]
+      ite_eq_left hlc, Units.val_one, Polynomial.C_1, mul_one]
   have hprod_norm :
       (UniqueFactorizationMonoid.normalizedFactors X).prod = X := by
     have h := UniqueFactorizationMonoid.prod_normalizedFactors_eq hX_ne
@@ -889,7 +889,7 @@ theorem bhksSingleAllOnesPartition_eq_true_of_span_eq
             (Hex.ZPoly.directLiftData core B data).k
             (Hex.ZPoly.directLiftData core B data).liftedFactors) hrows)
         (directTrueSupports core B data) hspan hcover hclasses_ne)
-  rw [Hex.bhksSingleAllOnesPartition, dif_pos hrows]
+  rw [Hex.bhksSingleAllOnesPartition, dite_eq_left hrows]
   change (!indicators.isEmpty && !projected.projectedRows.isEmpty &&
     indicators.size == 1 &&
       Hex.bhksIndicatorAllOnes projected.factorCount

--- a/HexBerlekampZassenhausMathlib/Lattice/DirectSupport.lean
+++ b/HexBerlekampZassenhausMathlib/Lattice/DirectSupport.lean
@@ -329,8 +329,8 @@ theorem directSupport_nonempty_of_represents
     (hnorm : Hex.normalizeFactorSign factor = factor)
     (hrep : RepresentsIntegerFactorModP data factor S) :
     S.Nonempty := by
-  letI := data.bounds
-  letI : Hex.ZMod64.PrimeModulus data.p :=
+  let := data.bounds
+  let : Hex.ZMod64.PrimeModulus data.p :=
     Hex.ZMod64.primeModulusOfPrime hval.prime
   by_contra hempty
   rw [Finset.not_nonempty_iff_eq_empty] at hempty

--- a/HexBerlekampZassenhausMathlib/Lattice/ProjectedRows.lean
+++ b/HexBerlekampZassenhausMathlib/Lattice/ProjectedRows.lean
@@ -370,8 +370,8 @@ theorem vecMul_first_of_blockForm
     intro j _
     rw [hentry]
     unfold Hex.bhksLatticeEntry
-    rw [dif_neg (by simp only [Fin.val_natAdd]; omega),
-      dif_pos (by simp only [Fin.val_castAdd]; exact i.isLt), zero_mul]
+    rw [dite_eq_right (by simp only [Fin.val_natAdd]; omega),
+      dite_eq_left (by simp only [Fin.val_castAdd]; exact i.isLt), zero_mul]
   rw [hsnd, add_zero]
   rw [Finset.sum_eq_single i]
   · rw [hentry]
@@ -380,9 +380,9 @@ theorem vecMul_first_of_blockForm
   · intro i' _ hne
     rw [hentry]
     unfold Hex.bhksLatticeEntry
-    rw [dif_pos (by simp only [Fin.val_castAdd]; exact i'.isLt),
-      dif_pos (by simp only [Fin.val_castAdd]; exact i.isLt),
-      if_neg (by
+    rw [dite_eq_left (by simp only [Fin.val_castAdd]; exact i'.isLt),
+      dite_eq_left (by simp only [Fin.val_castAdd]; exact i.isLt),
+      ite_eq_right (by
         intro hval
         exact hne (Fin.ext hval))]
     exact zero_mul _
@@ -417,8 +417,8 @@ theorem vecMul_tail_of_blockForm
     intro i _
     rw [hentry]
     unfold Hex.bhksLatticeEntry
-    rw [dif_pos (by simp only [Fin.val_castAdd]; exact i.isLt),
-      dif_neg (by simp only [Fin.val_natAdd]; omega)]
+    rw [dite_eq_left (by simp only [Fin.val_castAdd]; exact i.isLt),
+      dite_eq_right (by simp only [Fin.val_natAdd]; omega)]
     simp only [Fin.val_castAdd, Fin.val_natAdd, Nat.add_sub_cancel_left]
     ring
   have hsnd : (∑ j' : Fin L.coeffWidth,
@@ -435,10 +435,10 @@ theorem vecMul_tail_of_blockForm
     · intro j' _ hne
       rw [hentry]
       unfold Hex.bhksLatticeEntry
-      rw [dif_neg (by simp only [Fin.val_natAdd]; omega),
-        dif_neg (by simp only [Fin.val_natAdd]; omega)]
+      rw [dite_eq_right (by simp only [Fin.val_natAdd]; omega),
+        dite_eq_right (by simp only [Fin.val_natAdd]; omega)]
       simp only [Fin.val_natAdd, Nat.add_sub_cancel_left]
-      rw [if_neg (by
+      rw [ite_eq_right (by
         intro hval
         exact hne (Fin.ext hval.symm))]
       exact zero_mul _
@@ -734,8 +734,8 @@ private theorem foldl_cut_ge_of_bound {N : Nat} (g : Fin N → Bool) (bound : Na
       intro init hinit hbnd
       apply ih
       · by_cases hga : g a
-        · simp only [hga, if_true]; exact hbnd a (by simp)
-        · simp only [hga, Bool.false_eq_true, if_false]; exact hinit
+        · simp only [hga, ite_true]; exact hbnd a (by simp)
+        · simp only [hga, Bool.false_eq_true, ite_false]; exact hinit
       · intro i hi; exact hbnd i (List.mem_cons_of_mem a hi)
 
 /-- The cut fold over a strictly increasing index list reaches at least
@@ -779,7 +779,7 @@ private theorem exists_cut_of_lt_foldl {N : Nat} (g : Fin N → Bool) (j : Nat) 
       · by_cases hga : g a = true
         · right
           refine ⟨a, by simp, ?_, hga⟩
-          simp only [hga, if_true] at hstep
+          simp only [hga, ite_true] at hstep
           omega
         · left
           have hgaf : g a = false := Bool.eq_false_of_not_eq_true hga
@@ -835,7 +835,7 @@ theorem bhksWithinGramSchmidtCut_eq_true_of_le
         (dets.get ⟨i.val, by omega⟩ : ℚ)) ≤ (Hex.bhksCutRadiusSq4 L : ℚ)) :
     Hex.bhksWithinGramSchmidtCut L dets i = true := by
   unfold Hex.bhksWithinGramSchmidtCut
-  rw [if_neg hne]
+  rw [ite_eq_right hne]
   exact decide_eq_true hle
 
 /-- A successful executable cut test exposes its determinant-ratio
@@ -850,7 +850,7 @@ theorem bhksWithinGramSchmidtCut_le_of_eq_true
   unfold Hex.bhksWithinGramSchmidtCut at hpass
   by_cases hzero : dets.get ⟨i.val, by omega⟩ = 0
   · simp [hzero] at hpass
-  · rw [if_neg hzero] at hpass
+  · rw [ite_eq_right hzero] at hpass
     exact of_decide_eq_true hpass
 
 /-- Every row in the retained prefix has a certified norm bound.  A retained

--- a/HexBerlekampZassenhausMathlib/Lattice/SupportEquivalence.lean
+++ b/HexBerlekampZassenhausMathlib/Lattice/SupportEquivalence.lean
@@ -70,7 +70,7 @@ theorem mem_trueSupportSpanInt_of_constant_on_partition
       ∀ S ∈ trueSupports, ∀ i ∈ S, ∀ j ∈ S, v i = v j) :
     v ∈ trueSupportSpanInt trueSupports := by
   classical
-  letI : Fintype trueSupports := (Set.toFinite trueSupports).fintype
+  let : Fintype trueSupports := (Set.toFinite trueSupports).fintype
   let rep : trueSupports → Fin r :=
     fun S => (hne S.1 S.2).choose
   have hrep (S : trueSupports) : rep S ∈ S.1 :=
@@ -159,7 +159,7 @@ theorem exists_adjustedVector
       ∀ x : Fin (L.factorCount + L.coeffWidth),
         w[x].natAbs ≤ V + V * U + trueSupports.ncard * U := by
   classical
-  letI : Fintype trueSupports := (Set.toFinite trueSupports).fintype
+  let : Fintype trueSupports := (Set.toFinite trueSupports).fintype
   let e : Fin L.factorCount → ℤ :=
     fun i => v[Fin.castAdd L.coeffWidth i]
   obtain ⟨S₀, hS₀, i₀, hi₀, k₀, hk₀, hik⟩ :=

--- a/HexBerlekampZassenhausMathlib/Lattice/SupportEquivalence.lean
+++ b/HexBerlekampZassenhausMathlib/Lattice/SupportEquivalence.lean
@@ -232,17 +232,17 @@ theorem exists_adjustedVector
         if zeroOn T then 1 else 0 := by
     rw [Finset.sum_eq_single T]
     · by_cases hzero : zeroOn T
-      · rw [if_pos hzero, if_pos hzero,
+      · rw [ite_eq_left hzero, ite_eq_left hzero,
           indicatorVector_apply_mem T.1 hi]
-      · rw [if_neg hzero, if_neg hzero]
+      · rw [ite_eq_right hzero, ite_eq_right hzero]
     · intro S _ hST
       have hiS : i ∉ S.1 := by
         intro hiS
         apply hST
         exact Subtype.ext (hdisjoint S.1 S.2 T.1 T.2 i hiS hi)
       by_cases hzero : zeroOn S
-      · rw [if_pos hzero, indicatorVector_apply_not_mem S.1 hiS]
-      · rw [if_neg hzero]
+      · rw [ite_eq_left hzero, indicatorVector_apply_not_mem S.1 hiS]
+      · rw [ite_eq_right hzero]
     · intro h
       exact absurd (Finset.mem_univ T) h
   have hS₀_not_zero : ¬ zeroOn S₀' := by
@@ -251,7 +251,7 @@ theorem exists_adjustedVector
   have hzeroCoord :
       w[Fin.castAdd L.coeffWidth i₀] = 0 := by
     rw [hcoord i₀, indicatorVector_apply_mem S₀ hi₀,
-      hcorrection S₀' i₀ hi₀, if_neg hS₀_not_zero]
+      hcorrection S₀' i₀ hi₀, ite_eq_right hS₀_not_zero]
     ring
   refine ⟨w, hwL, ⟨i₀, hzeroCoord⟩, ?_, ?_⟩
   · intro T hT
@@ -260,7 +260,7 @@ theorem exists_adjustedVector
     · subst T
       refine ⟨k₀, hk₀, ?_⟩
       rw [hcoord k₀, indicatorVector_apply_mem S₀ hk₀,
-        hcorrection S₀' k₀ hk₀, if_neg hS₀_not_zero]
+        hcorrection S₀' k₀ hk₀, ite_eq_right hS₀_not_zero]
       intro h
       apply hik
       linarith
@@ -271,14 +271,14 @@ theorem exists_adjustedVector
       · obtain ⟨i, hi⟩ := hne T hT
         refine ⟨i, hi, ?_⟩
         rw [hcoord i, indicatorVector_apply_not_mem S₀ (hS₀T i hi),
-          hcorrection T' i hi, if_pos hzero, hzero i hi]
+          hcorrection T' i hi, ite_eq_left hzero, hzero i hi]
         norm_num
       · dsimp only [zeroOn] at hzero
         push Not at hzero
         obtain ⟨i, hi, hei⟩ := hzero
         refine ⟨i, hi, ?_⟩
         rw [hcoord i, indicatorVector_apply_not_mem S₀ (hS₀T i hi),
-          hcorrection T' i hi, if_neg]
+          hcorrection T' i hi, ite_eq_right]
         · simpa using hei
         · exact fun hz => hei (hz i hi)
   · intro x
@@ -323,7 +323,7 @@ theorem exists_adjustedVector
         apply Finset.sum_congr rfl
         intro S _
         by_cases hzero : zeroOn S
-        · simp only [if_pos hzero]
+        · simp only [ite_eq_left hzero]
           rw [← vecMul_getElem_eq_sum, hsupportCoeffs]
           simp only [Fin.getElem_fin]
         · simp [hzero]

--- a/HexBerlekampZassenhausMathlib/LatticeFactorization.lean
+++ b/HexBerlekampZassenhausMathlib/LatticeFactorization.lean
@@ -304,9 +304,9 @@ theorem latticeCoreFactorsWithBound_ne_none
         hnonunit).ne'
   rw [Hex.latticeCoreFactorsWithBound]
   by_cases hsmall : data.factorsModP.size ≤ 1
-  · rw [if_pos hsmall]
+  · rw [ite_eq_left hsmall]
     simp
-  · rw [if_neg hsmall]
+  · rw [ite_eq_right hsmall]
     cases hlattice :
         Hex.latticeCoreWithBound core B data
           (Hex.initialHenselPrecision B)
@@ -320,9 +320,9 @@ theorem latticeCoreFactorsWithBound_ne_none
               hcover hdisjoint (by simpa only [d] using hrows)
               (by simpa only [d] using hspan)
               (by simpa only [classes] using hsingle)
-          rw [Hex.bhksRecoveryThreshold_eq, if_pos hB_floor]
+          rw [Hex.bhksRecoveryThreshold_eq, ite_eq_left hB_floor]
           rw [show Hex.ZPoly.directLiftData core B data = d by rfl,
-            if_pos hallones]
+            ite_eq_left hallones]
           simp
         · have hclasses_two : 2 ≤ classes.length := by omega
           have hrecover :
@@ -411,7 +411,7 @@ theorem factorLatticeFactorsWithPlan_factor_irreducible
   unfold Hex.factorLatticeFactorsWithPlan at hresult
   by_cases hdegree :
       (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 = 0
-  · rw [if_pos hdegree] at hresult
+  · rw [ite_eq_left hdegree] at hresult
     obtain rfl := Option.some.inj hresult
     have hcomplete :=
       Hex.reassemblyExpansionComplete_constant_of_ne_zero f hf hdegree
@@ -428,11 +428,11 @@ theorem factorLatticeFactorsWithPlan_factor_irreducible
       rw [hraw_one, Hex.normalizeFactorSign_one,
         Hex.shouldRecordPolynomialFactor_one] at hrecord
       exact absurd hrecord (by decide)
-  · rw [if_neg hdegree] at hresult
+  · rw [ite_eq_right hdegree] at hresult
     by_cases hcap : Hex.latticePrecisionCap f = 0
-    · rw [if_pos hcap] at hresult
+    · rw [ite_eq_left hcap] at hresult
       exact absurd hresult.symm (Option.some_ne_none factors)
-    · rw [if_neg hcap] at hresult
+    · rw [ite_eq_right hcap] at hresult
       cases hquadratic :
           Hex.quadraticIntegerRootFactors?
             (Hex.normalizeForFactor f).squareFreeCore with
@@ -499,7 +499,7 @@ theorem factorLatticeFactorsWithBound_factor_irreducible
   rw [Hex.factorLatticeFactorsWithBound] at hresult
   by_cases hdegree :
       (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 = 0
-  · rw [if_pos hdegree] at hresult
+  · rw [ite_eq_left hdegree] at hresult
     obtain rfl := Option.some.inj hresult
     have hcomplete :=
       Hex.reassemblyExpansionComplete_constant_of_ne_zero f hf hdegree
@@ -516,11 +516,11 @@ theorem factorLatticeFactorsWithBound_factor_irreducible
       rw [hraw_one, Hex.normalizeFactorSign_one,
         Hex.shouldRecordPolynomialFactor_one] at hrecord
       exact absurd hrecord (by decide)
-  · rw [if_neg hdegree] at hresult
+  · rw [ite_eq_right hdegree] at hresult
     by_cases hcap : Hex.latticePrecisionCap f = 0
-    · rw [if_pos hcap] at hresult
+    · rw [ite_eq_left hcap] at hresult
       exact absurd hresult.symm (Option.some_ne_none factors)
-    · rw [if_neg hcap] at hresult
+    · rw [ite_eq_right hcap] at hresult
       cases hquadratic :
           Hex.quadraticIntegerRootFactors?
             (Hex.normalizeForFactor f).squareFreeCore with

--- a/HexBerlekampZassenhausMathlib/LatticeFactorization.lean
+++ b/HexBerlekampZassenhausMathlib/LatticeFactorization.lean
@@ -42,7 +42,7 @@ theorem irreducible_of_directSingleton
     (hcore_prim : Hex.ZPoly.Primitive core)
     (hsmall : data.factorsModP.size ≤ 1) :
     Hex.ZPoly.Irreducible core := by
-  letI := data.bounds
+  let := data.bounds
   have hadm :
       Hex.leadingCoeffAdmissible core data.p :=
     Hex.isGoodPrime_leadingCoeffAdmissible core data.p

--- a/HexBerlekampZassenhausMathlib/LatticeTotality.lean
+++ b/HexBerlekampZassenhausMathlib/LatticeTotality.lean
@@ -36,9 +36,9 @@ theorem factorLatticeFactorsWithBound_ne_none_of_directPrimePlan
   · rw [Hex.factorLatticeFactorsWithBound]
     by_cases hdeg :
         (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 = 0
-    · rw [if_pos hdeg]
+    · rw [ite_eq_left hdeg]
       simp
-    · rw [if_neg hdeg]
+    · rw [ite_eq_right hdeg]
       have hB_ne : Hex.latticePrecisionCap f ≠ 0 := by
         have hcore_lc_pos :=
           Hex.squareFreeCore_leadingCoeff_pos_of_ne_zero f hf
@@ -50,7 +50,7 @@ theorem factorLatticeFactorsWithBound_ne_none_of_directPrimePlan
         have hbound_le :=
           Hex.defaultFactorCoeffBound_squareFreeCore_le_latticePrecisionCap f
         omega
-      rw [if_neg hB_ne]
+      rw [ite_eq_right hB_ne]
       cases hquad :
           Hex.quadraticIntegerRootFactors?
             (Hex.normalizeForFactor f).squareFreeCore with

--- a/HexBerlekampZassenhausMathlib/LiftedFactor.lean
+++ b/HexBerlekampZassenhausMathlib/LiftedFactor.lean
@@ -541,7 +541,7 @@ private theorem centeredLiftPoly_reduceModPow_eq
   rw [Hex.coeff_centeredLiftPoly, Hex.coeff_centeredLiftPoly,
     Hex.ZPoly.coeff_reduceModPow_eq_emod_of_pos _ _ _ _ hpkpos]
   unfold Hex.centeredModNat
-  rw [if_neg hpkne, if_neg hpkne, Int.emod_emod_of_dvd _ (dvd_refl _)]
+  rw [ite_eq_right hpkne, ite_eq_right hpkne, Int.emod_emod_of_dvd _ (dvd_refl _)]
 
 /-- Precision-conditional exact recovery for `liftedRecoveryCandidate` in the
 dilation-coordinate model. -/

--- a/HexBerlekampZassenhausMathlib/M1Recovery.lean
+++ b/HexBerlekampZassenhausMathlib/M1Recovery.lean
@@ -408,7 +408,7 @@ theorem leadingCoeffAdmissible_of_gcd_pow
     (hgcd : Int.gcd (Hex.DensePoly.leadingCoeff core)
       (Int.ofNat (p ^ k)) = 1) :
     Hex.leadingCoeffAdmissible core p := by
-  letI : Fact (_root_.Nat.Prime p) := ⟨natPrime_of_hexNatPrime hprime⟩
+  let : Fact (_root_.Nat.Prime p) := ⟨natPrime_of_hexNatPrime hprime⟩
   have hs_inv :
       (Hex.ZPoly.leadingCoeffInverse core p k *
           Hex.DensePoly.leadingCoeff core) %
@@ -475,7 +475,7 @@ theorem monicModularImage_modP_eq_modP_monicTarget
     (hgcd : Int.gcd (Hex.DensePoly.leadingCoeff core) (Int.ofNat (p ^ k)) = 1) :
     Hex.monicModularImage (Hex.ZPoly.modP p core) =
       Hex.ZPoly.modP p (Hex.ZPoly.monicTarget core p k) := by
-  haveI : Fact (_root_.Nat.Prime p) := ⟨natPrime_of_hexNatPrime hprime⟩
+  have : Fact (_root_.Nat.Prime p) := ⟨natPrime_of_hexNatPrime hprime⟩
   have hadm : Hex.leadingCoeffAdmissible core p :=
     leadingCoeffAdmissible_of_gcd_pow core p k hprime hpk hk hgcd
   have hsize : 0 < (Hex.ZPoly.modP p core).size := by

--- a/HexBerlekampZassenhausMathlib/M1Recovery.lean
+++ b/HexBerlekampZassenhausMathlib/M1Recovery.lean
@@ -694,7 +694,7 @@ theorem normalizeFactorSign_eq_self_of_leadingCoeff_nonneg (g : Hex.ZPoly)
     (h : 0 ≤ Hex.DensePoly.leadingCoeff g) :
     Hex.normalizeFactorSign g = g := by
   unfold Hex.normalizeFactorSign
-  rw [if_neg (by omega : ¬ Hex.DensePoly.leadingCoeff g < 0)]
+  rw [ite_eq_right (by omega : ¬ Hex.DensePoly.leadingCoeff g < 0)]
 
 
 /--

--- a/HexBerlekampZassenhausMathlib/ModPFactor.lean
+++ b/HexBerlekampZassenhausMathlib/ModPFactor.lean
@@ -65,7 +65,7 @@ theorem toMathlibPolynomial_modPFactorProduct
     HexBerlekampMathlib.toMathlibPolynomial (modPFactorProduct primeData S) =
       ∏ i ∈ S,
         HexBerlekampMathlib.toMathlibPolynomial (modPFactor primeData i) := by
-  letI := primeData.bounds
+  let := primeData.bounds
   unfold modPFactorProduct
   rw [show
       (S.toList.foldl (fun acc i => acc * modPFactor primeData i)
@@ -152,7 +152,7 @@ private theorem monicModularImage_dvd_self_of_isZero_false
     {p : Nat} [Hex.ZMod64.Bounds p] (hprime : Hex.Nat.Prime p)
     {f : Hex.FpPoly p} (hf : f.isZero = false) :
     Hex.monicModularImage f ∣ f := by
-  letI : Hex.ZMod64.PrimeModulus p := Hex.ZMod64.primeModulusOfPrime hprime
+  let : Hex.ZMod64.PrimeModulus p := Hex.ZMod64.primeModulusOfPrime hprime
   have hsize_pos : 0 < f.size :=
     (Hex.DensePoly.isZero_eq_false_iff _).mp hf
   have hlead_ne :
@@ -170,7 +170,7 @@ theorem monicModPImage_dvd_self_of_ne_zero
     {p : Nat} [Hex.ZMod64.Bounds p]
     (hprime : Hex.Nat.Prime p) {f : Hex.FpPoly p} (hf : f.isZero = false) :
     monicModPImage f ∣ f := by
-  letI : Hex.ZMod64.PrimeModulus p := Hex.ZMod64.primeModulusOfPrime hprime
+  let : Hex.ZMod64.PrimeModulus p := Hex.ZMod64.primeModulusOfPrime hprime
   unfold monicModPImage
   simp only [hf, Bool.false_eq_true, ↓reduceIte]
   have hf_ne : f ≠ 0 := by
@@ -303,8 +303,8 @@ theorem monicModPImage_dvd_monicModularImage_of_dvd_of_goodPrime
         (@Hex.ZPoly.modP primeData.p primeData.bounds factor) ∣
       Hex.monicModularImage
         (@Hex.ZPoly.modP primeData.p primeData.bounds core) := by
-  letI := primeData.bounds
-  letI : Hex.ZMod64.PrimeModulus primeData.p :=
+  let := primeData.bounds
+  let : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
   have hcore_iszero :
       (@Hex.ZPoly.modP primeData.p primeData.bounds core).isZero = false :=
@@ -494,8 +494,8 @@ theorem mem_modPSubset_of_dvd
           (@Hex.ZPoly.modP primeData.p primeData.bounds factor))) :
     i ∈ S := by
   classical
-  letI := primeData.bounds
-  haveI : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
+  let := primeData.bounds
+  have : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
   let F : ModPFactorIndex primeData → Polynomial (ZMod primeData.p) :=
     fun j => @HexBerlekampMathlib.toMathlibPolynomial primeData.p primeData.bounds
       (modPFactor primeData j)
@@ -561,7 +561,7 @@ leading-coefficient normalisation divides the unit scalar back out. -/
 theorem monicModPImage_scale {p : Nat} [Hex.ZMod64.Bounds p]
     (hprime : Hex.Nat.Prime p) {c : Hex.ZMod64 p} (hc : c ≠ 0) (f : Hex.FpPoly p) :
     monicModPImage (Hex.DensePoly.scale c f) = monicModPImage f := by
-  letI : Hex.ZMod64.PrimeModulus p := Hex.ZMod64.primeModulusOfPrime hprime
+  let : Hex.ZMod64.PrimeModulus p := Hex.ZMod64.primeModulusOfPrime hprime
   cases hf : f.isZero with
   | true =>
     have hf_size : f.size = 0 := by
@@ -633,7 +633,7 @@ private theorem modP_scale_neg_one {p : Nat} [Hex.ZMod64.Bounds p] (f : Hex.ZPol
 /-- `-1` is a nonzero residue modulo a prime. -/
 private theorem neg_one_ne_zero_zmod {p : Nat} [Hex.ZMod64.Bounds p]
     (hprime : Hex.Nat.Prime p) : (-1 : Hex.ZMod64 p) ≠ 0 := by
-  haveI : Fact (_root_.Nat.Prime p) := ⟨natPrime_of_hexNatPrime hprime⟩
+  have : Fact (_root_.Nat.Prime p) := ⟨natPrime_of_hexNatPrime hprime⟩
   intro h
   have hz : HexModArithMathlib.ZMod64.toZMod (-1 : Hex.ZMod64 p) =
       HexModArithMathlib.ZMod64.toZMod (0 : Hex.ZMod64 p) := by rw [h]
@@ -684,7 +684,7 @@ theorem representsIntegerFactorModP_of_associated
       Associated (HexPolyZMathlib.toPolynomial f) (HexPolyZMathlib.toPolynomial g))
     (hf : RepresentsIntegerFactorModP primeData f S) :
     RepresentsIntegerFactorModP primeData g S := by
-  letI := primeData.bounds
+  let := primeData.bounds
   unfold RepresentsIntegerFactorModP at hf ⊢
   rw [hf]
   exact monicModPImage_modP_eq_of_associated hprime hassoc
@@ -759,7 +759,7 @@ theorem modPFactorSubset_disjoint_of_not_associated
       ¬ Associated (HexPolyZMathlib.toPolynomial f) (HexPolyZMathlib.toPolynomial g)) :
     Disjoint S T := by
   classical
-  letI := primeData.bounds
+  let := primeData.bounds
   set p := primeData.p with hp_def
   -- `modP f`, `modP g` are nonzero because they divide the nonzero `modP core`.
   have hf_modP_nz : (Hex.ZPoly.modP p f).isZero = false :=

--- a/HexBerlekampZassenhausMathlib/ModPFactorization.lean
+++ b/HexBerlekampZassenhausMathlib/ModPFactorization.lean
@@ -182,11 +182,11 @@ theorem ModPFactorization.factorCount_le_degree_of_product
         (Array.polyProduct (data.factorsModP.map Hex.FpPoly.liftToZ))
         target data.p) :
     data.factorsModP.size ≤ target.degree?.getD 0 := by
-  letI := data.bounds
+  let := data.bounds
   have hp : 1 < data.p := h.prime.one_lt
-  haveI : Fact (_root_.Nat.Prime data.p) :=
+  have : Fact (_root_.Nat.Prime data.p) :=
     ⟨natPrime_of_hexNatPrime h.prime⟩
-  haveI : Nontrivial (ZMod data.p) := inferInstance
+  have : Nontrivial (ZMod data.p) := inferInstance
   let t : Multiset (Polynomial ℤ) :=
     (data.factorsModP.toList : Multiset (Hex.FpPoly data.p)).map
       (fun g => HexPolyZMathlib.toPolynomial (Hex.FpPoly.liftToZ g))

--- a/HexBerlekampZassenhausMathlib/ModPPartition.lean
+++ b/HexBerlekampZassenhausMathlib/ModPPartition.lean
@@ -282,7 +282,7 @@ theorem exists_factor_of_modPIndex
           @monicModPImage primeData.p primeData.bounds
               (@Hex.ZPoly.modP primeData.p primeData.bounds g) = 0 := by
         unfold monicModPImage
-        rw [if_pos hzero]
+        rw [ite_eq_left hzero]
       rw [hmonic_zero]
       have hz : HexBerlekampMathlib.toMathlibPolynomial
           (0 : Hex.FpPoly primeData.p) = 0 := by

--- a/HexBerlekampZassenhausMathlib/ModPPartition.lean
+++ b/HexBerlekampZassenhausMathlib/ModPPartition.lean
@@ -47,9 +47,9 @@ private lemma toMathlibPolynomial_factorsModP_product_eq_monicModularImage
       HexBerlekampMathlib.toMathlibPolynomial
         (Hex.monicModularImage
           (@Hex.ZPoly.modP primeData.p primeData.bounds core)) := by
-  letI := primeData.bounds
+  let := primeData.bounds
   have hprime : Hex.Nat.Prime primeData.p := hval.prime
-  letI : Hex.ZMod64.PrimeModulus primeData.p :=
+  let : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
   have hp : 1 < primeData.p := by have := hprime.two_le; omega
   -- Descend the bundle's `ℤ` congruence to an `FpPoly` product equality;
@@ -81,7 +81,7 @@ private lemma univ_val_map_modPFactor_eq_factorsModP_map
         HexBerlekampMathlib.toMathlibPolynomial (modPFactor primeData i)) =
       ((primeData.factorsModP.toList : Multiset _).map
         HexBerlekampMathlib.toMathlibPolynomial) := by
-  letI := primeData.bounds
+  let := primeData.bounds
   unfold modPFactor
   rw [Finset.val_univ_fin]
   rw [show (primeData.factorsModP.toList : List _) =
@@ -144,9 +144,9 @@ theorem exists_factor_of_modPIndex
         HexBerlekampMathlib.toMathlibPolynomial
           (monicModPImage (Hex.ZPoly.modP primeData.p g)) := by
   classical
-  letI := primeData.bounds
+  let := primeData.bounds
   have hprime : Hex.Nat.Prime primeData.p := hval.prime
-  letI : Hex.ZMod64.PrimeModulus primeData.p :=
+  let : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
   have hprime_root : _root_.Nat.Prime primeData.p := by
     refine _root_.Nat.prime_def_lt.mpr ⟨hprime.two_le, ?_⟩
@@ -154,7 +154,7 @@ theorem exists_factor_of_modPIndex
     rcases hprime.right m hmdvd with h | h
     · exact h
     · exact absurd h (Nat.ne_of_lt hmlt)
-  haveI : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime_root⟩
+  have : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime_root⟩
   have hgood : @Hex.isGoodPrime core primeData.p primeData.bounds = true :=
     hval.good
   have hcore_modP_iszero :
@@ -162,7 +162,7 @@ theorem exists_factor_of_modPIndex
     Hex.isGoodPrime_modP_isZero_false core primeData.p hgood
   let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
-  letI := hfield
+  let := hfield
   set f : ModPFactorIndex primeData → Polynomial (ZMod primeData.p) :=
       fun i => HexBerlekampMathlib.toMathlibPolynomial (modPFactor primeData i)
       with hf_def
@@ -318,9 +318,9 @@ theorem existsUnique_modPFactorSubset_of_choosePrimeData_of_some
     ∃! S : ModPFactorSubset primeData,
       RepresentsIntegerFactorModP primeData factor S := by
   classical
-  letI := primeData.bounds
+  let := primeData.bounds
   have hprime : Hex.Nat.Prime primeData.p := hval.prime
-  letI : Hex.ZMod64.PrimeModulus primeData.p :=
+  let : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
   have hprime_root : _root_.Nat.Prime primeData.p := by
     refine _root_.Nat.prime_def_lt.mpr ⟨hprime.two_le, ?_⟩
@@ -328,7 +328,7 @@ theorem existsUnique_modPFactorSubset_of_choosePrimeData_of_some
     rcases hprime.right m hmdvd with h | h
     · exact h
     · exact absurd h (Nat.ne_of_lt hmlt)
-  haveI : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime_root⟩
+  have : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime_root⟩
   have hgood : @Hex.isGoodPrime core primeData.p primeData.bounds = true :=
     hval.good
   have hzero : (@Hex.ZPoly.modP primeData.p primeData.bounds core).isZero = false :=
@@ -336,7 +336,7 @@ theorem existsUnique_modPFactorSubset_of_choosePrimeData_of_some
   have hnodup : primeData.factorsModP.toList.Nodup := hval.nodup
   let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
-  letI := hfield
+  let := hfield
   -- Set up abbreviations.
   set f : ModPFactorIndex primeData → Polynomial (ZMod primeData.p) :=
       fun i => HexBerlekampMathlib.toMathlibPolynomial (modPFactor primeData i)
@@ -497,7 +497,7 @@ theorem existsUnique_modPFactorSubset_of_modPFactorization
     (hval : ModPFactorization core primeData) :
     ∃! S : ModPFactorSubset primeData,
       RepresentsIntegerFactorModP primeData factor S := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   -- `core ≠ 0` from `isGoodPrime` (which forces `(modP p core).isZero = false`).
   have hcore_ne : core ≠ 0 := by
     intro hcore_zero
@@ -561,7 +561,7 @@ theorem core_ne_zero_of_modPFactorization
     (core : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
     (hval : ModPFactorization core primeData) :
     core ≠ 0 := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   intro hcore_zero
   have hgood : @Hex.isGoodPrime core primeData.p primeData.bounds = true :=
     hval.good
@@ -584,7 +584,7 @@ theorem toMathlibPolynomial_modPFactor_injective_of_modPFactorization
     letI := primeData.bounds
     Function.Injective (fun i : ModPFactorIndex primeData =>
       HexBerlekampMathlib.toMathlibPolynomial (modPFactor primeData i)) := by
-  letI := primeData.bounds
+  let := primeData.bounds
   have hnodup : primeData.factorsModP.toList.Nodup := hval.nodup
   have hinjPoly : Function.Injective
       (HexBerlekampMathlib.toMathlibPolynomial : Hex.FpPoly primeData.p → _) :=
@@ -601,7 +601,7 @@ theorem toMathlibPolynomial_modPFactor_monic_of_modPFactorization
     letI := primeData.bounds
     ∀ i : ModPFactorIndex primeData,
       (HexBerlekampMathlib.toMathlibPolynomial (modPFactor primeData i)).Monic := by
-  letI := primeData.bounds
+  let := primeData.bounds
   have hmonic := hval.monic
   intro i
   exact HexBerlekampMathlib.toMathlibPolynomial_monic _ (hmonic _ (Array.getElem_mem _))
@@ -623,7 +623,7 @@ theorem modPFactor_index_cover
       g ∣ core ∧
       i ∈ S ∧
       RepresentsIntegerFactorModP primeData g S := by
-  letI := primeData.bounds
+  let := primeData.bounds
   have hcore_ne : core ≠ 0 := core_ne_zero_of_modPFactorization core primeData hval
   obtain ⟨g, hirr, hdvd, hfi_dvd⟩ :=
     exists_factor_of_modPIndex core hcore_ne hcore_pos primeData hval i

--- a/HexBerlekampZassenhausMathlib/Modular/FactorCoprimality.lean
+++ b/HexBerlekampZassenhausMathlib/Modular/FactorCoprimality.lean
@@ -236,11 +236,11 @@ theorem factorsModP_coprime_of_factorsModPBerlekampForm
     letI := primeData.bounds
     Hex.ZPoly.QuadraticMultifactorCoprimeSplits primeData.p
       primeData.factorsModP.toList := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   obtain ⟨hprime, hzero, heq⟩ := hform
   let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
-  letI : Hex.ZMod64.PrimeModulus primeData.p :=
+  let : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
   -- The modular image is square-free under `isGoodPrime`.
   have hsf_common :
@@ -361,11 +361,11 @@ theorem factorsModP_monic_of_factorsModPBerlekampForm
     (hform : Hex.factorsModPBerlekampForm core primeData) :
     letI := primeData.bounds
     ∀ g ∈ primeData.factorsModP, Hex.DensePoly.Monic g := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   obtain ⟨hprime, hzero, heq⟩ := hform
   let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
-  letI : Hex.ZMod64.PrimeModulus primeData.p :=
+  let : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
   have hmonicImage_monic :
       Hex.DensePoly.Monic (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core)) :=
@@ -589,7 +589,7 @@ theorem factors_irreducible_of_factorsModPBerlekampForm
       Irreducible
         (@HexBerlekampMathlib.toMathlibPolynomial primeData.p primeData.bounds
           (modPFactor primeData i)) := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   have hmonicImage_pos :
       0 < (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core)).degree?.getD 0 :=
     monicModularImage_modP_degree?_pos_of_factorsModPBerlekampForm
@@ -597,7 +597,7 @@ theorem factors_irreducible_of_factorsModPBerlekampForm
   obtain ⟨hprime, hzero, heq⟩ := hform
   let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
-  letI : Hex.ZMod64.PrimeModulus primeData.p :=
+  let : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
   have hprime_root : _root_.Nat.Prime primeData.p := by
     refine _root_.Nat.prime_def_lt.mpr ⟨hprime.two_le, ?_⟩
@@ -605,7 +605,7 @@ theorem factors_irreducible_of_factorsModPBerlekampForm
     rcases hprime.right m hmdvd with h | h
     · exact h
     · exact absurd h (Nat.ne_of_lt hmlt)
-  haveI : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime_root⟩
+  have : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime_root⟩
   have hsf_common :
       ∀ d : Hex.FpPoly primeData.p,
         d ∣ Hex.ZPoly.modP primeData.p core →
@@ -652,7 +652,7 @@ theorem factors_irreducible_of_factorsModPBerlekampForm
       Hex.DensePoly.Monic
         (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core)) :=
     Hex.monicModularImage_monic hprime (Hex.ZPoly.modP primeData.p core) hzero
-  letI := hfield
+  let := hfield
   have hraw_irr :
       ∀ g ∈ (@Hex.Berlekamp.berlekampFactor primeData.p primeData.bounds
           (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core))
@@ -752,7 +752,7 @@ theorem factors_irreducible_of_choosePrimeData_of_some
       Irreducible
         (@HexBerlekampMathlib.toMathlibPolynomial primeData.p primeData.bounds
           (modPFactor primeData i)) := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   have hform : Hex.factorsModPBerlekampForm core primeData := by
     obtain ⟨hzero, hfactors_eq⟩ :=
       Hex.choosePrimeData?_factorsModP_berlekamp_form core primeData hselected

--- a/HexBerlekampZassenhausMathlib/Modular/FactorCoprimality.lean
+++ b/HexBerlekampZassenhausMathlib/Modular/FactorCoprimality.lean
@@ -194,7 +194,7 @@ theorem quadraticMultifactorCoprimeSplits_of_factorProduct_no_squared
         | succ k =>
             have hcoeff_zero : rawGcd.coeff (k + 1) = (0 : Hex.ZMod64 p) :=
               Hex.DensePoly.coeff_eq_zero_of_size_le rawGcd (by omega)
-            rw [hcoeff_zero, if_neg (Nat.succ_ne_zero k)]
+            rw [hcoeff_zero, ite_eq_right (Nat.succ_ne_zero k)]
             exact hzero_mul
       rw [Hex.ZPoly.QuadraticMultifactorCoprimeSplits]
       exact ⟨hgcd _ _ hmodP_L hmodP_R, ihL hL_dvd_X, ihR hR_dvd_X⟩

--- a/HexBerlekampZassenhausMathlib/Modular/FactorProduct.lean
+++ b/HexBerlekampZassenhausMathlib/Modular/FactorProduct.lean
@@ -60,7 +60,7 @@ theorem henselLiftData_liftedFactor_modP_eq_modPFactor
         (liftedIndexOfModPIndex primeData (Hex.henselLiftData core B primeData)
           (henselLiftData_liftedFactors_size_eq core B primeData) i)) =
       modPFactor primeData i := by
-  letI := primeData.bounds
+  let := primeData.bounds
   set arr :=
     Hex.ZPoly.multifactorLiftQuadratic primeData.p B core
       (primeData.factorsModP.map Hex.FpPoly.liftToZ) with harr_def
@@ -170,11 +170,11 @@ theorem factorsModP_nodup_of_factorsModPBerlekampForm
       letI := data.bounds
       Hex.isGoodPrime f data.p = true) :
     data.factorsModP.toList.Nodup := by
-  letI : Hex.ZMod64.Bounds data.p := data.bounds
+  let : Hex.ZMod64.Bounds data.p := data.bounds
   obtain ⟨hprime, hzero, heq⟩ := hform
   let hfield : Hex.ZMod64.PrimeModulus data.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
-  letI : Hex.ZMod64.PrimeModulus data.p := Hex.ZMod64.primeModulusOfPrime hprime
+  let : Hex.ZMod64.PrimeModulus data.p := Hex.ZMod64.primeModulusOfPrime hprime
   -- Square-free precondition on the modular image, extracted from `isGoodPrime`.
   have hsf_common :
       ∀ d : Hex.FpPoly data.p,
@@ -395,9 +395,9 @@ theorem monicModularImage_modP_degree?_pos_of_factorsModPBerlekampForm
     (hf_pos : 0 < f.degree?.getD 0) :
     letI := data.bounds
     0 < (Hex.monicModularImage (Hex.ZPoly.modP data.p f)).degree?.getD 0 := by
-  letI : Hex.ZMod64.Bounds data.p := data.bounds
+  let : Hex.ZMod64.Bounds data.p := data.bounds
   obtain ⟨hprime, hzero, heq⟩ := hform
-  letI : Hex.ZMod64.PrimeModulus data.p := Hex.ZMod64.primeModulusOfPrime hprime
+  let : Hex.ZMod64.PrimeModulus data.p := Hex.ZMod64.primeModulusOfPrime hprime
   have hfsize_ge_two : 2 ≤ f.size := by
     unfold Hex.DensePoly.degree? at hf_pos
     by_cases hfs0 : f.size = 0
@@ -481,7 +481,7 @@ theorem factorsModP_natDegree_pos_of_factorsModPBerlekampForm
     letI := data.bounds
     ∀ g ∈ data.factorsModP,
       0 < (HexPolyZMathlib.toPolynomial (Hex.FpPoly.liftToZ g)).natDegree := by
-  letI : Hex.ZMod64.Bounds data.p := data.bounds
+  let : Hex.ZMod64.Bounds data.p := data.bounds
   -- Step A: 0 < (monicModularImage (modP data.p f)).degree?.getD 0
   have hmonicImage_pos :
       0 < (Hex.monicModularImage (Hex.ZPoly.modP data.p f)).degree?.getD 0 :=
@@ -489,7 +489,7 @@ theorem factorsModP_natDegree_pos_of_factorsModPBerlekampForm
   obtain ⟨hprime, hzero, heq⟩ := hform
   let hfield : Hex.ZMod64.PrimeModulus data.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
-  letI : Hex.ZMod64.PrimeModulus data.p := Hex.ZMod64.primeModulusOfPrime hprime
+  let : Hex.ZMod64.PrimeModulus data.p := Hex.ZMod64.primeModulusOfPrime hprime
   -- Step B: positivity for every entry in the Berlekamp factor list.
   have hFactorsPos :
       ∀ h ∈ (@Hex.Berlekamp.berlekampFactor data.p data.bounds
@@ -742,11 +742,11 @@ theorem factorsModP_polyProduct_congr_of_factorsModPBerlekampForm_of_primitive_p
       (Hex.FpPoly.liftToZ
         (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core)))
       primeData.p := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   obtain ⟨hprime, hzero, heq⟩ := hform
   let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
-  letI : Hex.ZMod64.PrimeModulus primeData.p :=
+  let : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
   -- `monicModularImage (modP p core)` is monic.
   have hmonicImage_monic :
@@ -821,11 +821,11 @@ theorem factorsModP_polyProduct_congr_of_factorsModPBerlekampForm
     Hex.ZPoly.congr
       (Array.polyProduct (primeData.factorsModP.map Hex.FpPoly.liftToZ))
       core primeData.p := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   obtain ⟨hprime, hzero, heq⟩ := hform
   let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
-  letI : Hex.ZMod64.PrimeModulus primeData.p :=
+  let : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
   have hp : 1 < primeData.p := by have := hprime.two_le; omega
   -- `monicModularImage (modP p core) = modP p core` (because `core` is monic).
@@ -864,7 +864,7 @@ theorem factorsModP_ne_nil_of_factorsModPBerlekampForm
     (core : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
     (hform : Hex.factorsModPBerlekampForm core primeData) :
     primeData.factorsModP.toList ≠ [] := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   obtain ⟨hprime, hzero, heq⟩ := hform
   let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime

--- a/HexBerlekampZassenhausMathlib/Modular/PrimePlan.lean
+++ b/HexBerlekampZassenhausMathlib/Modular/PrimePlan.lean
@@ -178,7 +178,7 @@ private theorem map_natDegree_factorsModP
     data.factorsModP.toList.map
         (fun g => (HexBerlekampMathlib.toMathlibPolynomial g).natDegree) =
       (Hex.directFactorDegrees data).toList := by
-  letI := data.bounds
+  let := data.bounds
   simp only [Hex.directFactorDegrees, Array.toList_map]
   refine List.map_congr_left ?_
   intro g _
@@ -199,9 +199,9 @@ theorem exists_subMultiset_directFactorDegrees_of_dvd
     {c : Hex.ZPoly} (hdvd : c ∣ core) :
     ∃ S ≤ ((Hex.directFactorDegrees data).toList : Multiset Nat),
       S.sum = c.degree?.getD 0 := by
-  letI := data.bounds
-  haveI : Fact (_root_.Nat.Prime data.p) := ⟨natPrime_of_hexNatPrime hval.prime⟩
-  letI : Hex.ZMod64.PrimeModulus data.p :=
+  let := data.bounds
+  have : Fact (_root_.Nat.Prime data.p) := ⟨natPrime_of_hexNatPrime hval.prime⟩
+  let : Hex.ZMod64.PrimeModulus data.p :=
     Hex.ZMod64.primeModulusOfPrime hval.prime
   have hcore_modP_nz :
       (@Hex.ZPoly.modP data.p data.bounds core).isZero = false :=

--- a/HexBerlekampZassenhausMathlib/ModularPolynomial.lean
+++ b/HexBerlekampZassenhausMathlib/ModularPolynomial.lean
@@ -122,7 +122,7 @@ theorem toMathlibPolynomial_factorProduct (primeData : Hex.PrimeFactorData) :
     HexBerlekampMathlib.toMathlibPolynomial primeData.factorProduct =
       (primeData.factorPolys.toList.map
         HexBerlekampMathlib.toMathlibPolynomial).prod := by
-  letI := primeData.bounds
+  let := primeData.bounds
   show HexBerlekampMathlib.toMathlibPolynomial
       (primeData.factorPolys.foldl (· * ·) 1) = _
   rw [← Array.foldl_toList]
@@ -153,7 +153,7 @@ theorem toMathlibPolynomial_factorProduct_eq_map_intCast_zmod
     HexBerlekampMathlib.toMathlibPolynomial primeData.factorProduct =
       (HexPolyZMathlib.toPolynomial f).map
         (Int.castRingHom (ZMod primeData.p)) := by
-  letI := primeData.bounds
+  let := primeData.bounds
   have hprod : primeData.factorProduct = Hex.ZPoly.modP primeData.p f := by
     simp [Hex.PrimeFactorData.checkForPolynomial] at hcheck
     exact hcheck.1.2
@@ -179,7 +179,7 @@ theorem map_intCast_zmod_toPolynomial_eq_factorPolys_product
         (Int.castRingHom (ZMod primeData.p)) =
       (primeData.factorPolys.toList.map
         HexBerlekampMathlib.toMathlibPolynomial).prod := by
-  letI := primeData.bounds
+  let := primeData.bounds
   rw [← toMathlibPolynomial_factorProduct_eq_map_intCast_zmod f primeData hcheck]
   exact toMathlibPolynomial_factorProduct primeData
 

--- a/HexBerlekampZassenhausMathlib/Multiquadratic.lean
+++ b/HexBerlekampZassenhausMathlib/Multiquadratic.lean
@@ -87,7 +87,7 @@ theorem rootSet_X_pow_two_sub_C (d : ℤ) :
     (X ^ 2 - C ((d : ℤ) : ℚ)).rootSet ℂ = {x : ℂ | x ^ 2 = (d : ℂ)} := by
   have hne : (X ^ 2 - C ((d : ℤ) : ℚ) : ℚ[X]) ≠ 0 := (monic_X_pow_sub_C _ two_ne_zero).ne_zero
   ext x
-  rw [Polynomial.mem_rootSet, Set.mem_setOf_eq]
+  rw [Polynomial.mem_rootSet, Set.mem_ofPred_eq]
   simp only [map_sub, map_pow, aeval_X, aeval_C, sub_eq_zero]
   constructor
   · rintro ⟨-, h⟩
@@ -368,7 +368,7 @@ theorem eq_one_of_gen_fixed (h : Independent ds) (hr : ∀ i, r i ^ 2 = ((ds[i] 
       intro i
       by_cases hei : signOf hr σ i = true
       · simp [ha, hei]
-      · simp only [ha, hei, Bool.false_eq_true, if_false]
+      · simp only [ha, hei, Bool.false_eq_true, ite_false]
         push_cast
         ring
     rw [Finset.sum_congr rfl fun i _ => hterm i, Finset.sum_sub_distrib, ← hsum, sub_self]
@@ -378,7 +378,7 @@ theorem eq_one_of_gen_fixed (h : Independent ds) (hr : ∀ i, r i ^ 2 = ((ds[i] 
     simpa using hval
   have hai := eq_zero_of_sum_eq_zero h hr hzero i
   have hei : signOf hr σ i = true := by by_contra hc; simp [ha, hc] at hai
-  rw [he i, hei, if_pos rfl]
+  rw [he i, hei, ite_eq_left rfl]
 
 end Roots
 

--- a/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
+++ b/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
@@ -105,7 +105,7 @@ theorem supportPartitionByMinColumn_length_eq_ncard_of_partition {r : Nat}
   have hF_mem : ∀ rep ∈ L, F rep ∈ trueSupports := by
     intro rep hrep
     have hlt : rep < r := supportRepresentativeColumns_lt trueSupports (hL ▸ hrep)
-    simp only [F, dif_pos hlt]
+    simp only [F, dite_eq_left hlt]
     exact partOf_mem trueSupports hcover _
   -- Bijection between the representative finset and the parts.
   have hbij : Set.BijOn F (↑L.toFinset) trueSupports := by
@@ -119,7 +119,7 @@ theorem supportPartitionByMinColumn_length_eq_ncard_of_partition {r : Nat}
       rw [Finset.mem_coe, List.mem_toFinset] at hrep1 hrep2
       have hlt1 : rep1 < r := supportRepresentativeColumns_lt trueSupports (hL ▸ hrep1)
       have hlt2 : rep2 < r := supportRepresentativeColumns_lt trueSupports (hL ▸ hrep2)
-      simp only [F, dif_pos hlt1, dif_pos hlt2] at hFeq
+      simp only [F, dite_eq_left hlt1, dite_eq_left hlt2] at hFeq
       have hequiv : supportEquivalent trueSupports ⟨rep1, hlt1⟩ ⟨rep2, hlt2⟩ :=
         hpart_equiv hFeq
       have hequivAt : supportEquivalentAt trueSupports rep1 rep2 :=
@@ -168,7 +168,7 @@ theorem supportPartitionByMinColumn_length_eq_ncard_of_partition {r : Nat}
         (supportEquivalentAt_iff trueSupports hm_lt i.isLt).mp
           (by simpa using hm_equiv_i)
       have hmS : (⟨m, hm_lt⟩ : Fin r) ∈ S := (hmi S hS).mpr hi
-      simp only [F, dif_pos hm_lt]
+      simp only [F, dite_eq_left hm_lt]
       exact partOf_eq_of_mem trueSupports hcover hdisj hS hmS
   -- Conclude via the bijection.
   have hncard : trueSupports.ncard = L.length := by

--- a/HexBerlekampZassenhausMathlib/RecombinationCandidate.lean
+++ b/HexBerlekampZassenhausMathlib/RecombinationCandidate.lean
@@ -161,7 +161,7 @@ theorem subsetsOfSizeWithComplement_liftedFactors_exists_subset
   classical
   have hpos : 0 < d.liftedFactors.size := by
     rw [← Array.length_toList, hloc]; simp
-  haveI : Nonempty (LiftedFactorIndex d) := ⟨⟨0, hpos⟩⟩
+  have : Nonempty (LiftedFactorIndex d) := ⟨⟨0, hpos⟩⟩
   have hne : (Finset.univ : LiftedFactorSubset d).Nonempty := Finset.univ_nonempty
   -- A Boolean mask over the tail, from the `subsetSplits` enumeration.
   have hsplit : (sc_sel, sc_rest) ∈ Hex.subsetSplits tail :=

--- a/HexBerlekampZassenhausMathlib/RecombinationSplit.lean
+++ b/HexBerlekampZassenhausMathlib/RecombinationSplit.lean
@@ -100,7 +100,7 @@ private theorem subsetSplits_zip_filterMap_partition :
           rw [List.zip_cons_cons, List.filterMap_cons, List.filterMap_cons]
           by_cases hb : b = true
           · subst hb
-            simp only [if_true]
+            simp only [ite_true]
             exact Hex.subsetSplits_cons_left_mem (ih bs hmask)
           · have hb' : b = false := by cases b <;> simp_all
             subst hb'
@@ -154,7 +154,7 @@ private theorem subsetSplitsWithFirst_zip_filterMap_partition
       ((x :: xs).zip (true :: bs)).filterMap (fun p => if p.2 then none else some p.1)) ∈
       Hex.subsetSplitsWithFirst (x :: xs) := by
   rw [List.zip_cons_cons, List.filterMap_cons, List.filterMap_cons]
-  simp only [if_true]
+  simp only [ite_true]
   exact Hex.subsetSplitsWithFirst_mem_cons (subsetSplits_zip_filterMap_partition xs bs h)
 
 /-- Converse at the `subsetSplitsWithFirst` surface: every split comes from a
@@ -569,7 +569,7 @@ private theorem List.nodup_filter_mem_toFinset_zip_filterMap_selected
                 have ha_xs : a ∈ xs := (List.of_mem_zip hp_mem).1
                 cases b' with
                 | true =>
-                    simp only [if_true, Option.some.injEq] at hp_eq
+                    simp only [ite_true, Option.some.injEq] at hp_eq
                     rw [← hp_eq] at hx_notin
                     exact hx_notin ha_xs
                 | false => simp at hp_eq
@@ -630,7 +630,7 @@ private theorem List.nodup_filter_not_mem_toFinset_zip_filterMap_rest
                 have ha_xs : a ∈ xs := (List.of_mem_zip hp_mem).1
                 cases b' with
                 | true =>
-                    simp only [if_true, Option.some.injEq] at hp_eq
+                    simp only [ite_true, Option.some.injEq] at hp_eq
                     rw [← hp_eq] at hx_notin
                     exact hx_notin ha_xs
                 | false => simp at hp_eq
@@ -703,7 +703,7 @@ theorem liftedSubsetSelectedList_eq_mask_partition_of_matches
     obtain ⟨⟨a, b⟩, hp_mem, hp_eq⟩ := hx
     have ha_ys : a ∈ ys := (List.of_mem_zip hp_mem).1
     cases b with
-    | true => simp only [if_true, Option.some.injEq] at hp_eq; rw [← hp_eq]; exact ha_ys
+    | true => simp only [ite_true, Option.some.injEq] at hp_eq; rw [← hp_eq]; exact ha_ys
     | false => simp at hp_eq
   -- T ⊆ J.
   have hTJ : T ⊆ J := by

--- a/HexBerlekampZassenhausMathlib/Recovery.lean
+++ b/HexBerlekampZassenhausMathlib/Recovery.lean
@@ -391,14 +391,14 @@ theorem bhksIndicatorSelectedFactorsArray_classIndicatorArray_toList
         · have hone : indicator.getD i 0 = 1 := by
             simpa [indicator] using
               classIndicatorArray_has_one_of_mem liftedFactors.size members hi himem
-          rw [if_pos (by simp [hone]), ih _ htail]
+          rw [ite_eq_left (by simp [hone]), ih _ htail]
           simp [himem, Array.toList_push, List.append_assoc]
         · have hzero : indicator.getD i 0 = 0 := by
             change
               (classIndicatorArray liftedFactors.size members).getD i 0 = 0
             rw [classIndicatorArray_getD]
             simp [hi, himem]
-          rw [if_neg (by simp [hzero]), ih _ htail]
+          rw [ite_eq_right (by simp [hzero]), ih _ htail]
           simp [himem]
   unfold Hex.bhksIndicatorSelectedFactorsArray
   simpa [indicator] using

--- a/HexBerlekampZassenhausMathlib/Resultant.lean
+++ b/HexBerlekampZassenhausMathlib/Resultant.lean
@@ -969,12 +969,12 @@ private lemma prod_threshold {R : Type*} [CommRing R] (C : R) {n d : Nat}
     intro i _
     have := i.is_lt
     simp only [Fin.val_cast, Fin.val_castAdd]
-    exact if_neg (by omega)
+    exact ite_eq_right (by omega)
   have h2 : (∏ i : Fin d,
       (fun x : Fin ((n - d) + d) => if n - d ≤ ((Fin.cast hn x : Fin n) : ℕ) then C else (1 : R))
         (Fin.natAdd (n - d) i)) = C ^ d := by
     rw [Finset.prod_congr rfl (fun i _ => by
-      simp only [Fin.val_cast, Fin.val_natAdd]; exact if_pos (by omega))]
+      simp only [Fin.val_cast, Fin.val_natAdd]; exact ite_eq_left (by omega))]
     exact Fin.prod_const d C
   rw [h1, h2, one_mul]
 
@@ -1020,11 +1020,11 @@ theorem colReduceTransform_blockTriangular {R : Type*} [CommRing R] (a b : Polyn
   induction j using Fin.addCases with
   | left j₁ =>
       simp only [Fin.addCases_left]
-      exact if_neg (fun h => by simp [h] at hlt)
+      exact ite_eq_right (fun h => by simp [h] at hlt)
   | right j₂ =>
       simp only [Fin.addCases_right, Fin.val_natAdd] at hlt ⊢
       by_cases hpiv : n - d ≤ (j₂ : ℕ)
-      · simp only [hpiv, if_true]
+      · simp only [hpiv, ite_true]
         induction i using Fin.addCases with
         | left i₁ =>
             simp only [Fin.val_castAdd] at hlt
@@ -1037,14 +1037,14 @@ theorem colReduceTransform_blockTriangular {R : Type*} [CommRing R] (a b : Polyn
             split_ifs with h
             · exact Polynomial.coeff_eq_zero_of_natDegree_lt hbz
             · rfl
-      · simp only [hpiv, if_false]
-        exact if_neg (fun h => by simp [h] at hlt)
+      · simp only [hpiv, ite_false]
+        exact ite_eq_right (fun h => by simp [h] at hlt)
 
 /-- The determinant of `colReduceTransform` is `(b.coeff (n - d)) ^ d`. -/
 theorem colReduceTransform_det {R : Type*} [CommRing R] (a b : Polynomial R)
     {m n d : Nat} (hd : d ≤ n) (hb : b.natDegree + d ≤ n) :
     (colReduceTransform a b m n d).det = (b.coeff (n - d)) ^ d := by
-  rw [Matrix.det_of_upperTriangular (colReduceTransform_blockTriangular a b hd hb),
+  rw [Matrix.det_of_isUpperTriangular (colReduceTransform_blockTriangular a b hd hb),
     Fin.prod_univ_add]
   have hleft : (∏ i₁ : Fin m,
       colReduceTransform a b m n d (i₁.castAdd n) (i₁.castAdd n)) = 1 := by
@@ -1058,8 +1058,8 @@ theorem colReduceTransform_det {R : Type*} [CommRing R] (a b : Polynomial R)
     intro i₂ _
     rw [colReduceTransform, Matrix.of_apply, Fin.addCases_right]
     by_cases hpiv : n - d ≤ (i₂ : ℕ)
-    · simp only [hpiv, if_true, Fin.addCases_right]
-      rw [Polynomial.coeff_mul_X_pow', if_pos (by omega)]
+    · simp only [hpiv, ite_true, Fin.addCases_right]
+      rw [Polynomial.coeff_mul_X_pow', ite_eq_left (by omega)]
       congr 1
       omega
     · simp [hpiv]
@@ -1077,7 +1077,7 @@ theorem colReduceTransform_pivot_col {R : Type*} [CommRing R] (a b : Polynomial 
           (⟨-a * Polynomial.X ^ t, hl⟩, ⟨b * Polynomial.X ^ t, hr⟩) := by
   funext k
   rw [colReduceTransform, Matrix.of_apply, Fin.addCases_right]
-  rw [if_pos (Nat.le_add_right (n - d) t)]
+  rw [ite_eq_left (Nat.le_add_right (n - d) t)]
   have hexp : n - d + t - (n - d) = t := by omega
   rw [hexp]
   induction k using Fin.addCases with
@@ -1502,15 +1502,15 @@ theorem cldColReduceTransform_det {R : Type*} [CommRing R] (q : Polynomial R)
             rw [finSumFinEquiv_symm_apply_castAdd, Matrix.fromBlocks_apply₁₁, hTLL,
               Matrix.of_apply]
             by_cases hpiv : d ≤ (j₁ : ℕ) ∧ (j₁ : ℕ) < 2 * d
-            · simp only [if_pos hpiv, Fin.addCases_left]
-            · simp only [if_neg hpiv, Fin.ext_iff, Fin.val_castAdd]
+            · simp only [ite_eq_left hpiv, Fin.addCases_left]
+            · simp only [ite_eq_right hpiv, Fin.ext_iff, Fin.val_castAdd]
         | right i₂ =>
             rw [finSumFinEquiv_symm_apply_natAdd, Matrix.fromBlocks_apply₂₁, hTRL,
               Matrix.of_apply]
             by_cases hpiv : d ≤ (j₁ : ℕ) ∧ (j₁ : ℕ) < 2 * d
-            · simp only [if_pos hpiv, Fin.addCases_right]
-            · simp only [if_neg hpiv]
-              refine if_neg (fun h => ?_)
+            · simp only [ite_eq_left hpiv, Fin.addCases_right]
+            · simp only [ite_eq_right hpiv]
+              refine ite_eq_right (fun h => ?_)
               have := j₁.is_lt
               simp only [Fin.ext_iff, Fin.val_natAdd, Fin.val_castAdd] at h
               omega
@@ -1521,7 +1521,7 @@ theorem cldColReduceTransform_det {R : Type*} [CommRing R] (q : Polynomial R)
         | left i₁ =>
             rw [finSumFinEquiv_symm_apply_castAdd, Matrix.fromBlocks_apply₁₂,
               Matrix.zero_apply]
-            refine if_neg (fun h => ?_)
+            refine ite_eq_right (fun h => ?_)
             have := i₁.is_lt
             simp only [Fin.ext_iff, Fin.val_castAdd, Fin.val_natAdd] at h
             omega
@@ -1536,19 +1536,19 @@ theorem cldColReduceTransform_det {R : Type*} [CommRing R] (q : Polynomial R)
     simp only [id_eq, Fin.lt_def] at hlt
     rw [hTLL, Matrix.of_apply]
     by_cases hpiv : d ≤ (j₁ : ℕ) ∧ (j₁ : ℕ) < 2 * d
-    · rw [if_pos hpiv, Polynomial.coeff_mul_X_pow']
+    · rw [ite_eq_left hpiv, Polynomial.coeff_mul_X_pow']
       split_ifs with hk
       · apply Polynomial.coeff_eq_zero_of_natDegree_lt
         rw [hq_deg]; omega
       · rfl
-    · rw [if_neg hpiv]
-      exact if_neg (fun h => by rw [h] at hlt; exact lt_irrefl _ hlt)
-  rw [Matrix.det_of_upperTriangular htri]
+    · rw [ite_eq_right hpiv]
+      exact ite_eq_right (fun h => by rw [h] at hlt; exact lt_irrefl _ hlt)
+  rw [Matrix.det_of_isUpperTriangular htri]
   apply Finset.prod_eq_one
   intro i₁ _
   rw [hTLL, Matrix.of_apply]
   by_cases hpiv : d ≤ (i₁ : ℕ) ∧ (i₁ : ℕ) < 2 * d
-  · rw [if_pos hpiv, Polynomial.coeff_mul_X_pow', if_pos (Nat.sub_le _ _)]
+  · rw [ite_eq_left hpiv, Polynomial.coeff_mul_X_pow', ite_eq_left (Nat.sub_le _ _)]
     have hidx : (i₁ : ℕ) - ((i₁ : ℕ) - d) = d := by omega
     rw [hidx, ← hq_deg]
     exact hq_monic.coeff_natDegree
@@ -1567,7 +1567,7 @@ theorem cldColReduceTransform_pivot_col {R : Type*} [CommRing R] (q : Polynomial
            ⟨-Polynomial.derivative q * Polynomial.X ^ t, hr⟩) := by
   funext k
   rw [cldColReduceTransform, Matrix.of_apply, Fin.addCases_left]
-  rw [if_pos ⟨Nat.le_add_right d t, show d + t < 2 * d by omega⟩]
+  rw [ite_eq_left ⟨Nat.le_add_right d t, show d + t < 2 * d by omega⟩]
   have hexp : d + t - d = t := by omega
   rw [hexp]
   induction k using Fin.addCases with

--- a/HexBerlekampZassenhausMathlib/Resultant.lean
+++ b/HexBerlekampZassenhausMathlib/Resultant.lean
@@ -42,7 +42,7 @@ theorem abs_det_le_row_l2norm_prod
   let o := b.toBasis.orientation
   let rows : Fin N → EuclideanSpace ℝ (Fin N) :=
     fun i => WithLp.toLp 2 (fun j => (A i j : ℝ))
-  haveI : Fact (Module.finrank ℝ (EuclideanSpace ℝ (Fin N)) = N) := ⟨by simp⟩
+  have : Fact (Module.finrank ℝ (EuclideanSpace ℝ (Fin N)) = N) := ⟨by simp⟩
   have hvol : |o.volumeForm rows| ≤ ∏ i : Fin N, ‖rows i‖ :=
     o.abs_volumeForm_apply_le rows
   have hrob : |o.volumeForm rows| = |b.toBasis.det rows| :=
@@ -1382,7 +1382,7 @@ theorem pow_dvd_resultant_of_map_dvd_left_coprime
   by_cases hdg : d ≤ g.natDegree
   · exact pow_dvd_resultant_of_map_dvd hq_monic hq_deg hf_ne hf_lc_coprime hdf hdg
       hf_dvd hg_dvd
-  · letI : Fact (1 < p ^ k) := ⟨hmod⟩
+  · let : Fact (1 < p ^ k) := ⟨hmod⟩
     let φ := Int.castRingHom (ZMod (p ^ k))
     have hgmap : g.map φ = 0 := by
       by_contra hgmap_ne

--- a/HexBerlekampZassenhausMathlib/SignatureClasses.lean
+++ b/HexBerlekampZassenhausMathlib/SignatureClasses.lean
@@ -285,7 +285,7 @@ theorem representativeColumns_decompose_at
       rw [List.mem_range] at hmem
       exact (hk₀_fresh k hmem) (by simpa using hsig)
     rw [List.filter_cons]
-    rw [if_pos (by simpa using hk₀_pred)]
+    rw [ite_eq_left (by simpa using hk₀_pred)]
   · intro rep hrep
     rw [List.mem_filter] at hrep
     rcases hrep with ⟨hmem, hpred⟩
@@ -423,7 +423,7 @@ private theorem partitionAcc_succ_of_match
       (sig m, (List.range m).filter (fun j => sig j = sig k₀) ++ [m]) := by
     show (sig k₀, (List.range (m + 1)).filter (fun j => sig j = sig k₀)) =
          (sig m, (List.range m).filter (fun j => sig j = sig k₀) ++ [m])
-    rw [filter_range_succ_sig_eq, if_pos hk₀_sig.symm, hk₀_sig]
+    rw [filter_range_succ_sig_eq, ite_eq_left hk₀_sig.symm, hk₀_sig]
   -- Each suffix entry: p' rep = p rep when sig m ≠ sig rep.
   have hsuffix_eq : suffix.map p' = suffix.map p := by
     apply List.map_congr_left

--- a/HexBerlekampZassenhausMathlib/SquareClass.lean
+++ b/HexBerlekampZassenhausMathlib/SquareClass.lean
@@ -273,7 +273,7 @@ theorem sqrtSet_nil : sqrtSet [] = ∅ := by simp [sqrtSet]
 theorem sqrtSet_cons (d : ℤ) (ds : List ℤ) :
     sqrtSet (d :: ds) = {x : ℂ | x ^ 2 = (d : ℂ)} ∪ sqrtSet ds := by
   ext x
-  simp only [sqrtSet, Set.mem_setOf_eq, Set.mem_union, List.mem_cons]
+  simp only [sqrtSet, Set.mem_ofPred_eq, Set.mem_union, List.mem_cons]
   constructor
   · rintro ⟨e, he | he, hx⟩
     · exact Or.inl (by rw [hx, he])

--- a/HexBerlekampZassenhausMathlib/SubsetCoprimality.lean
+++ b/HexBerlekampZassenhausMathlib/SubsetCoprimality.lean
@@ -80,7 +80,7 @@ theorem henselLiftData_liftedFactor_injective_of_choosePrimeData
     (hfactorsModP_nodup : primeData.factorsModP.toList.Nodup) :
     Function.Injective
       (liftedFactor (Hex.henselLiftData core B primeData)) := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   have hinv :
       Hex.ZPoly.QuadraticMultifactorLiftInvariant
         primeData.p B core
@@ -140,8 +140,8 @@ theorem henselLiftData_liftedFactor_natDegree_pos
     ∀ i : Fin (Hex.henselLiftData core B primeData).liftedFactors.size,
       0 < (HexPolyZMathlib.toPolynomial
             (liftedFactor (Hex.henselLiftData core B primeData) i)).natDegree := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
-  haveI : Fact (1 < primeData.p) := ⟨hp⟩
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  have : Fact (1 < primeData.p) := ⟨hp⟩
   intro i
   change 0 < (HexPolyZMathlib.toPolynomial
     (Hex.henselLiftData core B primeData).liftedFactors[i]).natDegree
@@ -310,7 +310,7 @@ theorem henselLiftData_liftedFactor_natDegree_pos_of_choosePrimeData
     ∀ i : Fin (Hex.henselLiftData core B primeData).liftedFactors.size,
       0 < (HexPolyZMathlib.toPolynomial
             (liftedFactor (Hex.henselLiftData core B primeData) i)).natDegree := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   have hinv :
       Hex.ZPoly.QuadraticMultifactorLiftInvariant
         primeData.p B core
@@ -404,7 +404,7 @@ theorem henselLiftData_liftedSubset_product_congr_mod_base
             (henselLiftData_liftedFactors_size_eq core B primeData) S))
         (Hex.FpPoly.liftToZ (modPFactorProduct primeData S))
         primeData.p := by
-  letI := primeData.bounds
+  let := primeData.bounds
   intro S
   let d := Hex.henselLiftData core B primeData
   let hsize := henselLiftData_liftedFactors_size_eq core B primeData
@@ -537,7 +537,7 @@ private theorem toPolynomial_liftedSubset_map_intCast_zmod_eq_toMathlibPolynomia
         (liftedFactorProduct d (liftedSubsetOfModPSubset primeData d hsize S))).map
           (Int.castRingHom (ZMod primeData.p)) =
       HexBerlekampMathlib.toMathlibPolynomial (modPFactorProduct primeData S) := by
-  letI := primeData.bounds
+  let := primeData.bounds
   intro d hsize
   have hcongr :=
     henselLiftData_liftedSubset_product_congr_mod_base core B primeData
@@ -560,7 +560,7 @@ private theorem modPFactor_ne_of_ne
     {i j : ModPFactorIndex primeData} (hij : i ≠ j) :
     letI := primeData.bounds
     modPFactor primeData i ≠ modPFactor primeData j := by
-  letI := primeData.bounds
+  let := primeData.bounds
   intro h
   apply hij
   have hi_list : i.val < primeData.factorsModP.toList.length := by
@@ -606,8 +606,8 @@ private theorem isCoprime_toMathlibPolynomial_modPFactor_of_ne
     IsCoprime
       (HexBerlekampMathlib.toMathlibPolynomial (modPFactor primeData i))
       (HexBerlekampMathlib.toMathlibPolynomial (modPFactor primeData j)) := by
-  letI := primeData.bounds
-  haveI : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
+  let := primeData.bounds
+  have : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
   have hi_monic_fp : Hex.DensePoly.Monic (modPFactor primeData i) :=
     hfactors_monic _ (Array.getElem_mem _)
   have hj_monic_fp : Hex.DensePoly.Monic (modPFactor primeData j) :=
@@ -688,9 +688,9 @@ theorem henselLiftData_liftedSubset_complement_isCoprime_mod_p
           (liftedFactorProduct d ((Finset.univ : LiftedFactorSubset d) \
             liftedSubsetOfModPSubset primeData d hsize S))).map
         (Int.castRingHom (ZMod primeData.p))) := by
-  letI := primeData.bounds
+  let := primeData.bounds
   intro d hsize
-  haveI : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
+  have : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
   -- Rewrite both lifted products via the modP identification with `toMathlibPolynomial`
   -- of `modPFactorProduct`. The complement requires the
   -- `liftedSubsetOfModPSubset_compl_eq` rewrite first.
@@ -820,7 +820,7 @@ theorem henselLiftData_liftedFactorProduct_univ_congr_core
         (Finset.univ : Finset
           (LiftedFactorIndex (Hex.henselLiftData core B primeData))))
       core (primeData.p ^ B) := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   rw [liftedFactorProduct_univ_eq_polyProduct_liftedFactors]
   change Hex.ZPoly.congr
     (Array.polyProduct
@@ -858,7 +858,7 @@ theorem henselLiftData_liftedFactorProduct_subset_complement_congr_core
         liftedFactorProduct (Hex.henselLiftData core B primeData)
           (Finset.univ \ S))
       core (primeData.p ^ B) := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   have hfull :=
     henselLiftData_liftedFactorProduct_univ_congr_core core B primeData
       hprime_invariant hp hB

--- a/HexBerlekampZassenhausMathlib/UFDPartition.lean
+++ b/HexBerlekampZassenhausMathlib/UFDPartition.lean
@@ -498,7 +498,7 @@ theorem normalizedFactors_le_map_normalize_of_dvd_prod_irreducibles
     have hunit : IsUnit g := isUnit_of_dvd_one hdvd
     rw [normalizedFactors_of_isUnit hunit]
     exact Multiset.zero_le _
-  · haveI : Nontrivial α := nontrivial_of_ne b 0 (hirr b hb).ne_zero
+  · have : Nontrivial α := nontrivial_of_ne b 0 (hirr b hb).ne_zero
     have hprod_ne : qs.prod ≠ 0 :=
       Multiset.prod_ne_zero fun hmem => (hirr 0 hmem).ne_zero rfl
     have hnorm_prod : normalizedFactors qs.prod = qs.map normalize :=
@@ -543,7 +543,7 @@ theorem existsUnique_subset_product_eq_of_dvd_of_squarefree_prod
     · rintro S ⟨hSle, _⟩
       exact Multiset.le_zero.mp hSle
   · -- factors ≠ ∅: pick `b ∈ factors` to derive `Nontrivial α`.
-    haveI : Nontrivial α := nontrivial_of_ne b 0 (hirr b hb).ne_zero
+    have : Nontrivial α := nontrivial_of_ne b 0 (hirr b hb).ne_zero
     have hprod_ne : factors.prod ≠ 0 :=
       Multiset.prod_ne_zero fun hmem => (hirr 0 hmem).ne_zero rfl
     have hd_ne : d ≠ 0 := by

--- a/HexBerlekampZassenhausMathlib/WordCld.lean
+++ b/HexBerlekampZassenhausMathlib/WordCld.lean
@@ -313,7 +313,7 @@ theorem cldQuotientModWord?_eq (f g : Hex.ZPoly) (p a : Nat)
     rw [ZPoly.coeff_reduceModPow, hmtoNat, hmeq, Int.ofNat_eq_natCast]
     exact ⟨Int.natCast_nonneg _, by exact_mod_cast intModNat_lt _ (p ^ a) (by omega)⟩
   · -- the cast equality: both quotients are `numerator /ₘ divisor` in `ZMod (p^a)[X]`
-    haveI : Fact (1 < (UInt64.ofNat mval).toNat) := ⟨by rw [hmtoNat]; exact hm1⟩
+    have : Fact (1 < (UInt64.ofNat mval).toNat) := ⟨by rw [hmtoNat]; exact hm1⟩
     have hmpa : (UInt64.ofNat mval).toNat = p ^ a := by rw [hmtoNat]; exact hmeq
     have hpapos : 0 < (UInt64.ofNat mval).toNat := by rw [hmtoNat]; omega
     -- `g` is monic in the various images

--- a/HexBerlekampZassenhausMathlib/WordCld.lean
+++ b/HexBerlekampZassenhausMathlib/WordCld.lean
@@ -213,10 +213,10 @@ theorem powLtWordAux_eq (p : Nat) : ∀ (n acc r : Nat),
       intro acc r h
       simp only [Hex.powLtWordAux] at h
       by_cases hlt : acc * p < UInt64.word
-      · rw [if_pos hlt] at h
+      · rw [_root_.ite_eq_left hlt] at h
         have := ih (acc * p) r h
         rw [this]; ring
-      · rw [if_neg hlt] at h; exact absurd h (by simp)
+      · rw [_root_.ite_eq_right hlt] at h; exact absurd h (by simp)
 
 /-- A successful `powLtWordAux` run stays below the word bound. -/
 theorem powLtWordAux_lt (p : Nat) : ∀ (n acc r : Nat),
@@ -231,8 +231,8 @@ theorem powLtWordAux_lt (p : Nat) : ∀ (n acc r : Nat),
       intro acc r _ h
       simp only [Hex.powLtWordAux] at h
       by_cases hlt : acc * p < UInt64.word
-      · rw [if_pos hlt] at h; exact ih (acc * p) r hlt h
-      · rw [if_neg hlt] at h; exact absurd h (by simp)
+      · rw [_root_.ite_eq_left hlt] at h; exact ih (acc * p) r hlt h
+      · rw [_root_.ite_eq_right hlt] at h; exact absurd h (by simp)
 
 /-- A successful `powLtWord?` guard certifies both the power value and the word
 bound. -/
@@ -278,7 +278,7 @@ theorem cldQuotientModWord?_eq (f g : Hex.ZPoly) (p a : Nat)
   have hmtoNat : (UInt64.ofNat mval).toNat = mval := by
     rw [UInt64.toNat_ofNat_mod_word]; exact Nat.mod_eq_of_lt hmlt
   rw [Hex.cldQuotientModWord?, hpow]
-  simp only [dif_pos hodd]
+  simp only [_root_.dite_eq_left hodd]
   set ctx := _root_.MontCtx.mk (UInt64.ofNat mval) hodd with hctx
   -- the kernel's fW, gW are `toWMap ctx f`, `toWMap ctx g`
   have hgW : Hex.DensePoly.ofCoeffs
@@ -327,8 +327,8 @@ theorem cldQuotientModWord?_eq (f g : Hex.ZPoly) (p a : Nat)
     have hgsize2 : 1 < g.size := by
       unfold Hex.DensePoly.degree? at hgdeg
       by_cases hs : g.size = 0
-      · rw [dif_pos hs] at hgdeg; simp at hgdeg
-      · rw [dif_neg hs] at hgdeg; simp only [Option.getD_some] at hgdeg; omega
+      · rw [_root_.dite_eq_left hs] at hgdeg; simp at hgdeg
+      · rw [_root_.dite_eq_right hs] at hgdeg; simp only [Option.getD_some] at hgdeg; omega
     have hgpos : 0 < g.size := by omega
     have hgleading : g.coeff (g.size - 1) = 1 := by
       rw [← Hex.DensePoly.leadingCoeff_eq_coeff_last g hgpos]; exact hg
@@ -358,7 +358,7 @@ theorem cldQuotientModWord?_eq (f g : Hex.ZPoly) (p a : Nat)
         coeff_toWMap, hgleading, htoW1]
     have hgWd : 0 < (toWMap ctx g).degree?.getD 0 := by
       unfold Hex.DensePoly.degree?
-      rw [dif_neg (by rw [hsz]; omega)]
+      rw [_root_.dite_eq_right (by rw [hsz]; omega)]
       simp only [Option.getD_some]; rw [hsz]; omega
     -- shared cancellation shape
     have hcancelZ : ∀ c : Int, c - c / g.leadingCoeff * g.leadingCoeff = 0 := by

--- a/HexCharPolyMathlib/Basic.lean
+++ b/HexCharPolyMathlib/Basic.lean
@@ -790,12 +790,12 @@ theorem equiv_charPoly {n : Nat} (A : Hex.Matrix R n n) :
       simpa using (show n + 1 ≤ k by omega)
     rw [hhex]
     by_cases hR : Nontrivial R
-    · letI : Nontrivial R := hR
+    · let : Nontrivial R := hR
       symm
       apply Polynomial.coeff_eq_zero_of_natDegree_lt
       rw [Matrix.charpoly_natDegree_eq_dim]
       simpa only [Fintype.card_fin] using Nat.lt_of_not_ge hk
-    · haveI : Subsingleton R := not_nontrivial_iff_subsingleton.mp hR
+    · have : Subsingleton R := not_nontrivial_iff_subsingleton.mp hR
       exact Subsingleton.elim _ _
 
 end HexCharPolyMathlib

--- a/HexCharPolyMathlib/Basic.lean
+++ b/HexCharPolyMathlib/Basic.lean
@@ -404,7 +404,7 @@ private theorem toeplitz_add_two {k : Nat} (t : Vector R (k + 2))
           apply Finset.sum_congr rfl
           intro l hl
           by_cases hle : l.val ≤ j.val + 2
-          · simp only [if_pos hle, f]
+          · simp only [ite_eq_left hle, f]
             rw [← Array.getElem_eq_getD (xs := t.toArray) (i := j.val + 2 - l.val)
               (h := by simp; omega) (fallback := (0 : R)),
               ← Array.getElem_eq_getD (xs := v.toArray) (i := l.val)
@@ -563,7 +563,7 @@ private theorem coeff_charpoly_border_one {k : Nat}
       simp only [Fintype.card_fin] at hB
       dsimp only [M] at hM
       rw [htrace] at hM
-      simp only [Nat.succ_ne_zero, if_false, Nat.succ_sub_one]
+      simp only [Nat.succ_ne_zero, ite_false, Nat.succ_sub_one]
       rw [show k + 1 - 1 = k by omega] at hB
       rw [show 1 + (k + 1) - 1 = k + 1 by omega] at hM
       rw [hB] at hM
@@ -662,7 +662,7 @@ private theorem berkowitzStep_correct {n k : Nat} (A : Hex.Matrix R n n)
           have hBtop : B.charpoly.coeff (k + 1) = 1 := by
             simpa using charpoly_coeff_card B
           rw [hBtop, mul_one, one_mul, hchar, coeff_charpoly_border_one]
-          simp only [Nat.succ_ne_zero, if_false, Nat.succ_sub_one]
+          simp only [Nat.succ_ne_zero, ite_false, Nat.succ_sub_one]
           dsimp only [M, a, r, c, B]
           have hone : (1 : Fin (k + 2)).val = 1 := rfl
           rw [hone, Nat.succ_sub_one]
@@ -730,9 +730,9 @@ private theorem berkowitzStep_correct {n k : Nat} (A : Hex.Matrix R n n)
         Hex.Matrix.getElem_berkowitzColumn_zero]
       dsimp only [a]
       by_cases hlast : j.val + 2 < k + 1
-      · rw [dif_pos hlast, hvTwo hlast, if_neg (by omega)]
+      · rw [dite_eq_left hlast, hvTwo hlast, ite_eq_right (by omega)]
         ring
-      · rw [dif_neg hlast, if_pos (by omega)]
+      · rw [dite_eq_right hlast, ite_eq_left (by omega)]
         ring
 
 private theorem berkowitzAux_correct {n : Nat} (A : Hex.Matrix R n n)

--- a/HexConway/Api.lean
+++ b/HexConway/Api.lean
@@ -1565,7 +1565,7 @@ private theorem ofCoeffs_degree_pos_of_back_ne_zero
   rw [show (DensePoly.ofCoeffs arr).degree? =
         if _h : (DensePoly.ofCoeffs arr).size = 0 then none
         else some ((DensePoly.ofCoeffs arr).size - 1) from rfl]
-  rw [dif_neg (by omega : (DensePoly.ofCoeffs arr).size ≠ 0)]
+  rw [dite_eq_right (by omega : (DensePoly.ofCoeffs arr).size ≠ 0)]
   simp only [Option.getD_some]
   omega
 

--- a/HexDeterminant/Adjugate.lean
+++ b/HexDeterminant/Adjugate.lean
@@ -160,9 +160,9 @@ theorem mul_adjugate_apply {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     rw [hrow, hcol, adjugate_get]
   by_cases hij : i = j
   · subst hij
-    rw [hentry, if_pos rfl]
+    rw [hentry, ite_eq_left rfl]
     exact (det_eq_foldl_laplace_row M i).symm
-  · rw [hentry, if_neg hij, ← Fin.foldl_eq_finRange_foldl]
+  · rw [hentry, ite_eq_right hij, ← Fin.foldl_eq_finRange_foldl]
     exact foldl_alien_cofactor_eq_zero M i j hij
 
 /-- The adjugate identity `M * adjugate M = det M • identity`. -/
@@ -173,8 +173,8 @@ theorem mul_adjugate {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
   intro i j
   rw [mul_adjugate_apply, Matrix.smul_getElem, getElem_identity]
   by_cases h : i = j
-  · rw [if_pos h, if_pos h]; show det M = det M * 1; grind
-  · rw [if_neg h, if_neg h]; show (0 : R) = det M * 0; grind
+  · rw [ite_eq_left h, ite_eq_left h]; show det M = det M * 1; grind
+  · rw [ite_eq_right h, ite_eq_right h]; show (0 : R) = det M * 0; grind
 
 /-- Entrywise version of `adjugate M * M = det M • 1`.
 
@@ -228,9 +228,9 @@ theorem adjugate_mul_apply {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
   by_cases hij : i = j
   · subst hij
     rfl
-  · rw [if_neg hij]
+  · rw [ite_eq_right hij]
     have hji : j ≠ i := fun h => hij h.symm
-    rw [if_neg hji]
+    rw [ite_eq_right hji]
 
 /-- The adjugate identity `adjugate M * M = det M • identity`.
 
@@ -244,8 +244,8 @@ theorem adjugate_mul {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
   intro i j
   rw [adjugate_mul_apply, Matrix.smul_getElem, getElem_identity]
   by_cases h : i = j
-  · rw [if_pos h, if_pos h]; show det M = det M * 1; grind
-  · rw [if_neg h, if_neg h]; show (0 : R) = det M * 0; grind
+  · rw [ite_eq_left h, ite_eq_left h]; show det M = det M * 1; grind
+  · rw [ite_eq_right h, ite_eq_right h]; show (0 : R) = det M * 0; grind
 
 /-- Column-`0` view of `M * adjugate M`. -/
 theorem mul_adjugate_apply_zero {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
@@ -469,9 +469,9 @@ private theorem setRow_mul_adjugate_apply_ne
   rw [setRow_mul_adjugate_apply_row, setRow_row_ne M r i u hir]
   by_cases his : i = s
   · subst his
-    rw [if_pos rfl]
+    rw [ite_eq_left rfl]
     exact cofactorRowPairing_self M i
-  · rw [if_neg his]
+  · rw [ite_eq_right his]
     exact cofactorRowPairing_alien_eq_zero M i s his
 
 /-- Lift a bilinear "`det · f = a · g - b · h`" pointwise identity over a
@@ -544,9 +544,9 @@ private theorem det_mul_cofactor_setRow_eq
       rw [adjugate_mul_apply, adjugate_get]
       by_cases hcl : c = l
       · subst hcl
-        rw [if_pos rfl, if_pos rfl]
+        rw [ite_eq_left rfl, ite_eq_left rfl]
       · have hlc : l ≠ c := fun h => hcl h.symm
-        rw [if_neg hcl, if_neg hlc]
+        rw [ite_eq_right hcl, ite_eq_right hlc]
         grind
     rw [hcongr]
     have hmatch :=
@@ -584,13 +584,13 @@ private theorem det_mul_cofactor_setRow_eq
       by_cases hir : i = r
       · subst hir
         have his_ne : i ≠ s := fun h => hrs h.symm
-        rw [setRow_mul_adjugate_apply_self M i u s, if_pos rfl, if_neg his_ne,
+        rw [setRow_mul_adjugate_apply_self M i u s, ite_eq_left rfl, ite_eq_right his_ne,
           Lean.Grind.AddCommMonoid.add_zero]
-      · rw [setRow_mul_adjugate_apply_ne M r u i s hir, if_neg hir]
+      · rw [setRow_mul_adjugate_apply_ne M r u i s hir, ite_eq_right hir]
         by_cases his : i = s
         · subst his
-          rw [if_pos rfl, if_pos rfl, Lean.Grind.AddCommMonoid.zero_add]
-        · rw [if_neg his, if_neg his, Lean.Grind.Semiring.mul_zero,
+          rw [ite_eq_left rfl, ite_eq_left rfl, Lean.Grind.AddCommMonoid.zero_add]
+        · rw [ite_eq_right his, ite_eq_right his, Lean.Grind.Semiring.mul_zero,
             Lean.Grind.AddCommMonoid.add_zero]
     rw [hbody, List.foldl_add_add]
     have hr_extract :=

--- a/HexDeterminant/CauchyBinet.lean
+++ b/HexDeterminant/CauchyBinet.lean
@@ -295,7 +295,7 @@ private theorem columnSumMatrixWithSuffix_nil
   change (columnSumMatrixWithSuffix source coeff [])[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)] =
       (columnSumMatrix source coeff)[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)]
   rw [getElem_columnSumMatrixWithSuffix, getElem_columnSumMatrix,
-    dif_neg (show ¬ n - ([] : List (Fin m)).length ≤ c by simp; omega)]
+    dite_eq_right (show ¬ n - ([] : List (Fin m)).length ≤ c by simp; omega)]
   simp [getElem_pair_eq_nested]
 
 private theorem columnSumMatrixWithSuffix_eq
@@ -308,7 +308,7 @@ private theorem columnSumMatrixWithSuffix_eq
   simp only [getElem_rows]
   change (columnSumMatrixWithSuffix source coeff chosen)[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)] =
       (columnTupleMatrix source (fun j => chosen[j.val]'(by omega)))[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)]
-  rw [getElem_columnSumMatrixWithSuffix, dif_pos (by omega : n - chosen.length ≤ c),
+  rw [getElem_columnSumMatrixWithSuffix, dite_eq_left (by omega : n - chosen.length ≤ c),
     getElem_columnTupleMatrix]
   simp [hfull]
 
@@ -334,7 +334,7 @@ private theorem setCol_columnSumMatrixWithSuffix_extend
   by_cases hkd : (⟨k, hk2⟩ : Fin n) = (⟨n - chosen.length - 1, by omega⟩ : Fin n)
   · have hkeq : k = n - chosen.length - 1 := by
       have := congrArg Fin.val hkd; simpa using this
-    rw [if_pos hkd, dif_pos (show n - (c :: chosen).length ≤ k by rw [hccons_len]; omega)]
+    rw [ite_eq_left hkd, dite_eq_left (show n - (c :: chosen).length ≤ k by rw [hccons_len]; omega)]
     have hsub0 : k - (n - (c :: chosen).length) = 0 := by rw [hccons_len]; omega
     have hgetval : (c :: chosen)[k - (n - (c :: chosen).length)]'(by
         have : k < n := hk2; rw [hccons_len]; omega) = c := by
@@ -345,12 +345,12 @@ private theorem setCol_columnSumMatrixWithSuffix_extend
       rw [h1]
       rfl
     exact congrArg (fun x : Fin m => source[(⟨r, hr⟩ : Fin n)][x]) hgetval.symm
-  · rw [if_neg hkd]
+  · rw [ite_eq_right hkd]
     have hkne : k ≠ n - chosen.length - 1 := fun h => hkd (Fin.ext h)
     by_cases hkge : n - chosen.length ≤ k
-    · rw [dif_pos hkge]
+    · rw [dite_eq_left hkge]
       have hkge' : n - (c :: chosen).length ≤ k := by rw [hccons_len]; omega
-      rw [dif_pos hkge']
+      rw [dite_eq_left hkge']
       have hidx_eq : k - (n - (c :: chosen).length) = (k - (n - chosen.length)) + 1 := by
         rw [hccons_len]; omega
       have hgetval : (c :: chosen)[k - (n - (c :: chosen).length)]'(by
@@ -364,9 +364,9 @@ private theorem setCol_columnSumMatrixWithSuffix_extend
         rw [h1]
         rfl
       exact congrArg (fun x : Fin m => source[(⟨r, hr⟩ : Fin n)][x]) hgetval.symm
-    · rw [dif_neg hkge]
+    · rw [dite_eq_right hkge]
       have hkge' : ¬ n - (c :: chosen).length ≤ k := by rw [hccons_len]; omega
-      rw [dif_neg hkge']
+      rw [dite_eq_right hkge']
 
 /-- One-step expansion of the suffix-partial matrix: peel off the rightmost sum
 column as a sum over `Fin m`. -/
@@ -391,9 +391,9 @@ private theorem det_columnSumMatrixWithSuffix_expand
       (columnSumMatrixWithSuffix source coeff chosen)[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)]
     rw [getElem_setCol, getElem_columnSumMatrixWithSuffix]
     by_cases hcd : (⟨c, hc⟩ : Fin n) = dst
-    · rw [if_pos hcd, hcd]
-      rw [dif_neg (show ¬ n - chosen.length ≤ dst.val by simp [dst]; omega)]
-    · rw [if_neg hcd]
+    · rw [ite_eq_left hcd, hcd]
+      rw [dite_eq_right (show ¬ n - chosen.length ≤ dst.val by simp [dst]; omega)]
+    · rw [ite_eq_right hcd]
   have hsum := det_setCol_sum_list
       (columnSumMatrixWithSuffix source coeff chosen) dst
       (List.finRange m) (fun k => coeff[dst][k]) (fun k r => source[r][k])

--- a/HexDeterminant/ColumnLinear.lean
+++ b/HexDeterminant/ColumnLinear.lean
@@ -65,8 +65,8 @@ private theorem detProduct_setCol_add {R : Type u} [Lean.Grind.CommRing R]
         rw [getElem_setCol, getElem_setCol, getElem_setCol]
         by_cases hxp : x = pivot
         · subst x
-          rw [if_pos hpivot, if_pos hpivot, if_pos hpivot, if_pos rfl]
-        · rw [if_neg hxp]
+          rw [ite_eq_left hpivot, ite_eq_left hpivot, ite_eq_left hpivot, ite_eq_left rfl]
+        · rw [ite_eq_right hxp]
           have hperm_ne : perm[x] ≠ dst := by
             intro hperm
             have hxidx : perm.toList.idxOf perm[x] = x.val := by
@@ -78,7 +78,7 @@ private theorem detProduct_setCol_add {R : Type u} [Lean.Grind.CommRing R]
             exact hxp (Fin.ext hval)
           change (if perm[x] = dst then v x + w x else M[x][perm[x]]) =
             (if perm[x] = dst then v x else M[x][perm[x]])
-          rw [if_neg hperm_ne, if_neg hperm_ne]
+          rw [ite_eq_right hperm_ne, ite_eq_right hperm_ne]
     _ =
       (List.finRange n).foldl
         (fun acc x =>
@@ -89,7 +89,7 @@ private theorem detProduct_setCol_add {R : Type u} [Lean.Grind.CommRing R]
         apply List.foldl_mul_congr
         intro x _hx
         by_cases hxp : x = pivot
-        · rw [if_pos hxp]
+        · rw [ite_eq_left hxp]
           grind
         · simp [hxp]
     _ =
@@ -119,7 +119,7 @@ private theorem detProduct_setCol_add {R : Type u} [Lean.Grind.CommRing R]
               rw [getElem_setCol, getElem_setCol]
               change (if perm[x] = dst then w x else M[x][perm[x]]) =
                 (if perm[x] = dst then v x else M[x][perm[x]])
-              rw [if_neg hperm_ne, if_neg hperm_ne])
+              rw [ite_eq_right hperm_ne, ite_eq_right hperm_ne])
     _ =
       (List.finRange n).foldl
           (fun acc x => acc * (setCol M dst v)[x][perm[x]]) 1 +
@@ -161,8 +161,8 @@ private theorem detProduct_setCol_smul {R : Type u} [Lean.Grind.CommRing R]
         rw [getElem_setCol, getElem_setCol]
         by_cases hxp : x = pivot
         · subst x
-          rw [if_pos hpivot, if_pos hpivot, if_pos rfl]
-        · rw [if_neg hxp]
+          rw [ite_eq_left hpivot, ite_eq_left hpivot, ite_eq_left rfl]
+        · rw [ite_eq_right hxp]
           have hperm_ne : perm[x] ≠ dst := by
             intro hperm
             have hxidx : perm.toList.idxOf perm[x] = x.val := by
@@ -174,7 +174,7 @@ private theorem detProduct_setCol_smul {R : Type u} [Lean.Grind.CommRing R]
             exact hxp (Fin.ext hval)
           change (if perm[x] = dst then c * v x else M[x][perm[x]]) =
             (if perm[x] = dst then v x else M[x][perm[x]])
-          rw [if_neg hperm_ne, if_neg hperm_ne]
+          rw [ite_eq_right hperm_ne, ite_eq_right hperm_ne]
     _ =
       c * (List.finRange n).foldl
           (fun acc x => acc * (setCol M dst v)[x][perm[x]]) 1 := by
@@ -391,7 +391,7 @@ private theorem setCol_columnSumMatrix_self
   rw [getElem_setCol]
   by_cases hcol : c = dst
   · subst dst
-    rw [if_pos rfl, getElem_columnSumMatrix]
+    rw [ite_eq_left rfl, getElem_columnSumMatrix]
     simp only [getElem_pair_eq_nested]
   · simp [hcol]
 
@@ -466,7 +466,7 @@ theorem det_setCol_existing_col_eq_zero
     det (setCol M dst (fun r => M[r][src])) = 0 := by
   apply det_eq_zero_of_col_eq (setCol M dst (fun r => M[r][src])) src dst hsrcdst
   intro r
-  rw [getElem_setCol, getElem_setCol, if_neg hsrcdst, if_pos rfl]
+  rw [getElem_setCol, getElem_setCol, ite_eq_right hsrcdst, ite_eq_left rfl]
 
 /-- Adding a finite linear combination of other columns of `M` to column `dst`
 preserves the determinant. The sources are given as a list and each source is

--- a/HexDeterminant/Gram.lean
+++ b/HexDeterminant/Gram.lean
@@ -684,9 +684,9 @@ private theorem countP_finRange_val_lt :
       simp only [List.countP_singleton, Fin.last]
       -- Goal: min n k + (if decide (n < k) then 1 else 0) = min (n+1) k.
       by_cases hnk : n < k
-      · rw [if_pos (by simpa using hnk)]
+      · rw [ite_eq_left (by simpa using hnk)]
         omega
-      · rw [if_neg (by simpa using hnk)]
+      · rw [ite_eq_right (by simpa using hnk)]
         omega
 
 /-- A permutation as a `Vector` acts as an injective function on `Fin n`. -/

--- a/HexDeterminant/LastRow.lean
+++ b/HexDeterminant/LastRow.lean
@@ -62,10 +62,10 @@ private theorem detSignParity_add {R : Type u} [Lean.Grind.Ring R] (a m : Nat) :
       rw [hsucc]
       by_cases hm : (a + m) % 2 = 0
       · have hmnot' : ¬(a + (m + 1)) % 2 = 0 := by omega
-        rw [if_pos hm, if_neg hmnot']
+        rw [ite_eq_left hm, ite_eq_right hmnot']
         grind
       · have hmnext' : (a + (m + 1)) % 2 = 0 := by omega
-        rw [if_neg hm, if_pos hmnext']
+        rw [ite_eq_right hm, ite_eq_left hmnext']
         grind
 
 private theorem detSign_of_inversionCount_add {R : Type u} [Lean.Grind.Ring R]
@@ -180,7 +180,7 @@ private theorem cofactorSign_last_eq_pow {R : Type u} [Lean.Grind.Ring R] {n : N
   have hle : i.val ≤ n := Nat.le_of_lt_succ i.isLt
   have h := detSignParity_add (R := R) (2 * i.val) (n - i.val)
   have heven : (2 * i.val) % 2 = 0 := by omega
-  rw [if_pos heven] at h
+  rw [ite_eq_left heven] at h
   have hsum : 2 * i.val + (n - i.val) = i.val + n := by omega
   rw [hsum] at h
   -- h : (if (i.val + n) % 2 = 0 then 1 else -1) = (-1) ^ (n - i.val) * 1

--- a/HexDeterminant/Leibniz.lean
+++ b/HexDeterminant/Leibniz.lean
@@ -153,7 +153,7 @@ private theorem foldl_det_product_no_scale {R : Type u}
       have hx : x ≠ i := by
         intro hxi
         exact hnot.1 hxi.symm
-      rw [if_neg hx]
+      rw [ite_eq_right hx]
       exact ih (z * f x) hnot.2
 
 /-- For a `Nodup` list `xs` containing `i`, scaling only the factor at `i` by `c`
@@ -173,7 +173,7 @@ private theorem foldl_det_product_single_scale {R : Type u}
       simp only [List.foldl_cons]
       by_cases hx : x = i
       · subst x
-        rw [if_pos rfl]
+        rw [ite_eq_left rfl]
         calc
           xs.foldl (fun acc x => acc * if x = i then c * f x else f x) (z * (c * f i)) =
               xs.foldl (fun acc x => acc * f x) (z * (c * f i)) := by
@@ -183,7 +183,7 @@ private theorem foldl_det_product_single_scale {R : Type u}
                 grind
           _ = c * xs.foldl (fun acc x => acc * f x) (z * f i) := by
                 exact foldl_det_product_mul_left xs c f (z * f i)
-      · rw [if_neg hx]
+      · rw [ite_eq_right hx]
         have hmemTail : i ∈ xs := by
           cases hmem with
           | inl hxi => exact False.elim (hx hxi.symm)
@@ -231,7 +231,7 @@ private theorem foldl_det_product_single_add {R : Type u}
       simp only [List.foldl_cons]
       by_cases hx : x = i
       · subst x
-        rw [if_pos rfl]
+        rw [ite_eq_left rfl]
         have hnot : i ∉ xs := hnodup.1
         calc
           xs.foldl (fun acc x => acc * if x = i then f x + c * g x else f x)
@@ -242,7 +242,7 @@ private theorem foldl_det_product_single_add {R : Type u}
               have hyi : y ≠ i := by
                 intro h
                 exact hnot (h ▸ hy)
-              rw [if_neg hyi]
+              rw [ite_eq_right hyi]
           _ = xs.foldl (fun acc x => acc * f x) (z * f i + c * (z * g i)) := by
               congr 1
               grind
@@ -266,7 +266,7 @@ private theorem foldl_det_product_single_add {R : Type u}
               exact (hagree y (List.mem_cons.mpr (Or.inr hy)) (by
                 intro h
                 exact hnot (h ▸ hy))).symm
-      · rw [if_neg hx]
+      · rw [ite_eq_right hx]
         have hmemTail : i ∈ xs := by
           cases hmem with
           | inl hxi => exact False.elim (hx hxi.symm)
@@ -343,7 +343,7 @@ private theorem detProduct_identity_zero {R : Type u}
     (List.mem_finRange i) (by
       change (Matrix.identity (R := R) n)[i][perm[i]] = 0
       rw [identity_get]
-      rw [if_neg hsymm])
+      rw [ite_eq_right hsymm])
 
 
 /-- `detProduct` of the identity matrix along `insertAt (Fin.last n) (v.map

--- a/HexDeterminant/Permutation.lean
+++ b/HexDeterminant/Permutation.lean
@@ -116,7 +116,7 @@ private theorem rowSwap_get_finTranspose {R : Type u} {n m : Nat}
   · by_cases hri : r = i
     · subst r
       simp [finTranspose, hrj]
-    · rw [if_neg hrj, if_neg hri]
+    · rw [ite_eq_right hrj, ite_eq_right hri]
       exact congrArg (fun row => M[row][k]) (finTranspose_of_ne i j r hri hrj).symm
 
 /-- The `r`-th entry of `transposePermutationValues perm i j` is

--- a/HexDeterminant/Plucker.lean
+++ b/HexDeterminant/Plucker.lean
@@ -105,7 +105,7 @@ theorem mMatrix_entry_lt {R : Type u} {n : Nat}
     (i : Fin (n + 1)) (j : Fin (n + 1)) (h : j.val < n) :
     (mMatrix B v p)[i][j] = B[skipIndex p i][(⟨j.val, h⟩ : Fin n)] := by
   unfold mMatrix
-  rw [getElem_ofFn, dif_pos h, getElem_pair_eq_nested]
+  rw [getElem_ofFn, dite_eq_left h, getElem_pair_eq_nested]
 
 /-- The last column of `mMatrix B v p` is the vector `v` with row `p`
 deleted. -/
@@ -117,7 +117,7 @@ theorem mMatrix_entry_last {R : Type u} {n : Nat}
     simp [Fin.last]
   unfold mMatrix
   rw [getElem_ofFn]
-  exact dif_neg h
+  exact dite_eq_right h
 
 /-- The determinant of `mMatrix B v p`: the `(n + 1)`-maximal minor of
 `[B | v]` with row `p` deleted. -/
@@ -215,7 +215,7 @@ private theorem rowMoveUp_row_of_lt {R : Type u} {n m : Nat}
         intro heq; have := congrArg Fin.val heq; simp at this; omega
       have h_ne_i : i ≠ ⟨src + k, by omega⟩ := by
         intro heq; have := congrArg Fin.val heq; simp at this; omega
-      rw [if_neg h_ne_j, if_neg h_ne_i]
+      rw [ite_eq_right h_ne_j, ite_eq_right h_ne_i]
 
 /-- Rows of `M` strictly above the move interval are unchanged by
 `rowMoveUp`. -/
@@ -237,7 +237,7 @@ private theorem rowMoveUp_row_of_gt {R : Type u} {n m : Nat}
         intro heq; have := congrArg Fin.val heq; simp at this; omega
       have h_ne_i : i ≠ ⟨src + k, by omega⟩ := by
         intro heq; have := congrArg Fin.val heq; simp at this; omega
-      rw [if_neg h_ne_j, if_neg h_ne_i]
+      rw [ite_eq_right h_ne_j, ite_eq_right h_ne_i]
 
 /-- The bottom of the move interval (`i.val = src`) receives the row
 originally at the top of the interval (`src + k`). -/
@@ -259,7 +259,7 @@ private theorem rowMoveUp_row_eq_src {R : Type u} {n m : Nat}
       rw [rowSwap_get]
       have h_ne_j : (⟨src + k, by omega⟩ : Fin n) ≠ ⟨src + k + 1, h⟩ := by
         intro heq; have := congrArg Fin.val heq; simp at this
-      rw [if_neg h_ne_j, if_pos rfl]
+      rw [ite_eq_right h_ne_j, ite_eq_left rfl]
       have hii : (⟨src + k + 1, h⟩ : Fin n) = ⟨src + (k + 1), h⟩ := by
         apply Fin.ext; simp; omega
       rw [hii]
@@ -297,7 +297,7 @@ private theorem rowMoveUp_row_between {R : Type u} {n m : Nat}
             (⟨i.val - 1, by have := i.isLt; omega⟩ : Fin n)
               ≠ ⟨src + k, by omega⟩ := by
           intro heq; have := congrArg Fin.val heq; simp at this; omega
-        rw [if_neg h_ne_j, if_neg h_ne_i]
+        rw [ite_eq_right h_ne_j, ite_eq_right h_ne_i]
       · -- Boundary case: i.val = src + k + 1
         have hi_eq : i.val = src + k + 1 := by omega
         have h_gt : src + k < i.val := by omega
@@ -311,7 +311,7 @@ private theorem rowMoveUp_row_between {R : Type u} {n m : Nat}
         rw [rowSwap_get]
         have h_eq_j : i = (⟨src + k + 1, h⟩ : Fin n) := by
           apply Fin.ext; simp [hi_eq]
-        rw [if_pos h_eq_j]
+        rw [ite_eq_left h_eq_j]
         have hii : (⟨src + k, by omega⟩ : Fin n) =
             ⟨i.val - 1, by have := i.isLt; omega⟩ := by
           apply Fin.ext; simp; omega
@@ -904,7 +904,7 @@ theorem twoColMatrix_entry_lt {R : Type u} {n : Nat}
     (i j : Fin (n + 2)) (h : j.val < n) :
     (twoColMatrix B u v)[i][j] = B[i][(⟨j.val, h⟩ : Fin n)] := by
   unfold twoColMatrix
-  rw [getElem_ofFn, dif_pos h, getElem_pair_eq_nested]
+  rw [getElem_ofFn, dite_eq_left h, getElem_pair_eq_nested]
 
 /-- The penultimate column of `twoColMatrix B u v` is `u`. -/
 theorem twoColMatrix_entry_penultimate {R : Type u} {n : Nat}
@@ -917,7 +917,7 @@ theorem twoColMatrix_entry_penultimate {R : Type u} {n : Nat}
     simp
   have hneq : (⟨n, by omega⟩ : Fin (n + 2)).val = n := by
     simp
-  rw [dif_neg hnlt, dif_pos hneq]
+  rw [dite_eq_right hnlt, dite_eq_left hneq]
 
 /-- The last column of `twoColMatrix B u v` is `v`. -/
 theorem twoColMatrix_entry_last {R : Type u} {n : Nat}
@@ -930,7 +930,7 @@ theorem twoColMatrix_entry_last {R : Type u} {n : Nat}
     simp [Fin.last]
   have hlast_ne : ¬ (Fin.last (n + 1) : Fin (n + 2)).val = n := by
     simp [Fin.last]
-  rw [dif_neg hlast_lt, dif_neg hlast_ne]
+  rw [dite_eq_right hlast_lt, dite_eq_right hlast_ne]
 
 /-- The determinant of `[B | u | v]`. -/
 @[expose]
@@ -1026,19 +1026,20 @@ theorem mMatrix_eq_setCol_last {R : Type u} {n : Nat}
       have hval := congrArg Fin.val h
       simp [Fin.last] at hval
       omega
-    rw [if_neg hjne, mMatrix_entry_lt B v p (⟨i, hi⟩ : Fin (n + 1)) (⟨j, hj⟩ : Fin (n + 1)) hjlt,
+    rw [ite_eq_right hjne,
+      mMatrix_entry_lt B v p (⟨i, hi⟩ : Fin (n + 1)) (⟨j, hj⟩ : Fin (n + 1)) hjlt,
       mMatrix_entry_lt B w p (⟨i, hi⟩ : Fin (n + 1)) (⟨j, hj⟩ : Fin (n + 1)) hjlt]
   · have hjeq : j = n := by omega
     have hjlast : (⟨j, hj⟩ : Fin (n + 1)) = Fin.last n := by
       apply Fin.ext
       simp [Fin.last, hjeq]
-    rw [if_pos hjlast]
+    rw [ite_eq_left hjlast]
     show (mMatrix B v p)[(⟨i, hi⟩ : Fin (n + 1))][(⟨j, hj⟩ : Fin (n + 1))] = v[skipIndex p (⟨i, hi⟩ : Fin (n + 1))]
     unfold mMatrix
     rw [getElem_ofFn]
     have hjnlt : ¬ (⟨j, hj⟩ : Fin (n + 1)).val < n := by
       show ¬ j < n; exact hjlt
-    exact dif_neg hjnlt
+    exact dite_eq_right hjnlt
 
 /-- `mDet` is additive in the augmented vector column. -/
 theorem mDet_add_v {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
@@ -1072,10 +1073,10 @@ private theorem getElem_unit_num {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (Vector.unit R q)[i] = if i = q then (1 : R) else (0 : R) := by
   rw [Vector.getElem_unit]
   by_cases h : i = q
-  · rw [if_pos h.symm, if_pos h]
+  · rw [ite_eq_left h.symm, ite_eq_left h]
     rfl
   · have hqi : q ≠ i := fun hqi => h hqi.symm
-    rw [if_neg hqi, if_neg h]
+    rw [ite_eq_right hqi, ite_eq_right h]
     rfl
 
 /-- For `p < q`, the unique row of `Fin (n + 1)` that maps to `q` under
@@ -1168,9 +1169,9 @@ private theorem foldl_unit_weighted_single
     apply List.foldl_congr
     intro acc p _hmem
     by_cases hp : p = q
-    · rw [if_pos hp]
-    · rw [if_neg hp]
-      rw [getElem_unit_num, if_neg hp]
+    · rw [ite_eq_left hp]
+    · rw [ite_eq_right hp]
+      rw [getElem_unit_num, ite_eq_right hp]
       grind
   calc
     (List.finRange (n + 2)).foldl
@@ -1180,7 +1181,7 @@ private theorem foldl_unit_weighted_single
           acc + if p = q then (Vector.unit R q)[p] * f p else 0) 0 := hcongr
     _ = 0 + (Vector.unit R q)[q] * f q := hfold
     _ = f q := by
-      rw [getElem_unit_num, if_pos rfl]
+      rw [getElem_unit_num, ite_eq_left rfl]
       grind
 
 /-- Expands the augmented vector column of `mDet` in the standard basis. -/
@@ -1214,9 +1215,9 @@ theorem mDet_eq_sum_unit
       apply List.foldl_congr
       intro acc q _hmem
       by_cases hq : q = skipIndex p i
-      · rw [if_pos hq]
-      · rw [if_neg hq]
-        rw [getElem_unit_num, if_neg (fun h => hq h.symm)]
+      · rw [ite_eq_left hq]
+      · rw [ite_eq_right hq]
+        rw [getElem_unit_num, ite_eq_right (fun h => hq h.symm)]
         grind
     symm
     calc
@@ -1228,7 +1229,7 @@ theorem mDet_eq_sum_unit
               v[q] * (Vector.unit R q)[skipIndex p i] else 0) 0 := hcongr
       _ = 0 + v[skipIndex p i] * (Vector.unit R (skipIndex p i))[skipIndex p i] := hfold
       _ = v[skipIndex p i] := by
-        rw [getElem_unit_num, if_pos rfl]
+        rw [getElem_unit_num, ite_eq_left rfl]
         grind
   rw [hcol, det_setCol_sum_finRange]
   apply List.foldl_congr
@@ -1252,9 +1253,9 @@ theorem det_eq_signed_minor_of_col_basis
     rw [hcol row]
     by_cases h : row = q
     · subst h
-      rw [if_pos rfl, if_pos rfl]
+      rw [ite_eq_left rfl, ite_eq_left rfl]
       grind
-    · rw [if_neg h, if_neg h]
+    · rw [ite_eq_right h, ite_eq_right h]
       grind
   have hfold :
       (List.finRange (n + 1)).foldl
@@ -1423,19 +1424,19 @@ theorem mDet_unit_eq_signed_nDet_of_gt
     rw [mMatrix_entry_last, getElem_unit_num]
     by_cases hreq : r = r_q
     · subst hreq
-      rw [if_pos rfl]
+      rw [ite_eq_left rfl]
       have : skipIndex p r_q = q :=
         skipIndex_at_q_eq_q_of_gt p q hqp
       rw [this]
-      exact if_pos rfl
-    · rw [if_neg hreq]
+      exact ite_eq_left rfl
+    · rw [ite_eq_right hreq]
       have hne : skipIndex p r ≠ q := by
         intro heq
         have hq_eq : skipIndex p r_q = q :=
           skipIndex_at_q_eq_q_of_gt p q hqp
         have : skipIndex p r = skipIndex p r_q := heq.trans hq_eq.symm
         exact hreq (skipIndex_injective p this)
-      exact if_neg hne
+      exact ite_eq_right hne
   rw [det_eq_signed_minor_of_col_basis (mMatrix B (Vector.unit R q) p) r_q
         (Fin.last n) hcol]
   congr 1
@@ -1467,12 +1468,12 @@ theorem mDet_unit_eq_signed_nDet_of_lt
     rw [mMatrix_entry_last, getElem_unit_num]
     by_cases hreq : r = r_q
     · subst hreq
-      rw [if_pos rfl]
+      rw [ite_eq_left rfl]
       have : skipIndex p r_q = q :=
         skipIndex_at_q_minus_one_eq_q_of_lt p q hpq
       rw [this]
-      exact if_pos rfl
-    · rw [if_neg hreq]
+      exact ite_eq_left rfl
+    · rw [ite_eq_right hreq]
       -- Need: (if skipIndex p r = q then 1 else 0) = 0, i.e., skipIndex p r ≠ q.
       have hne : skipIndex p r ≠ q := by
         intro heq
@@ -1481,7 +1482,7 @@ theorem mDet_unit_eq_signed_nDet_of_lt
           skipIndex_at_q_minus_one_eq_q_of_lt p q hpq
         have : skipIndex p r = skipIndex p r_q := heq.trans hq_eq.symm
         exact hreq (skipIndex_injective p this)
-      exact if_neg hne
+      exact ite_eq_right hne
   rw [det_eq_signed_minor_of_col_basis (mMatrix B (Vector.unit R q) p) r_q
         (Fin.last n) hcol]
   congr 1
@@ -1502,7 +1503,7 @@ theorem mDet_unit_eq_zero_of_eq {R : Type u} [Lean.Grind.CommRing R]
       (Vector.unit R p)[skipIndex p r]) = (fun _ => (0 : R)) := by
     funext r
     rw [getElem_unit_num]
-    exact if_neg (skipIndex_ne p r)
+    exact ite_eq_right (skipIndex_ne p r)
   -- Express mMatrix as setCol with that zero function on the last column.
   rw [mMatrix_eq_setCol_last B (Vector.unit R p)
         (Vector.unit R p) p]
@@ -1617,9 +1618,9 @@ private theorem cofactorSign_consecutive_last_neg
   simp only [Fin.val_mk, Fin.last]
   by_cases h : (a + n) % 2 = 0
   · have hnext : (a + 1 + n) % 2 ≠ 0 := by omega
-    rw [if_pos h, if_neg hnext]
+    rw [ite_eq_left h, ite_eq_right hnext]
   · have hnext : (a + 1 + n) % 2 = 0 := by omega
-    rw [if_neg h, if_pos hnext]
+    rw [ite_eq_right h, ite_eq_left hnext]
     grind
 
 private theorem det_plucker_three_term_unit_of_eq_p1

--- a/HexDeterminant/RowOps.lean
+++ b/HexDeterminant/RowOps.lean
@@ -274,8 +274,8 @@ private theorem detProduct_colAdd {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
         rw [colAdd_get]
         by_cases hxp : x = pivot
         · subst x
-          rw [if_pos hpivot, if_pos rfl, colAddDuplicate_get, if_pos hpivot]
-        · rw [if_neg hxp]
+          rw [ite_eq_left hpivot, ite_eq_left rfl, colAddDuplicate_get, ite_eq_left hpivot]
+        · rw [ite_eq_right hxp]
           have hperm_ne : perm[x] ≠ dst := by
             intro hperm
             have hxidx : perm.toList.idxOf perm[x] = x.val := by
@@ -285,7 +285,7 @@ private theorem detProduct_colAdd {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
             have hval : x.val = pivot.val := by
               rw [← hxidx, hperm, hpidx]
             exact hxp (Fin.ext hval)
-          rw [if_neg hperm_ne]
+          rw [ite_eq_right hperm_ne]
     _ =
       (List.finRange n).foldl (fun acc x => acc * M[x][perm[x]]) 1 +
         c * (List.finRange n).foldl
@@ -309,7 +309,7 @@ private theorem detProduct_colAdd {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
               have hval : x.val = pivot.val := by
                 rw [← hxidx, hperm, hpidx]
               exact hxp (Fin.ext hval)
-            rw [if_neg hperm_ne])
+            rw [ite_eq_right hperm_ne])
 
 /-- For a nodup permutation, the signed term of `colAdd M src dst c` splits as
 `detTerm M perm + c · detTerm (colAddDuplicate M src dst) perm`. -/
@@ -533,11 +533,11 @@ private theorem rowSwap_rowAddDuplicate_eq {R : Type u} {n : Nat}
   intro fr fk
   rw [rowSwap_get]
   by_cases hrd : fr = dst
-  · rw [if_pos hrd]
+  · rw [ite_eq_left hrd]
     rw [rowAddDuplicate_get M src dst src fk, rowAddDuplicate_get M src dst fr fk]
     simp [hrd]
   · by_cases hrs : fr = src
-    · rw [if_neg hrd, if_pos hrs]
+    · rw [ite_eq_right hrd, ite_eq_left hrs]
       rw [rowAddDuplicate_get M src dst dst fk, rowAddDuplicate_get M src dst fr fk]
       simp [hrs]
     · simp [hrd, hrs]

--- a/HexDeterminantMathlib/CorePlucker.lean
+++ b/HexDeterminantMathlib/CorePlucker.lean
@@ -1072,7 +1072,7 @@ private theorem bareissDesnanotIndex_succ_lt (k : Nat) (s : Fin (k + 1))
   have hzero : s.succ.val ≠ 0 := Nat.succ_ne_zero _
   have hne_last : s.succ.val ≠ k + 1 := by
     show s.val + 1 ≠ k + 1; omega
-  rw [dif_neg hzero, dif_neg hne_last]
+  rw [dite_eq_right hzero, dite_eq_right hne_last]
   ext
   show s.succ.val - 1 = s.val
   simp
@@ -1086,7 +1086,7 @@ private theorem bareissDesnanotIndex_succ_top (k : Nat) (s : Fin (k + 1))
   have hzero : s.succ.val ≠ 0 := Nat.succ_ne_zero _
   have hlast : s.succ.val = k + 1 := by
     show s.val + 1 = k + 1; omega
-  rw [dif_neg hzero, dif_pos hlast]
+  rw [dite_eq_right hzero, dite_eq_left hlast]
 
 private theorem bareissDesnanotIndex_castSucc_zero (k : Nat) (s : Fin (k + 1))
     (hs : s.val = 0) :
@@ -1095,7 +1095,7 @@ private theorem bareissDesnanotIndex_castSucc_zero (k : Nat) (s : Fin (k + 1))
         else if hlast : s.castSucc.val = k + 1 then Fin.last (k + 1)
         else ⟨s.castSucc.val - 1, by omega⟩) = _
   have hzero' : s.castSucc.val = 0 := hs
-  rw [dif_pos hzero']
+  rw [dite_eq_left hzero']
 
 private theorem bareissDesnanotIndex_castSucc_pos (k : Nat) (s : Fin (k + 1))
     (hs : 0 < s.val) :
@@ -1107,7 +1107,7 @@ private theorem bareissDesnanotIndex_castSucc_pos (k : Nat) (s : Fin (k + 1))
   have hne_zero : s.castSucc.val ≠ 0 := by rw [hcv]; exact Nat.ne_of_gt hs
   have hne_last : s.castSucc.val ≠ k + 1 := by
     rw [hcv]; exact Nat.ne_of_lt (by have := s.isLt; omega)
-  rw [dif_neg hne_zero, dif_neg hne_last]
+  rw [dite_eq_right hne_zero, dite_eq_right hne_last]
   ext
   show s.castSucc.val - 1 = s.val - 1
   rw [hcv]
@@ -1317,14 +1317,14 @@ private theorem fin_n_cyclicShift_eq_castSucc_index (k : Nat) (hk : k < n)
       rw [hr0]; exact bareissCyclicShift_apply_zero k
     have hge : ¬ (bareissCyclicShift k r).val < k := by
       rw [hbs]; show ¬ k < k; exact Nat.lt_irrefl _
-    rw [if_pos hr, dif_neg hge]
+    rw [ite_eq_left hr, dite_eq_right hge]
   · have hpos : 0 < r.val := Nat.pos_of_ne_zero hr
     have hbs : bareissCyclicShift k r = (⟨r.val - 1, by omega⟩ : Fin (k + 1)) :=
       bareissCyclicShift_apply_of_pos k r hpos
     have hbs_val : (bareissCyclicShift k r).val = r.val - 1 := by rw [hbs]
     have hlt : (bareissCyclicShift k r).val < k := by
       rw [hbs_val]; have := r.isLt; omega
-    rw [if_neg hr, dif_pos hlt]
+    rw [ite_eq_right hr, dite_eq_left hlt]
     apply Fin.ext
     show r.val - 1 = (bareissCyclicShift k r).val
     rw [hbs_val]

--- a/HexDeterminantMathlib/CoreTransport.lean
+++ b/HexDeterminantMathlib/CoreTransport.lean
@@ -476,9 +476,9 @@ private theorem cofactorSign_eq_neg_one_pow
       (-1 : R) ^ (row.val + col.val) := by
   unfold Hex.Matrix.cofactorSign
   by_cases h : (row.val + col.val) % 2 = 0
-  · rw [if_pos h]
+  · rw [ite_eq_left h]
     exact (Even.neg_one_pow (Nat.even_iff.mpr h)).symm
-  · rw [if_neg h]
+  · rw [ite_eq_right h]
     have hmod : (row.val + col.val) % 2 = 1 := by omega
     have hodd : Odd (row.val + col.val) := Nat.odd_iff.mpr hmod
     exact (Odd.neg_one_pow hodd).symm

--- a/HexDeterminantMathlib/DesnanotJacobi.lean
+++ b/HexDeterminantMathlib/DesnanotJacobi.lean
@@ -110,17 +110,17 @@ private lemma mul_aux_adjugate_m_eq_aux_p (M : Matrix (Fin (n + 2)) (Fin (n + 2)
   simp only [auxAdjugateM, auxP, mul_apply]
   rcases eq_or_ne j 0 with rfl | hj0
   · have h := congr_fun (congr_fun (mul_adjugate M) i) 0
-    simpa only [smul_eq_mul, Matrix.smul_apply, one_apply, mul_boole, if_true, mul_apply] using h
+    simpa only [smul_eq_mul, Matrix.smul_apply, one_apply, mul_boole, ite_true, mul_apply] using h
   · rcases eq_or_ne j (Fin.last (n + 1)) with rfl | hjk
     · have h := congr_fun (congr_fun (mul_adjugate M) i) (Fin.last (n + 1))
       have hlast : (Fin.last (n + 1) : Fin (n + 2)) ≠ 0 := by
         simp [Fin.ext_iff, Fin.val_last]
       simpa only [smul_eq_mul, Matrix.smul_apply, one_apply, mul_boole, mul_apply,
-        if_true, if_neg hlast] using h
+        ite_true, ite_eq_right hlast] using h
     · simp only [hj0, hjk, mul_ite, mul_one, mul_zero]
       rw [sum_eq_single j]
-      · exact if_pos rfl
-      · exact fun b _ hbj => if_neg hbj
+      · exact ite_eq_left rfl
+      · exact fun b _ hbj => ite_eq_right hbj
       · exact fun hj => False.elim (hj (mem_univ j))
 
 private lemma det_aux_p_eq (M : Matrix (Fin (n + 2)) (Fin (n + 2)) R) :

--- a/HexGF2/Basic.lean
+++ b/HexGF2/Basic.lean
@@ -1086,8 +1086,8 @@ theorem xorWords_get?_getD (xs ys : Array UInt64) (i : Nat) :
       simp [hks]
   unfold xorWords
   by_cases h : xs.size ≤ ys.size
-  · rw [if_pos h, key xs ys h i, UInt64.xor_comm]
-  · rw [if_neg h, key ys xs (Nat.le_of_lt (Nat.lt_of_not_le h)) i, UInt64.xor_comm]
+  · rw [ite_eq_left h, key xs ys h i, UInt64.xor_comm]
+  · rw [ite_eq_right h, key ys xs (Nat.le_of_lt (Nat.lt_of_not_le h)) i, UInt64.xor_comm]
 
 /-- Raw XOR output has one word for every word position present in either
 input. -/

--- a/HexGF2/Clmul.lean
+++ b/HexGF2/Clmul.lean
@@ -396,7 +396,7 @@ private theorem foldl_oneHot_left_snd_eq_lowStep (a : UInt64) {hot : Nat}
       rw [List.foldl_cons, List.foldl_cons]
       by_cases hset : (((a >>> bitIdx.toUInt64) &&& 1) != 0) = true
       · by_cases hsum : hot + bitIdx < 64
-        · rw [if_pos hset]
+        · rw [ite_eq_left hset]
           have hlowStep :
               clmulOneHotLeftLowStep hot a acc.2 bitIdx =
                 acc.2 ^^^ ((1 : UInt64) <<< (hot + bitIdx).toUInt64) := by
@@ -405,13 +405,13 @@ private theorem foldl_oneHot_left_snd_eq_lowStep (a : UInt64) {hot : Nat}
           simpa [hlowStep] using
             ih (acc.1, acc.2 ^^^ ((1 : UInt64) <<< (hot + bitIdx).toUInt64)) hltTail
         · have hsumGe : 64 ≤ hot + bitIdx := Nat.le_of_not_gt hsum
-          rw [if_pos hset]
+          rw [ite_eq_left hset]
           have hlowStep : clmulOneHotLeftLowStep hot a acc.2 bitIdx = acc.2 := by
             simp [clmulOneHotLeftLowStep, hset, hsum]
           rw [clmulAccumulateBit_oneHot_high acc hhot hbitIdx hsumGe]
           simpa [hlowStep] using
             ih (acc.1 ^^^ ((1 : UInt64) <<< (hot + bitIdx - 64).toUInt64), acc.2) hltTail
-      · rw [if_neg hset]
+      · rw [ite_eq_right hset]
         have hlowStep : clmulOneHotLeftLowStep hot a acc.2 bitIdx = acc.2 := by
           simp [clmulOneHotLeftLowStep, hset]
         simpa [hlowStep] using ih acc hltTail
@@ -489,14 +489,14 @@ private theorem foldl_oneHot_left_fst_eq_highStep (a : UInt64) {hot : Nat}
       rw [List.foldl_cons, List.foldl_cons]
       by_cases hset : (((a >>> bitIdx.toUInt64) &&& 1) != 0) = true
       · by_cases hsum : hot + bitIdx < 64
-        · rw [if_pos hset]
+        · rw [ite_eq_left hset]
           have hhighStep : clmulOneHotLeftHighStep hot a acc.1 bitIdx = acc.1 := by
             simp [clmulOneHotLeftHighStep, hset, hsum]
           rw [clmulAccumulateBit_oneHot_low acc hhot hbitIdx hsum]
           simpa [hhighStep] using
             ih (acc.1, acc.2 ^^^ ((1 : UInt64) <<< (hot + bitIdx).toUInt64)) hltTail
         · have hsumGe : 64 ≤ hot + bitIdx := Nat.le_of_not_gt hsum
-          rw [if_pos hset]
+          rw [ite_eq_left hset]
           have hhighStep :
               clmulOneHotLeftHighStep hot a acc.1 bitIdx =
                 acc.1 ^^^ ((1 : UInt64) <<< (hot + bitIdx - 64).toUInt64) := by
@@ -505,7 +505,7 @@ private theorem foldl_oneHot_left_fst_eq_highStep (a : UInt64) {hot : Nat}
           simpa [hhighStep] using
             ih (acc.1 ^^^ ((1 : UInt64) <<< (hot + bitIdx - 64).toUInt64), acc.2)
               hltTail
-      · rw [if_neg hset]
+      · rw [ite_eq_right hset]
         have hhighStep : clmulOneHotLeftHighStep hot a acc.1 bitIdx = acc.1 := by
           simp [clmulOneHotLeftHighStep, hset]
         simpa [hhighStep] using ih acc hltTail

--- a/HexGF2/Euclid.lean
+++ b/HexGF2/Euclid.lean
@@ -744,7 +744,7 @@ private theorem lowerMask_toNat_of_lt_64 {n : Nat} (hn64 : n < 64) :
   have hle : (1 : UInt64) ≤ ((1 : UInt64) <<< n.toUInt64) := by
     rw [UInt64.le_iff_toNat_le, hshift]
     exact Nat.one_le_two_pow
-  rw [if_pos hn64, UInt64.toNat_sub_of_le _ _ hle, hshift]
+  rw [ite_eq_left hn64, UInt64.toNat_sub_of_le _ _ hle, hshift]
   simp
 
 /-- Masking a word whose value is already `< 2 ^ n` with `lowerMask n` returns
@@ -803,7 +803,7 @@ private theorem coeff_ofUInt64_and_lowerMask (w : UInt64) {n i : Nat} (hn64 : n 
     by_cases hin : i < n <;> simp [hin]
   · have hi64le : 64 ≤ i := Nat.le_of_not_gt hi64
     have hinFalse : ¬ i < n := by omega
-    rw [coeff_ofUInt64_eq_false_of_ge_64 _ hi64le, if_neg hinFalse]
+    rw [coeff_ofUInt64_eq_false_of_ge_64 _ hi64le, ite_eq_right hinFalse]
 
 /-- The packed single-word monic modulus has the advertised degree when
 `n < 64`. -/
@@ -905,9 +905,9 @@ theorem ofUInt64_packedReduceWord_eq_of_degree_lt
   intro i
   rw [coeff_ofUInt64_and_lowerMask low hn64]
   by_cases hin : i < n
-  · rw [if_pos hin]
+  · rw [ite_eq_left hin]
     exact congrArg (fun q : GF2Poly => q.coeff i) hlow
-  · rw [if_neg hin]
+  · rw [ite_eq_right hin]
     exact (coeff_eq_false_of_reduced_le (p := r) hred' (Nat.le_of_not_gt hin)).symm
 
 /-- Reducedness below `bound` (zero, or degree `< bound`) is preserved by

--- a/HexGF2/Field/Grind.lean
+++ b/HexGF2/Field/Grind.lean
@@ -31,11 +31,11 @@ variable {f : GF2Poly} {hirr : GF2Poly.Irreducible f}
     (natCast (k + 1) : GF2nPoly f hirr) = natCast k + 1 := by
   unfold natCast
   by_cases hk : k % 2 = 0
-  · rw [if_pos hk, if_neg (by omega)]
+  · rw [ite_eq_left hk, ite_eq_right (by omega)]
     show (one : GF2nPoly f hirr) = zero + 1
     rw [show (zero : GF2nPoly f hirr) = 0 from rfl, zero_add]
     rfl
-  · rw [if_neg hk, if_pos (by omega)]
+  · rw [ite_eq_right hk, ite_eq_left (by omega)]
     show (zero : GF2nPoly f hirr) = one + 1
     rw [show (one : GF2nPoly f hirr) = 1 from rfl,
       show (zero : GF2nPoly f hirr) = 0 from rfl, add_self]
@@ -47,10 +47,10 @@ depend only on parity. -/
   show nsmul k a = natCast k * a
   unfold nsmul natCast
   by_cases hk : k % 2 = 0
-  · rw [if_pos hk, if_pos hk]
+  · rw [ite_eq_left hk, ite_eq_left hk]
     show (0 : GF2nPoly f hirr) = 0 * a
     rw [zero_mul]
-  · rw [if_neg hk, if_neg hk]
+  · rw [ite_eq_right hk, ite_eq_right hk]
     show a = one * a
     rw [show (one : GF2nPoly f hirr) = 1 from rfl, one_mul]
 
@@ -104,8 +104,8 @@ characteristic two is trivial on both sides. -/
   unfold zsmul
   rw [Int.natAbs_neg]
   by_cases hk : i.natAbs % 2 = 0
-  · rw [if_pos hk]; exact (neg_eq_self 0).symm
-  · rw [if_neg hk]; exact (neg_eq_self a).symm
+  · rw [ite_eq_left hk]; exact (neg_eq_self 0).symm
+  · rw [ite_eq_right hk]; exact (neg_eq_self a).symm
 
 /-- Integer casts negate trivially, since negation is the identity. -/
 @[grind =] theorem intCast_neg (i : Int) :
@@ -227,13 +227,13 @@ theorem isCharPOfDegreePos (hdeg : 0 < f.degree) :
     · intro h
       by_cases hx : x % 2 = 0 <;> by_cases hy : y % 2 = 0
       · omega
-      · rw [if_pos hx, if_neg hy] at h; exact absurd h hne
-      · rw [if_neg hx, if_pos hy] at h; exact absurd h.symm hne
+      · rw [ite_eq_left hx, ite_eq_right hy] at h; exact absurd h hne
+      · rw [ite_eq_right hx, ite_eq_left hy] at h; exact absurd h.symm hne
       · omega
     · intro h
       by_cases hx : x % 2 = 0
-      · rw [if_pos hx, if_pos (by omega)]
-      · rw [if_neg hx, if_neg (by omega)]
+      · rw [ite_eq_left hx, ite_eq_left (by omega)]
+      · rw [ite_eq_right hx, ite_eq_right (by omega)]
 
 end GF2nPoly
 

--- a/HexGF2/Field/Roots.lean
+++ b/HexGF2/Field/Roots.lean
@@ -805,7 +805,7 @@ theorem pow_go_eq_acc_mul_linearPow (acc base : GF2nPoly f hirr) (k : Nat) :
       by_cases hk : k = 0
       · subst hk
         simp [linearPow_zero, mul_one]
-      · rw [dif_neg hk]
+      · rw [dite_eq_right hk]
         have hlt : k / 2 < k :=
           Nat.div_lt_self (Nat.pos_of_ne_zero hk) (by decide : 1 < 2)
         cases Nat.mod_two_eq_zero_or_one k with
@@ -814,14 +814,14 @@ theorem pow_go_eq_acc_mul_linearPow (acc base : GF2nPoly f hirr) (k : Nat) :
               have h := Nat.mod_add_div k 2
               omega
             have hnot : ¬k % 2 = 1 := by omega
-            rw [if_neg hnot, ih (k / 2) hlt acc (base * base), linearPow_double]
+            rw [ite_eq_right hnot, ih (k / 2) hlt acc (base * base), linearPow_double]
             congr 2
             omega
         | inr hmod1 =>
             have hk_eq : k = 2 * (k / 2) + 1 := by
               have h := Nat.mod_add_div k 2
               omega
-            rw [if_pos hmod1, ih (k / 2) hlt (acc * base) (base * base)]
+            rw [ite_eq_left hmod1, ih (k / 2) hlt (acc * base) (base * base)]
             calc acc * base * linearPow (base * base) (k / 2)
                 = acc * (base * linearPow (base * base) (k / 2)) := by rw [mul_assoc]
               _ = acc * linearPow base (2 * (k / 2) + 1) := by
@@ -908,7 +908,7 @@ private theorem evalCoeffList_frobeniusFixedCoeffList_of_pos
         rw [Nat.pow_succ]
         have hpos : 0 < 2 ^ k := Nat.pow_pos (by decide : 0 < 2)
         omega
-  rw [frobeniusFixedCoeffList, if_neg hk_ne]
+  rw [frobeniusFixedCoeffList, ite_eq_right hk_ne]
   simp only [evalCoeffList_cons]
   rw [zero_add, evalCoeffList_replicate_zero_append_one,
     Internal.frobeniusIter_eq_linearPow_two_pow]
@@ -949,7 +949,7 @@ private theorem coeffListTopNonzero_frobeniusFixedCoeffList_of_pos
       (frobeniusFixedCoeffList (f := f) (hirr := hirr) k) := by
   have hk_ne : k ≠ 0 := Nat.ne_of_gt hk
   refine ⟨1, ?_, one_ne_zero (f := f) (hirr := hirr) hf_pos⟩
-  rw [frobeniusFixedCoeffList, if_neg hk_ne]
+  rw [frobeniusFixedCoeffList, ite_eq_right hk_ne]
   change
     (((0 : GF2nPoly f hirr) :: 1 ::
         List.replicate (2 ^ k - 2) (0 : GF2nPoly f hirr)) ++ [1]).getLast? =
@@ -1000,7 +1000,7 @@ theorem frobeniusIter_fixed_elements_length_le_two_pow
           have hpos : 0 < 2 ^ k := Nat.pow_pos (by decide : 0 < 2)
           omega
     dsimp [cs]
-    rw [frobeniusFixedCoeffList, if_neg hk_ne]
+    rw [frobeniusFixedCoeffList, ite_eq_right hk_ne]
     simp
     omega
   have hfilter :

--- a/HexGF2/Multiply.lean
+++ b/HexGF2/Multiply.lean
@@ -149,7 +149,7 @@ private theorem xorBoolList_map_decide_eq (M T : Nat) (g : Nat → Bool) :
     xorBoolList ((List.range M).map (fun t => g t && decide (t = T))) =
       if T < M then g T else false := by
   by_cases hT : T < M
-  · rw [if_pos hT]
+  · rw [ite_eq_left hT]
     have hmap : (List.range M).map (fun t => g t && decide (t = T)) =
         (List.range M).map (fun t => g T && decide (t = T)) := by
       apply List.map_congr_left
@@ -158,7 +158,7 @@ private theorem xorBoolList_map_decide_eq (M T : Nat) (g : Nat → Bool) :
       · subst htT; rfl
       · simp [htT]
     rw [hmap, xorBoolList_range_single_decide (g T) hT]
-  · rw [if_neg hT]
+  · rw [ite_eq_right hT]
     have hmap : (List.range M).map (fun t => g t && decide (t = T)) =
         (List.range M).map (fun _ => false) := by
       apply List.map_congr_left
@@ -203,7 +203,7 @@ private theorem xorBoolList_map_decide_add (M s n : Nat) (g : Nat → Bool) :
     xorBoolList ((List.range M).map (fun t => g t && decide (s + t = n))) =
       if s ≤ n then (if n - s < M then g (n - s) else false) else false := by
   by_cases hsn : s ≤ n
-  · rw [if_pos hsn]
+  · rw [ite_eq_left hsn]
     have hmap : (List.range M).map (fun t => g t && decide (s + t = n)) =
         (List.range M).map (fun t => g t && decide (t = n - s)) := by
       apply List.map_congr_left
@@ -214,7 +214,7 @@ private theorem xorBoolList_map_decide_add (M s n : Nat) (g : Nat → Bool) :
       · have hne : ¬ (s + t = n) := by omega
         simp [h, hne]
     rw [hmap, xorBoolList_map_decide_eq M (n - s) g]
-  · rw [if_neg hsn]
+  · rw [ite_eq_right hsn]
     have hmap : (List.range M).map (fun t => g t && decide (s + t = n)) =
         (List.range M).map (fun _ => false) := by
       apply List.map_congr_left
@@ -242,7 +242,7 @@ private theorem clmulCoeffAt_diag (c : Nat) (x y : UInt64) (n : Nat) :
       (fun a b => (wordBitAt x a && wordBitAt y b) && decide (64 * c + a + b = n))
   rw [hswap, clmulCoeffAt_sourcePairCoeff]
   by_cases hlow : n / 64 = c
-  · rw [if_pos hlow]
+  · rw [ite_eq_left hlow]
     unfold clmulSourcePairCoeff
     apply congrArg xorBoolList
     apply List.flatMap_congr_left
@@ -257,7 +257,7 @@ private theorem clmulCoeffAt_diag (c : Nat) (x y : UInt64) (n : Nat) :
     · have h2 : ¬ (a + b = n % 64) := by omega
       simp [h, h2]
   · by_cases hhigh : n / 64 = c + 1
-    · rw [if_neg hlow, if_pos hhigh]
+    · rw [ite_eq_right hlow, ite_eq_left hhigh]
       unfold clmulSourcePairCoeff
       apply congrArg xorBoolList
       apply List.flatMap_congr_left
@@ -271,7 +271,7 @@ private theorem clmulCoeffAt_diag (c : Nat) (x y : UInt64) (n : Nat) :
         simp [h, h2]
       · have h2 : ¬ (a + b = n % 64 + 64) := by omega
         simp [h, h2]
-    · rw [if_neg hlow, if_neg hhigh]
+    · rw [ite_eq_right hlow, ite_eq_right hhigh]
       have hguard :
           (List.range 64).flatMap (fun b =>
             (List.range 64).map (fun a =>
@@ -378,15 +378,15 @@ theorem coeff_mul_diagonal (p q : GF2Poly) (n : Nat) :
           xorBoolList_map_decide_add (64 * q.words.size) s n (fun t => q.coeff t)]
         congr 1
         by_cases hsn : s ≤ n
-        · rw [if_pos hsn, if_pos hsn]
+        · rw [ite_eq_left hsn, ite_eq_left hsn]
           by_cases hlt : n - s < 64 * q.words.size
-          · rw [if_pos hlt]
-          · rw [if_neg hlt]
+          · rw [ite_eq_left hlt]
+          · rw [ite_eq_right hlt]
             symm
             apply coeff_eq_false_of_wordCount_le
             simp only [wordCount]
             omega
-        · rw [if_neg hsn, if_neg hsn]
+        · rw [ite_eq_right hsn, ite_eq_right hsn]
     _ = xorBoolList ((List.range (n + 1)).map (fun s => p.coeff s && q.coeff (n - s))) := by
         have hzero : ∀ s, min (64 * p.words.size) (n + 1) ≤ s →
             (p.coeff s && (if s ≤ n then q.coeff (n - s) else false)) = false := by
@@ -571,7 +571,7 @@ private theorem clmulCoeffAt_degree_add_eq_false_of_not_leading_word
     clmulCoeffAt (i + j) p.words[i]! q.words[j]! (dp + dq) = false := by
   rw [clmulCoeffAt_sourcePairCoeff]
   by_cases hlow : (dp + dq) / 64 = i + j
-  · simp only [if_pos hlow]
+  · simp only [ite_eq_left hlow]
     apply clmulSourcePairCoeff_eq_false_of_forall
     intro a b ha hb hsum
     apply source_pair_and_eq_false_of_not_leading hp hq ha hb
@@ -581,7 +581,7 @@ private theorem clmulCoeffAt_degree_add_eq_false_of_not_leading_word
       | inl hi => exact Or.inl hi
       | inr hj => exact Or.inr (Or.inl hj)
   · by_cases hhigh : (dp + dq) / 64 = i + j + 1
-    · simp only [if_neg hlow, if_pos hhigh]
+    · simp only [ite_eq_right hlow, ite_eq_left hhigh]
       apply clmulSourcePairCoeff_eq_false_of_forall
       intro a b ha hb hsum
       apply source_pair_and_eq_false_of_not_leading hp hq ha hb
@@ -590,7 +590,7 @@ private theorem clmulCoeffAt_degree_add_eq_false_of_not_leading_word
       · cases hnot with
         | inl hi => exact Or.inl hi
         | inr hj => exact Or.inr (Or.inl hj)
-    · simp only [if_neg hlow, if_neg hhigh]
+    · simp only [ite_eq_right hlow, ite_eq_right hhigh]
 
 private theorem clmulCoeffAt_degree_add_leading_word
     {p q : GF2Poly} {dp dq : Nat}
@@ -607,7 +607,7 @@ private theorem clmulCoeffAt_degree_add_leading_word
       have hdp := Nat.div_add_mod dp 64
       have hdq := Nat.div_add_mod dq 64
       omega
-    simp only [if_pos hlow]
+    simp only [ite_eq_left hlow]
     rw [hmod]
     apply clmulSourcePairCoeff_single_active
       (a₀ := dp % 64) (b₀ := dq % 64)
@@ -636,7 +636,7 @@ private theorem clmulCoeffAt_degree_add_leading_word
       have hdpbit : dp % 64 < 64 := Nat.mod_lt dp (by decide : 0 < 64)
       have hdqbit : dq % 64 < 64 := Nat.mod_lt dq (by decide : 0 < 64)
       omega
-    simp only [if_neg hlow, if_pos hhigh]
+    simp only [ite_eq_right hlow, ite_eq_left hhigh]
     rw [hmod]
     apply clmulSourcePairCoeff_single_active
       (a₀ := dp % 64) (b₀ := dq % 64)
@@ -691,7 +691,7 @@ private theorem clmulCoeffAt_above_degree_add_eq_false
     clmulCoeffAt (i + j) p.words[i]! q.words[j]! n = false := by
   rw [clmulCoeffAt_sourcePairCoeff]
   by_cases hlow : n / 64 = i + j
-  · simp only [if_pos hlow]
+  · simp only [ite_eq_left hlow]
     apply clmulSourcePairCoeff_eq_false_of_forall
     intro a b ha hb hsum
     have htotal : 64 * i + a + (64 * j + b) = n := by
@@ -704,7 +704,7 @@ private theorem clmulCoeffAt_above_degree_add_eq_false
       have hqfalse := wordBitAt_getElem!_eq_false_of_degree?_lt hq hb hqgt
       simp [hqfalse]
   · by_cases hhigh : n / 64 = i + j + 1
-    · simp only [if_neg hlow, if_pos hhigh]
+    · simp only [ite_eq_right hlow, ite_eq_left hhigh]
       apply clmulSourcePairCoeff_eq_false_of_forall
       intro a b ha hb hsum
       have htotal : 64 * i + a + (64 * j + b) = n := by
@@ -716,7 +716,7 @@ private theorem clmulCoeffAt_above_degree_add_eq_false
       · have hqgt : dq < 64 * j + b := by omega
         have hqfalse := wordBitAt_getElem!_eq_false_of_degree?_lt hq hb hqgt
         simp [hqfalse]
-    · simp only [if_neg hlow, if_neg hhigh]
+    · simp only [ite_eq_right hlow, ite_eq_right hhigh]
 
 private theorem coeffWords_mulWords_above_degree_add_eq_false
     {p q : GF2Poly} {dp dq n : Nat}

--- a/HexGF2/Multiply/Coeff.lean
+++ b/HexGF2/Multiply/Coeff.lean
@@ -1055,7 +1055,7 @@ private theorem clmul_oneHot_source_high
   by_cases hbZero : b = 0
   · subst hbZero
     rw [clmul_oneHot_fst x hb]
-    simp only [if_true]
+    simp only [ite_true]
     have hzero : wordBitAt 0 bit = false := by
       simp [wordBitAt]
     rw [hzero]

--- a/HexGF2/Multiply/SourceTriple.lean
+++ b/HexGF2/Multiply/SourceTriple.lean
@@ -145,18 +145,18 @@ private theorem clmulCoeffAt_sourcePairCoeff
         false := by
   unfold clmulCoeffAt
   by_cases hlow : n / 64 = idx
-  · simp only [if_pos hlow]
+  · simp only [ite_eq_left hlow]
     have hbit : n % 64 < 64 := Nat.mod_lt n (by decide : 0 < 64)
     change wordBitAt (clmul x y).2 (n % 64) =
       clmulSourcePairCoeff x y (n % 64)
     exact clmulSourcePairCoeff_low x y hbit
   · by_cases hhigh : n / 64 = idx + 1
-    · simp only [if_neg hlow, if_pos hhigh]
+    · simp only [ite_eq_right hlow, ite_eq_left hhigh]
       have hbit : n % 64 < 64 := Nat.mod_lt n (by decide : 0 < 64)
       change wordBitAt (clmul x y).1 (n % 64) =
         clmulSourcePairCoeff x y (n % 64 + 64)
       exact clmulSourcePairCoeff_high x y hbit
-    · simp only [if_neg hlow, if_neg hhigh]
+    · simp only [ite_eq_right hlow, ite_eq_right hhigh]
 
 /-- Source bit-triple contribution for the coefficient of total bit index
 `total` in a three-word carry-less product. -/

--- a/HexGF2/Multiply/WordBits.lean
+++ b/HexGF2/Multiply/WordBits.lean
@@ -496,7 +496,7 @@ private theorem words_monomial_getElem!_active (k : Nat) :
       ((1 : UInt64) <<< (k % 64).toUInt64) := by
   rw [words_monomial, Array.getElem!_eq_getD]
   unfold Array.getD
-  rw [dif_pos (by simp)]
+  rw [dite_eq_left (by simp)]
   change ((Array.replicate (k / 64) (0 : UInt64)).push
     ((1 : UInt64) <<< (k % 64).toUInt64))[k / 64] =
       ((1 : UInt64) <<< (k % 64).toUInt64)
@@ -508,7 +508,7 @@ private theorem words_monomial_getElem!_zero_lt {j k : Nat} (hj : j < k / 64) :
     (monomial k).words[j]! = 0 := by
   rw [words_monomial, Array.getElem!_eq_getD]
   unfold Array.getD
-  rw [dif_pos]
+  rw [dite_eq_left]
   · simp [Array.getElem_push, hj]
   · simp
     omega

--- a/HexGF2Mathlib/Basic.lean
+++ b/HexGF2Mathlib/Basic.lean
@@ -87,14 +87,14 @@ theorem coeff_toFpPoly (p : Hex.GF2Poly) (i : Nat) :
     intro b; cases b <;> rfl
   by_cases hz : p.isZero = true
   · have hbody : toFpPoly p = Hex.DensePoly.ofList ([] : List (Hex.ZMod64 2)) := by
-      unfold toFpPoly; rw [if_pos hz]
+      unfold toFpPoly; rw [_root_.ite_eq_left hz]
     rw [hbody, Hex.DensePoly.coeff_ofList,
       Hex.GF2Poly.eq_zero_of_isZero hz, Hex.GF2Poly.coeff_zero]
     rfl
   · have hbody : toFpPoly p =
         Hex.DensePoly.ofList
           ((List.range (p.degree + 1)).map (fun j => coeffToFp (p.coeff j))) := by
-      unfold toFpPoly; rw [if_neg hz]
+      unfold toFpPoly; rw [_root_.ite_eq_right hz]
     rw [hbody, Hex.DensePoly.coeff_ofList]
     have hrange :
         ((List.range (p.degree + 1)).map (fun j => coeffToFp (p.coeff j))).getD i
@@ -104,8 +104,8 @@ theorem coeff_toFpPoly (p : Hex.GF2Poly) (i : Nat) :
       by_cases hi : i < p.degree + 1 <;> simp [hi, List.getD]
     rw [hrange]
     by_cases hi : i < p.degree + 1
-    · rw [if_pos hi, hcoeffToFp]
-    · rw [if_neg hi]
+    · rw [_root_.ite_eq_left hi, hcoeffToFp]
+    · rw [_root_.ite_eq_right hi]
       have hzf : p.isZero = false := by
         cases hb : p.isZero with
         | false => rfl
@@ -156,7 +156,7 @@ theorem toFpPoly_one :
   rw [Hex.DensePoly.coeff_C]
   by_cases hi : i = 0
   · subst hi; rfl
-  · simp only [decide_eq_true_eq, if_neg hi]; rfl
+  · simp only [decide_eq_true_eq, _root_.ite_eq_right hi]; rfl
 
 /-- A packed coefficient bit `coeffOfFp a` holds at most one set bit. -/
 private theorem coeffOfFp_toNat_lt (a : Hex.ZMod64 2) : (coeffOfFp a).toNat < 2 := by
@@ -170,9 +170,9 @@ private theorem coeffOfFp_testBit_zero (a : Hex.ZMod64 2) :
   unfold coeffOfFp
   by_cases h : a = Hex.ZMod64.zero
   · have ha0 : a = 0 := h
-    rw [if_pos h, ha0]; decide
+    rw [_root_.ite_eq_left h, ha0]; decide
   · have ha0 : a ≠ 0 := h
-    rw [if_neg h]; simp [ha0]
+    rw [_root_.ite_eq_right h]; simp [ha0]
 
 private theorem zmod2_toNat_zero : (0 : Hex.ZMod64 2).toNat = 0 :=
   Hex.ZMod64.toNat_zero
@@ -424,15 +424,15 @@ theorem toFpPoly_mul (p q : Hex.GF2Poly) :
     have hsn : s ≤ n := by have := List.mem_range.mp hs; omega
     rw [chi_mul, ← coeff_toFpPoly, ← coeff_toFpPoly]
     unfold Hex.FpPoly.mulCoeffTerm
-    rw [if_neg (by omega : ¬ n < s)]
+    rw [_root_.ite_eq_right (by omega : ¬ n < s)]
   rw [foldl_add_congr (List.range (n + 1)) _ _ hterm 0]
   have hzero : ∀ i, min ((toFpPoly p).size) (n + 1) ≤ i →
       Hex.FpPoly.mulCoeffTerm (toFpPoly p) (toFpPoly q) n i = 0 := by
     intro i hi
     unfold Hex.FpPoly.mulCoeffTerm
     by_cases hni : n < i
-    · rw [if_pos hni]
-    · rw [if_neg hni]
+    · rw [_root_.ite_eq_left hni]
+    · rw [_root_.ite_eq_right hni]
       have hcase : (toFpPoly p).size ≤ i ∨ n + 1 ≤ i := by
         rcases Nat.le_total ((toFpPoly p).size) (n + 1) with hle | hle
         · left; rw [Nat.min_eq_left hle] at hi; exact hi
@@ -870,8 +870,8 @@ theorem coeff_equivPolynomial (q : Hex.GF2Poly) (i : Nat) :
   rw [equivPolynomial_apply, HexPolyFpMathlib.fpPolyEquiv_apply,
     HexPolyFpMathlib.coeff_toMathlibPolynomial, coeff_toFpPoly]
   by_cases h : q.coeff i
-  · rw [if_pos h, if_pos h, HexModArithMathlib.ZMod64.toZMod_one]
-  · rw [if_neg h, if_neg h, HexModArithMathlib.ZMod64.toZMod_zero]
+  · rw [_root_.ite_eq_left h, _root_.ite_eq_left h, HexModArithMathlib.ZMod64.toZMod_one]
+  · rw [_root_.ite_eq_right h, _root_.ite_eq_right h, HexModArithMathlib.ZMod64.toZMod_zero]
 
 end GF2Poly
 

--- a/HexGFqMathlib/GF2q.lean
+++ b/HexGFqMathlib/GF2q.lean
@@ -106,11 +106,11 @@ private theorem coeff_packedGF2FpPoly (lower : UInt64) (n i : Nat) :
   rw [hsz]
   by_cases hin : i = n
   · simp [hin]
-  · rw [if_neg hin, List.getElem?_toArray, List.getElem?_map, if_neg hin]
+  · rw [ite_eq_right hin, List.getElem?_toArray, List.getElem?_map, ite_eq_right hin]
     by_cases hlt : i < n
-    · rw [List.getElem?_range hlt, if_pos hlt]
+    · rw [List.getElem?_range hlt, ite_eq_left hlt]
       simp
-    · rw [List.getElem?_eq_none (by simp; omega), if_neg hlt]
+    · rw [List.getElem?_eq_none (by simp; omega), ite_eq_right hlt]
       rfl
 
 /-- The packed `GF2n` modulus, transported to `FpPoly 2`, is the Conway
@@ -130,13 +130,13 @@ theorem modulusFpPoly_eq_conway :
     coeff_packedGF2FpPoly]
   by_cases hin : i = n
   · subst hin; simp
-  · rw [if_neg hin]
+  · rw [ite_eq_right hin]
     by_cases hlt : i < n
-    · simp only [hin, decide_false, Bool.false_bne, if_pos hlt]
+    · simp only [hin, decide_false, Bool.false_bne, ite_eq_left hlt]
       by_cases hb : (h.lower >>> i.toUInt64 &&& 1) = 0
-      · rw [if_pos hb, (bit_and_one_eq_zero_iff h.lower (by omega)).mp hb]
+      · rw [ite_eq_left hb, (bit_and_one_eq_zero_iff h.lower (by omega)).mp hb]
         simp
-      · rw [if_neg hb]
+      · rw [ite_eq_right hb]
         have hc : (Hex.GF2Poly.ofUInt64 h.lower).coeff i = true := by
           by_contra hcf
           exact hb ((bit_and_one_eq_zero_iff h.lower (by omega)).mpr (by simpa using hcf))

--- a/HexGFqMathlib/Subfield.lean
+++ b/HexGFqMathlib/Subfield.lean
@@ -207,7 +207,7 @@ theorem substHom_reduceMod (b : Hex.FpPoly p) (fm : Hex.FpPoly p)
     (hzero : substHom f hf hp hirr b fm = 0) (g : Hex.FpPoly p) :
     substHom f hf hp hirr b (Hex.GFqRing.reduceMod fm g) =
       substHom f hf hp hirr b g := by
-  letI : Hex.DensePoly.DivModLaws (Hex.ZMod64 p) :=
+  let : Hex.DensePoly.DivModLaws (Hex.ZMod64 p) :=
     Hex.ZMod64.instDivModLawsZMod64Fp p
   have hspec := Hex.DensePoly.DivModLaws.divMod_spec (R := Hex.ZMod64 p) g fm
   have hg : (Hex.DensePoly.divMod g fm).1 * fm + Hex.GFqRing.reduceMod fm g = g := hspec

--- a/HexGFqRing/Operations.lean
+++ b/HexGFqRing/Operations.lean
@@ -777,7 +777,7 @@ private theorem nsmul_go_eq_acc_add_linearNSmul
       · subst hk
         simp only [↓reduceDIte, linearNSmul_zero]
         exact (ext (repr_add_zero acc)).symm
-      · rw [dif_neg hk]
+      · rw [dite_eq_right hk]
         have hlt : k / 2 < k :=
           Nat.div_lt_self (Nat.pos_of_ne_zero hk) (by decide : 1 < 2)
         cases Nat.mod_two_eq_zero_or_one k with
@@ -788,7 +788,7 @@ private theorem nsmul_go_eq_acc_add_linearNSmul
             have hnot : ¬k % 2 = 1 := by omega
             have hdiv : 2 * (k / 2) / 2 = k / 2 :=
               Nat.mul_div_right (k / 2) (by decide : 0 < 2)
-            rw [if_neg hnot]
+            rw [ite_eq_right hnot]
             calc
               nsmul.go acc (add base base) (k / 2)
                   = add acc (linearNSmul (add base base) (k / 2)) := by
@@ -799,7 +799,7 @@ private theorem nsmul_go_eq_acc_add_linearNSmul
             have hk_eq : k = 2 * (k / 2) + 1 := by
               have h := Nat.mod_add_div k 2
               omega
-            rw [if_pos hmod1]
+            rw [ite_eq_left hmod1]
             calc
               nsmul.go (add acc base) (add base base) (k / 2)
                   = add (add acc base) (linearNSmul (add base base) (k / 2)) := by
@@ -1015,7 +1015,7 @@ private theorem pow_go_eq_acc_mul_linearPow
       rw [pow.go.eq_def]
       by_cases hk : k = 0
       · simp [hk, linearPow_mul_one_raw]
-      · rw [dif_neg hk]
+      · rw [dite_eq_right hk]
         have hlt : k / 2 < k :=
           Nat.div_lt_self (Nat.pos_of_ne_zero hk) (by decide : 1 < 2)
         cases Nat.mod_two_eq_zero_or_one k with
@@ -1026,7 +1026,7 @@ private theorem pow_go_eq_acc_mul_linearPow
             have hnot : ¬k % 2 = 1 := by omega
             have hdiv : 2 * (k / 2) / 2 = k / 2 :=
               Nat.mul_div_right (k / 2) (by decide : 0 < 2)
-            rw [if_neg hnot]
+            rw [ite_eq_right hnot]
             calc
               pow.go acc (mul base base) (k / 2)
                   = mul acc (linearPow (mul base base) (k / 2)) := by
@@ -1037,7 +1037,7 @@ private theorem pow_go_eq_acc_mul_linearPow
             have hk_eq : k = 2 * (k / 2) + 1 := by
               have h := Nat.mod_add_div k 2
               omega
-            rw [if_pos hmod1]
+            rw [ite_eq_left hmod1]
             calc
               pow.go (mul acc base) (mul base base) (k / 2)
                   = mul (mul acc base) (linearPow (mul base base) (k / 2)) := by

--- a/HexGramSchmidt/Basic/IntCast.lean
+++ b/HexGramSchmidt/Basic/IntCast.lean
@@ -97,10 +97,10 @@ private theorem castIntMatrix_rowAdd (b : Matrix Int n m) (src dst : Fin n) (c :
   rw [getElem_castIntMatrix, Matrix.getElem_rowAdd, Matrix.getElem_rowAdd,
     getElem_castIntMatrix, getElem_castIntMatrix]
   by_cases hdst : r = dst
-  · simp only [hdst, if_true]
+  · simp only [hdst, ite_true]
     push_cast
     rfl
-  · simp only [hdst, if_false, getElem_castIntMatrix]
+  · simp only [hdst, ite_false, getElem_castIntMatrix]
 
 private theorem castIntMatrix_rowSwap (b : Matrix Int n m) (i j : Fin n) :
     GramSchmidt.castIntMatrix (Matrix.rowSwap b i j) =

--- a/HexGramSchmidt/Basic/Linearity.lean
+++ b/HexGramSchmidt/Basic/Linearity.lean
@@ -1188,14 +1188,14 @@ private theorem foldl_indicator_mul_unique_rat
       simp only [List.foldl_cons]
       rcases List.mem_cons.mp hi with hix | hitail
       · subst i
-        rw [if_pos rfl]
+        rw [ite_eq_left rfl]
         have hxs_zero :
             ∀ y ∈ xs, f y * (if y = x then (1 : Rat) else 0) = 0 := by
           intro y hy
           have hyx : y ≠ x := by
             intro heq
             exact (List.nodup_cons.mp hnodup).1 (heq ▸ hy)
-          rw [if_neg hyx]
+          rw [ite_eq_right hyx]
           grind
         have hfold :=
           foldl_add_eq_acc_rat xs
@@ -1211,7 +1211,7 @@ private theorem foldl_indicator_mul_unique_rat
           intro h
           subst i
           exact (List.nodup_cons.mp hnodup).1 hitail
-        rw [if_neg hxi]
+        rw [ite_eq_right hxi]
         have hzero : f x * (0 : Rat) = 0 := by grind
         rw [hzero]
         have hacc : acc + (0 : Rat) = acc := by grind

--- a/HexGramSchmidt/Int/Canonical.lean
+++ b/HexGramSchmidt/Int/Canonical.lean
@@ -373,7 +373,7 @@ at `fuel + 1` to its explicit Bareiss exact-division update. -/
            (state.matrix[k][k] * (bareissGramCanonicalCoeff b fuel i)[a] -
              state.matrix[i][k] * (bareissGramCanonicalCoeff b fuel k)[a])
            state.prevPivot) := by
-  simp [bareissGramCanonicalCoeff, dif_pos hnext, if_pos hi]
+  simp [bareissGramCanonicalCoeff, dite_eq_left hnext, ite_eq_left hi]
   intro hc
   simp only [Matrix.getElem_nat_eq_getRow] at hp
   exact absurd hc hp
@@ -397,7 +397,7 @@ coefficient at `fuel + 1` collapses to the one at `fuel`. -/
         (Matrix.noPivotInitialState (Matrix.gramMatrix b))).step + 1 ≤ i.val) :
     bareissGramCanonicalCoeff b (fuel + 1) i =
       bareissGramCanonicalCoeff b fuel i := by
-  simp [bareissGramCanonicalCoeff, dif_pos hnext, if_neg hi]
+  simp [bareissGramCanonicalCoeff, dite_eq_left hnext, ite_eq_right hi]
 
 /-- Recursion equation: singular branch (zero diagonal). A zero pivot skips the
 update, so the canonical coefficient at `fuel + 1` collapses to the one at
@@ -416,7 +416,7 @@ update, so the canonical coefficient at `fuel + 1` collapses to the one at
             (Matrix.noPivotInitialState (Matrix.gramMatrix b))).step] = 0) :
     bareissGramCanonicalCoeff b (fuel + 1) i =
       bareissGramCanonicalCoeff b fuel i := by
-  simp [bareissGramCanonicalCoeff, dif_pos hnext]
+  simp [bareissGramCanonicalCoeff, dite_eq_left hnext]
   intro hc
   simp only [Matrix.getElem_nat_eq_getRow] at hp
   exact absurd hp hc
@@ -430,7 +430,7 @@ collapses to the one at `fuel`. -/
         (Matrix.noPivotInitialState (Matrix.gramMatrix b))).step + 1 < n) :
     bareissGramCanonicalCoeff b (fuel + 1) i =
       bareissGramCanonicalCoeff b fuel i := by
-  simp only [bareissGramCanonicalCoeff, dif_neg hDone]
+  simp only [bareissGramCanonicalCoeff, dite_eq_right hDone]
 
 /-- A `BareissGramRowInvariant` on `noPivotLoop fuel (noPivotInitialState …)`
 is *canonical at `fuel`* when every row's coefficient vector matches
@@ -689,7 +689,7 @@ theorem bareissGramRowInvariant_regular_step_coeff_canonical
         (bareissGramRowInvariant_regular_step hnext hp hinv hentry).coeff i =
           bareissGramRowInvariantStepCoeff hinv hnext i hi := by
       show (if hi : _ then _ else _) = _
-      rw [dif_pos hi]
+      rw [dite_eq_left hi]
     rw [hLHS, bareissGramCanonicalCoeff_succ_regular b elapsed i hnext hp hi]
     show Vector.ofFn (fun a : Fin n =>
         Matrix.exactDiv
@@ -704,7 +704,7 @@ theorem bareissGramRowInvariant_regular_step_coeff_canonical
         (bareissGramRowInvariant_regular_step hnext hp hinv hentry).coeff i =
           hinv.coeff i := by
       show (if hi : _ then _ else _) = _
-      rw [dif_neg hi]
+      rw [dite_eq_right hi]
     rw [hLHS, bareissGramCanonicalCoeff_succ_processed b elapsed i hnext hp hi]
     exact h_canon i
 

--- a/HexGramSchmidt/Int/Combination.lean
+++ b/HexGramSchmidt/Int/Combination.lean
@@ -1595,7 +1595,7 @@ theorem getArrayEntry_scaledCoeffRowsSchur_eq_noPivotLoop_of_nonsing
         show schurScaledCoeffEntry (scaledCoeffRowsSchur b) (gramRows b) (q' + 1)
             (q' + 1) = _
         unfold schurScaledCoeffEntry
-        rw [if_neg (Nat.succ_ne_zero q')]
+        rw [ite_eq_right (Nat.succ_ne_zero q')]
         simp only [Nat.add_sub_cancel]
         rw [ih_diag,
           show getArrayEntry (gramRows b) (q' + 1) (q' + 1) =
@@ -1610,7 +1610,7 @@ theorem getArrayEntry_scaledCoeffRowsSchur_eq_noPivotLoop_of_nonsing
           h_pa hcn]
         show schurScaledCoeffEntry (scaledCoeffRowsSchur b) (gramRows b) c (q' + 1) = _
         unfold schurScaledCoeffEntry
-        rw [if_neg (Nat.succ_ne_zero q')]
+        rw [ite_eq_right (Nat.succ_ne_zero q')]
         simp only [Nat.add_sub_cancel]
         rw [ih_diag,
           show getArrayEntry (gramRows b) c (q' + 1) =
@@ -1682,7 +1682,7 @@ theorem getArrayEntry_scaledCoeffRowsSchur_eq_zero_of_singularStep_lt
     rw [getArrayEntry_scaledCoeffRowsSchur_eq_schurScaledCoeffEntry b i' j' hj'i' hi'n]
     show schurScaledCoeffEntry (scaledCoeffRowsSchur b) (gramRows b) i' j' = 0
     unfold schurScaledCoeffEntry
-    rw [if_neg (Nat.ne_of_gt hj'_pos)]
+    rw [ite_eq_right (Nat.ne_of_gt hj'_pos)]
     -- Diagonal factor at `(j' - 1, j' - 1)` is zero.
     have h_diag_zero :
         getArrayEntry (scaledCoeffRowsSchur b) (j' - 1) (j' - 1) = 0 := by
@@ -1997,7 +1997,7 @@ private theorem rowSwap_row_eq_of_ne_int {n' m' : Nat}
   have hr_ne_j : r ≠ j := fun h => hrj (congrArg Fin.val h)
   have hr_ne_i : r ≠ i := fun h => hri (congrArg Fin.val h)
   have hget := Matrix.getElem_rowSwap M i j r ⟨c, hc⟩
-  rw [if_neg hr_ne_j, if_neg hr_ne_i] at hget
+  rw [ite_eq_right hr_ne_j, ite_eq_right hr_ne_i] at hget
   simpa [Matrix.row] using hget
 
 /-- For a `Matrix Int`, the `Fin`-indexed left swap row `i` becomes the old row
@@ -2011,10 +2011,10 @@ theorem rowSwap_row_left_int {n' m' : Nat}
   by_cases hij : i = j
   · subst j
     have hget := Matrix.getElem_rowSwap M i i i ⟨c, hc⟩
-    rw [if_pos rfl] at hget
+    rw [ite_eq_left rfl] at hget
     exact hget
   · have hget := Matrix.getElem_rowSwap M i j i ⟨c, hc⟩
-    rw [if_neg hij, if_pos rfl] at hget
+    rw [ite_eq_right hij, ite_eq_left rfl] at hget
     simpa [Matrix.row] using hget
 
 /-- For a `Matrix Int`, the `Fin`-indexed right swap row `j` becomes the old row
@@ -2026,7 +2026,7 @@ theorem rowSwap_row_right_int {n' m' : Nat}
   apply Vector.ext
   intro c hc
   have hget := Matrix.getElem_rowSwap M i j j ⟨c, hc⟩
-  rw [if_pos rfl] at hget
+  rw [ite_eq_left rfl] at hget
   simpa [Matrix.row] using hget
 
 /-- Raw-`Nat` row-access version of `rowSwap_row_eq_of_ne_int`: with a bound
@@ -2094,7 +2094,7 @@ theorem scaledCoeffMatrix_rowSwap_adjacent_pivot_transpose
         simpa [last, GramSchmidt.liftFinLE] using congrArg Fin.val hq_last
       rw [Matrix.getElem_transpose]
       simp only [GramSchmidt.scaledCoeffMatrix, Matrix.getElem_ofFn, Matrix.row]
-      rw [if_pos hq_val, if_pos (by simpa [last] using congrArg Fin.val hp_last),
+      rw [ite_eq_left hq_val, ite_eq_left (by simpa [last] using congrArg Fin.val hp_last),
         rowSwap_getRow_right_val_int]
       rw [hp_lift]
       rw [rowSwap_getRow_left_val_int]
@@ -2111,7 +2111,7 @@ theorem scaledCoeffMatrix_rowSwap_adjacent_pivot_transpose
         exact hp_last (Fin.ext (by simpa [last] using h))
       rw [Matrix.getElem_transpose]
       simp only [GramSchmidt.scaledCoeffMatrix, Matrix.getElem_ofFn, Matrix.row]
-      rw [if_pos hq_val, if_neg hp_val_ne, rowSwap_getRow_right_val_int,
+      rw [ite_eq_left hq_val, ite_eq_right hp_val_ne, rowSwap_getRow_right_val_int,
         rowSwap_getRow_eq_of_ne_val_int]
       · rw [hq_lift]
         exact dot_comm_int _ _
@@ -2133,7 +2133,7 @@ theorem scaledCoeffMatrix_rowSwap_adjacent_pivot_transpose
         exact hq_ne_val (by simpa [GramSchmidt.liftFinLE] using h)
       rw [Matrix.getElem_transpose]
       simp only [GramSchmidt.scaledCoeffMatrix, Matrix.getElem_ofFn, Matrix.row]
-      rw [if_neg hq_ne_val, if_pos hp_val]
+      rw [ite_eq_right hq_ne_val, ite_eq_left hp_val]
       rw [hp_lift]
       rw [rowSwap_getRow_left_val_int, rowSwap_getRow_eq_of_ne_val_int]
       · exact dot_comm_int _ _
@@ -2152,7 +2152,7 @@ theorem scaledCoeffMatrix_rowSwap_adjacent_pivot_transpose
         exact hq_ne_val (by simpa [GramSchmidt.liftFinLE] using h)
       rw [Matrix.getElem_transpose]
       simp only [GramSchmidt.scaledCoeffMatrix, Matrix.getElem_ofFn, Matrix.row]
-      rw [if_neg hq_ne_val, if_neg hp_ne_val, rowSwap_getRow_eq_of_ne_val_int]
+      rw [ite_eq_right hq_ne_val, ite_eq_right hp_ne_val, rowSwap_getRow_eq_of_ne_val_int]
       · rw [rowSwap_getRow_eq_of_ne_val_int]
         · exact dot_comm_int _ _
         · dsimp [GramSchmidt.liftFinLE]

--- a/HexGramSchmidt/Int/Core.lean
+++ b/HexGramSchmidt/Int/Core.lean
@@ -220,7 +220,7 @@ remains the direct reference definition used by proofs. -/
       split <;> rename_i hij
       · rfl
       · have hji : j ≤ i := by omega
-        rw [if_pos hji]
+        rw [ite_eq_left hji]
         exact Vector.dotProduct_comm (R := Int) _ _
 
 /-- Reading entry `(i, j)` of `gramRows b` recovers the Gram matrix entry

--- a/HexGramSchmidt/Int/Correspondence.lean
+++ b/HexGramSchmidt/Int/Correspondence.lean
@@ -807,12 +807,12 @@ private theorem scaledCoeffRows_diag_toNat_eq_gramDetVecEntry
     · have hsi' : s ≤ i := by
         simpa [iFin] using hsi
       have hs_lt : s < i + 1 := by omega
-      rw [if_pos hs_lt]
+      rw [ite_eq_left hs_lt]
       exact congrArg Int.toNat h_zero
     · have his' : i < s := by
         simpa [iFin] using his
       have hs_not_lt : ¬ s < i + 1 := by omega
-      rw [if_neg hs_not_lt]
+      rw [ite_eq_right hs_not_lt]
       exact congrArg Int.toNat h_eq
 
 /-- The scaled-coefficient loop stores the next leading Gram determinant on

--- a/HexGramSchmidtMathlib/Int/Augmented.lean
+++ b/HexGramSchmidtMathlib/Int/Augmented.lean
@@ -64,7 +64,7 @@ private theorem scaledCoeffMatrix_det_eq_gramDet_mul_coeffs
         (Matrix.setCol _ _ _)[pp][cc]
     rw [Matrix.getElem_setCol, castIntDetMatrix_get]
     by_cases hc_eq : cc = (⟨j, Nat.lt_succ_self j⟩ : Fin (j + 1))
-    · rw [if_pos hc_eq]
+    · rw [ite_eq_left hc_eq]
       have hc_val : cc.val = j := congrArg Fin.val hc_eq
       have hsc :
           (GramSchmidt.scaledCoeffMatrix b ⟨i, hi⟩ ⟨j, hjlt⟩ hj)[pp][cc] =
@@ -74,7 +74,7 @@ private theorem scaledCoeffMatrix_det_eq_gramDet_mul_coeffs
         simp [GramSchmidt.scaledCoeffMatrix, getRow_ofFn,
           GramSchmidt.liftFinLE, hc_val]
       rw [hsc, ← dot_castIntRow_eq_cast_dot]
-    · rw [if_neg hc_eq, castIntDetMatrix_get]
+    · rw [ite_eq_right hc_eq, castIntDetMatrix_get]
       have hc_ne : cc.val ≠ j := fun h => hc_eq (Fin.ext h)
       have hsc :
           (GramSchmidt.scaledCoeffMatrix b ⟨i, hi⟩ ⟨j, hjlt⟩ hj)[pp][cc] =
@@ -299,7 +299,7 @@ theorem augmentedGram_trailing_row
   unfold augmentedGram
   rw [Matrix.getElem_ofFn]
   have hn : ¬ (Fin.last n).val < n := by show ¬ n < n; omega
-  rw [dif_neg hn]
+  rw [dite_eq_right hn]
 
 /-- Substitution helper: matrix entries agree when Fin indices are equal.
 Used to reindex matrix-entry equalities across propositionally-equal Fin

--- a/HexGramSchmidtMathlib/Int/GramDet.lean
+++ b/HexGramSchmidtMathlib/Int/GramDet.lean
@@ -715,7 +715,7 @@ private theorem progressMatrix_succ_eq_colReplace
   -- Case split on Fin k equality.
   by_cases hjs : (⟨j, hj⟩ : Fin k) = (⟨s, hs⟩ : Fin k)
   · -- Column s case.
-    rw [if_pos hjs]
+    rw [ite_eq_left hjs]
     -- Get j = s from the Fin equality, then substitute hj with hs.
     have hjs_val : j = s := congrArg Fin.val hjs
     -- Replace [⟨j, hj⟩] with [⟨s, hs⟩] in the LHS by the Fin equality.
@@ -822,7 +822,7 @@ private theorem progressMatrix_succ_eq_colReplace
     -- Now use hfold_match to conclude.
     grind
   · -- j ≠ s case.
-    rw [if_neg hjs]
+    rw [ite_eq_right hjs]
     have hjs_ne : j ≠ s := fun h => hjs (Fin.ext h)
     by_cases hjlt : j < s
     · -- j < s: both versions use basis-row dot.

--- a/HexGramSchmidtMathlib/Int/RowAdd.lean
+++ b/HexGramSchmidtMathlib/Int/RowAdd.lean
@@ -131,8 +131,8 @@ theorem scaledCoeffMatrix_rowAdd_pivot_det
     · have hqNat : qf.val = j.val := hqj
       have hq_last : qf = last := Fin.ext hqj
       simp only [GramSchmidt.scaledCoeffMatrix, Hex.Matrix.getElem_setCol,
-        Hex.Matrix.getElem_ofFn, hqNat, if_true]
-      rw [if_pos hq_last]
+        Hex.Matrix.getElem_ofFn, hqNat, ite_true]
+      rw [ite_eq_left hq_last]
       simp only [Matrix.row]
       change ((Matrix.rowAdd b j k c)[GramSchmidt.liftFinLE p ht]).dotProduct
           ((Matrix.rowAdd b j k c)[k]) =
@@ -153,8 +153,8 @@ theorem scaledCoeffMatrix_rowAdd_pivot_det
             b[GramSchmidt.liftFinLE qf ht] :=
         rowAdd_row_eq_of_ne b j k (GramSchmidt.liftFinLE qf ht) c hq_ne_k
       simp only [GramSchmidt.scaledCoeffMatrix, Hex.Matrix.getElem_setCol,
-        Hex.Matrix.getElem_ofFn, if_neg hqNat]
-      rw [if_neg hq_ne_last]
+        Hex.Matrix.getElem_ofFn, ite_eq_right hqNat]
+      rw [ite_eq_right hq_ne_last]
       simp only [Matrix.row, ← Hex.Matrix.getElem_eq_getRow]
       rw [hp_row, hq_row]
       show _ = (GramSchmidt.leadingGramMatrixInt b t ht)[p][qf]
@@ -168,15 +168,15 @@ theorem scaledCoeffMatrix_rowAdd_pivot_det
     · have hqNat : qf.val = j.val := hqj
       have hq_last : qf = last := Fin.ext hqj
       simp only [GramSchmidt.scaledCoeffMatrix, Hex.Matrix.getElem_setCol,
-        Hex.Matrix.getElem_ofFn, hqNat, if_true]
-      rw [if_pos hq_last]
+        Hex.Matrix.getElem_ofFn, hqNat, ite_true]
+      rw [ite_eq_left hq_last]
     · have hq_ne_last : qf ≠ last := by
         intro h
         exact hqj (congrArg Fin.val h)
       have hqNat : qf.val ≠ j.val := hqj
       simp only [GramSchmidt.scaledCoeffMatrix, Hex.Matrix.getElem_setCol,
-        Hex.Matrix.getElem_ofFn, if_neg hqNat]
-      rw [if_neg hq_ne_last]
+        Hex.Matrix.getElem_ofFn, ite_eq_right hqNat]
+      rw [ite_eq_right hq_ne_last]
       show _ = (GramSchmidt.leadingGramMatrixInt b t ht)[p][qf]
       rw [getElem_leadingGramMatrixInt]
       rfl
@@ -192,10 +192,10 @@ theorem scaledCoeffMatrix_rowAdd_pivot_det
         simpa [last] using hval
       simp only [M, gramCol, GramSchmidt.leadingGramMatrixInt, Hex.Matrix.getElem_setCol,
         Hex.Matrix.getElem_ofFn]
-      rw [if_pos hq_last, hq_lift]
+      rw [ite_eq_left hq_last, hq_lift]
     · simp only [M, gramCol, GramSchmidt.leadingGramMatrixInt, Hex.Matrix.getElem_setCol,
         Hex.Matrix.getElem_ofFn]
-      rw [if_neg hq_last]
+      rw [ite_eq_right hq_last]
   calc
     Matrix.det (GramSchmidt.scaledCoeffMatrix (Matrix.rowAdd b j k c) k j hjk)
         = Matrix.det (Matrix.setCol M last (fun p => oldCol p + c * gramCol p)) := by
@@ -282,7 +282,7 @@ private theorem leadingGramMatrixInt_rowAdd_entry_inside
   -- Case split on `q = kt` and `p = kt`.
   by_cases hqk : q = kt
   · -- q = kt branch
-    rw [if_pos hqk]
+    rw [ite_eq_left hqk]
     rw [rowAdd_get_rect (GramSchmidt.leadingGramMatrixInt b t ht) jt kt p c q,
         rowAdd_get_rect (GramSchmidt.leadingGramMatrixInt b t ht) jt kt p c jt]
     -- The `b[·]` rewrites for `liftFinLE jt ht` and `liftFinLE kt ht`
@@ -317,7 +317,7 @@ private theorem leadingGramMatrixInt_rowAdd_entry_inside
             b[j].dotProduct b[k] + c * b[j].dotProduct b[j] :=
         dot_rowAdd_row_at_right b j k c b[j]
       rw [hrec_k, hrec_j]
-      simp only [if_pos hpk]
+      simp only [ite_eq_left hpk]
       rw [hM_entry kt q, hM_entry jt q, hM_entry kt jt, hM_entry jt jt]
       have hb_q : b[GramSchmidt.liftFinLE q ht] = b[k] :=
         congrArg b.getRow hqn_k
@@ -337,10 +337,10 @@ private theorem leadingGramMatrixInt_rowAdd_entry_inside
         congrArg b.getRow hqn_k
       rw [hrowAdd_q, rowAdd_row_eq_of_ne b j k (GramSchmidt.liftFinLE p ht) c hpn_ne,
         dot_rowAdd_row_at_right b j k c (b[GramSchmidt.liftFinLE p ht])]
-      simp only [if_neg hpk]
+      simp only [ite_eq_right hpk]
       rw [hM_entry p q, hM_entry p jt, hbjt_lift, hb_q]
   · -- q ≠ kt branch
-    rw [if_neg hqk]
+    rw [ite_eq_right hqk]
     have hqn_ne : (GramSchmidt.liftFinLE q ht).val ≠ k.val :=
       fun h => hqk (Fin.ext h)
     rw [rowAdd_get_rect (GramSchmidt.leadingGramMatrixInt b t ht) jt kt p c q,
@@ -358,13 +358,13 @@ private theorem leadingGramMatrixInt_rowAdd_entry_inside
             (Matrix.rowAdd b j k c)[k] :=
         congrArg (Matrix.rowAdd b j k c).getRow hpn_k
       rw [hrowAdd_p, dot_rowAdd_row_at_left b j k c (b[GramSchmidt.liftFinLE q ht])]
-      simp only [if_pos hpk]
+      simp only [ite_eq_left hpk]
       rw [hM_entry kt q, hM_entry jt q, hbjt_lift, hbkt_lift]
     · -- p ≠ kt, q ≠ kt
       have hpn_ne : (GramSchmidt.liftFinLE p ht).val ≠ k.val :=
         fun h => hpk (Fin.ext h)
       rw [rowAdd_row_eq_of_ne b j k (GramSchmidt.liftFinLE p ht) c hpn_ne]
-      simp only [if_neg hpk]
+      simp only [ite_eq_right hpk]
       rw [hM_entry p q]
 
 /-- When the modified row index `k` lies inside the leading `t`-prefix

--- a/HexGramSchmidtMathlib/Update.lean
+++ b/HexGramSchmidtMathlib/Update.lean
@@ -244,7 +244,7 @@ private theorem leadingGramMatrixInt_rowSwap_inside
       (Matrix.rowSwap b km1 k)[r] = (Matrix.rowSwap b km1 k)[r'] := by
     intros r r' h; exact congrArg (Matrix.rowSwap b km1 k).getRow h
   by_cases hqk : qq = k'
-  · simp only [if_pos hqk]
+  · simp only [ite_eq_left hqk]
     rw [entry_after_outer_swap km1']
     have hqn_k : qn = k := by
       apply Fin.ext
@@ -255,7 +255,7 @@ private theorem leadingGramMatrixInt_rowSwap_inside
       (heq_get_swap qn k hqn_k).trans (rowSwap_row_right_int b km1 k)
     rw [hqn_eq]
     by_cases hpk : pp = k'
-    · simp only [if_pos hpk]
+    · simp only [ite_eq_left hpk]
       have hpn_k : pn = k := by
         apply Fin.ext
         have hv : pp.val = k'.val := congrArg Fin.val hpk
@@ -265,7 +265,7 @@ private theorem leadingGramMatrixInt_rowSwap_inside
         (heq_get_swap pn k hpn_k).trans (rowSwap_row_right_int b km1 k)
       rw [hpn_eq, hM_entry]
     · by_cases hpkm1 : pp = km1'
-      · simp only [if_neg hpk, if_pos hpkm1]
+      · simp only [ite_eq_right hpk, ite_eq_left hpkm1]
         have hpn_km1 : pn = km1 := by
           apply Fin.ext
           have hv : pp.val = km1'.val := congrArg Fin.val hpkm1
@@ -274,7 +274,7 @@ private theorem leadingGramMatrixInt_rowSwap_inside
         have hpn_eq : (Matrix.rowSwap b km1 k)[pn] = b[k] :=
           (heq_get_swap pn km1 hpn_km1).trans (rowSwap_row_left_int b km1 k)
         rw [hpn_eq, hM_entry]
-      · simp only [if_neg hpk, if_neg hpkm1]
+      · simp only [ite_eq_right hpk, ite_eq_right hpkm1]
         have hpn_ne_km1 : pn ≠ km1 := by
           intro h
           apply hpkm1
@@ -293,7 +293,7 @@ private theorem leadingGramMatrixInt_rowSwap_inside
           rowSwap_row_eq_of_ne_int b km1 k pn hpn_ne_km1 hpn_ne_k
         rw [hp_swap, hM_entry]
   · by_cases hqkm1 : qq = km1'
-    · simp only [if_neg hqk, if_pos hqkm1]
+    · simp only [ite_eq_right hqk, ite_eq_left hqkm1]
       rw [entry_after_outer_swap k']
       have hqn_km1 : qn = km1 := by
         apply Fin.ext
@@ -304,7 +304,7 @@ private theorem leadingGramMatrixInt_rowSwap_inside
         (heq_get_swap qn km1 hqn_km1).trans (rowSwap_row_left_int b km1 k)
       rw [hqn_eq]
       by_cases hpk : pp = k'
-      · simp only [if_pos hpk]
+      · simp only [ite_eq_left hpk]
         have hpn_k : pn = k := by
           apply Fin.ext
           have hv : pp.val = k'.val := congrArg Fin.val hpk
@@ -314,7 +314,7 @@ private theorem leadingGramMatrixInt_rowSwap_inside
           (heq_get_swap pn k hpn_k).trans (rowSwap_row_right_int b km1 k)
         rw [hpn_eq, hM_entry]
       · by_cases hpkm1 : pp = km1'
-        · simp only [if_neg hpk, if_pos hpkm1]
+        · simp only [ite_eq_right hpk, ite_eq_left hpkm1]
           have hpn_km1 : pn = km1 := by
             apply Fin.ext
             have hv : pp.val = km1'.val := congrArg Fin.val hpkm1
@@ -323,7 +323,7 @@ private theorem leadingGramMatrixInt_rowSwap_inside
           have hpn_eq : (Matrix.rowSwap b km1 k)[pn] = b[k] :=
             (heq_get_swap pn km1 hpn_km1).trans (rowSwap_row_left_int b km1 k)
           rw [hpn_eq, hM_entry]
-        · simp only [if_neg hpk, if_neg hpkm1]
+        · simp only [ite_eq_right hpk, ite_eq_right hpkm1]
           have hpn_ne_km1 : pn ≠ km1 := by
             intro h
             apply hpkm1
@@ -341,7 +341,7 @@ private theorem leadingGramMatrixInt_rowSwap_inside
           have hp_swap : (Matrix.rowSwap b km1 k)[pn] = b[pn] :=
             rowSwap_row_eq_of_ne_int b km1 k pn hpn_ne_km1 hpn_ne_k
           rw [hp_swap, hM_entry]
-    · simp only [if_neg hqk, if_neg hqkm1]
+    · simp only [ite_eq_right hqk, ite_eq_right hqkm1]
       rw [entry_after_outer_swap qq]
       have hqn_ne_km1 : qn ≠ km1 := by
         intro h
@@ -361,7 +361,7 @@ private theorem leadingGramMatrixInt_rowSwap_inside
         rowSwap_row_eq_of_ne_int b km1 k qn hqn_ne_km1 hqn_ne_k
       rw [hq_swap]
       by_cases hpk : pp = k'
-      · simp only [if_pos hpk]
+      · simp only [ite_eq_left hpk]
         have hpn_k : pn = k := by
           apply Fin.ext
           have hv : pp.val = k'.val := congrArg Fin.val hpk
@@ -371,7 +371,7 @@ private theorem leadingGramMatrixInt_rowSwap_inside
           (heq_get_swap pn k hpn_k).trans (rowSwap_row_right_int b km1 k)
         rw [hpn_eq, hM_entry]
       · by_cases hpkm1 : pp = km1'
-        · simp only [if_neg hpk, if_pos hpkm1]
+        · simp only [ite_eq_right hpk, ite_eq_left hpkm1]
           have hpn_km1 : pn = km1 := by
             apply Fin.ext
             have hv : pp.val = km1'.val := congrArg Fin.val hpkm1
@@ -380,7 +380,7 @@ private theorem leadingGramMatrixInt_rowSwap_inside
           have hpn_eq : (Matrix.rowSwap b km1 k)[pn] = b[k] :=
             (heq_get_swap pn km1 hpn_km1).trans (rowSwap_row_left_int b km1 k)
           rw [hpn_eq, hM_entry]
-        · simp only [if_neg hpk, if_neg hpkm1]
+        · simp only [ite_eq_right hpk, ite_eq_right hpkm1]
           have hpn_ne_km1 : pn ≠ km1 := by
             intro h
             apply hpkm1

--- a/HexHensel/Linear.lean
+++ b/HexHensel/Linear.lean
@@ -355,7 +355,7 @@ private theorem liftToZ_mulCoeffTerm_congr
   unfold FpPoly.mulCoeffTerm DensePoly.mulCoeffStep
   by_cases hni : n < i
   · have hneq : i + (n - i) ≠ n := by omega
-    rw [if_pos hni, if_neg hneq]
+    rw [ite_eq_left hni, ite_eq_right hneq]
     change (Int.ofNat (ZMod64.zero : ZMod64 p).toNat - 0) % (p : Int) = 0
     rw [ZMod64.toNat_zero]
     simp
@@ -912,10 +912,10 @@ private theorem mulCoeffStep_scale_left_int
       c * DensePoly.mulCoeffStep f g n i acc j := by
   unfold DensePoly.mulCoeffStep
   by_cases hij : i + j = n
-  · rw [if_pos hij, if_pos hij]
+  · rw [ite_eq_left hij, ite_eq_left hij]
     rw [DensePoly.coeff_scale _ _ _ (Int.mul_zero c)]
     grind
-  · rw [if_neg hij, if_neg hij]
+  · rw [ite_eq_right hij, ite_eq_right hij]
 
 /-- Scaling the left factor by `c` factors that constant out of a
 `DensePoly.mulCoeffStep` fold over any index list. -/

--- a/HexHensel/ModularDivision.lean
+++ b/HexHensel/ModularDivision.lean
@@ -259,15 +259,15 @@ private theorem getD_setIfInBounds (a : Array Int) (i j : Nat) (v : Int) :
   by_cases hji : j = i
   · subst hji
     by_cases hi : j < a.size
-    · rw [if_pos ⟨rfl, hi⟩, Array.getD_eq_getD_getElem?,
+    · rw [ite_eq_left ⟨rfl, hi⟩, Array.getD_eq_getD_getElem?,
         Array.getElem?_eq_getElem (by simpa using hi)]
       simp
-    · rw [if_neg (by omega : ¬ (j = j ∧ j < a.size)),
-        Array.setIfInBounds, dif_neg hi]
-  · rw [if_neg (by omega : ¬ (j = i ∧ i < a.size)),
+    · rw [ite_eq_right (by omega : ¬ (j = j ∧ j < a.size)),
+        Array.setIfInBounds, dite_eq_right hi]
+  · rw [ite_eq_right (by omega : ¬ (j = i ∧ i < a.size)),
       Array.getD_eq_getD_getElem?, Array.getD_eq_getD_getElem?,
       Array.getElem?_setIfInBounds]
-    rw [if_neg (by omega : ¬ (i = j))]
+    rw [ite_eq_right (by omega : ¬ (i = j))]
 
 private theorem elimFold_size (M : Nat) (q : ZPoly) (k : Nat) (c : Int) :
     ∀ (len : Nat) (a : Array Int),
@@ -306,19 +306,19 @@ private theorem elimFold_getD (M : Nat) (q : ZPoly) (k : Nat) (c : Int) :
       simp only [List.foldl_cons, List.foldl_nil]
       rw [getD_setIfInBounds, elimFold_size M q k c len a,
         ih a (k + len) (by omega), ih a n (by omega),
-        if_neg (by omega : ¬ (k ≤ k + len ∧ k + len - k < len))]
+        ite_eq_right (by omega : ¬ (k ≤ k + len ∧ k + len - k < len))]
       by_cases hn : n = k + len
       · subst hn
-        rw [if_pos ⟨rfl, by omega⟩, if_pos ⟨by omega, by omega⟩,
+        rw [ite_eq_left ⟨rfl, by omega⟩, ite_eq_left ⟨by omega, by omega⟩,
           show k + len - k = len by omega]
-      · rw [if_neg (by omega : ¬ (n = k + len ∧ k + len < a.size))]
+      · rw [ite_eq_right (by omega : ¬ (n = k + len ∧ k + len < a.size))]
         by_cases hk : k ≤ n
         · by_cases hlt : n - k < len
-          · rw [if_pos ⟨hk, hlt⟩, if_pos ⟨hk, by omega⟩]
-          · rw [if_neg (by omega : ¬ (k ≤ n ∧ n - k < len)),
-              if_neg (by omega : ¬ (k ≤ n ∧ n - k < len + 1))]
-        · rw [if_neg (by omega : ¬ (k ≤ n ∧ n - k < len)),
-            if_neg (by omega : ¬ (k ≤ n ∧ n - k < len + 1))]
+          · rw [ite_eq_left ⟨hk, hlt⟩, ite_eq_left ⟨hk, by omega⟩]
+          · rw [ite_eq_right (by omega : ¬ (k ≤ n ∧ n - k < len)),
+              ite_eq_right (by omega : ¬ (k ≤ n ∧ n - k < len + 1))]
+        · rw [ite_eq_right (by omega : ¬ (k ≤ n ∧ n - k < len)),
+            ite_eq_right (by omega : ¬ (k ≤ n ∧ n - k < len + 1))]
 
 private theorem coeff_elimStep (m : Nat) (rem q : ZPoly) (k : Nat) (coeff : Int)
     (hwindow : k + q.size ≤ rem.size) (i : Nat) :
@@ -360,9 +360,9 @@ private theorem intArray_ofFn_getD {n : Nat} (f : Fin n → Int) (i : Nat) :
       if h : i < n then f ⟨i, h⟩ else (Zero.zero : Int) := by
   rw [Array.getD_eq_getD_getElem?, Array.getElem?_ofFn]
   by_cases h : i < n
-  · rw [dif_pos h, dif_pos h]
+  · rw [dite_eq_left h, dite_eq_left h]
     rfl
-  · rw [dif_neg h, dif_neg h]
+  · rw [dite_eq_right h, dite_eq_right h]
     rfl
 
 private theorem coeff_quotStep (quot : ZPoly) (k : Nat) (coeff : Int) (i : Nat) :
@@ -370,17 +370,17 @@ private theorem coeff_quotStep (quot : ZPoly) (k : Nat) (coeff : Int) (i : Nat) 
   unfold quotStep
   rw [DensePoly.coeff_ofCoeffs]
   by_cases hk : k < quot.size
-  · rw [if_pos hk, getD_setIfInBounds]
+  · rw [ite_eq_left hk, getD_setIfInBounds]
     by_cases hik : i = k
-    · rw [if_pos ⟨hik, by simpa using hk⟩, if_pos hik]
-    · rw [if_neg (by omega : ¬ (i = k ∧ k < quot.toArray.size)), if_neg hik,
+    · rw [ite_eq_left ⟨hik, by simpa using hk⟩, ite_eq_left hik]
+    · rw [ite_eq_right (by omega : ¬ (i = k ∧ k < quot.toArray.size)), ite_eq_right hik,
         DensePoly.toArray_getD]
-  · rw [if_neg hk, intArray_ofFn_getD]
+  · rw [ite_eq_right hk, intArray_ofFn_getD]
     by_cases hik : i = k
-    · rw [dif_pos (by omega : i < k + 1), if_pos hik]
+    · rw [dite_eq_left (by omega : i < k + 1), ite_eq_left hik]
     · by_cases hi : i < k + 1
-      · rw [dif_pos hi, if_neg hik]
-      · rw [dif_neg hi, if_neg hik,
+      · rw [dite_eq_left hi, ite_eq_right hik]
+      · rw [dite_eq_right hi, ite_eq_right hik,
           DensePoly.coeff_eq_zero_of_size_le quot (by omega)]
 
 private theorem pow_two_eq_mul (m : Nat) : m ^ 2 = m * m := by
@@ -396,11 +396,11 @@ private theorem coeff_mulMonomialModSquare (m : Nat) (q : ZPoly) (k : Nat)
   rw [monomial_mul_eq_shift_scale, coeff_reduceModPow, pow_two_eq_mul,
     DensePoly.coeff_shift]
   by_cases hk : i < k
-  · rw [if_pos hk, if_neg (by omega : ¬ k ≤ i)]
+  · rw [ite_eq_left hk, ite_eq_right (by omega : ¬ k ≤ i)]
     show intEmod 0 (m * m) = 0
     unfold intEmod intModNat
     simp
-  · rw [if_neg hk, if_pos (by omega : k ≤ i), DensePoly.coeff_scale_semiring]
+  · rw [ite_eq_right hk, ite_eq_left (by omega : k ≤ i), DensePoly.coeff_scale_semiring]
     rfl
 
 /-- The windowed elimination is the specification's elimination, given a
@@ -424,18 +424,18 @@ private theorem elimStep_eq (m : Nat) (hm : 0 < m) (rem q : ZPoly) (k : Nat) (co
     rfl
   rw [coeff_elimStep m rem q k coeff (by omega) i, hrhs]
   by_cases hk : k ≤ i
-  · simp only [if_pos hk]
+  · simp only [ite_eq_left hk]
     rw [intEmod_sub_intEmod _ _ hmm]
     by_cases hi : i - k < q.size
-    · rw [if_pos ⟨hk, hi⟩]
-    · rw [if_neg (by omega : ¬ (k ≤ i ∧ i - k < q.size))]
+    · rw [ite_eq_left ⟨hk, hi⟩]
+    · rw [ite_eq_right (by omega : ¬ (k ≤ i ∧ i - k < q.size))]
       have hr : rem.coeff i = 0 :=
         DensePoly.coeff_eq_zero_of_size_le rem (by omega)
       have hq : q.coeff (i - k) = 0 :=
         DensePoly.coeff_eq_zero_of_size_le q (by omega)
       rw [hr, hq, Int.mul_zero, Int.sub_zero, hzero]
-  · simp only [if_neg hk]
-    rw [Int.sub_zero, if_neg (by omega : ¬ (k ≤ i ∧ i - k < q.size))]
+  · simp only [ite_eq_right hk]
+    rw [Int.sub_zero, ite_eq_right (by omega : ¬ (k ≤ i ∧ i - k < q.size))]
     exact (intEmod_eq_self (hrem i).1 (hrem i).2).symm
 
 /-- The windowed quotient write is the specification's quotient update, given a
@@ -457,10 +457,10 @@ private theorem quotStep_eq (m : Nat) (_hm : 0 < m) (quot : ZPoly) (k : Nat) (co
     rfl
   rw [coeff_quotStep, hrhs]
   by_cases hik : i = k
-  · simp only [if_pos hik]
+  · simp only [ite_eq_left hik]
     rw [hik, hslot, Int.zero_add]
     exact (intEmod_eq_self hc0 hc1).symm
-  · simp only [if_neg hik]
+  · simp only [ite_eq_right hik]
     rw [Int.add_zero]
     exact (intEmod_eq_self (hquot i).1 (hquot i).2).symm
 
@@ -471,9 +471,9 @@ private theorem size_of_degree?_eq_some {p : ZPoly} {d : Nat} (h : p.degree? = s
     p.size = d + 1 := by
   unfold DensePoly.degree? at h
   by_cases hz : p.size = 0
-  · rw [dif_pos hz] at h
+  · rw [dite_eq_left hz] at h
     exact absurd h (by simp)
-  · rw [dif_neg hz] at h
+  · rw [dite_eq_right hz] at h
     have hd : p.size - 1 = d := by
       injection h
     omega
@@ -497,7 +497,7 @@ private theorem elimStep_size_lt (m : Nat) (hm : 0 < m) (rem q : ZPoly) (rd qd :
   have htop : (elimStep m rem q (rd - qd)
       (reduceCoeffModSquare rem.leadingCoeff m)).coeff rd = 0 := by
     rw [coeff_elimStep m rem q (rd - qd) _ (by omega) rd,
-      if_pos ⟨by omega, by omega⟩,
+      ite_eq_left ⟨by omega, by omega⟩,
       show rd - (rd - qd) = qd by omega, hqlead, Int.mul_one,
       reduceCoeffModSquare_eq_intEmod, hrlead, intEmod_sub_intEmod _ _ hmm,
       Int.sub_self]
@@ -558,8 +558,8 @@ private theorem divModMonicModSquareAux_eq_impl
       intro quot rem hquot hrem hsupp
       rw [divModMonicModSquareAux, divModMonicModSquareAuxImpl]
       by_cases hz : q.isZero = true
-      · simp only [hz, if_true]
-      · simp only [hz, if_false, Bool.false_eq_true]
+      · simp only [hz, ite_true]
+      · simp only [hz, ite_false, Bool.false_eq_true]
         cases hrd : rem.degree? with
         | none => simp only
         | some rd =>
@@ -568,8 +568,8 @@ private theorem divModMonicModSquareAux_eq_impl
             | some qd =>
                 simp only
                 by_cases hlt : rd < qd
-                · simp only [if_pos hlt]
-                · simp only [if_neg hlt]
+                · simp only [ite_eq_left hlt]
+                · simp only [ite_eq_right hlt]
                   have hle : qd ≤ rd := by omega
                   have hrsize : rem.size = rd + 1 := size_of_degree?_eq_some hrd
                   have hqsize : q.size = qd + 1 := size_of_degree?_eq_some hqd
@@ -614,7 +614,7 @@ private theorem divModMonicModSquareAux_eq_impl
                         (reduceCoeffModSquare rem.leadingCoeff m)).coeff i = 0 := by
                     intro i hi
                     have hik : i < rd - qd := by omega
-                    rw [coeff_quotStep, if_neg (by omega : ¬ i = rd - qd)]
+                    rw [coeff_quotStep, ite_eq_right (by omega : ¬ i = rd - qd)]
                     exact hsupp i (by omega)
                   rw [← hstepQ, ← hstepR]
                   exact ih _ _ hcanonQ hcanonR hsupp'
@@ -637,7 +637,7 @@ def divModMonicModSquareImpl (p q : ZPoly) (m : Nat) : ZPoly × ZPoly :=
   funext p q m
   unfold divModMonicModSquare divModMonicModSquareImpl
   by_cases hguard : 0 < m ∧ DensePoly.leadingCoeff q = 1
-  · rw [if_pos hguard]
+  · rw [ite_eq_left hguard]
     have hm := hguard.1
     have hpow : 0 < m ^ 2 := Nat.pow_pos hm
     have hcanon : Canonical (QuadraticLiftResult.reduceModSquare p m) (m * m) := by
@@ -653,7 +653,7 @@ def divModMonicModSquareImpl (p q : ZPoly) (m : Nat) : ZPoly × ZPoly :=
       omega
     · intro i _
       simp
-  · rw [if_neg hguard]
+  · rw [ite_eq_right hguard]
 
 end ZPoly
 

--- a/HexHensel/ModularPolynomial.lean
+++ b/HexHensel/ModularPolynomial.lean
@@ -68,19 +68,19 @@ theorem intModNat_eq_impl_value (z : Int) (m : Nat) :
     intModNat z m = intModNatImpl z m := by
   unfold intModNat intModNatImpl
   by_cases hz : 0 ≤ z
-  · rw [if_pos hz]
+  · rw [ite_eq_left hz]
     by_cases hlt : z < Int.ofNat m
-    · rw [if_pos hlt, Int.emod_eq_of_lt hz hlt]
-    · rw [if_neg hlt]
-  · rw [if_neg hz]
+    · rw [ite_eq_left hlt, Int.emod_eq_of_lt hz hlt]
+    · rw [ite_eq_right hlt]
+  · rw [ite_eq_right hz]
     dsimp only
     by_cases hshift : 0 ≤ z + Int.ofNat m
-    · rw [if_pos hshift]
+    · rw [ite_eq_left hshift]
       have hlt : z + Int.ofNat m < Int.ofNat m := by omega
       have hshift_emod : (z + Int.ofNat m) % Int.ofNat m = z % Int.ofNat m := by
         simp
       rw [← hshift_emod, Int.emod_eq_of_lt hshift hlt]
-    · rw [if_neg hshift]
+    · rw [ite_eq_right hshift]
 
 /-- Proof-backed compiled implementation of the canonical representative. -/
 @[csimp] theorem intModNat_eq_impl : @intModNat = @intModNatImpl := by
@@ -128,31 +128,31 @@ theorem intEmod_eq_impl_value (z : Int) (m : Nat) :
     intEmod z m = intEmodImpl z m := by
   unfold intEmod intEmodImpl intModNat
   by_cases hm : m = 0
-  · rw [if_pos hm, hm]
+  · rw [ite_eq_left hm, hm]
     simp
-  · rw [if_neg hm]
+  · rw [ite_eq_right hm]
     have hmpos : 0 < m := Nat.pos_of_ne_zero hm
     have hnonneg : 0 ≤ z % Int.ofNat m :=
       Int.emod_nonneg _ (Int.ofNat_ne_zero.mpr hm)
     have hround : Int.ofNat (Int.toNat (z % Int.ofNat m)) = z % Int.ofNat m := by
       rw [Int.ofNat_eq_natCast, Int.toNat_of_nonneg hnonneg]
     by_cases hz : 0 ≤ z
-    · rw [if_pos hz]
+    · rw [ite_eq_left hz]
       by_cases hlt : z < Int.ofNat m
-      · rw [if_pos hlt, Int.emod_eq_of_lt hz hlt, Int.ofNat_eq_natCast,
+      · rw [ite_eq_left hlt, Int.emod_eq_of_lt hz hlt, Int.ofNat_eq_natCast,
           Int.toNat_of_nonneg hz]
-      · rw [if_neg hlt]
+      · rw [ite_eq_right hlt]
         exact hround
-    · rw [if_neg hz]
+    · rw [ite_eq_right hz]
       dsimp only
       by_cases hshift : 0 ≤ z + Int.ofNat m
-      · rw [if_pos hshift]
+      · rw [ite_eq_left hshift]
         have hlt : z + Int.ofNat m < Int.ofNat m := by omega
         have hshift_emod : (z + Int.ofNat m) % Int.ofNat m = z % Int.ofNat m := by
           simp
         rw [← hshift_emod, Int.emod_eq_of_lt hshift hlt, Int.ofNat_eq_natCast,
           Int.toNat_of_nonneg hshift]
-      · rw [if_neg hshift]
+      · rw [ite_eq_right hshift]
         exact hround
 
 /-- Proof-backed compiled implementation of the `Int`-valued canonical

--- a/HexHensel/Quadratic.lean
+++ b/HexHensel/Quadratic.lean
@@ -548,7 +548,7 @@ private theorem monomial_zero_mod_base
   rw [DensePoly.coeff_monomial, DensePoly.coeff_zero]
   by_cases hi : i = k
   · simp [hi, hc]
-  · rw [if_neg hi]
+  · rw [ite_eq_right hi]
     change ((0 : Int) - 0) % (m : Int) = 0
     simp
 
@@ -1930,10 +1930,10 @@ def quadraticHenselStepBignumImpl
   funext m f g h s t
   unfold quadraticHenselStepBignum quadraticHenselStepBignumImpl
   by_cases hm : 0 < m
-  · simp only [if_pos hm, mulModSquare_factorError_reduce m hm,
+  · simp only [ite_eq_left hm, mulModSquare_factorError_reduce m hm,
       addModSquare_addModSquare m hm, subModSquare_addModSquare m hm,
       subModSquare_subModSquare m hm]
-  · simp only [if_neg hm]
+  · simp only [ite_eq_right hm]
 
 /-- Guarded selection: the word-sized step when its guard holds, else the bignum step. -/
 def quadraticHenselStep
@@ -2011,9 +2011,9 @@ def quadraticHenselFactorsBignumImpl
   funext m f g h s t
   unfold quadraticHenselFactorsBignum quadraticHenselFactorsBignumImpl
   by_cases hm : 0 < m
-  · simp only [if_pos hm, mulModSquare_factorError_reduce m hm,
+  · simp only [ite_eq_left hm, mulModSquare_factorError_reduce m hm,
       addModSquare_addModSquare m hm]
-  · simp only [if_neg hm]
+  · simp only [ite_eq_right hm]
 
 /-- Update only the two factors in one quadratic Hensel step. The result is
 byte-identical to the `g` and `h` fields of `quadraticHenselStep`, while the
@@ -2031,20 +2031,20 @@ private theorem quadraticHenselFactorsWord?_eq
       (quadraticHenselStepWord? m f g h s t).map fun r => (r.g, r.h) := by
   unfold quadraticHenselFactorsWord? quadraticHenselStepWord?
   by_cases h2 : m * m < UInt64.word
-  · simp only [dif_pos h2]
+  · simp only [dite_eq_left h2]
     by_cases hodd : (UInt64.ofNat (m * m)) % 2 = 1
-    · simp only [dif_pos hodd]
+    · simp only [dite_eq_left hodd]
       by_cases h1 : 1 < m * m
-      · simp only [dif_pos h1]
+      · simp only [dite_eq_left h1]
         by_cases hm : DensePoly.leadingCoeff g = 1
-        · simp only [dif_pos hm]
+        · simp only [dite_eq_left hm]
           by_cases hd : 0 < g.degree?.getD 0
-          · simp only [dif_pos hd, Option.map_some]
-          · simp only [dif_neg hd, Option.map_none]
-        · simp only [dif_neg hm, Option.map_none]
-      · simp only [dif_neg h1, Option.map_none]
-    · simp only [dif_neg hodd, Option.map_none]
-  · simp only [dif_neg h2, Option.map_none]
+          · simp only [dite_eq_left hd, Option.map_some]
+          · simp only [dite_eq_right hd, Option.map_none]
+        · simp only [dite_eq_right hm, Option.map_none]
+      · simp only [dite_eq_right h1, Option.map_none]
+    · simp only [dite_eq_right hodd, Option.map_none]
+  · simp only [dite_eq_right h2, Option.map_none]
 
 /-- The factor-only step agrees exactly with the factor fields of the full
 quadratic step. -/
@@ -2501,7 +2501,7 @@ private theorem toWP_divModMonicModSquare (m : Nat)
   have hqpos : 0 < q.size := by
     rcases Nat.eq_zero_or_pos q.size with h0 | h0
     · exfalso
-      rw [DensePoly.degree?, dif_pos h0] at hqd
+      rw [DensePoly.degree?, dite_eq_left h0] at hqd
       simp at hqd
     · exact h0
   have hm1' : 1 < (UInt64.ofNat (m * m)).toNat := by
@@ -2539,7 +2539,7 @@ private theorem toWP_divModMonicModSquare (m : Nat)
           (DensePoly.coeff_last_ne_zero_of_pos_size _ (by omega))
       · exact hge
     rcases Nat.eq_zero_or_pos (divModMonicModSquare p q m).2.size with h0 | h0
-    · rw [DensePoly.degree?, dif_pos h0, Option.getD_none,
+    · rw [DensePoly.degree?, dite_eq_left h0, Option.getD_none,
         DensePoly.degree?_eq_some_of_pos_size q hqpos, Option.getD_some]
       omega
     · rw [DensePoly.degree?_eq_some_of_pos_size _ h0,
@@ -2558,7 +2558,7 @@ theorem quadraticHenselStepWord?_eq (m : Nat) (f g h s t : ZPoly)
   have hgpos : 0 < g.size := by
     rcases Nat.eq_zero_or_pos g.size with h0 | h0
     · exfalso
-      rw [DensePoly.degree?, dif_pos h0] at hd
+      rw [DensePoly.degree?, dite_eq_left h0] at hd
       simp at hd
     · exact h0
   have hg2 : 2 ≤ g.size := by
@@ -2567,7 +2567,8 @@ theorem quadraticHenselStepWord?_eq (m : Nat) (f g h s t : ZPoly)
     omega
   have hmbase : 1 < m := one_lt_of_mul m h1
   unfold quadraticHenselStepWord?
-  simp only [dif_pos h2, dif_pos hodd, dif_pos h1, dif_pos hmlc, dif_pos hd]
+  simp only [dite_eq_left h2, dite_eq_left hodd, dite_eq_left h1, dite_eq_left hmlc,
+    dite_eq_left hd]
   generalize hctx : _root_.MontCtx.mk (UInt64.ofNat (m * m)) hodd = ctx
   simp only [WordPoly.mul_eq, WordPoly.mulAdd_eq, WordPoly.add_eq, WordPoly.sub_eq]
   refine congrArg some ?_
@@ -2693,20 +2694,20 @@ theorem quadraticHenselStep_eq_bignum
   · have hnone : quadraticHenselStepWord? m f g h s t = none := by
       unfold quadraticHenselStepWord?
       by_cases a : m * m < UInt64.word
-      · rw [dif_pos a]
+      · rw [dite_eq_left a]
         by_cases b : (UInt64.ofNat (m * m)) % 2 = 1
-        · rw [dif_pos b]
+        · rw [dite_eq_left b]
           by_cases c : 1 < m * m
-          · rw [dif_pos c]
+          · rw [dite_eq_left c]
             by_cases d : DensePoly.leadingCoeff g = 1
-            · rw [dif_pos d]
+            · rw [dite_eq_left d]
               by_cases e : 0 < g.degree?.getD 0
               · exact absurd ⟨a, b, c, d, e⟩ hguard
-              · rw [dif_neg e]
-            · rw [dif_neg d]
-          · rw [dif_neg c]
-        · rw [dif_neg b]
-      · rw [dif_neg a]
+              · rw [dite_eq_right e]
+            · rw [dite_eq_right d]
+          · rw [dite_eq_right c]
+        · rw [dite_eq_right b]
+      · rw [dite_eq_right a]
     rw [hnone]
 
 /-! # Coefficient-range invariant of one quadratic step

--- a/HexHensel/QuadraticMultifactor.lean
+++ b/HexHensel/QuadraticMultifactor.lean
@@ -142,16 +142,16 @@ private theorem liftExact_eq_impl_value
   induction k, acc using liftExact.induct (p := p) (f := f) with
   | case1 k acc hsmall =>
       rw [liftExact, liftExactImpl]
-      simp only [if_pos hsmall]
+      simp only [ite_eq_left hsmall]
   | case2 k acc hlarge half ih =>
       rw [liftExact, liftExactImpl]
-      simp only [if_neg hlarge]
+      simp only [ite_eq_right hlarge]
       have ih' : liftExact p f ((k + 1) / 2) acc = liftExactImpl p f ((k + 1) / 2) acc := ih
       rw [ih']
       by_cases heven : 2 * ((k + 1) / 2) = k
-      · simp only [if_pos heven]
+      · simp only [ite_eq_left heven]
         exact reduceLift_step_eq_of_even p k ((k + 1) / 2) f _ _ _ _ heven
-      · simp only [if_neg heven]
+      · simp only [ite_eq_right heven]
 
 /-- Proof-backed compiled implementation of the exact-exponent quadratic
 recursion. -/
@@ -213,7 +213,7 @@ def henselLiftFactorsImpl
   · rename_i hlarge
     dsimp only
     by_cases heven : 2 * ((k + 1) / 2) = k
-    · simp only [if_pos heven]
+    · simp only [ite_eq_left heven]
       have hmpos : 0 < p ^ ((k + 1) / 2) :=
         Nat.pow_pos (ZMod64.Bounds.pPos (p := p))
       have hmm : p ^ ((k + 1) / 2) * p ^ ((k + 1) / 2) = p ^ k := by
@@ -226,7 +226,7 @@ def henselLiftFactorsImpl
       rw [hmm] at hfst hsnd
       rw [ZPoly.reduceModPow_eq_self_of_canonical _ p k hpk hfst,
         ZPoly.reduceModPow_eq_self_of_canonical _ p k hpk hsnd]
-    · simp only [if_neg heven]
+    · simp only [ite_eq_right heven]
 
 /-- The factor-only final step is byte-identical to projecting the full lift. -/
 theorem henselLiftFactors_eq
@@ -418,7 +418,7 @@ private theorem multifactorLiftQuadraticList_eq_impl_value
       cases canonical with
       | false => simp
       | true =>
-          simp only [if_true]
+          simp only [ite_true]
           rw [ZPoly.reduceModPow_eq_self_of_canonical f p k hpk (hcanonical rfl)]
   | case3 f g₀ g₁ rest =>
       rename_i ihL ihR
@@ -623,7 +623,7 @@ private theorem liftExact_invariant
       simpa using hinv
   | case2 k acc hlarge half ih =>
       rw [liftExact]
-      simp only [if_neg hlarge]
+      simp only [ite_eq_right hlarge]
       let prior := liftExact p f half acc
       let next := quadraticHenselStep (p ^ half) f
         prior.g prior.h prior.s prior.t
@@ -676,7 +676,7 @@ private theorem liftExact_factors_congr_mod_base
       exact reduceLift_factors_congr_mod_base p 1 acc (by omega)
   | case2 k acc hlarge half ih =>
       rw [liftExact]
-      simp only [if_neg hlarge]
+      simp only [ite_eq_right hlarge]
       let prior := liftExact p f half acc
       let next := quadraticHenselStep (p ^ half) f
         prior.g prior.h prior.s prior.t

--- a/HexHensel/WordTransport.lean
+++ b/HexHensel/WordTransport.lean
@@ -121,8 +121,8 @@ theorem intModNat_one {M : Nat} (hM : 0 < M) : ZPoly.intModNat 1 M = 1 % M := by
     DensePoly.coeff_C, DensePoly.coeff_C]
   rcases Nat.eq_zero_or_pos j with hj | hj
   · subst hj
-    rw [if_pos rfl, if_pos rfl, WordMod.toNat_one, intModNat_one ctx.p_pos, Nat.mod_mod]
-  · rw [if_neg (Nat.ne_of_gt hj), if_neg (Nat.ne_of_gt hj),
+    rw [ite_eq_left rfl, ite_eq_left rfl, WordMod.toNat_one, intModNat_one ctx.p_pos, Nat.mod_mod]
+  · rw [ite_eq_right (Nat.ne_of_gt hj), ite_eq_right (Nat.ne_of_gt hj),
       show (Zero.zero : WordMod ctx) = 0 from rfl, WordMod.toNat_zero,
       show (Zero.zero : Int) = 0 from rfl, ZPoly.intModNat]
     simp
@@ -153,9 +153,9 @@ theorem mulCoeffStep_ge (p q : DensePoly R) (n i : Nat) (acc : R) (j : Nat) (hj 
     mulCoeffStep p q n i acc j = acc := by
   unfold mulCoeffStep
   by_cases h : i + j = n
-  · rw [if_pos h, coeff_eq_zero_of_size_le q hj, show (Zero.zero : R) = 0 from rfl,
+  · rw [ite_eq_left h, coeff_eq_zero_of_size_le q hj, show (Zero.zero : R) = 0 from rfl,
       Lean.Grind.Semiring.mul_zero, Lean.Grind.Semiring.add_zero]
-  · rw [if_neg h]
+  · rw [ite_eq_right h]
 
 /-- Extending the inner fold past `q.size` changes nothing. -/
 theorem mulCoeffStep_inner_extend (p q : DensePoly R) (n i : Nat) (acc : R) (t : Nat)
@@ -180,9 +180,9 @@ theorem mulCoeffStep_inner_all_zero (p q : DensePoly R) (n i : Nat) (acc : R) (h
       rw [show mulCoeffStep p q n i acc j = acc from by
         unfold mulCoeffStep
         by_cases h : i + j = n
-        · rw [if_pos h, coeff_eq_zero_of_size_le p hi, show (Zero.zero : R) = 0 from rfl,
+        · rw [ite_eq_left h, coeff_eq_zero_of_size_le p hi, show (Zero.zero : R) = 0 from rfl,
             Lean.Grind.Semiring.zero_mul, Lean.Grind.Semiring.add_zero]
-        · rw [if_neg h], ih]
+        · rw [ite_eq_right h], ih]
 
 /-- Extending the outer fold past `p.size` changes nothing. -/
 theorem mulCoeffStep_outer_extend (p q : DensePoly R) (n : Nat) (acc : R) (s : Nat)
@@ -283,9 +283,9 @@ private theorem Res_inner_fold (x y : ZPoly) (n i : Nat) (L : List Nat) :
       apply ih
       unfold mulCoeffStep
       by_cases hc : i + a = n
-      · rw [if_pos hc, if_pos hc]
+      · rw [ite_eq_left hc, ite_eq_left hc]
         exact Res_add ctx h (Res_mul ctx (Res_coeff_toWP ctx x i) (Res_coeff_toWP ctx y a))
-      · rw [if_neg hc, if_neg hc]; exact h
+      · rw [ite_eq_right hc, ite_eq_right hc]; exact h
 
 private theorem Res_outer_fold (x y : ZPoly) (n t : Nat) (L : List Nat) :
     ∀ (w : WordMod ctx) (z : Int), Res ctx w z →
@@ -374,7 +374,7 @@ theorem toWP_degree_eq_of_monic {z : ZPoly} (hz : DensePoly.Monic z) (hzpos : 0 
 theorem toWP_degree_le (z : ZPoly) : (toWP ctx z).degree?.getD 0 ≤ z.degree?.getD 0 := by
   have hs := size_toWP_le ctx z
   rcases Nat.eq_zero_or_pos (toWP ctx z).size with h0 | h0
-  · rw [DensePoly.degree?, dif_pos h0]; simp
+  · rw [DensePoly.degree?, dite_eq_left h0]; simp
   · rw [DensePoly.degree?_eq_some_of_pos_size _ h0, Option.getD_some]
     rcases Nat.eq_zero_or_pos z.size with hz0 | hz0
     · omega

--- a/HexHenselMathlib/HenselLemmas.lean
+++ b/HexHenselMathlib/HenselLemmas.lean
@@ -546,7 +546,7 @@ private theorem normalizedXGCD_gcd_eq_one_of_common_dvd_one
     have hcoeff : (DensePoly.C (1 : ZMod64 p) : FpPoly p).coeff 0 = (0 : FpPoly p).coeff 0 := by
       rw [show (DensePoly.C (1 : ZMod64 p) : FpPoly p) = 1 from rfl, hh]
     rw [DensePoly.coeff_C, DensePoly.coeff_zero] at hcoeff
-    simp only [if_true] at hcoeff
+    simp only [_root_.ite_true] at hcoeff
     exact ZMod64.one_ne_zero_of_prime (ZMod64.PrimeModulus.prime (p := p)) hcoeff
   have hr_dvd_one : DensePoly.gcd (ZPoly.modP p g) (ZPoly.modP p h) ∣ (1 : FpPoly p) :=
     hcommon _ (DensePoly.gcd_dvd_left _ _) (DensePoly.gcd_dvd_right _ _)

--- a/HexHenselMathlib/HenselLemmas.lean
+++ b/HexHenselMathlib/HenselLemmas.lean
@@ -250,7 +250,7 @@ theorem quadraticHenselStep_bezout_correct
       Polynomial.map_mul, Polynomial.map_add, Polynomial.map_one, hone] using hmap
   · have hm_eq : m = 1 := by omega
     subst m
-    haveI : Subsingleton (ZMod (1 * 1)) := ZMod.subsingleton_iff.mpr (by norm_num)
+    have : Subsingleton (ZMod (1 * 1)) := ZMod.subsingleton_iff.mpr (by norm_num)
     apply Polynomial.ext
     intro n
     exact Subsingleton.elim _ _
@@ -333,7 +333,7 @@ theorem hensel_unique (f g h g' h' : Polynomial ℤ) (p : ℕ) (k : ℕ)
   simp only at hprod hprod' hg1 hcop ⊢
   induction k with
   | zero =>
-    haveI : Subsingleton (ZMod (p ^ 0)) := ZMod.subsingleton_iff.mpr (by simp)
+    have : Subsingleton (ZMod (p ^ 0)) := ZMod.subsingleton_iff.mpr (by simp)
     refine ⟨?_, ?_⟩ <;>
     · apply Polynomial.ext; intro n
       exact Subsingleton.elim _ _

--- a/HexHermite/Hermite.lean
+++ b/HexHermite/Hermite.lean
@@ -111,7 +111,7 @@ theorem swapStep_pivot_ne (ops : Accumulator α n) (s : Result α n m)
   · rename_i hne
     dsimp only
     rw [Matrix.getElem_pair_eq_nested, Matrix.getElem_rowSwap]
-    simp only [if_neg hne, if_pos]
+    simp only [ite_eq_right hne, ite_eq_left]
     simpa only [Matrix.getElem_pair_eq_nested] using hfound
 
 /-- Swapping two zero entries leaves the whole selected column unchanged. -/
@@ -130,10 +130,10 @@ theorem swapStep_zero (ops : Accumulator α n) (s : Result α n m)
     rw [Matrix.getElem_pair_eq_nested, Matrix.getElem_rowSwap]
     by_cases hrk : row = k
     · subst row
-      simpa only [if_pos, Matrix.getElem_pair_eq_nested] using hi'.trans hk'.symm
+      simpa only [ite_eq_left, Matrix.getElem_pair_eq_nested] using hi'.trans hk'.symm
     · by_cases hri : row = i
       · subst row
-        simp only [if_neg hrk, if_pos, Matrix.getElem_pair_eq_nested]
+        simp only [ite_eq_right hrk, ite_eq_left, Matrix.getElem_pair_eq_nested]
         exact hk'.trans hi'.symm
       · simp [hrk, hri, Matrix.getElem_pair_eq_nested]
 
@@ -148,7 +148,7 @@ theorem gcdStep_column (ops : Accumulator α n) (s : Result α n m)
   rcases hc : gcdCoeffs s.matrix[(i, col)] s.matrix[(k, col)] with ⟨x, y, z, w⟩
   rw [hc] at hspec
   dsimp only at hspec
-  rw [gcdStep, if_neg hb]
+  rw [gcdStep, ite_eq_right hb]
   dsimp only
   rw [hc]
   dsimp only [Prod.fst, Prod.snd]
@@ -165,7 +165,7 @@ theorem gcdStep_ne_zero (ops : Accumulator α n) (s : Result α n m)
     (gcdStep ops col i k s).matrix[(i, col)] ≠ 0 ∧
       (gcdStep ops col i k s).matrix[(k, col)] = 0 := by
   by_cases hb : s.matrix[(k, col)] = 0
-  · rw [gcdStep, if_pos hb]
+  · rw [gcdStep, ite_eq_left hb]
     exact ⟨hi, hb⟩
   · have h := gcdStep_column ops s col i k hik hb
     exact ⟨Int.ne_of_gt h.1, h.2⟩
@@ -207,7 +207,7 @@ theorem signStep_column (ops : Accumulator α n) (s : Result α n m)
   · rename_i hneg
     dsimp only
     rw [Matrix.getElem_pair_eq_nested, Matrix.getElem_rowScale]
-    simp only [if_pos]
+    simp only [ite_eq_left]
     simp only [Matrix.getElem_pair_eq_nested] at hneg hne ⊢
     omega
   · rename_i hnneg
@@ -238,7 +238,7 @@ theorem signStep_zero (ops : Accumulator α n) (s : Result α n m)
     split
     · dsimp only
       rw [Matrix.getElem_pair_eq_nested, Matrix.getElem_rowScale]
-      simp only [if_pos, Matrix.getElem_pair_eq_nested]
+      simp only [ite_eq_left, Matrix.getElem_pair_eq_nested]
       simp [hi']
     · rfl
   · exact signStep_other ops s col j i row hri
@@ -267,7 +267,7 @@ theorem reduceStep_column (ops : Accumulator α n) (s : Result α n m)
     exact hdiv.symm
   · dsimp only
     rw [Matrix.getElem_pair_eq_nested, Matrix.getElem_rowAdd]
-    simp only [if_pos]
+    simp only [ite_eq_left]
     simp only [q, p, x, Matrix.getElem_pair_eq_nested] at hdiv ⊢
     calc
       s.matrix[row][col] +
@@ -306,7 +306,7 @@ theorem reduceStep_zero (ops : Accumulator α n) (s : Result α n m)
     · rfl
     · dsimp only
       rw [Matrix.getElem_pair_eq_nested, Matrix.getElem_rowAdd]
-      simp only [if_pos, Matrix.getElem_pair_eq_nested]
+      simp only [ite_eq_left, Matrix.getElem_pair_eq_nested]
       simp [hp']
   · exact reduceStep_other ops s col j pivot target row hrt
 
@@ -653,14 +653,14 @@ theorem columnStep_rank_le (ops : Accumulator α n) (s : Result α n m)
     (col : Fin m) (h : s.pivots.length ≤ n) :
     (columnStep ops s col).pivots.length ≤ n := by
   by_cases hr : s.pivots.length < n
-  · rw [columnStep, dif_pos hr]
+  · rw [columnStep, dite_eq_left hr]
     cases hp : findPivot? s.matrix col s.pivots.length with
     | none => exact h
     | some found =>
         change ((clearColumn ops s col ⟨s.pivots.length, hr⟩ found).pivots ++ [col]).length ≤ n
         rw [clearColumn_pivots, List.length_append, List.length_singleton]
         omega
-  · rw [columnStep, dif_neg hr]
+  · rw [columnStep, dite_eq_right hr]
     exact h
 
 /-- The shared bounded Hermite sweep, parameterized by certificate state. -/
@@ -1019,7 +1019,7 @@ private theorem columnStep_prefix (ops : Accumulator α n) {s : Result α n m}
     {bound : Nat} (h : PrefixForm s bound) (col : Fin m) (hcol : col.val = bound) :
     PrefixForm (columnStep ops s col) (bound + 1) := by
   by_cases hr : s.pivots.length < n
-  · rw [columnStep, dif_pos hr]
+  · rw [columnStep, dite_eq_left hr]
     cases hp : findPivot? s.matrix col s.pivots.length with
     | none =>
         exact h.extend col hcol (fun row hrow => findPivot?_none hp row hrow)
@@ -1029,7 +1029,7 @@ private theorem columnStep_prefix (ops : Accumulator α n) {s : Result α n m}
         simp only
         have hpiv := clearColumn_pivots ops s col ⟨s.pivots.length, hr⟩ found
         simpa [hpiv] using ha
-  · rw [columnStep, dif_neg hr]
+  · rw [columnStep, dite_eq_right hr]
     exact h.extend col hcol (fun row hrow => by
       have hn := h.rank_le_n
       omega)
@@ -1082,12 +1082,12 @@ private theorem checkedRun_form (ops : Accumulator α n) (A : Matrix Int n m) :
       (principalRun ops A).pivots.length (principalRun ops A).pivotVector = true
   · have hc : checkedRun ops A = principalRun ops A := by
       rw [checkedRun]
-      exact if_pos h
+      exact ite_eq_left h
     rw [hc]
     exact (isHNFForm_iff _ _ _).mp h
   · have hc : checkedRun ops A = run ops A := by
       rw [checkedRun]
-      exact if_neg h
+      exact ite_eq_right h
     rw [hc]
     exact (run_form ops A).hnfForm
 
@@ -1237,7 +1237,7 @@ private theorem columnStep_same (ops : Accumulator α n) (ops' : Accumulator β 
   simp only [Result.Same] at h
   rcases h with ⟨rfl, rfl⟩
   by_cases hr : pivots.length < n
-  · rw [columnStep, columnStep, dif_pos hr, dif_pos hr]
+  · rw [columnStep, columnStep, dite_eq_left hr, dite_eq_left hr]
     cases hp : findPivot? matrix col pivots.length with
     | none => exact ⟨rfl, rfl⟩
     | some found =>
@@ -1247,7 +1247,7 @@ private theorem columnStep_same (ops : Accumulator α n) (ops' : Accumulator β 
           (t := { matrix := matrix, pivots := pivots, accumulator := acc' })
           ⟨rfl, rfl⟩ col ⟨pivots.length, hr⟩ found
         exact ⟨hclear.1, congrArg (fun ps => ps ++ [col]) hclear.2⟩
-  · rw [columnStep, columnStep, dif_neg hr, dif_neg hr]
+  · rw [columnStep, columnStep, dite_eq_right hr, dite_eq_right hr]
     exact ⟨rfl, rfl⟩
 
 /-- The shared schedule produces the same matrix for every accumulator. -/
@@ -1538,7 +1538,7 @@ private theorem run_accumulator_map (f : α → β)
     simp only [Result.Mapped] at h
     rcases h with ⟨rfl, rfl, rfl⟩
     by_cases hr : pivots.length < n
-    · rw [columnStep, columnStep, dif_pos hr, dif_pos hr]
+    · rw [columnStep, columnStep, dite_eq_left hr, dite_eq_left hr]
       cases hp : findPivot? matrix col pivots.length with
       | none => exact ⟨rfl, rfl, rfl⟩
       | some found =>
@@ -1548,7 +1548,7 @@ private theorem run_accumulator_map (f : α → β)
             (t := { matrix := matrix, pivots := pivots, accumulator := f acc })
             ⟨rfl, rfl, rfl⟩ col ⟨pivots.length, hr⟩ found
           exact ⟨hc.1, congrArg (fun ps => ps ++ [col]) hc.2.1, hc.2.2⟩
-    · rw [columnStep, columnStep, dif_neg hr, dif_neg hr]
+    · rw [columnStep, columnStep, dite_eq_right hr, dite_eq_right hr]
       exact ⟨rfl, rfl, rfl⟩
   have result := fold_mapped (columnStep ops) (columnStep ops')
     (List.finRange m) (s :=

--- a/HexHermite/Lattice.lean
+++ b/HexHermite/Lattice.lean
@@ -83,14 +83,14 @@ private theorem det_eq_zero_of_zero_row (M : Matrix Int n n) (i : Fin n)
     rw [Matrix.getElem_rowScale]
     by_cases hri : r = i
     · subst r
-      rw [if_pos rfl]
+      rw [ite_eq_left rfl]
       have hentry := congrArg (fun row : Vector Int n => row[c.val]'c.isLt) hi
       have hzero : M[i][c] = 0 := by
         change M[i][c.val]'c.isLt = 0
         simpa only [Vector.getElem_zero] using hentry
       rw [hzero]
       omega
-    · rw [if_neg hri]
+    · rw [ite_eq_right hri]
   have hdet := det_rowScale M i 0
   rw [hscale] at hdet
   simpa using hdet
@@ -243,7 +243,7 @@ private theorem solveStep_complete {A : Matrix Int n m}
       omega
     refine ⟨(residual, coeffs), ?_, hmem, hpivots, hrecord⟩
     unfold solveStep
-    rw [dif_pos hr]
+    rw [dite_eq_left hr]
     simp only [Matrix.getElem_pair_eq_nested]
     change (if p = 0 then none else
       if state.1[col] % p = 0 then
@@ -251,7 +251,7 @@ private theorem solveStep_complete {A : Matrix Int n m}
           (Vector.ofFn fun j => state.1.get j - state.1[col] / p * D.echelon[row][j],
             state.2 + (state.1[col] / p) • Vector.unit Int row)
       else none) = some (residual, coeffs)
-    rw [if_neg hpne, if_pos hmod]
+    rw [ite_eq_right hpne, ite_eq_left hmod]
     congr 2
     · apply Vector.ext
       intro j hj
@@ -259,7 +259,7 @@ private theorem solveStep_complete {A : Matrix Int n m}
     · exact congrArg (fun b => state.2 + b • Vector.unit Int row) hdiv
   · refine ⟨state, ?_, hinv.1, ?_, hinv.2.2⟩
     · unfold solveStep
-      rw [dif_neg hr]
+      rw [dite_eq_right hr]
     · intro q hq
       exact hinv.2.1 q (by omega)
 
@@ -272,7 +272,7 @@ private theorem solveLoop_complete {A : Matrix Int n m}
         some (0, coeffs) ∧ vecMul coeffs D.echelon = v := by
   unfold solveLoop
   by_cases hend : row = n
-  · rw [dif_pos hend]
+  · rw [dite_eq_left hend]
     subst row
     have hzero : state.1 = 0 := h.eq_zero_of_pivots hinv.1 (by
       intro q
@@ -290,7 +290,7 @@ private theorem solveLoop_complete {A : Matrix Int n m}
       have hentry := congrArg (fun w : Vector Int m => w[j]) hrecord
       simp only [Vector.getElem_add, Vector.getElem_zero] at hentry
       omega
-  · rw [dif_neg hend]
+  · rw [dite_eq_right hend]
     have hlt : row < n := by omega
     rcases solveStep_complete h v state ⟨row, hlt⟩ hinv with
       ⟨next, hstep, hnext⟩
@@ -540,7 +540,7 @@ private theorem form_mul_basis (A : Matrix Int n m) :
       have hq : (Matrix.row Q i)[kk] = 0 := by
         rw [Matrix.getElem_row]
         simp only [Q, Matrix.getElem_ofFn]
-        rw [if_neg]
+        rw [ite_eq_right]
         omega
       have hz : (0 : Vector Int (hnfRank A))[kk.val] = 0 :=
         Vector.getElem_zero kk.val kk.isLt
@@ -613,7 +613,7 @@ theorem latticeCoeffs_complete {A : Matrix Int n m} {v : Vector Int m} :
   dsimp only
   rw [hsolve]
   dsimp only
-  rw [if_pos hc]
+  rw [ite_eq_left hc]
   rfl
 
 /-- The executable lattice predicate is equivalent to integer row-lattice
@@ -863,13 +863,13 @@ theorem kernelBasis_independent {A : Matrix Int n m}
 theorem latticeIndex_eq_prod_pivots (A : Matrix Int n m) (h : hnfRank A = m) :
     latticeIndex A = (pivots A).foldl (· * ·) 1 := by
   change (Hermite.checkedRun (Hermite.formAccumulator n) A).pivots.length = m at h
-  simp only [latticeIndex, pivots, hnfRank, h, if_pos]
+  simp only [latticeIndex, pivots, hnfRank, h, ite_eq_left]
 
 /-- A non-full-rank row lattice has infinite index, represented by zero. -/
 theorem latticeIndex_eq_zero (A : Matrix Int n m) (h : hnfRank A ≠ m) :
     latticeIndex A = 0 := by
   unfold latticeIndex
-  rw [if_neg]
+  rw [ite_eq_right]
   intro heq
   apply h
   simpa only [hnfRank] using heq
@@ -1003,7 +1003,7 @@ theorem latticeIndex_eq_det (A : Matrix Int n n) :
         omega
     have hidx : latticeIndex A = 0 := by
       unfold latticeIndex
-      rw [if_neg]
+      rw [ite_eq_right]
       intro heq
       apply hfull
       simpa only [hnfRank] using heq

--- a/HexHermite/Step.lean
+++ b/HexHermite/Step.lean
@@ -25,8 +25,8 @@ private theorem getElem_setRow (M : Matrix R n m) (dst r : Fin n)
     (M.setRow dst v)[r][c] = if r = dst then v[c] else M[r][c] := by
   by_cases h : r = dst
   · subst r
-    rw [if_pos rfl, Matrix.setRow_get_self]
-  · rw [if_neg h, Matrix.setRow_row_ne M dst r v h]
+    rw [ite_eq_left rfl, Matrix.setRow_get_self]
+  · rw [ite_eq_right h, Matrix.setRow_row_ne M dst r v h]
 
 /-- Replace rows `i` and `k` by two simultaneous linear combinations. -/
 @[expose]
@@ -53,9 +53,9 @@ theorem getElem_combineRows (M : Matrix Int n m) (i k r : Fin n)
       else M[(r, j)] := by
   unfold combineRows
   by_cases hik : i = k
-  · rw [dif_pos hik, getElem_setRow]
+  · rw [dite_eq_left hik, getElem_setRow]
     by_cases hr : r = k <;> simp [hik, hr, Matrix.row]
-  · rw [dif_neg hik, getElem_setRow, getElem_setRow]
+  · rw [dite_eq_right hik, getElem_setRow, getElem_setRow]
     by_cases hrk : r = k <;> by_cases hri : r = i <;> simp_all [Matrix.row]
 
 /-- Replace columns `i` and `k` by two simultaneous linear combinations. -/
@@ -84,10 +84,10 @@ theorem getElem_combineCols (M : Matrix Int n m) (i k : Fin m)
       else M[(r, j)] := by
   unfold combineCols
   by_cases hik : i = k
-  · rw [dif_pos hik, Matrix.getElem_setCol]
+  · rw [dite_eq_left hik, Matrix.getElem_setCol]
     by_cases hj : j = k <;>
       simp [hik, hj]
-  · rw [dif_neg hik, Matrix.getElem_setCol, Matrix.getElem_setCol]
+  · rw [dite_eq_right hik, Matrix.getElem_setCol, Matrix.getElem_setCol]
     by_cases hjk : j = k <;> by_cases hji : j = i <;>
       simp_all
 /-- Simultaneous two-row replacement commutes with multiplication on the
@@ -107,7 +107,7 @@ theorem combineRows_mul (A : Matrix Int n p) (B : Matrix Int p m)
       change (combineRows A i k a b c d)[i][qq] =
         (a • Matrix.row A i + b • Matrix.row A k)[qq]
       rw [getElem_combineRows]
-      simp only [if_pos]
+      simp only [ite_eq_left]
       rw [Matrix.getElem_pair_eq_nested, Matrix.getElem_pair_eq_nested]
       simp only [Fin.getElem_fin, Vector.getElem_add, Vector.getElem_smul]
       rfl
@@ -115,7 +115,7 @@ theorem combineRows_mul (A : Matrix Int n p) (B : Matrix Int p m)
     rw [Vector.dotProduct_add_left, Vector.dotProduct_smul_left,
       Vector.dotProduct_smul_left]
     rw [getElem_combineRows]
-    simp only [if_pos, Matrix.getElem_pair_eq_nested]
+    simp only [ite_eq_left, Matrix.getElem_pair_eq_nested]
     rw [Matrix.getElem_mul, Matrix.getElem_mul]
   · by_cases hrk : r = k
     · subst r
@@ -126,14 +126,14 @@ theorem combineRows_mul (A : Matrix Int n p) (B : Matrix Int p m)
         change (combineRows A i k a b c d)[k][qq] =
           (c • Matrix.row A i + d • Matrix.row A k)[qq]
         rw [getElem_combineRows]
-        simp only [if_neg hri, if_pos]
+        simp only [ite_eq_right hri, ite_eq_left]
         rw [Matrix.getElem_pair_eq_nested, Matrix.getElem_pair_eq_nested]
         simp only [Fin.getElem_fin, Vector.getElem_add, Vector.getElem_smul]
         rfl]
       rw [Vector.dotProduct_add_left, Vector.dotProduct_smul_left,
         Vector.dotProduct_smul_left]
       rw [getElem_combineRows]
-      simp only [if_neg hri, if_pos, Matrix.getElem_pair_eq_nested]
+      simp only [ite_eq_right hri, ite_eq_left, Matrix.getElem_pair_eq_nested]
       rw [Matrix.getElem_mul, Matrix.getElem_mul]
     · rw [show Matrix.row (combineRows A i k a b c d) r = Matrix.row A r by
         ext q hq
@@ -142,7 +142,7 @@ theorem combineRows_mul (A : Matrix Int n p) (B : Matrix Int p m)
         rw [getElem_combineRows]
         simp [hri, hrk, Matrix.getElem_pair_eq_nested]]
       rw [getElem_combineRows]
-      simp only [if_neg hri, if_neg hrk, Matrix.getElem_pair_eq_nested]
+      simp only [ite_eq_right hri, ite_eq_right hrk, Matrix.getElem_pair_eq_nested]
       exact (Matrix.getElem_mul A B r j).symm
 
 /-- Transposition exchanges a simultaneous two-column replacement with the

--- a/HexHermite/Unique.lean
+++ b/HexHermite/Unique.lean
@@ -69,9 +69,9 @@ private theorem vecMul_pivot {A : Matrix Int n m} {D : RowEchelonData Int n m}
         rw [getElem_col]
         by_cases hki : k = pivotRow
         · subst k
-          rw [if_pos rfl]
+          rw [ite_eq_left rfl]
           exact Int.mul_comm _ _
-        · rw [if_neg hki]
+        · rw [ite_eq_right hki]
           have hkval : k.val ≠ i.val := by
             intro heq
             exact hki (Fin.ext (by simpa [pivotRow, IsEchelonForm.pivotRow] using heq))
@@ -137,7 +137,7 @@ private theorem firstCoeff {A : Matrix Int n m} {D : RowEchelonData Int n m}
       have hall := List.find?_range_eq_none.mp hfind
       rcases hex with ⟨q, hq⟩
       have hfalse := hall q.val q.isLt
-      simp only [p, dif_pos q.isLt, decide_not, Bool.not_not] at hfalse
+      simp only [p, dite_eq_left q.isLt, decide_not, Bool.not_not] at hfalse
       have heq : c[h.toIsEchelonForm.pivotRow q] = 0 := by
         exact of_decide_eq_true hfalse
       exact absurd heq hq
@@ -147,12 +147,12 @@ private theorem firstCoeff {A : Matrix Int n m} {D : RowEchelonData Int n m}
       let q : Fin D.rank := ⟨qv, hqrank⟩
       have hqne : c[h.toIsEchelonForm.pivotRow q] ≠ 0 := by
         have hp := hspec.1
-        simpa only [p, dif_pos hqrank, decide_eq_true_eq] using hp
+        simpa only [p, dite_eq_left hqrank, decide_eq_true_eq] using hp
       refine ⟨q, hqne, ?_⟩
       intro k hk
       have hkrank : k.val < D.rank := Nat.lt_trans hk q.isLt
       have hfalse := hspec.2.2 k.val hk
-      simp only [p, dif_pos hkrank, decide_not, Bool.not_not] at hfalse
+      simp only [p, dite_eq_left hkrank, decide_not, Bool.not_not] at hfalse
       have heq : c[h.toIsEchelonForm.pivotRow
           (⟨k.val, hkrank⟩ : Fin D.rank)] = 0 := of_decide_eq_true hfalse
       simpa only [IsEchelonForm.pivotRow] using heq

--- a/HexInterval/Experiment/Rational.lean
+++ b/HexInterval/Experiment/Rational.lean
@@ -131,9 +131,9 @@ theorem inv_sound {a c : Raw} (h : invOk a c = true) : a.value⁻¹ = c.value :=
   rw [Rat.inv_divInt]
   simp only [invOk, Bool.and_eq_true, valid, decide_eq_true_eq] at h
   by_cases hn : a.num = 0
-  · simp only [if_pos hn, decide_eq_true_eq] at h
+  · simp only [ite_eq_left hn, decide_eq_true_eq] at h
     rw [hn, Rat.divInt_zero, h.2, Rat.zero_divInt]
-  · simp only [if_neg hn, decide_eq_true_eq] at h
+  · simp only [ite_eq_right hn, decide_eq_true_eq] at h
     exact (Rat.divInt_eq_divInt_iff hn h.1.2).2 h.2
 
 end Raw

--- a/HexIntervalMathlib/Experiment/Center.lean
+++ b/HexIntervalMathlib/Experiment/Center.lean
@@ -846,7 +846,7 @@ theorem checkFacts_sound {limit : EndpointLimit} {program : Program}
           simp [checkFacts, hcost] at hcheck
       | some cost =>
           by_cases hbudget : cost ≤ remainingSteps
-          · simp only [checkFacts, hcost, hbudget, if_true, Bool.and_eq_true] at hcheck
+          · simp only [checkFacts, hcost, hbudget, ite_true, Bool.and_eq_true] at hcheck
             have hfact : fact.row.Holds valuation :=
               Fact.sound hcheck.1 hprogram hsources hedges hprior
             have hprior' : RowsHold valuation (fact.row :: priorRev) := by
@@ -905,7 +905,7 @@ theorem sound {certificate : Certificate} {endpointLimit : EndpointLimit}
       simp [hcost] at hresult
   | some resultCost =>
       by_cases hbudget : resultCost ≤ structureLimit.maxLookupSteps
-      · simp only [hcost, hbudget, if_true, Bool.and_eq_true, beq_iff_eq] at hresult
+      · simp only [hcost, hbudget, ite_true, Bool.and_eq_true, beq_iff_eq] at hresult
         have hfacts : FactsHold valuation certificate.facts :=
           checkFacts_sound hresult.1 hprogram hsources hedges (by simp [RowsHold])
         cases hfactLookup : certificate.facts[certificate.result]? with

--- a/HexIntervalMathlib/Experiment/CosBillion.lean
+++ b/HexIntervalMathlib/Experiment/CosBillion.lean
@@ -151,7 +151,7 @@ theorem constantEntailsOf (provider : Evidence DecimalPi.Claim) :
   have output : valuation (node 2) = Real.pi := by
     simpa [piModel, piInstruction] using related
   change Contains finePiFact (valuation (node 2))
-  simp only [Contains, finePiFact, openInterval, rat, ratValue, if_true]
+  simp only [Contains, finePiFact, openInterval, rat, ratValue, ite_true]
   rw [output]
   simpa [DecimalPi.Claim,
     Hex.IntervalMathlib.Experiment.SinTen.MachinReplay.Claim,
@@ -185,7 +185,7 @@ theorem reductionEntails :
   change Contains finePiFact (valuation (node 2)) at piBounds
   change Contains residualFact (valuation (node 3))
   simp only [Contains, finePiFact, residualFact, openInterval, rat, ratValue,
-    if_true] at piBounds ⊢
+    ite_true] at piBounds ⊢
   rw [residualValue, sourceValue]
   norm_num [quotient, finePiCandidate] at piBounds ⊢
   constructor <;> nlinarith
@@ -204,13 +204,13 @@ theorem localEntails :
   have residualBounds := holds { node := node 3, fact := residualFact } (by simp)
   change Contains residualFact (valuation (node 3)) at residualBounds
   simp only [Contains, residualFact, openInterval, rat, ratValue,
-    if_true] at residualBounds
+    ite_true] at residualBounds
   have localNegative : Real.cos (valuation (node 3)) < 0 := by
     apply Real.cos_neg_of_pi_div_two_lt_of_lt
     · nlinarith [Real.pi_lt_four]
     · nlinarith [Real.pi_gt_three]
   change Contains negativeFact (valuation (node 4))
-  simp only [Contains, negativeFact, rat, ratValue, if_true]
+  simp only [Contains, negativeFact, rat, ratValue, ite_true]
   rw [output]
   norm_num
   exact ⟨Real.neg_one_le_cos _, localNegative⟩
@@ -229,7 +229,7 @@ theorem negationEntails :
   have negative := holds { node := node 4, fact := negativeFact } (by simp)
   change Contains negativeFact (valuation (node 4)) at negative
   change Contains positiveFact (valuation (node 5))
-  simp only [Contains, negativeFact, positiveFact, rat, ratValue, if_true] at negative ⊢
+  simp only [Contains, negativeFact, positiveFact, rat, ratValue, ite_true] at negative ⊢
   rw [output]
   norm_num at negative ⊢
   constructor <;> linarith

--- a/HexIntervalMathlib/Experiment/PntBKLNWExp.lean
+++ b/HexIntervalMathlib/Experiment/PntBKLNWExp.lean
@@ -65,7 +65,7 @@ private theorem bandRatio (numerator : Nat → Nat) (b stop : Nat) :
   | zero => simp [bandPowerSum]
   | succ stop ih =>
       by_cases h : 4 ≤ stop + 1
-      · rw [sum_Icc_succ_top h, bandPowerSum, if_pos h, ih]
+      · rw [sum_Icc_succ_top h, bandPowerSum, ite_eq_left h, ih]
         rw [div_pow]
         push_cast
         field_simp

--- a/HexIntervalMathlib/Experiment/PntChebyshevProbe.lean
+++ b/HexIntervalMathlib/Experiment/PntChebyshevProbe.lean
@@ -288,7 +288,7 @@ theorem vonMangoldt_le_contribution {n : Nat} (hn : n ≤ 11723) :
     (ArithmeticFunction.vonMangoldt n : Real) ≤ contribution n / 10 := by
   rw [ArithmeticFunction.vonMangoldt_apply]
   by_cases hpp : IsPrimePow n
-  · rw [if_pos hpp]
+  · rw [ite_eq_left hpp]
     obtain ⟨p, k, hp, hk, hpow⟩ := (isPrimePow_nat_iff n).mp hpp
     subst n
     rw [hp.pow_minFac hk.ne']
@@ -310,7 +310,7 @@ theorem vonMangoldt_le_contribution {n : Nat} (hn : n ≤ 11723) :
       have base := powerBase_pow hp hk2 hn
       simpa [contribution, checked, base, hp.ne_zero] using
         logData_log_le p hp.two_le
-  · rw [if_neg hpp]
+  · rw [ite_eq_right hpp]
     positivity
 
 /-- Incremental all-coordinate checker state with a natural-number

--- a/HexIntervalMathlib/Experiment/PntTable10A2.lean
+++ b/HexIntervalMathlib/Experiment/PntTable10A2.lean
@@ -233,7 +233,7 @@ private theorem bandRatio (b stop : Nat) :
   | zero => simp [PntBKLNWExp.bandPowerSum]
   | succ stop ih =>
       by_cases h : 4 ≤ stop + 1
-      · rw [sum_Icc_succ_top h, PntBKLNWExp.bandPowerSum, if_pos h, ih]
+      · rw [sum_Icc_succ_top h, PntBKLNWExp.bandPowerSum, ite_eq_left h, ih]
         rw [div_pow]
         push_cast
         field_simp

--- a/HexIntervalMathlib/Experiment/PntTable10Exact.lean
+++ b/HexIntervalMathlib/Experiment/PntTable10Exact.lean
@@ -68,7 +68,7 @@ theorem exactBound_le_of_majorant (k : Nat) (a1 a2 epsilon A1 A2 E b b' T : Real
         A2 * y ^ k * Real.exp (-(2 * y / 3)) + E * y ^ k ≤ T) :
     exactBound k a1 a2 epsilon b b' ≤ T := by
   let interval : Set Real := Set.Icc (Real.exp b) (Real.exp b')
-  haveI : Nonempty interval :=
+  have : Nonempty interval :=
     ⟨Real.exp b, by
       change Real.exp b ∈ Set.Icc (Real.exp b) (Real.exp b')
       exact ⟨le_rfl, Real.exp_le_exp.mpr hbb'⟩⟩

--- a/HexIntervalMathlib/Experiment/SinTen.lean
+++ b/HexIntervalMathlib/Experiment/SinTen.lean
@@ -230,7 +230,7 @@ noncomputable def replay? (certificate : Certificate) :
         have reconstructed := reduction.proof.reconstruct
         rw [reductionEqual] at positive reconstructed
         simp only [Reduction.candidate, LocalReplay.Claim] at positive
-        simp only [Reduction.candidate, ReductionReplay.signed, if_true] at reconstructed
+        simp only [Reduction.candidate, ReductionReplay.signed, ite_true] at reconstructed
         linarith }
 
 end CertificateReplay

--- a/HexIntervalMathlib/Experiment/SinTenInterval.lean
+++ b/HexIntervalMathlib/Experiment/SinTenInterval.lean
@@ -247,7 +247,7 @@ theorem constantEntails :
   have output : valuation (node 2) = Real.pi := by
     simpa [piModel, piInstruction] using related
   change Contains piFact (valuation (node 2))
-  simp only [Contains, piFact, openInterval, rat, ratValue, if_true]
+  simp only [Contains, piFact, openInterval, rat, ratValue, ite_true]
   rw [output]
   norm_num
   exact Hex.IntervalMathlib.Experiment.SinTen.MachinReplay.pi_bounds
@@ -276,7 +276,7 @@ theorem reductionEntails :
     change Contains piFact (valuation (node 2)) at this
     simpa [Contains, piFact, openInterval, rat, ratValue] using this
   change Contains residualFact (valuation (node 3))
-  simp only [Contains, residualFact, openInterval, rat, ratValue, if_true]
+  simp only [Contains, residualFact, openInterval, rat, ratValue, ite_true]
   rw [residualValue, sourceValue]
   constructor <;> linarith
 
@@ -298,7 +298,7 @@ theorem localEntails :
     change Contains residualFact (valuation (node 3)) at this
     simpa [Contains, residualFact, openInterval, rat, ratValue] using this
   change Contains positiveFact (valuation (node 4))
-  simp only [Contains, positiveFact, rat, ratValue, if_true]
+  simp only [Contains, positiveFact, rat, ratValue, ite_true]
   rw [output]
   norm_num
   exact ⟨Real.sin_pos_of_pos_of_lt_pi (by linarith)
@@ -324,7 +324,7 @@ theorem negationEntails :
     change Contains positiveFact (valuation (node 4)) at this
     simpa [Contains, positiveFact, rat, ratValue] using this
   change Contains negativeFact (valuation (node 5))
-  simp only [Contains, negativeFact, rat, ratValue, if_true]
+  simp only [Contains, negativeFact, rat, ratValue, ite_true]
   rw [output]
   norm_num
   exact ⟨positive.2, positive.1⟩

--- a/HexIntervalMathlib/Inverse.lean
+++ b/HexIntervalMathlib/Inverse.lean
@@ -95,7 +95,7 @@ private theorem invLower_positive (precision : Precision) (upper : Upper) {x : ‚
         intro equal
         subst value
         simp [toReal] at valuePositive
-      simp only [Raw.invLowerUnchecked, valueNonzero, if_false, Lower.Contains]
+      simp only [Raw.invLowerUnchecked, valueNonzero, ite_false, Lower.Contains]
       exact (roundedDown_le_inv value precision).trans
         ((inv_le_inv‚ÇÄ valuePositive positive).2
           (by cases strict <;> simp [Upper.Contains] at member ‚ä¢ <;> linarith))
@@ -114,7 +114,7 @@ private theorem invLower_negative (precision : Precision) (upper : Upper) {x : ‚
           exact shape
         have valueNegative : toReal value < 0 := by
           simpa only [toReal_zero] using toReal_lt valueNegativeDyadic
-        simp only [Raw.invLowerUnchecked, valueZero, if_false, Lower.Contains]
+        simp only [Raw.invLowerUnchecked, valueZero, ite_false, Lower.Contains]
         exact (roundedDown_le_inv value precision).trans
           ((inv_le_inv_of_neg valueNegative negative).2
             (by cases strict
@@ -135,7 +135,7 @@ private theorem invUpper_positive (precision : Precision) (lower : Lower) {x : ‚
             simp [Raw.strictlyPositive, valueZero] at shape
             exact shape
           simpa only [toReal_zero] using toReal_lt valuePositiveDyadic
-        simp only [Raw.invUpperUnchecked, valueZero, if_false, Upper.Contains]
+        simp only [Raw.invUpperUnchecked, valueZero, ite_false, Upper.Contains]
         exact ((inv_le_inv‚ÇÄ positive valuePositive).2
             (by cases strict
                 ¬∑ exact member
@@ -154,7 +154,7 @@ private theorem invUpper_negative (precision : Precision) (lower : Lower) {x : ‚
         intro equal
         subst value
         simp [toReal] at valueNegative
-      simp only [Raw.invUpperUnchecked, valueNonzero, if_false, Upper.Contains]
+      simp only [Raw.invUpperUnchecked, valueNonzero, ite_false, Upper.Contains]
       exact ((inv_le_inv_of_neg negative valueNegative).2
           (by cases strict
               ¬∑ exact member

--- a/HexLLL/Native.lean
+++ b/HexLLL/Native.lean
@@ -143,7 +143,7 @@ theorem foldl_finRange_set_outerSubMul_get_eq
       refine ⟨⟨l.val, Nat.lt_of_lt_of_le hlj hjn⟩, ?_, rfl⟩
       rw [List.mem_map]
       exact ⟨⟨l.val, hlj⟩, List.mem_finRange _, rfl⟩
-    rw [if_pos hex, if_pos hlj]
+    rw [ite_eq_left hex, ite_eq_left hlj]
   · have hno : ¬ ∃ i ∈ (List.finRange jVal).map cast, i.val = l.val := by
       rintro ⟨i, hi_mem, hi_eq⟩
       rw [List.mem_map] at hi_mem
@@ -153,7 +153,7 @@ theorem foldl_finRange_set_outerSubMul_get_eq
         rw [← hi_eq, ← hl', hcast]
         exact l'.isLt
       exact hlj this
-    rw [if_neg hno, if_neg hlj]
+    rw [ite_eq_right hno, ite_eq_right hlj]
 
 /-- Single-column size reduction update for row `k` against row `j`. -/
 @[expose]
@@ -334,13 +334,13 @@ def swapStep (s : LLLState n m) (k : Nat) : LLLState n m :=
     Matrix.memLattice (s.swapStep k).b v ↔ Matrix.memLattice s.b v := by
   unfold swapStep
   by_cases hk : k < n
-  · rw [dif_pos hk]
+  · rw [dite_eq_left hk]
     by_cases hk0 : 0 < k
-    · rw [dif_pos hk0]
+    · rw [dite_eq_left hk0]
       simpa [GramSchmidt.Int.adjacentSwap] using
         rowSwap_memLattice_iff s.b (GramSchmidt.prevRow ⟨k, hk⟩ hk0) ⟨k, hk⟩ v
-    · rw [dif_neg hk0]
-  · rw [dif_neg hk]
+    · rw [dite_eq_right hk0]
+  · rw [dite_eq_right hk]
 
 /-- A single-column size reduction preserves the generated lattice. -/
 @[grind =] theorem sizeReduceColumn_memLattice_iff
@@ -349,10 +349,10 @@ def swapStep (s : LLLState n m) (k : Nat) : LLLState n m :=
   unfold sizeReduceColumn
   by_cases hreduce : 2 * Int.natAbs ((s.ν.getRow k).get j) >
       s.d.get ⟨j.val + 1, Nat.succ_lt_succ j.isLt⟩
-  · rw [dif_pos hreduce]
+  · rw [dite_eq_left hreduce]
     have hne : j ≠ k := fun h => Nat.lt_irrefl j.val (h ▸ hjk)
     exact rowAdd_memLattice_iff s.b hne _ v
-  · rw [dif_neg hreduce]
+  · rw [dite_eq_right hreduce]
 
 /-- `sizeReduce_foldl_memLattice_iff` states that folding size-reduction column
 steps over a list of columns preserves the integer row-lattice membership
@@ -377,10 +377,10 @@ private theorem sizeReduce_foldl_memLattice_iff (s : LLLState n m) (k : Nat) (hk
     Matrix.memLattice (s.sizeReduce k).b v ↔ Matrix.memLattice s.b v := by
   unfold sizeReduce
   by_cases hk : k < n
-  · rw [dif_pos hk]
+  · rw [dite_eq_left hk]
     simpa [Fin.foldr_eq_finRange_foldr] using
       sizeReduce_foldl_memLattice_iff s k hk (List.finRange k).reverse v
-  · rw [dif_neg hk]
+  · rw [dite_eq_right hk]
 
 /-- The updated swap state still packages the intended scaled coefficient
 representation for its basis. -/
@@ -508,8 +508,8 @@ def lllLoop (s : LLLState n m) (k : Nat) (δ : Rat)
     show Matrix.memLattice
       (if hdone : k = n then s.b else _) v ↔ _
     by_cases hdone : k = n
-    · rw [dif_pos hdone]
-    · rw [dif_neg hdone]
+    · rw [dite_eq_left hdone]
+    · rw [dite_eq_right hdone]
       by_cases hcond : Int.ofNat δ.den *
             (Int.ofNat ((s.sizeReduce k).d.get
                 ⟨k + 1, Nat.succ_lt_succ (Nat.lt_of_le_of_ne hkn hdone)⟩) *
@@ -523,8 +523,8 @@ def lllLoop (s : LLLState n m) (k : Nat) (δ : Rat)
                   (Nat.lt_of_le_of_ne hkn hdone)⟩ ^ 2) ≥
           δ.num * (Int.ofNat ((s.sizeReduce k).d.get
             ⟨k, Nat.lt_succ_of_lt (Nat.lt_of_le_of_ne hkn hdone)⟩) ^ 2)
-      · rw [if_pos hcond, ih, LLLState.sizeReduce_memLattice_iff]
-      · rw [if_neg hcond, ih, LLLState.swapStep_memLattice_iff,
+      · rw [ite_eq_left hcond, ih, LLLState.sizeReduce_memLattice_iff]
+      · rw [ite_eq_right hcond, ih, LLLState.swapStep_memLattice_iff,
           LLLState.sizeReduce_memLattice_iff]
 
 /-- Initial fuel bound for `lllLoop`, sufficient for valid independent inputs

--- a/HexMatrix/Basic.lean
+++ b/HexMatrix/Basic.lean
@@ -493,11 +493,11 @@ theorem getElem_writeRow (d : Vector R (n * m)) (dst : Nat) (hdst : dst < n) (v 
   rw [Fin.foldl_eq_finRange_foldl]
   by_cases hrd : r = dst
   · subst hrd
-    rw [if_pos rfl]
+    rw [ite_eq_left rfl]
     exact foldl_set_mem (fun s : Fin m => r * m + s.val) (fun s => v[s])
       (fun s => flatIdx_lt hr s.isLt) flatIdx_col_inj
       (List.finRange m) (nodup_finRange m) d ⟨t, ht⟩ (List.mem_finRange _)
-  · rw [if_neg hrd]
+  · rw [ite_eq_right hrd]
     exact foldl_set_ne (fun s : Fin m => dst * m + s.val) (fun s => v[s])
       (fun s => flatIdx_lt hdst s.isLt) (flatIdx_lt hr ht)
       (List.finRange m) d (fun s _ heq => by
@@ -517,8 +517,8 @@ theorem getElem_writeRow (d : Vector R (n * m)) (dst : Nat) (hdst : dst < n) (v 
   show (writeRow M.data dst.val dst.isLt v)[r * m + t]'(flatIdx_lt hr ht) = _
   rw [getElem_writeRow M.data dst.val dst.isLt v hr ht]
   by_cases hrd : r = dst.val
-  · rw [if_pos hrd, if_pos hrd.symm]
-  · rw [if_neg hrd, if_neg (fun h => hrd h.symm), getElem_rows, getElem_getRow_nat]
+  · rw [ite_eq_left hrd, ite_eq_left hrd.symm]
+  · rw [ite_eq_right hrd, ite_eq_right (fun h => hrd h.symm), getElem_rows, getElem_getRow_nat]
 
 /-- Reading back the replaced row `dst` of `setRow M dst v` yields `v`. -/
 @[grind =] theorem setRow_get_self (M : Matrix R n m) (dst : Fin n) (v : Vector R m) :
@@ -559,17 +559,17 @@ other row is unchanged. -/
   by_cases h : i < n
   · have hred : modifyEntries (⟨d⟩ : Matrix R n m) i g =
         ⟨Fin.foldl m (fun d t => d.modify (i * m + t.val) (g t)) d⟩ := by
-      simp only [modifyEntries, dif_pos h]
+      simp only [modifyEntries, dite_eq_left h]
     rw [hred, getElem_eq_getRow, getElem_getRow, getElem_eq_getRow, getElem_getRow]
     show (Fin.foldl m (fun d t => d.modify (i * m + t.val) (g t)) d)[r.val * m + c.val]'_ = _
     rw [Fin.foldl_eq_finRange_foldl]
     by_cases hri : r.val = i
     · subst hri
-      rw [if_pos rfl]
+      rw [ite_eq_left rfl]
       exact foldl_modify_mem (fun t : Fin m => r.val * m + t.val) g
         (fun t => flatIdx_lt r.isLt t.isLt) flatIdx_col_inj
         (List.finRange m) (nodup_finRange m) d c (List.mem_finRange _)
-    · rw [if_neg hri]
+    · rw [ite_eq_right hri]
       exact foldl_modify_ne (fun t : Fin m => i * m + t.val) g
         (flatIdx_lt r.isLt c.isLt) (List.finRange m) d (fun t _ heq => by
           have h1 : (i * m + t.val) / m = i := flatIdx_div t.isLt
@@ -577,8 +577,8 @@ other row is unchanged. -/
           rw [heq, h2] at h1
           exact hri h1)
   · have hred : modifyEntries (⟨d⟩ : Matrix R n m) i g = ⟨d⟩ := by
-      simp only [modifyEntries, dif_neg h]
-    rw [hred, if_neg (fun heq => h (by rw [← heq]; exact r.isLt))]
+      simp only [modifyEntries, dite_eq_right h]
+    rw [hred, ite_eq_right (fun heq => h (by rw [← heq]; exact r.isLt))]
 
 /-- The transpose of a dense matrix. -/
 @[expose]
@@ -825,8 +825,8 @@ against `col N j`. -/
   intro i j
   rw [getElem_transpose, getElem_identity, getElem_identity]
   by_cases hij : i = j
-  · rw [if_pos hij, if_pos hij.symm]
-  · rw [if_neg hij, if_neg (fun h => hij h.symm)]
+  · rw [ite_eq_left hij, ite_eq_left hij.symm]
+  · rw [ite_eq_right hij, ite_eq_right (fun h => hij h.symm)]
 
 /-- Row `i` of the identity matrix has a `1` in position `i` and `0` elsewhere. -/
 @[simp, grind =] theorem row_identity [OfNat R 0] [OfNat R 1] {n : Nat} (i : Fin n) :
@@ -852,15 +852,15 @@ against `col N j`. -/
   by_cases h : i < n
   · have hred : modifyRow (⟨d⟩ : Matrix R n m) i f =
         setRow ⟨d⟩ ⟨i, h⟩ (f (getRow ⟨d⟩ ⟨i, h⟩)) := by
-      simp only [modifyRow, dif_pos h, setRow]
+      simp only [modifyRow, dite_eq_left h, setRow]
       rfl
     rw [hred, rows_setRow, Vector.modify_eq_set _ _ _ h, getElem_rows]
   · have hred : modifyRow (⟨d⟩ : Matrix R n m) i f = ⟨d⟩ := by
-      simp only [modifyRow, dif_neg h]
+      simp only [modifyRow, dite_eq_right h]
     rw [hred]
     apply Vector.ext
     intro r hr
-    rw [Vector.getElem_modify hr, if_neg (fun heq => h (by omega))]
+    rw [Vector.getElem_modify hr, ite_eq_right (fun heq => h (by omega))]
 
 /-- Row `i` of `modifyRow M i f` is `f` applied to the old row `i`. -/
 @[simp, grind =] theorem getRow_modifyRow_self (M : Matrix R n m) (i : Fin n)
@@ -888,8 +888,8 @@ private theorem foldl_swap_ne {N : Nat} (idxA idxB : Fin m → Nat)
   | cons x xs ih =>
     intro d0 hne
     rw [List.foldl_cons, ih _ (fun t ht => hne t (List.mem_cons_of_mem _ ht)),
-      Vector.getElem_swap, if_neg (fun heq => (hne x List.mem_cons_self).1 heq.symm),
-      if_neg (fun heq => (hne x List.mem_cons_self).2 heq.symm)]
+      Vector.getElem_swap, ite_eq_right (fun heq => (hne x List.mem_cons_self).1 heq.symm),
+      ite_eq_right (fun heq => (hne x List.mem_cons_self).2 heq.symm)]
 
 /-- A left fold of per-index `swap`s at pairwise-disjoint index pairs over a
 `Nodup` list exchanges the pair values at every member index. -/
@@ -914,23 +914,23 @@ private theorem foldl_swap_mem {N : Nat} (idxA idxB : Fin m → Nat)
       constructor
       · rw [foldl_swap_ne idxA idxB bdA bdB (bdA r) xs _ (fun t ht =>
           ⟨(hdisj t r (hnotail t ht)).1, (hdisj t r (hnotail t ht)).2.2.1⟩),
-          Vector.getElem_swap, if_pos rfl]
+          Vector.getElem_swap, ite_eq_left rfl]
       · rw [foldl_swap_ne idxA idxB bdA bdB (bdB r) xs _ (fun t ht =>
           ⟨(hdisj t r (hnotail t ht)).2.1, (hdisj t r (hnotail t ht)).2.2.2⟩),
           Vector.getElem_swap]
         by_cases hab : idxB r = idxA r
-        · rw [if_pos hab]
+        · rw [ite_eq_left hab]
           simp only [hab]
-        · rw [if_neg hab, if_pos rfl]
+        · rw [ite_eq_right hab, ite_eq_left rfl]
     · have hxr : x ≠ r := fun heq => (List.nodup_cons.mp hnd).1 (heq ▸ hr')
       have hd := hdisj x r hxr
       obtain ⟨h1, h2⟩ := ih (List.nodup_cons.mp hnd).2
         (d0.swap (idxA x) (idxB x) (bdA x) (bdB x)) r hr'
       constructor
-      · rw [h1, Vector.getElem_swap, if_neg (fun heq => hd.2.1 heq.symm),
-          if_neg (fun heq => hd.2.2.2 heq.symm)]
-      · rw [h2, Vector.getElem_swap, if_neg (fun heq => hd.1 heq.symm),
-          if_neg (fun heq => hd.2.2.1 heq.symm)]
+      · rw [h1, Vector.getElem_swap, ite_eq_right (fun heq => hd.2.1 heq.symm),
+          ite_eq_right (fun heq => hd.2.2.2 heq.symm)]
+      · rw [h2, Vector.getElem_swap, ite_eq_right (fun heq => hd.1 heq.symm),
+          ite_eq_right (fun heq => hd.2.2.1 heq.symm)]
 
 /-- Flat index pairs of two distinct rows are pairwise disjoint across distinct
 columns (and within a column, across the two rows). -/
@@ -967,8 +967,8 @@ private theorem flatIdx_swap_disj {i j : Nat} (hij : i ≠ j) :
       rw [Vector.getElem_swap]
       by_cases hpt : p = i * m + t.val
       · subst hpt
-        rw [if_pos rfl]
-      · rw [if_neg hpt, if_neg hpt]
+        rw [ite_eq_left rfl]
+      · rw [ite_eq_right hpt, ite_eq_right hpt]
     have hid : (swap (⟨d⟩ : Matrix R n m) i i hi hi).data = d := by
       simp only [swap]
       rw [Fin.foldl_eq_finRange_foldl]
@@ -982,9 +982,9 @@ private theorem flatIdx_swap_disj {i j : Nat} (hij : i ≠ j) :
     show (swap (⟨d⟩ : Matrix R n m) i i hi hi).data[r * m + t]'(flatIdx_lt hr ht) = _
     rw [hid]
     by_cases hri : r = i
-    · rw [if_pos hri, getElem_rows, getElem_getRow_nat]
+    · rw [ite_eq_left hri, getElem_rows, getElem_getRow_nat]
       simp only [hri]
-    · rw [if_neg hri, if_neg hri, getElem_rows, getElem_getRow_nat]
+    · rw [ite_eq_right hri, ite_eq_right hri, getElem_rows, getElem_getRow_nat]
   · apply Vector.ext
     intro r hr
     rw [getElem_rows, Vector.getElem_swap]
@@ -996,7 +996,7 @@ private theorem flatIdx_swap_disj {i j : Nat} (hij : i ≠ j) :
       rw [Fin.foldl_eq_finRange_foldl]
     by_cases hri : r = i
     · subst hri
-      rw [if_pos rfl]
+      rw [ite_eq_left rfl]
       apply Vector.ext
       intro t ht
       rw [getElem_getRow_nat, getElem_rows, getElem_getRow_nat]
@@ -1007,7 +1007,7 @@ private theorem flatIdx_swap_disj {i j : Nat} (hij : i ≠ j) :
         (List.mem_finRange _)).1
     · by_cases hrj : r = j
       · subst hrj
-        rw [if_neg hri, if_pos rfl]
+        rw [ite_eq_right hri, ite_eq_left rfl]
         apply Vector.ext
         intro t ht
         rw [getElem_getRow_nat, getElem_rows, getElem_getRow_nat]
@@ -1016,7 +1016,7 @@ private theorem flatIdx_swap_disj {i j : Nat} (hij : i ≠ j) :
         exact (foldl_swap_mem _ _ (fun s => flatIdx_lt hi s.isLt) (fun s => flatIdx_lt hr s.isLt)
           (flatIdx_swap_disj hij) (List.finRange m) (nodup_finRange m) d ⟨t, ht⟩
           (List.mem_finRange _)).2
-      · rw [if_neg hri, if_neg hrj, getElem_rows]
+      · rw [ite_eq_right hri, ite_eq_right hrj, getElem_rows]
         apply Vector.ext
         intro t ht
         rw [getElem_getRow_nat, getElem_getRow_nat]
@@ -1105,11 +1105,11 @@ the replacement function and every other column is read from `M`. -/
   rw [Fin.foldl_eq_finRange_foldl]
   by_cases hc : c = dst
   · subst hc
-    rw [if_pos rfl]
+    rw [ite_eq_left rfl]
     exact foldl_set_mem (fun i : Fin n => i.val * m + c.val) v
       (fun i => flatIdx_lt i.isLt c.isLt) (flatIdx_row_inj c.isLt)
       (List.finRange n) (nodup_finRange n) d r (List.mem_finRange _)
-  · rw [if_neg hc]
+  · rw [ite_eq_right hc]
     exact foldl_set_ne (fun i : Fin n => i.val * m + dst.val) v
       (fun i => flatIdx_lt i.isLt dst.isLt) (flatIdx_lt r.isLt c.isLt)
       (List.finRange n) d (fun i _ heq => by
@@ -1125,9 +1125,9 @@ the replacement function and every other column is read from `M`. -/
   intro r c
   rw [getElem_setCol]
   by_cases hc' : c = dst
-  · rw [if_pos hc']
+  · rw [ite_eq_left hc']
     exact congrArg (fun c' : Fin m => M[r][c']) hc'.symm
-  · rw [if_neg hc']
+  · rw [ite_eq_right hc']
 
 /-- Transposing a row replacement is a column replacement on the transpose:
 `setRow` on `M` corresponds to `setCol` on `Mᵀ`. This is the bridge the
@@ -1141,7 +1141,7 @@ theorem transpose_setRow (M : Matrix R n m) (dst : Fin n) (v : Vector R m) :
   · subst hb
     rw [show (setRow M b v)[b] = v from setRow_get_self M b v]
     simp
-  · rw [if_neg hb, show (setRow M dst v)[b] = M[b] from setRow_row_ne M dst b v hb,
+  · rw [ite_eq_right hb, show (setRow M dst v)[b] = M[b] from setRow_row_ne M dst b v hb,
       getElem_transpose]
 
 /-- In-place per-entry column modify: replace each entry `M[i][dst]` by
@@ -1164,11 +1164,11 @@ def modifyCol (M : Matrix R n m) (dst : Fin m) (g : Fin n → R → R) : Matrix 
   rw [Fin.foldl_eq_finRange_foldl]
   by_cases hc : c = dst
   · subst hc
-    rw [if_pos rfl]
+    rw [ite_eq_left rfl]
     exact foldl_modify_mem (fun i : Fin n => i.val * m + c.val) g
       (fun i => flatIdx_lt i.isLt c.isLt) (flatIdx_row_inj c.isLt)
       (List.finRange n) (nodup_finRange n) d r (List.mem_finRange _)
-  · rw [if_neg hc]
+  · rw [ite_eq_right hc]
     exact foldl_modify_ne (fun i : Fin n => i.val * m + dst.val) g
       (flatIdx_lt r.isLt c.isLt) (List.finRange n) d (fun i _ heq => by
         have h1 : (i.val * m + dst.val) % m = dst.val := flatIdx_mod dst.isLt
@@ -1180,7 +1180,7 @@ def modifyCol (M : Matrix R n m) (dst : Fin m) (g : Fin n → R → R) : Matrix 
 theorem getElem_modifyCol_of_ne (M : Matrix R n m) (dst : Fin m) (g : Fin n → R → R)
     (r : Fin n) {c : Fin m} (h : c ≠ dst) :
     (modifyCol M dst g)[r][c] = M[r][c] := by
-  rw [getElem_modifyCol, if_neg h]
+  rw [getElem_modifyCol, ite_eq_right h]
 
 /-- Scalar action on a matrix, delegated to the flat backing buffer. The single
 sanctioned `SMul` instance for matrices: the Mathlib bridge layer reuses it rather

--- a/HexMatrix/Diagonal.lean
+++ b/HexMatrix/Diagonal.lean
@@ -116,7 +116,7 @@ theorem row_diagMatrix_cast {R : Type u} [Lean.Grind.Semiring R] {r n m : Nat}
   by_cases hij : Fin.castLE hrm i = jj
   · have hval : i.val = jj.val := by
       simpa only [Fin.castLE, Fin.mk.injEq] using congrArg Fin.val hij
-    rw [if_pos hij, diagMatrix_apply_diag d (Fin.castLE hrn i) jj hval i.isLt]
+    rw [ite_eq_left hij, diagMatrix_apply_diag d (Fin.castLE hrn i) jj hval i.isLt]
     have hd : d[(⟨(Fin.castLE hrn i).val, i.isLt⟩ : Fin r)] = d[i] := by
       exact congrArg (fun q : Fin r => d[q]) (Fin.ext rfl)
     rw [hd]
@@ -125,7 +125,7 @@ theorem row_diagMatrix_cast {R : Type u} [Lean.Grind.Semiring R] {r n m : Nat}
       intro h
       apply hij
       exact Fin.ext h
-    rw [if_neg hij, diagMatrix_apply_of_ne d (Fin.castLE hrn i) jj hval]
+    rw [ite_eq_right hij, diagMatrix_apply_of_ne d (Fin.castLE hrn i) jj hval]
     exact (Lean.Grind.Semiring.mul_zero d[i]).symm
 
 end Hex.Matrix

--- a/HexMatrix/DotProduct.lean
+++ b/HexMatrix/DotProduct.lean
@@ -76,7 +76,7 @@ private theorem foldl_extend_zero {R : Type u} [Lean.Grind.Ring R] (m d : Nat)
     apply List.foldl_add_congr
     intro i _
     have hi : i.val < m := i.isLt
-    rw [dif_pos hi, dif_pos hi]
+    rw [dite_eq_left hi, dite_eq_left hi]
     congr 1
   | succ d ih =>
     show (List.finRange ((m + d) + 1)).foldl
@@ -85,7 +85,7 @@ private theorem foldl_extend_zero {R : Type u} [Lean.Grind.Ring R] (m d : Nat)
             * (if h : i.val < m then G ⟨i.val, h⟩ else 0)) 0 = _
     rw [foldl_finRange_succ_last]
     have hlast : ¬ ((Fin.last (m + d)).val < m) := by simp [Fin.last]
-    rw [dif_neg hlast]
+    rw [dite_eq_right hlast]
     have hpre : (List.finRange (m + d)).foldl
         (fun acc i => acc
           + (if h : (Fin.castSucc i).val < m then F ⟨(Fin.castSucc i).val, h⟩ else 0)

--- a/HexMatrix/Elementary.lean
+++ b/HexMatrix/Elementary.lean
@@ -115,8 +115,8 @@ theorem getElem_rowScale [Mul R] (M : Matrix R n m) (i r : Fin n) (c : R) (k : F
       if r = i then c * M[i][k] else M[r][k] := by
   rw [rowScale, getElem_modifyEntries]
   by_cases h : r = i
-  · rw [if_pos (congrArg Fin.val h), if_pos h, h]
-  · rw [if_neg (fun hv => h (Fin.ext hv)), if_neg h]
+  · rw [ite_eq_left (congrArg Fin.val h), ite_eq_left h, h]
+  · rw [ite_eq_right (fun hv => h (Fin.ext hv)), ite_eq_right h]
 
 /-- Row `i` of `rowScale M i c` is the pointwise scalar multiple of row `i`. -/
 @[simp, grind =] theorem row_rowScale_self [Mul R] (M : Matrix R n m) (i : Fin n) (c : R) :
@@ -157,9 +157,9 @@ theorem getElem_rowAdd [Mul R] [Add R]
       if r = dst then M[dst][k] + c * M[src][k] else M[r][k] := by
   rw [rowAdd, getElem_modifyEntries]
   by_cases h : r = dst
-  · rw [if_pos (congrArg Fin.val h), if_pos h, h]
+  · rw [ite_eq_left (congrArg Fin.val h), ite_eq_left h, h]
     rw [show (getRow M src)[k] = M[src][k] from rfl]
-  · rw [if_neg (fun hv => h (Fin.ext hv)), if_neg h]
+  · rw [ite_eq_right (fun hv => h (Fin.ext hv)), ite_eq_right h]
 
 /-- Source-row entries are unchanged by `rowAdd M src dst c` when `src ≠ dst`. -/
 theorem getElem_rowAdd_src_of_ne [Mul R] [Add R]
@@ -209,7 +209,7 @@ theorem rowScale_eq_set [Mul R] (M : Matrix R n m) (i : Fin n) (c : R) :
   · subst h
     rw [setRow_get_self]
     simp [Vector.getElem_ofFn]
-  · rw [if_neg h, setRow_row_ne M i r _ h]
+  · rw [ite_eq_right h, setRow_row_ne M i r _ h]
 
 /-- `rowAdd` as a single `set` of the combined row. The executable definition
 goes through `Vector.modify` for in-place update; this is the value-level
@@ -224,7 +224,7 @@ theorem rowAdd_eq_set [Mul R] [Add R] (M : Matrix R n m) (src dst : Fin n) (c : 
   · subst h
     rw [setRow_get_self]
     simp [Vector.getElem_ofFn]
-  · rw [if_neg h, setRow_row_ne M dst r _ h]
+  · rw [ite_eq_right h, setRow_row_ne M dst r _ h]
 
 /-- Column `k` of `rowSwap M i j` is column `k` of `M` with entries `i` and `j`
 exchanged. -/
@@ -298,8 +298,8 @@ theorem getElem_colAdd [Mul R] [Add R]
       if j = dst then M[i][j] + c * M[i][src] else M[i][j] := by
   rw [colAdd, getElem_modifyCol]
   by_cases hj : j = dst
-  · rw [if_pos hj, if_pos hj, hj, getElem_col]
-  · rw [if_neg hj, if_neg hj]
+  · rw [ite_eq_left hj, ite_eq_left hj, hj, getElem_col]
+  · rw [ite_eq_right hj, ite_eq_right hj]
 
 /-- Transposing a column addition is the corresponding row addition on the
 transpose. -/
@@ -311,8 +311,8 @@ theorem transpose_colAdd [Mul R] [Add R] (M : Matrix R n m)
   rw [getElem_transpose, getElem_colAdd, getElem_rowAdd]
   simp only [getElem_transpose]
   by_cases hi : i = dst
-  · rw [if_pos hi, if_pos hi, hi]
-  · rw [if_neg hi, if_neg hi]
+  · rw [ite_eq_left hi, ite_eq_left hi, hi]
+  · rw [ite_eq_right hi, ite_eq_right hi]
 
 /-- Read an entry of `colAddRight M src dst c` by cases on the column index:
 column `dst` returns `M[i][dst] + M[i][src] * c`, any other column is
@@ -323,8 +323,8 @@ theorem getElem_colAddRight [Mul R] [Add R]
       if j = dst then M[i][j] + M[i][src] * c else M[i][j] := by
   rw [colAddRight, getElem_modifyCol]
   by_cases hj : j = dst
-  · rw [if_pos hj, if_pos hj, hj, getElem_col]
-  · rw [if_neg hj, if_neg hj]
+  · rw [ite_eq_left hj, ite_eq_left hj, hj, getElem_col]
+  · rw [ite_eq_right hj, ite_eq_right hj]
 
 /-- Column `dst` of `colAdd M src dst c` is the pointwise column combination. -/
 @[simp, grind =] theorem col_colAdd_dst [Mul R] [Add R]
@@ -448,11 +448,11 @@ any other column is unchanged. -/
       if c = j then M[r][i] else if c = i then M[r][j] else M[r][c] := by
   rw [colSwap, getElem_setCol]
   by_cases hcj : c = j
-  · rw [if_pos hcj, if_pos hcj, getElem_col]
-  · rw [if_neg hcj, if_neg hcj, getElem_setCol]
+  · rw [ite_eq_left hcj, ite_eq_left hcj, getElem_col]
+  · rw [ite_eq_right hcj, ite_eq_right hcj, getElem_setCol]
     by_cases hci : c = i
-    · rw [if_pos hci, if_pos hci, getElem_col]
-    · rw [if_neg hci, if_neg hci]
+    · rw [ite_eq_left hci, ite_eq_left hci, getElem_col]
+    · rw [ite_eq_right hci, ite_eq_right hci]
 
 /-- Column `i` of `colSwap M i j` is the original column `j`. -/
 @[simp, grind =] theorem col_colSwap_left (M : Matrix R n m) (i j : Fin m) :

--- a/HexMatrix/ElementaryAlgebra.lean
+++ b/HexMatrix/ElementaryAlgebra.lean
@@ -134,31 +134,31 @@ theorem rowSwap_mul [Lean.Grind.Ring R]
   intro rr ll
   rw [getElem_mul (rowSwap A i j) B rr ll, getElem_rowSwap (A * B) i j rr ll]
   by_cases hrj : rr = j
-  · rw [if_pos hrj]
+  · rw [ite_eq_left hrj]
     rw [getElem_mul A B i ll]
     have hrow : (rowSwap A i j)[rr] = A[i] := by
       ext k' hk
       let kk : Fin m := ⟨k', hk⟩
       show (rowSwap A i j)[rr][kk] = A[i][kk]
-      rw [getElem_rowSwap]; rw [if_pos hrj]
+      rw [getElem_rowSwap]; rw [ite_eq_left hrj]
     rw [show row (rowSwap A i j) rr = row A i by simpa [row] using hrow]
-  · rw [if_neg hrj]
+  · rw [ite_eq_right hrj]
     by_cases hri : rr = i
-    · rw [if_pos hri]
+    · rw [ite_eq_left hri]
       rw [getElem_mul A B j ll]
       have hrow : (rowSwap A i j)[rr] = A[j] := by
         ext k' hk
         let kk : Fin m := ⟨k', hk⟩
         show (rowSwap A i j)[rr][kk] = A[j][kk]
-        rw [getElem_rowSwap]; rw [if_neg hrj, if_pos hri]
+        rw [getElem_rowSwap]; rw [ite_eq_right hrj, ite_eq_left hri]
       rw [show row (rowSwap A i j) rr = row A j by simpa [row] using hrow]
-    · rw [if_neg hri]
+    · rw [ite_eq_right hri]
       rw [getElem_mul A B rr ll]
       have hrow : (rowSwap A i j)[rr] = A[rr] := by
         ext k' hk
         let kk : Fin m := ⟨k', hk⟩
         show (rowSwap A i j)[rr][kk] = A[rr][kk]
-        rw [getElem_rowSwap]; rw [if_neg hrj, if_neg hri]
+        rw [getElem_rowSwap]; rw [ite_eq_right hrj, ite_eq_right hri]
       rw [show row (rowSwap A i j) rr = row A rr by simpa [row] using hrow]
 
 /-- Multiplication by `B` commutes with row scaling on the left factor. -/
@@ -169,13 +169,13 @@ theorem rowScale_mul [Lean.Grind.Ring R]
   intro rr ll
   rw [getElem_mul (rowScale A i s) B rr ll, getElem_rowScale (A * B) i rr s ll]
   by_cases hri : rr = i
-  · rw [if_pos hri]
+  · rw [ite_eq_left hri]
     rw [getElem_mul A B i ll]
     rw [show row (rowScale A i s) rr = Vector.ofFn (fun k' => s * A[i][k']) by
       rw [hri]
       exact row_rowScale_self A i s]
     exact dotProduct_smul_ofFn_left s A[i] (col B ll)
-  · rw [if_neg hri]
+  · rw [ite_eq_right hri]
     rw [getElem_mul A B rr ll]
     rw [show row (rowScale A i s) rr = row A rr by
       exact row_rowScale_of_ne A s hri]
@@ -189,14 +189,14 @@ theorem rowAdd_mul [Lean.Grind.Ring R]
   intro rr ll
   rw [getElem_mul (rowAdd A src dst s) B rr ll, getElem_rowAdd (A * B) src dst rr s ll]
   by_cases hrd : rr = dst
-  · rw [if_pos hrd]
+  · rw [ite_eq_left hrd]
     rw [getElem_mul A B dst ll, getElem_mul A B src ll]
     rw [show row (rowAdd A src dst s) rr =
         Vector.ofFn (fun k' => A[dst][k'] + s * A[src][k']) by
       rw [hrd]
       exact row_rowAdd_dst A src dst s]
     exact dotProduct_add_smul_ofFn_left A[dst] A[src] (col B ll) s
-  · rw [if_neg hrd]
+  · rw [ite_eq_right hrd]
     rw [getElem_mul A B rr ll]
     rw [show row (rowAdd A src dst s) rr = row A rr by
       exact row_rowAdd_of_ne A src s hrd]
@@ -208,17 +208,17 @@ theorem rowSwap_mulVec_getElem [Mul R] [Add R] [OfNat R 0]
       if r = j then (M * v)[i] else if r = i then (M * v)[j] else (M * v)[r] := by
   rw [getElem_mulVec (rowSwap M i j) v r]
   by_cases hrj : r = j
-  · rw [if_pos hrj, getElem_mulVec M v i]
+  · rw [ite_eq_left hrj, getElem_mulVec M v i]
     rw [show row (rowSwap M i j) r = row M i by
       rw [hrj]
       exact row_rowSwap_right M i j]
-  · rw [if_neg hrj]
+  · rw [ite_eq_right hrj]
     by_cases hri : r = i
-    · rw [if_pos hri, getElem_mulVec M v j]
+    · rw [ite_eq_left hri, getElem_mulVec M v j]
       rw [show row (rowSwap M i j) r = row M j by
         rw [hri]
         exact row_rowSwap_left M i j]
-    · rw [if_neg hri, getElem_mulVec M v r]
+    · rw [ite_eq_right hri, getElem_mulVec M v r]
       rw [show row (rowSwap M i j) r = row M r by
         exact row_rowSwap_of_ne M hri hrj]
 
@@ -230,11 +230,11 @@ theorem rowScale_mulVec_getElem [Lean.Grind.Ring R]
   rw [getElem_mulVec (rowScale M i s) v r]
   by_cases hri : r = i
   · subst r
-    rw [if_pos rfl, getElem_mulVec M v i]
+    rw [ite_eq_left rfl, getElem_mulVec M v i]
     rw [show row (rowScale M i s) i = Vector.ofFn (fun k => s * M[i][k]) by
       exact row_rowScale_self M i s]
     exact dotProduct_smul_ofFn_left s M[i] v
-  · rw [if_neg hri, getElem_mulVec M v r]
+  · rw [ite_eq_right hri, getElem_mulVec M v r]
     rw [show row (rowScale M i s) r = row M r by
       exact row_rowScale_of_ne M s hri]
 
@@ -246,12 +246,12 @@ theorem rowAdd_mulVec_getElem [Lean.Grind.Ring R]
   rw [getElem_mulVec (rowAdd M src dst s) v r]
   by_cases hrd : r = dst
   · subst r
-    rw [if_pos rfl, getElem_mulVec M v dst, getElem_mulVec M v src]
+    rw [ite_eq_left rfl, getElem_mulVec M v dst, getElem_mulVec M v src]
     rw [show row (rowAdd M src dst s) dst =
         Vector.ofFn (fun k => M[dst][k] + s * M[src][k]) by
       exact row_rowAdd_dst M src dst s]
     exact dotProduct_add_smul_ofFn_left M[dst] M[src] v s
-  · rw [if_neg hrd, getElem_mulVec M v r]
+  · rw [ite_eq_right hrd, getElem_mulVec M v r]
     rw [show row (rowAdd M src dst s) r = row M r by
       exact row_rowAdd_of_ne M src s hrd]
 
@@ -290,18 +290,18 @@ theorem rowSwap_rowSwap (M : Matrix R n m) (i j : Fin n) :
   intro rr kk
   rw [getElem_rowSwap]
   by_cases hrj : rr = j
-  · rw [if_pos hrj]
+  · rw [ite_eq_left hrj]
     rw [getElem_rowSwap]
     by_cases hji : i = j
     · simp [hrj, hji]
     · simp [hrj, hji]
-  · rw [if_neg hrj]
+  · rw [ite_eq_right hrj]
     by_cases hri : rr = i
-    · rw [if_pos hri]
+    · rw [ite_eq_left hri]
       rw [getElem_rowSwap]
       simp [hri]
-    · rw [if_neg hri]
-      rw [getElem_rowSwap, if_neg hrj, if_neg hri]
+    · rw [ite_eq_right hri]
+      rw [getElem_rowSwap, ite_eq_right hrj, ite_eq_right hri]
 
 /-- Swapping a row with itself leaves the matrix unchanged. -/
 @[simp, grind =] theorem rowSwap_self (M : Matrix R n m) (i : Fin n) :
@@ -321,9 +321,9 @@ theorem rowSwap_rowSwap (M : Matrix R n m) (i j : Fin n) :
   intro rr kk
   rw [getElem_rowScale]
   by_cases hri : rr = i
-  · rw [if_pos hri]
+  · rw [ite_eq_left hri]
     grind
-  · rw [if_neg hri]
+  · rw [ite_eq_right hri]
 
 /-- Adding zero times one row to another leaves the matrix unchanged. -/
 @[simp, grind =] theorem rowAdd_zero [Lean.Grind.Semiring R]
@@ -333,9 +333,9 @@ theorem rowSwap_rowSwap (M : Matrix R n m) (i j : Fin n) :
   intro rr kk
   rw [getElem_rowAdd]
   by_cases hrd : rr = dst
-  · rw [if_pos hrd]
+  · rw [ite_eq_left hrd]
     grind
-  · rw [if_neg hrd]
+  · rw [ite_eq_right hrd]
 
 /-- Scaling a row by `s` and then by `s⁻¹` restores the original matrix when
 `s` is nonzero. -/
@@ -346,11 +346,11 @@ theorem rowScale_rowScale_inv_left [Lean.Grind.Field R]
   intro rr kk
   rw [getElem_rowScale]
   by_cases hri : rr = i
-  · rw [if_pos hri]
-    rw [getElem_rowScale, if_pos rfl]
+  · rw [ite_eq_left hri]
+    rw [getElem_rowScale, ite_eq_left rfl]
     grind
-  · rw [if_neg hri]
-    rw [getElem_rowScale, if_neg hri]
+  · rw [ite_eq_right hri]
+    rw [getElem_rowScale, ite_eq_right hri]
 
 /-- Scaling a row by `s⁻¹` and then by `s` restores the original matrix when
 `s` is nonzero. -/
@@ -361,11 +361,11 @@ theorem rowScale_rowScale_inv_right [Lean.Grind.Field R]
   intro rr kk
   rw [getElem_rowScale]
   by_cases hri : rr = i
-  · rw [if_pos hri]
-    rw [getElem_rowScale, if_pos rfl]
+  · rw [ite_eq_left hri]
+    rw [getElem_rowScale, ite_eq_left rfl]
     grind
-  · rw [if_neg hri]
-    rw [getElem_rowScale, if_neg hri]
+  · rw [ite_eq_right hri]
+    rw [getElem_rowScale, ite_eq_right hri]
 
 /-- Adding `s` times a distinct source row to a destination row and then
 adding `-s` times that source row restores the original matrix. -/
@@ -376,13 +376,13 @@ theorem rowAdd_rowAdd_neg [Lean.Grind.Ring R]
   intro rr kk
   rw [getElem_rowAdd]
   by_cases hrd : rr = dst
-  · rw [if_pos hrd]
-    rw [getElem_rowAdd, if_pos rfl]
+  · rw [ite_eq_left hrd]
+    rw [getElem_rowAdd, ite_eq_left rfl]
     have hsrc_ne_dst : src ≠ dst := hsrcdst
-    rw [getElem_rowAdd, if_neg hsrc_ne_dst]
+    rw [getElem_rowAdd, ite_eq_right hsrc_ne_dst]
     grind
-  · rw [if_neg hrd]
-    rw [getElem_rowAdd, if_neg hrd]
+  · rw [ite_eq_right hrd]
+    rw [getElem_rowAdd, ite_eq_right hrd]
 
 /-- Adding `-s` times a distinct source row to a destination row and then
 adding `s` times that source row restores the original matrix. -/
@@ -393,13 +393,13 @@ theorem rowAdd_rowAdd_neg_left [Lean.Grind.Ring R]
   intro rr kk
   rw [getElem_rowAdd]
   by_cases hrd : rr = dst
-  · rw [if_pos hrd]
-    rw [getElem_rowAdd, if_pos rfl]
+  · rw [ite_eq_left hrd]
+    rw [getElem_rowAdd, ite_eq_left rfl]
     have hsrc_ne_dst : src ≠ dst := hsrcdst
-    rw [getElem_rowAdd, if_neg hsrc_ne_dst]
+    rw [getElem_rowAdd, ite_eq_right hsrc_ne_dst]
     grind
-  · rw [if_neg hrd]
-    rw [getElem_rowAdd, if_neg hrd]
+  · rw [ite_eq_right hrd]
+    rw [getElem_rowAdd, ite_eq_right hrd]
 
 private theorem leftMul_left_inverse_preserve [Lean.Grind.Ring R]
     {S Sinv T : Matrix R n n} (hSinvS : Sinv * S = (Matrix.identity (R := R) n))
@@ -525,7 +525,7 @@ theorem mul_colAdd [Lean.Grind.CommRing R]
   intro rr ll
   rw [getElem_mul A (colAdd B src dst s) rr ll, getElem_colAdd (A * B) src dst s rr ll]
   by_cases hld : ll = dst
-  · rw [if_pos hld]
+  · rw [ite_eq_left hld]
     rw [hld, getElem_mul A B rr dst, getElem_mul A B rr src]
     rw [show col (colAdd B src dst s) dst =
         Vector.ofFn (fun i => B[i][dst] + s * B[i][src]) by
@@ -533,7 +533,7 @@ theorem mul_colAdd [Lean.Grind.CommRing R]
     simpa [col] using
       dotProduct_add_smul_ofFn_right (row A rr)
         (Vector.ofFn fun i => B[i][dst]) (Vector.ofFn fun i => B[i][src]) s
-  · rw [if_neg hld]
+  · rw [ite_eq_right hld]
     rw [getElem_mul A B rr ll]
     rw [show col (colAdd B src dst s) ll = col B ll by
       exact col_colAdd_of_ne B src s hld]
@@ -548,14 +548,14 @@ theorem mul_colAddRight [Lean.Grind.Ring R]
   intro rr ll
   rw [getElem_mul A (colAddRight B src dst s) rr ll, getElem_colAddRight (A * B) src dst s rr ll]
   by_cases hld : ll = dst
-  · rw [if_pos hld]
+  · rw [ite_eq_left hld]
     rw [hld, getElem_mul A B rr dst, getElem_mul A B rr src]
     rw [show col (colAddRight B src dst s) dst =
         Vector.ofFn (fun i => B[i][dst] + B[i][src] * s) by
       exact col_colAddRight_dst B src dst s]
     simpa [col] using
       dotProduct_add_smulRight_ofFn_right (row A rr) (col B dst) (col B src) s
-  · rw [if_neg hld]
+  · rw [ite_eq_right hld]
     rw [getElem_mul A B rr ll]
     rw [show col (colAddRight B src dst s) ll = col B ll by
       exact col_colAddRight_of_ne B src s hld]
@@ -568,9 +568,9 @@ theorem mul_colAddRight [Lean.Grind.Ring R]
   intro ii jj
   rw [getElem_colAdd]
   by_cases hjd : jj = dst
-  · rw [if_pos hjd]
+  · rw [ite_eq_left hjd]
     grind
-  · rw [if_neg hjd]
+  · rw [ite_eq_right hjd]
 
 /-- Adding one column times zero to another leaves the matrix unchanged. -/
 @[simp, grind =] theorem colAddRight_zero [Lean.Grind.Semiring R]
@@ -580,8 +580,8 @@ theorem mul_colAddRight [Lean.Grind.Ring R]
   intro ii jj
   rw [getElem_colAddRight]
   by_cases hjd : jj = dst
-  · rw [if_pos hjd]
+  · rw [ite_eq_left hjd]
     grind
-  · rw [if_neg hjd]
+  · rw [ite_eq_right hjd]
 end Matrix
 end Hex

--- a/HexMatrix/Gram.lean
+++ b/HexMatrix/Gram.lean
@@ -81,8 +81,8 @@ private theorem foldl_indicator_square_eq {R : Type u} [Lean.Grind.CommRing R]
           (if i = x then (1 : R) else 0) * (if i = x then (1 : R) else 0) =
             if i = x then (1 : R) else 0 := by
         by_cases h : i = x
-        · rw [if_pos h]; grind
-        · rw [if_neg h]; grind
+        · rw [ite_eq_left h]; grind
+        · rw [ite_eq_right h]; grind
       rw [hsq]
       exact ih _
 
@@ -113,15 +113,15 @@ private theorem foldl_dotProduct_unit_body {R : Type u} [Lean.Grind.CommRing R]
     rw [foldl_indicator_square_eq]
     rw [foldl_indicator_unique (List.finRange n) i (List.mem_finRange i)
       (List.nodup_finRange n) (0 : R)]
-    rw [if_pos rfl]; grind
+    rw [ite_eq_left rfl]; grind
   · have hzero : ∀ l ∈ List.finRange n,
         (if i = l then (1 : R) else 0) * (if j = l then (1 : R) else 0) = 0 := by
       intro l _
       by_cases hil : i = l
       · have hjl : j ≠ l := fun heq => hij (hil.trans heq.symm)
-        rw [if_pos hil, if_neg hjl]; grind
-      · rw [if_neg hil]; grind
-    rw [foldl_add_eq_acc (List.finRange n) _ _ hzero, if_neg hij]
+        rw [ite_eq_left hil, ite_eq_right hjl]; grind
+      · rw [ite_eq_right hil]; grind
+    rw [foldl_add_eq_acc (List.finRange n) _ _ hzero, ite_eq_right hij]
 
 end Vector
 

--- a/HexMatrix/Lattice.lean
+++ b/HexMatrix/Lattice.lean
@@ -55,9 +55,9 @@ theorem vecMul_unit (B : Matrix Int n m) (i : Fin n) :
             (if k = i then B[i][col] else 0)
           by_cases hki : k = i
           · subst k
-            rw [if_pos rfl, Int.mul_one]
-            rw [if_pos rfl]
-          · rw [if_neg hki, if_neg (Ne.symm hki), Int.mul_zero]
+            rw [ite_eq_left rfl, Int.mul_one]
+            rw [ite_eq_left rfl]
+          · rw [ite_eq_right hki, ite_eq_right (Ne.symm hki), Int.mul_zero]
     _ = B[i][col] := by
       rw [List.foldl_add_single (List.finRange n) 0 i
         (fun _ => B[i][col]) (List.mem_finRange _) (List.nodup_finRange n)]

--- a/HexMatrix/MatrixAlgebra.lean
+++ b/HexMatrix/MatrixAlgebra.lean
@@ -41,15 +41,15 @@ private theorem foldl_indicator_mul_unique {R : Type u} [Lean.Grind.Ring R]
             ∀ y ∈ xs, (if x = y then (1 : R) else 0) * f y = 0 := by
           intro y hy
           have hxy : x ≠ y := fun heq => (List.nodup_cons.mp hnodup).1 (heq ▸ hy)
-          rw [if_neg hxy]
+          rw [ite_eq_right hxy]
           grind
-        rw [if_pos rfl, List.foldl_add_eq_self xs _ _ hxs_zero]
+        rw [ite_eq_left rfl, List.foldl_add_eq_self xs _ _ hxs_zero]
         grind
       · have hxi : i ≠ x := by
           intro heq
           rw [← heq] at hnodup
           exact (List.nodup_cons.mp hnodup).1 hitail
-        rw [if_neg hxi]
+        rw [ite_eq_right hxi]
         have hzero : (0 : R) * f x = 0 := by grind
         rw [hzero]
         have hac : acc + (0 : R) = acc := by grind
@@ -215,9 +215,9 @@ theorem getElem_vecMul_diagMatrix [Lean.Grind.CommRing R]
       intro i _hi
       by_cases hji : jj = i
       · subst i
-        rw [if_pos rfl, getElem_diagMatrix_of_eq d jj j rfl hj]
+        rw [ite_eq_left rfl, getElem_diagMatrix_of_eq d jj j rfl hj]
         grind
-      · rw [if_neg hji, getElem_diagMatrix_of_ne d i j]
+      · rw [ite_eq_right hji, getElem_diagMatrix_of_ne d i j]
         · grind
         · intro hij
           apply hji

--- a/HexMatrix/Pad.lean
+++ b/HexMatrix/Pad.lean
@@ -56,7 +56,7 @@ theorem takeCols_takeRows_pad [OfNat R 0] (M : Matrix R n m) (n' m' : Nat)
   apply ext_getElem
   intro i j
   rw [getElem_takeCols, getElem_takeRows, getElem_pad,
-    dif_pos (⟨i.isLt, j.isLt⟩ : i.val < n ∧ j.val < m)]
+    dite_eq_left (⟨i.isLt, j.isLt⟩ : i.val < n ∧ j.val < m)]
   rw [getElem_pair_eq_nested]
 
 /-- An in-range row of a padded matrix is the source row followed by zeros. -/
@@ -70,8 +70,8 @@ theorem row_pad [OfNat R 0] (M : Matrix R n m) (n' m' : Nat) (I : Fin n') (hI : 
   show (pad M n' m')[I][(⟨t, ht⟩ : Fin m')] = _
   rw [getElem_pad]
   by_cases htm : t < m
-  · rw [dif_pos htm, dif_pos (⟨hI, htm⟩ : I.val < n ∧ (⟨t, ht⟩ : Fin m').val < m)]
-  · rw [dif_neg (by simp [htm]), dif_neg htm]
+  · rw [dite_eq_left htm, dite_eq_left (⟨hI, htm⟩ : I.val < n ∧ (⟨t, ht⟩ : Fin m').val < m)]
+  · rw [dite_eq_right (by simp [htm]), dite_eq_right htm]
 
 /-- An in-range column of a padded matrix is the source column followed by zeros. -/
 theorem col_pad [OfNat R 0] (M : Matrix R n m) (n' m' : Nat) (J : Fin m') (hJ : J.val < m) :
@@ -84,8 +84,8 @@ theorem col_pad [OfNat R 0] (M : Matrix R n m) (n' m' : Nat) (J : Fin m') (hJ : 
   show (col (pad M n' m') J)[(⟨t, ht⟩ : Fin n')] = _
   rw [getElem_col, getElem_pad]
   by_cases htn : t < n
-  · rw [dif_pos htn, dif_pos (⟨htn, hJ⟩ : (⟨t, ht⟩ : Fin n').val < n ∧ J.val < m)]
-  · rw [dif_neg htn, dif_neg (by simp [htn])]
+  · rw [dite_eq_left htn, dite_eq_left (⟨htn, hJ⟩ : (⟨t, ht⟩ : Fin n').val < n ∧ J.val < m)]
+  · rw [dite_eq_right htn, dite_eq_right (by simp [htn])]
 
 /-- **Padding lemma.** Zero-padding each operand to a common larger middle
 dimension and reading back the top-left `n × k` block of the product returns the

--- a/HexMatrix/Strassen.lean
+++ b/HexMatrix/Strassen.lean
@@ -62,8 +62,8 @@ theorem toMatrix_pad_view [OfNat R 0] (A : Submatrix R n m) (n' m' : Nat)
   intro i j
   rw [Submatrix.getElem_toMatrix, Submatrix.entry_pad, getElem_pad]
   by_cases h : i.val < n ∧ j.val < m
-  · rw [dif_pos h, dif_pos h, getElem_pair_eq_nested, Submatrix.getElem_toMatrix]
-  · rw [dif_neg h, dif_neg h]
+  · rw [dite_eq_left h, dite_eq_left h, getElem_pair_eq_nested, Submatrix.getElem_toMatrix]
+  · rw [dite_eq_right h, dite_eq_right h]
 
 /-- Materializing the top-left quadrant view is `Matrix.toBlocks₁₁` of the
 materialized parent. -/

--- a/HexMatrix/Submatrix.lean
+++ b/HexMatrix/Submatrix.lean
@@ -233,7 +233,7 @@ def ofMatrix (Mx : Matrix R n m) : Submatrix R n m where
 @[simp, grind =] theorem entry_ofMatrix [OfNat R 0] (Mx : Matrix R n m) (i : Fin n) (j : Fin m) :
     (ofMatrix Mx).entry i j = Mx[i][j] := by
   rw [entry, ofMatrix]
-  rw [dif_pos (⟨by omega, by omega⟩ : (0 : Nat) + i.val < n ∧ (0 : Nat) + j.val < m)]
+  rw [dite_eq_left (⟨by omega, by omega⟩ : (0 : Nat) + i.val < n ∧ (0 : Nat) + j.val < m)]
   simp [Matrix.getElem_pair_nat]
 
 /-- Materializing the full-matrix view returns the matrix. -/
@@ -259,9 +259,9 @@ def pad (A : Submatrix R n m) (n' m' : Nat) (hn : n ≤ n') (hm : m ≤ m') : Su
     (A.pad n' m' hn hm).entry i j =
       if h : i.val < n ∧ j.val < m then A.entry ⟨i.val, h.1⟩ ⟨j.val, h.2⟩ else 0 := by
   by_cases hin : i.val < n ∧ j.val < m
-  · rw [dif_pos hin]; rfl
-  · rw [dif_neg hin, entry]
-    apply dif_neg
+  · rw [dite_eq_left hin]; rfl
+  · rw [dite_eq_right hin, entry]
+    apply dite_eq_right
     simp only [pad]
     intro hd
     have h1 := A.hrR

--- a/HexMatrixMathlib/Lemmas.lean
+++ b/HexMatrixMathlib/Lemmas.lean
@@ -41,9 +41,9 @@ Mathlib's `ᵀ`. -/
   rw [matrixEquiv_apply, Matrix.updateRow_apply]
   by_cases h : i = dst
   · subst h
-    rw [if_pos rfl, vectorEquiv_apply]
+    rw [ite_eq_left rfl, vectorEquiv_apply]
     exact congrArg (·[j.val]) (Hex.Matrix.setRow_get_self M i v)
-  · rw [if_neg h]
+  · rw [ite_eq_right h]
     rw [matrixEquiv_apply]
     exact congrArg (·[j.val]) (Hex.Matrix.setRow_row_ne M dst i v h)
 

--- a/HexModArith/Ntt/Convolution.lean
+++ b/HexModArith/Ntt/Convolution.lean
@@ -464,7 +464,7 @@ theorem ordinary?_eq_of_some {p n : Nat} [Bounds p] [PrimeModulus p]
     obtain ⟨hnext, hleft, hright⟩ := hvalid
     have href := ordinary?_eq_reference plan left right hnext hleft hright
     unfold ordinary? at href
-    rw [if_pos ⟨hnext, hleft, hright⟩] at href
+    rw [ite_eq_left ⟨hnext, hleft, hright⟩] at href
     rw [href] at hresult
     exact (Option.some.inj hresult).symm
   next hinvalid => simp at hresult

--- a/HexModArith/Residue.lean
+++ b/HexModArith/Residue.lean
@@ -798,13 +798,13 @@ private theorem pow_go_toNat (base acc : ZMod64 p) (k : Nat) :
             Nat.div_lt_self (Nat.succ_pos m) (by decide : 1 < 2)
           simp [pow.go]
           by_cases heven : (m + 1) % 2 = 0
-          · rw [if_pos heven]
+          · rw [ite_eq_left heven]
             have hrec := ih ((m + 1) / 2) hlt (mul base base) acc
             change (pow.go (mul base base) acc ((m + 1) / 2)).toNat =
               acc.toNat * base.toNat ^ (m + 1) % p
             rw [hrec, toNat_mul]
             exact nat_mod_mul_pow_square_even acc.toNat base.toNat (m + 1) p heven
-          · rw [if_neg heven]
+          · rw [ite_eq_right heven]
             have hrec := ih ((m + 1) / 2) hlt (mul base base) (mul acc base)
             change (pow.go (mul base base) (mul acc base) ((m + 1) / 2)).toNat =
               acc.toNat * base.toNat ^ (m + 1) % p

--- a/HexModArith/Ring.lean
+++ b/HexModArith/Ring.lean
@@ -168,12 +168,12 @@ theorem natCast_op_eq_ofNat (n : Nat) :
   unfold neg
   have hpLt : p < UInt64.word := Bounds.pLtWord p
   by_cases hzero : a.val = 0
-  · rw [dif_pos hzero]
+  · rw [dite_eq_left hzero]
     change (0 : UInt64).toNat = (p - a.toNat) % p
     have htoNat : a.toNat = 0 := by simp [toNat_eq_val, hzero]
     have hval : a.val.toNat = 0 := by simpa [toNat_eq_val] using htoNat
     simp [toNat_eq_val, hval]
-  · rw [dif_neg hzero]
+  · rw [dite_eq_right hzero]
     change (-a.val - complementWord p hpLt).toNat = (p - a.toNat) % p
     rw [neg_nonzero_toNat a hzero]
     have hzeroNat : a.toNat ≠ 0 := by

--- a/HexModArith/WordMod.lean
+++ b/HexModArith/WordMod.lean
@@ -65,7 +65,7 @@ theorem toNat_addModWord (m a b : UInt64) (hm : m.toNat ≤ UInt64.word)
           rw [UInt64.le_iff_toNat_le, hs]; exact hge
         simp [this]
       · simp [hle]
-    rw [if_pos hcond, UInt64.toNat_subBorrow_fst]
+    rw [ite_eq_left hcond, UInt64.toNat_subBorrow_fst]
     simp only [Bool.toNat_false, Nat.add_zero]
     rw [hfst, hmod]
     rcases Nat.lt_or_ge (a.toNat + b.toNat) UInt64.word with hlt | hle
@@ -90,7 +90,7 @@ theorem toNat_addModWord (m a b : UInt64) (hm : m.toNat ≤ UInt64.word)
       have hc2 : ¬ m ≤ (UInt64.addCarry a b false).1 := by
         rw [UInt64.le_iff_toNat_le, hs]; omega
       simp [hc1, hc2]
-    rw [if_neg (by rw [hcond]; simp), hs, hmod]
+    rw [ite_eq_right (by rw [hcond]; simp), hs, hmod]
 
 /-- `addModWord` stays below `m`. -/
 theorem addModWord_lt (m a b : UInt64) (hm : 0 < m.toNat) (hmw : m.toNat ≤ UInt64.word)
@@ -114,7 +114,7 @@ theorem toNat_subModWord (m a b : UInt64) (hm : m.toNat ≤ UInt64.word)
   by_cases hlt : a.toNat < b.toNat
   · -- borrow: result wraps up by `m`
     have hcond : (UInt64.subBorrow a b false).2 = true := by rw [hsnd]; simp [hlt]
-    rw [if_pos hcond, UInt64.toNat_addCarry_fst]
+    rw [ite_eq_left hcond, UInt64.toNat_addCarry_fst]
     simp only [Bool.toNat_false, Nat.add_zero]
     rw [hfst]
     have hs : (UInt64.word + a.toNat - b.toNat) % UInt64.word
@@ -128,7 +128,7 @@ theorem toNat_subModWord (m a b : UInt64) (hm : m.toNat ≤ UInt64.word)
     rw [he, Nat.add_mod_left, Nat.mod_eq_of_lt (by omega)]
   · -- no borrow: plain difference
     have hcond : (UInt64.subBorrow a b false).2 = false := by rw [hsnd]; simp [hlt]
-    rw [if_neg (by rw [hcond]; simp), hfst]
+    rw [ite_eq_right (by rw [hcond]; simp), hfst]
     have hs : (UInt64.word + a.toNat - b.toNat) % UInt64.word = a.toNat - b.toNat := by
       have he : UInt64.word + a.toNat - b.toNat = UInt64.word + (a.toNat - b.toNat) := by omega
       rw [he, Nat.add_mod_left, Nat.mod_eq_of_lt (by omega)]
@@ -247,7 +247,7 @@ other divisors return `0` and are never exercised by monic `divMod`. -/
 
 instance : Div (WordMod ctx) := ⟨div⟩
 
-@[simp] theorem div_one (a : WordMod ctx) : a / 1 = a := if_pos rfl
+@[simp] theorem div_one (a : WordMod ctx) : a / 1 = a := ite_eq_left rfl
 
 @[simp] theorem toNat_zero : (0 : WordMod ctx).toNat = 0 := by
   show (ofNat (ctx := ctx) 0).toNat = 0

--- a/HexModArithMathlib/WordMod.lean
+++ b/HexModArithMathlib/WordMod.lean
@@ -38,7 +38,7 @@ def toZMod (a : Hex.WordMod ctx) : ZMod m.toNat := (a.toNat : ZMod m.toNat)
 
 /-- The canonical representative of a transferred class is the residue's value. -/
 @[simp] theorem val_toZMod (a : Hex.WordMod ctx) : (toZMod a).val = a.toNat := by
-  haveI : NeZero m.toNat := ⟨Nat.ne_of_gt ctx.p_pos⟩
+  have : NeZero m.toNat := ⟨Nat.ne_of_gt ctx.p_pos⟩
   rw [toZMod, ZMod.val_natCast, Nat.mod_eq_of_lt a.toNat_lt]
 
 /-- `toZMod` is injective: its `ZMod` value is the residue, which pins the word. -/
@@ -55,24 +55,24 @@ theorem toZMod_injective : Function.Injective (toZMod (ctx := ctx)) := by
     _ = b.val.toNat := Hex.WordMod.toNat_mul_word b
 
 @[simp] theorem toZMod_zero : toZMod (0 : Hex.WordMod ctx) = 0 := by
-  haveI : NeZero m.toNat := ⟨Nat.ne_of_gt ctx.p_pos⟩
+  have : NeZero m.toNat := ⟨Nat.ne_of_gt ctx.p_pos⟩
   apply ZMod.val_injective
   rw [val_toZMod, ZMod.val_zero, Hex.WordMod.toNat_zero]
 
 @[simp] theorem toZMod_add (a b : Hex.WordMod ctx) :
     toZMod (a + b) = toZMod a + toZMod b := by
-  haveI : NeZero m.toNat := ⟨Nat.ne_of_gt ctx.p_pos⟩
+  have : NeZero m.toNat := ⟨Nat.ne_of_gt ctx.p_pos⟩
   apply ZMod.val_injective
   rw [ZMod.val_add, val_toZMod, val_toZMod, val_toZMod, Hex.WordMod.toNat_add]
 
 @[simp] theorem toZMod_mul (a b : Hex.WordMod ctx) :
     toZMod (a * b) = toZMod a * toZMod b := by
-  haveI : NeZero m.toNat := ⟨Nat.ne_of_gt ctx.p_pos⟩
+  have : NeZero m.toNat := ⟨Nat.ne_of_gt ctx.p_pos⟩
   apply ZMod.val_injective
   rw [ZMod.val_mul, val_toZMod, val_toZMod, val_toZMod, Hex.WordMod.toNat_mul]
 
 @[simp] theorem toZMod_one : toZMod (1 : Hex.WordMod ctx) = 1 := by
-  haveI : NeZero m.toNat := ⟨Nat.ne_of_gt ctx.p_pos⟩
+  have : NeZero m.toNat := ⟨Nat.ne_of_gt ctx.p_pos⟩
   apply ZMod.val_injective
   rw [val_toZMod, Hex.WordMod.toNat_one, ZMod.val_one_eq_one_mod]
 
@@ -106,7 +106,7 @@ ring structure back through the injective `toZMod`. -/
 
 @[simp] theorem toZMod_natCast (n : Nat) :
     toZMod ((n : Hex.WordMod ctx)) = (n : ZMod m.toNat) := by
-  haveI : NeZero m.toNat := ⟨Nat.ne_of_gt ctx.p_pos⟩
+  have : NeZero m.toNat := ⟨Nat.ne_of_gt ctx.p_pos⟩
   show toZMod (Hex.WordMod.ofNat n) = _
   rw [toZMod, Hex.WordMod.toNat_ofNat, ZMod.natCast_mod]
 

--- a/HexMvHensel/Shift.lean
+++ b/HexMvHensel/Shift.lean
@@ -54,14 +54,14 @@ def remainingVar (i : Fin (n + 1)) (j : Fin n) : Fin (n + 1) :=
   split
   case isTrue hlt =>
     unfold remainingVar
-    rw [if_pos hlt]
+    rw [ite_eq_left hlt]
   case isFalse hnlt =>
     have hval : j.val ≠ i.val := by
       intro hv
       exact h (Fin.ext hv)
     have hinsert : ¬ (j.val - 1 < i.val) := by omega
     unfold remainingVar
-    rw [if_neg hinsert]
+    rw [ite_eq_right hinsert]
     apply Fin.ext
     simp
     omega

--- a/HexMvPolyMathlib/Aeval.lean
+++ b/HexMvPolyMathlib/Aeval.lean
@@ -153,7 +153,7 @@ direct Mathlib-free evaluator. -/
     MvPoly n R cmp →ₐ[R] S where
   toRingHom := eval₂Hom (algebraMap R S) x
   commutes' r := by
-    letI : DecidableEq R := instDecidableEqOfLawfulBEq
+    let : DecidableEq R := instDecidableEqOfLawfulBEq
     rw [algebraMap_apply]
     change
       eval₂ (algebraMap R S) x
@@ -231,14 +231,14 @@ map. -/
 @[simp] theorem aeval_C [CommSemiring R]
     [CommSemiring S] [Algebra R S] (x : Fin n → S) (r : R) :
     aeval x (C r : MvPoly n R cmp) = algebraMap R S r := by
-  letI : DecidableEq R := instDecidableEqOfLawfulBEq
+  let : DecidableEq R := instDecidableEqOfLawfulBEq
   rw [aeval_apply, toMvPolynomial_C, MvPolynomial.aeval_C]
 
 /-- Algebra evaluation sends a variable polynomial to its assigned value. -/
 @[simp] theorem aeval_X [CommSemiring R]
     [CommSemiring S] [Algebra R S] (x : Fin n → S) (i : Fin n) :
     aeval x (X i : MvPoly n R cmp) = x i := by
-  letI : DecidableEq R := instDecidableEqOfLawfulBEq
+  let : DecidableEq R := instDecidableEqOfLawfulBEq
   rw [aeval_apply, toMvPolynomial_X, MvPolynomial.aeval_X]
 
 /-- Algebra evaluation preserves negation. -/

--- a/HexMvPolyMathlib/Equiv.lean
+++ b/HexMvPolyMathlib/Equiv.lean
@@ -271,10 +271,10 @@ def ofMvPolynomial [CommSemiring R] [DecidableEq R]
         simp only [List.foldl_cons]
         by_cases hdq : d = q
         · subst d
-          rw [if_pos (by simp), ih hds]
+          rw [_root_.ite_eq_left (by simp), ih hds]
           simp [hd]
         · have hqd : q ≠ d := Ne.symm hdq
-          rw [if_neg (by simp [hdq]), ih hds]
+          rw [_root_.ite_eq_right (by simp [hdq]), ih hds]
           simp [hqd]
   rw [fold_pick (monoEquiv m) (fun d => MvPolynomial.coeff d p)
     p.support.toList p.support.nodup_toList]
@@ -349,7 +349,7 @@ variable [BEq R] [LawfulBEq R]
   · have h' : monoEquiv (Mono.unit i) ≠ monoEquiv m := by
       intro heq
       exact h (monoEquiv.injective heq).symm
-    rw [if_neg h, if_neg h']
+    rw [_root_.ite_eq_right h, _root_.ite_eq_right h']
 
 /-- Forward conversion preserves the multiplicative identity. -/
 @[simp] theorem toMvPolynomial_one [CommSemiring R] [DecidableEq R] :

--- a/HexNumberField/Basic.lean
+++ b/HexNumberField/Basic.lean
@@ -161,8 +161,8 @@ private theorem zero_squarefree : HasOnlySimpleRoots ZPoly.X := by
     by_cases hn : n = 1
     · subst n
       simp [ZPoly.X]
-    · rw [if_neg hn]
-      rw [ZPoly.X, DensePoly.coeff_monomial, if_neg hn]
+    · rw [ite_eq_right hn]
+      rw [ZPoly.X, DensePoly.coeff_monomial, ite_eq_right hn]
       change ((0 : Int) : Rat) = 0
       simp
   have hderiv : DensePoly.derivative (ZPoly.toRatPoly ZPoly.X) =
@@ -174,7 +174,7 @@ private theorem zero_squarefree : HasOnlySimpleRoots ZPoly.X := by
       DensePoly.coeff_monomial]
     by_cases hn : n = 0
     · simp [hn]
-    · rw [if_neg hn, if_neg (by omega : n + 1 ≠ 1)]
+    · rw [ite_eq_right hn, ite_eq_right (by omega : n + 1 ≠ 1)]
       change ((n + 1 : Nat) : Rat) * 0 = 0
       exact Rat.mul_zero _
   unfold HasOnlySimpleRoots ZPoly.SquareFreeRat

--- a/HexNumberFieldMathlib/AdjoinRoot.lean
+++ b/HexNumberFieldMathlib/AdjoinRoot.lean
@@ -178,7 +178,7 @@ presentation. -/
 theorem toComplex_injective [ZPoly.CheckedIrreducible p]
     (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x) :
     Function.Injective (fun a : QAdjoin p x => toComplex a rep h) := by
-  letI : Fact (_root_.Irreducible (definingPolynomial p)) :=
+  let : Fact (_root_.Irreducible (definingPolynomial p)) :=
     ⟨definingPolynomial_irreducible p⟩
   intro a b hab
   apply toAdjoinRoot_bijective.1
@@ -543,7 +543,7 @@ noncomputable scoped instance (p : ZPoly) (x : SimpleRoot p)
 /-- A checked rational presentation has characteristic zero. -/
 noncomputable scoped instance (p : ZPoly) (x : SimpleRoot p)
     [ZPoly.CheckedIrreducible p] : CharZero (QAdjoin p x) := by
-  letI : Field (QAdjoin p x) := field p x
+  let : Field (QAdjoin p x) := field p x
   let rep : RefinedIsolation p := Quot.out x
   have hrep : SimpleRoot.mk rep = x := Quot.out_eq x
   constructor
@@ -585,7 +585,7 @@ theorem toAdjoinRoot_zero [ZPoly.CheckedIrreducible p] :
     toAdjoinRoot (0 : QAdjoin p x) = 0 := by
   let rep : RefinedIsolation p := Quot.out x
   have hrep : SimpleRoot.mk rep = x := Quot.out_eq x
-  letI : Fact (_root_.Irreducible (definingPolynomial p)) :=
+  let : Fact (_root_.Irreducible (definingPolynomial p)) :=
     ⟨definingPolynomial_irreducible p⟩
   apply (rootHom rep).injective
   rw [rootHom_toAdjoinRoot, (rootHom rep).map_zero]
@@ -596,7 +596,7 @@ theorem toAdjoinRoot_one [ZPoly.CheckedIrreducible p] :
     toAdjoinRoot (1 : QAdjoin p x) = 1 := by
   let rep : RefinedIsolation p := Quot.out x
   have hrep : SimpleRoot.mk rep = x := Quot.out_eq x
-  letI : Fact (_root_.Irreducible (definingPolynomial p)) :=
+  let : Fact (_root_.Irreducible (definingPolynomial p)) :=
     ⟨definingPolynomial_irreducible p⟩
   apply (rootHom rep).injective
   rw [rootHom_toAdjoinRoot, (rootHom rep).map_one]
@@ -608,7 +608,7 @@ theorem toAdjoinRoot_add [ZPoly.CheckedIrreducible p]
     toAdjoinRoot (a + b) = toAdjoinRoot a + toAdjoinRoot b := by
   let rep : RefinedIsolation p := Quot.out x
   have hrep : SimpleRoot.mk rep = x := Quot.out_eq x
-  letI : Fact (_root_.Irreducible (definingPolynomial p)) :=
+  let : Fact (_root_.Irreducible (definingPolynomial p)) :=
     ⟨definingPolynomial_irreducible p⟩
   apply (rootHom rep).injective
   rw [rootHom_toAdjoinRoot, (rootHom rep).map_add,
@@ -621,7 +621,7 @@ theorem toAdjoinRoot_mul [ZPoly.CheckedIrreducible p]
     toAdjoinRoot (a * b) = toAdjoinRoot a * toAdjoinRoot b := by
   let rep : RefinedIsolation p := Quot.out x
   have hrep : SimpleRoot.mk rep = x := Quot.out_eq x
-  letI : Fact (_root_.Irreducible (definingPolynomial p)) :=
+  let : Fact (_root_.Irreducible (definingPolynomial p)) :=
     ⟨definingPolynomial_irreducible p⟩
   apply (rootHom rep).injective
   rw [rootHom_toAdjoinRoot, (rootHom rep).map_mul,
@@ -635,7 +635,7 @@ theorem toAdjoinRoot_smul [ZPoly.CheckedIrreducible p]
     toAdjoinRoot (q • a) = q • toAdjoinRoot a := by
   let rep : RefinedIsolation p := Quot.out x
   have hrep : SimpleRoot.mk rep = x := Quot.out_eq x
-  letI : Fact (_root_.Irreducible (definingPolynomial p)) :=
+  let : Fact (_root_.Irreducible (definingPolynomial p)) :=
     ⟨definingPolynomial_irreducible p⟩
   apply (rootHom rep).injective
   rw [rootHom_toAdjoinRoot]

--- a/HexNumberFieldMathlib/AdjoinRoot.lean
+++ b/HexNumberFieldMathlib/AdjoinRoot.lean
@@ -327,7 +327,7 @@ theorem map_inv [ZPoly.CheckedIrreducible p] (a : QAdjoin p x)
   by_cases ha : a.isZero = true
   · have hazero : a = 0 := (isZero_iff a).mp ha
     change toComplex (QAdjoin.inv a) rep h = _
-    rw [QAdjoin.inv, if_pos ha, map_zero, hazero, map_zero, inv_zero]
+    rw [QAdjoin.inv, ite_eq_left ha, map_zero, hazero, map_zero, inv_zero]
   · have haFalse : a.isZero = false := by
       cases hzero : a.isZero <;> simp_all
     let m := ZPoly.toRatPoly p
@@ -396,8 +396,8 @@ theorem map_inv [ZPoly.CheckedIrreducible p] (a : QAdjoin p x)
       rw [map_zero]
       exact hzero
     change toComplex (QAdjoin.inv a) rep h = _
-    simp only [QAdjoin.inv, haFalse, Bool.false_eq_true, if_false]
-    rw [hs, if_pos rfl, if_neg hlc0]
+    simp only [QAdjoin.inv, haFalse, Bool.false_eq_true, ite_false]
+    rw [hs, ite_eq_left rfl, ite_eq_right hlc0]
     change
       (HexPolyMathlib.toPolynomial
         (reduceCoeffs p
@@ -437,12 +437,12 @@ theorem map_natPow (a : QAdjoin p x) (n : Nat)
             Nat.div_lt_self (Nat.succ_pos n) (by decide : 1 < 2)
           rw [natPow]
           by_cases heven : (n + 1) % 2 = 0
-          · rw [if_pos heven, map_mul, ih ((n + 1) / 2) hlt,
+          · rw [ite_eq_left heven, map_mul, ih ((n + 1) / 2) hlt,
               ← pow_add]
             have hdecomp := Nat.mod_add_div (n + 1) 2
             congr 1
             omega
-          · rw [if_neg heven, map_mul, map_mul,
+          · rw [ite_eq_right heven, map_mul, map_mul,
               ih ((n + 1) / 2) hlt, ← pow_add, ← pow_succ]
             have hdecomp := Nat.mod_add_div (n + 1) 2
             have hmod := Nat.mod_two_eq_zero_or_one (n + 1)

--- a/HexNumberFieldMathlib/AlgebraicRoots.lean
+++ b/HexNumberFieldMathlib/AlgebraicRoots.lean
@@ -61,7 +61,7 @@ theorem roots?_isSome (f : AlgebraicPoly) :
       cases h : f.isZero <;> simp_all
     obtain ⟨common, hcommon⟩ := exists_presentation f hf
     rw [hcommon]
-    letI : ZPoly.CheckedIrreducible common.generator.p :=
+    let : ZPoly.CheckedIrreducible common.generator.p :=
       common.generator.checked
     exact QAdjoin.roots?_isSome
       (DensePoly.ofCoeffs common.coefficients)
@@ -85,7 +85,7 @@ private theorem presentation_polynomial (f : AlgebraicPoly)
         (DensePoly.ofCoeffs common.coefficients)
         common.generator.rep common.generator.rep_mk =
       f.toPolynomial := by
-  letI : ZPoly.CheckedIrreducible common.generator.p :=
+  let : ZPoly.CheckedIrreducible common.generator.p :=
     common.generator.checked
   obtain ⟨hsize, hvalues⟩ :=
     Common.presentation?_sound f.coeffs hcommon
@@ -121,7 +121,7 @@ private theorem roots_eq_fixed (f : AlgebraicPoly)
     f.roots = @QAdjoin.roots _ _ common.generator.checked
       (DensePoly.ofCoeffs common.coefficients)
       common.generator.rep common.generator.rep_mk := by
-  letI : ZPoly.CheckedIrreducible common.generator.p :=
+  let : ZPoly.CheckedIrreducible common.generator.p :=
     common.generator.checked
   have halgebraic := roots?_eq_roots f
   rw [AlgebraicPoly.roots?, ite_eq_right (by simp [hf])] at halgebraic
@@ -152,7 +152,7 @@ theorem roots_all_iff (f : AlgebraicPoly) :
   · have hf : f.isZero = false := by
       cases h : f.isZero <;> simp_all
     obtain ⟨common, hcommon⟩ := exists_presentation f hf
-    letI : ZPoly.CheckedIrreducible common.generator.p :=
+    let : ZPoly.CheckedIrreducible common.generator.p :=
       common.generator.checked
     rw [roots_eq_fixed f common hf hcommon,
       ← presentation_polynomial f common hcommon]
@@ -172,7 +172,7 @@ theorem contains_roots_iff (f : AlgebraicPoly) (z : ℂ) :
   · have hf : f.isZero = false := by
       cases h : f.isZero <;> simp_all
     obtain ⟨common, hcommon⟩ := exists_presentation f hf
-    letI : ZPoly.CheckedIrreducible common.generator.p :=
+    let : ZPoly.CheckedIrreducible common.generator.p :=
       common.generator.checked
     rw [roots_eq_fixed f common hf hcommon,
       ← presentation_polynomial f common hcommon]
@@ -191,7 +191,7 @@ theorem multiplicity_roots (f : AlgebraicPoly) (z : ℂ) :
   · have hf : f.isZero = false := by
       cases h : f.isZero <;> simp_all
     obtain ⟨common, hcommon⟩ := exists_presentation f hf
-    letI : ZPoly.CheckedIrreducible common.generator.p :=
+    let : ZPoly.CheckedIrreducible common.generator.p :=
       common.generator.checked
     rw [roots_eq_fixed f common hf hcommon,
       ← presentation_polynomial f common hcommon]
@@ -217,7 +217,7 @@ theorem roots_noDuplicates (f : AlgebraicPoly) :
   · have hf : f.isZero = false := by
       cases h : f.isZero <;> simp_all
     obtain ⟨common, hcommon⟩ := exists_presentation f hf
-    letI : ZPoly.CheckedIrreducible common.generator.p :=
+    let : ZPoly.CheckedIrreducible common.generator.p :=
       common.generator.checked
     rw [roots_eq_fixed f common hf hcommon]
     exact QAdjoin.roots_noDuplicates
@@ -233,7 +233,7 @@ theorem roots_ordered (f : AlgebraicPoly) :
   · have hf : f.isZero = false := by
       cases h : f.isZero <;> simp_all
     obtain ⟨common, hcommon⟩ := exists_presentation f hf
-    letI : ZPoly.CheckedIrreducible common.generator.p :=
+    let : ZPoly.CheckedIrreducible common.generator.p :=
       common.generator.checked
     rw [roots_eq_fixed f common hf hcommon]
     exact QAdjoin.roots_ordered
@@ -251,7 +251,7 @@ theorem totalMultiplicity_roots (f : AlgebraicPoly)
     | true =>
         exact (hfPolynomial ((isZero_iff f).mp h)).elim
   obtain ⟨common, hcommon⟩ := exists_presentation f hf
-  letI : ZPoly.CheckedIrreducible common.generator.p :=
+  let : ZPoly.CheckedIrreducible common.generator.p :=
     common.generator.checked
   have hpolynomial := presentation_polynomial f common hcommon
   rw [roots_eq_fixed f common hf hcommon, ← hpolynomial]

--- a/HexNumberFieldMathlib/AlgebraicRoots.lean
+++ b/HexNumberFieldMathlib/AlgebraicRoots.lean
@@ -124,7 +124,7 @@ private theorem roots_eq_fixed (f : AlgebraicPoly)
   letI : ZPoly.CheckedIrreducible common.generator.p :=
     common.generator.checked
   have halgebraic := roots?_eq_roots f
-  rw [AlgebraicPoly.roots?, if_neg (by simp [hf])] at halgebraic
+  rw [AlgebraicPoly.roots?, ite_eq_right (by simp [hf])] at halgebraic
   obtain ⟨common', hcommon', hrun⟩ :=
     Option.bind_eq_some_iff.mp halgebraic
   have hcommonEq : common' = common :=
@@ -138,7 +138,7 @@ private theorem roots_eq_fixed (f : AlgebraicPoly)
 private theorem roots_eq_all_of_isZero (f : AlgebraicPoly)
     (hf : f.isZero = true) : f.roots = .all := by
   have hrun := roots?_eq_roots f
-  rw [AlgebraicPoly.roots?, if_pos hf] at hrun
+  rw [AlgebraicPoly.roots?, ite_eq_left hf] at hrun
   exact (Option.some.inj hrun).symm
 
 /-- The algebraic-coefficient driver returns `.all` exactly for the zero

--- a/HexNumberFieldMathlib/Approx.lean
+++ b/HexNumberFieldMathlib/Approx.lean
@@ -74,7 +74,7 @@ private theorem refineTo?_monotone {p : ZPoly} (rep : RefinedIsolation p)
             by_cases htarget :
                 max target (mahlerPrec p : Int) ≤ rep.1.square.prec
             · have hiso : rep.1 = iso' := by
-                rw [DyadicRootIsolation.refineTo?, if_pos htarget] at hraw
+                rw [DyadicRootIsolation.refineTo?, ite_eq_left htarget] at hraw
                 exact Option.some.inj hraw
               exact hiso ▸ le_rfl
             · exact (le_of_not_ge htarget).trans hready
@@ -1555,7 +1555,7 @@ theorem invBall_exists {p : ZPoly} (a : RefinedIsolation p)
   have hout : input.inv? target = some out := by
     unfold DyadicComplexBall.inv?
     dsimp only
-    rw [if_pos hsep]
+    rw [ite_eq_left hsep]
   refine ⟨out, by simpa only [input, target, G, C, D] using hout, ?_⟩
   have hqdistReal : (qdist : ℝ) =
       r / ((lower - r) * lower) := by

--- a/HexNumberFieldMathlib/Basic.lean
+++ b/HexNumberFieldMathlib/Basic.lean
@@ -77,7 +77,7 @@ rational minimal polynomial. -/
 theorem p_eq_minpoly (a : AlgebraicNumber) :
     (a.p.leadingCoeff : Rat)⁻¹ • HexPolyZMathlib.toPolyℚ a.p =
       minpoly Rat a.toComplex := by
-  letI : ZPoly.CheckedIrreducible a.p := a.checked
+  let : ZPoly.CheckedIrreducible a.p := a.checked
   have hroot :
       Polynomial.aeval a.toComplex (HexPolyZMathlib.toPolyℚ a.p) = 0 := by
     rw [Polynomial.aeval_def, Polynomial.eval₂_eq_eval_map]
@@ -388,7 +388,7 @@ theorem AlgebraicNumber.beq_iff (a b : AlgebraicNumber) :
   constructor
   · rintro ⟨hp, hmeet⟩
     let brep : RefinedIsolation a.p := b.rep.castPoly hp
-    letI : ZPoly.CheckedIrreducible a.p := a.checked
+    let : ZPoly.CheckedIrreducible a.p := a.checked
     have hinter : Intersects a.rep brep := by
       change a.rep.1.square.discsMeet brep.1.square = true
       rw [show brep.1.square = b.rep.1.square by
@@ -404,7 +404,7 @@ theorem AlgebraicNumber.beq_iff (a b : AlgebraicNumber) :
     have hp := AlgebraicNumber.eq_polynomial hroot
     refine ⟨hp, ?_⟩
     let brep : RefinedIsolation a.p := b.rep.castPoly hp
-    letI : ZPoly.CheckedIrreducible a.p := a.checked
+    let : ZPoly.CheckedIrreducible a.p := a.checked
     have hroot' : a.rep.root = brep.root := by
       rw [show brep.root = b.rep.root by
         exact RefinedIsolation.castPoly_root hp b.rep]

--- a/HexNumberFieldMathlib/ComponentRoots.lean
+++ b/HexNumberFieldMathlib/ComponentRoots.lean
@@ -103,7 +103,7 @@ private theorem rootLe_iff (a b : RootCount) :
       intro heq
       exact hp (rootPolynomial_eq_of_coefficients_eq a b heq)
     unfold rootKey
-    rw [rootLe, if_pos (by simpa using hp), intListLe_iff,
+    rw [rootLe, ite_eq_left (by simpa using hp), intListLe_iff,
       Prod.Lex.toLex_le_toLex]
     constructor
     · intro hle
@@ -702,7 +702,7 @@ private theorem componentFold_contains [ZPoly.CheckedIrreducible p]
       simp
   | cons component components ih =>
       have hcomponent := hall component (by simp)
-      rw [List.foldlM_cons, dif_pos hcomponent.2] at hrun
+      rw [List.foldlM_cons, dite_eq_left hcomponent.2] at hrun
       cases hfound : componentRoots? component.1 component.2 hcomponent.2 rep h with
       | none => simp [hfound] at hrun
       | some found =>
@@ -778,7 +778,7 @@ private theorem componentFold_nodup [ZPoly.CheckedIrreducible p]
     (hrun := hrun)
   intro roots component next hcomponent hstep hroots
   have hpositive := (hall component hcomponent).2
-  rw [dif_pos hpositive] at hstep
+  rw [dite_eq_left hpositive] at hstep
   cases hfound : componentRoots? component.1 component.2 hpositive rep h with
   | none => simp [hfound] at hstep
   | some found =>
@@ -820,7 +820,7 @@ private theorem componentFold_value [ZPoly.CheckedIrreducible p]
     (hrun := hrun)
   intro roots component next hcomponent hstep hroots
   have hpositive := (yun_positive f component hcomponent).2
-  rw [dif_pos hpositive] at hstep
+  rw [dite_eq_left hpositive] at hstep
   cases hfound : componentRoots? component.1 component.2 hpositive rep h with
   | none => simp [hfound] at hstep
   | some found =>
@@ -952,8 +952,8 @@ theorem contains_roots_iff [ZPoly.CheckedIrreducible p]
     · have heq := roots?_eq_roots f rep h
       have hfFalse : f.isZero = false := by
         cases hvalue : f.isZero <;> simp_all
-      rw [QAdjoin.roots?, if_neg (by simpa using hfFalse),
-        if_pos hdegree] at heq
+      rw [QAdjoin.roots?, ite_eq_right (by simpa using hfFalse),
+        ite_eq_left hdegree] at heq
       have hroots : QAdjoin.roots f rep h = .finite #[] :=
         (Option.some.inj heq).symm
       constructor
@@ -972,8 +972,8 @@ theorem contains_roots_iff [ZPoly.CheckedIrreducible p]
       have heq := roots?_eq_roots f rep h
       have hfFalse : f.isZero = false := by
         cases hvalue : f.isZero <;> simp_all
-      rw [QAdjoin.roots?, if_neg (by simpa using hfFalse),
-        if_neg hdegree] at heq
+      rw [QAdjoin.roots?, ite_eq_right (by simpa using hfFalse),
+        ite_eq_right hdegree] at heq
       cases hfold : (Roots.yun f).foldlM
           (fun out component =>
             if hm : 0 < component.2 then do
@@ -1121,8 +1121,8 @@ theorem multiplicity_roots [ZPoly.CheckedIrreducible p]
         have heq := roots?_eq_roots f rep h
         have hfFalse : f.isZero = false := by
           cases hvalueZero : f.isZero <;> simp_all
-        rw [QAdjoin.roots?, if_neg (by simpa using hfFalse),
-          if_neg hdegree] at heq
+        rw [QAdjoin.roots?, ite_eq_right (by simpa using hfFalse),
+          ite_eq_right hdegree] at heq
         cases hfold : (Roots.yun f).foldlM
             (fun out component =>
               if hm : 0 < component.2 then do

--- a/HexNumberFieldMathlib/Coordinates.lean
+++ b/HexNumberFieldMathlib/Coordinates.lean
@@ -116,7 +116,7 @@ theorem degree_dvd_of_mem (gamma a : AlgebraicNumber)
     degree a ∣ degree gamma := by
   let K : IntermediateField Rat ℂ := Rat⟮gamma.toComplex⟯
   let aK : K := ⟨a.toComplex, ha⟩
-  letI : FiniteDimensional Rat K :=
+  let : FiniteDimensional Rat K :=
     IntermediateField.adjoin.finiteDimensional (isIntegral_toComplex gamma)
   have hmin : minpoly Rat aK = minpoly Rat a.toComplex :=
     (minpoly.algHom_eq K.val K.val.injective aK).symm
@@ -142,7 +142,7 @@ theorem trace?_sound (gamma a : AlgebraicNumber)
   let K : IntermediateField Rat ℂ := Rat⟮gamma.toComplex⟯
   let aK : K := ⟨a.toComplex, ha⟩
   change t = Algebra.trace Rat K aK
-  letI : FiniteDimensional Rat K :=
+  let : FiniteDimensional Rat K :=
     IntermediateField.adjoin.finiteDimensional (isIntegral_toComplex gamma)
   have hmin : minpoly Rat aK = minpoly Rat a.toComplex :=
     (minpoly.algHom_eq K.val K.val.injective aK).symm
@@ -178,7 +178,7 @@ private theorem traceGram_det_ne_zero (gamma : AlgebraicNumber)
       (Matrix.ofFn fun i : Fin (degree gamma) =>
         fun j : Fin (degree gamma) => powerTraces[i.val + j.val]!))) ≠ 0 := by
   let K : IntermediateField Rat ℂ := Rat⟮gamma.toComplex⟯
-  letI : FiniteDimensional Rat K :=
+  let : FiniteDimensional Rat K :=
     IntermediateField.adjoin.finiteDimensional (isIntegral_toComplex gamma)
   let pb := IntermediateField.adjoin.powerBasis (isIntegral_toComplex gamma)
   have hpbdim : pb.dim = degree gamma := by
@@ -317,7 +317,7 @@ private theorem basisCoeffs_solve (gamma a : AlgebraicNumber)
               i.val⟩ : Rat⟮gamma.toComplex⟯) =
         (⟨a.toComplex, ha⟩ : Rat⟮gamma.toComplex⟯) := by
   let K : IntermediateField Rat ℂ := Rat⟮gamma.toComplex⟯
-  letI : FiniteDimensional Rat K :=
+  let : FiniteDimensional Rat K :=
     IntermediateField.adjoin.finiteDimensional (isIntegral_toComplex gamma)
   let pb := IntermediateField.adjoin.powerBasis (isIntegral_toComplex gamma)
   have hpbdim : pb.dim = degree gamma := by
@@ -595,7 +595,7 @@ theorem coordinates?_isSome (gamma a : AlgebraicNumber)
     let coordinate : QAdjoin gamma.p gamma.x :=
       QAdjoin.reduce gamma.p gamma.x
         (DensePoly.ofCoeffs coeffs.toArray)
-    letI : ZPoly.CheckedIrreducible gamma.p := gamma.checked
+    let : ZPoly.CheckedIrreducible gamma.p := gamma.checked
     obtain ⟨recovered, hrecovered⟩ := Option.isSome_iff_exists.mp
       (QAdjoin.toAlgebraicNumber?_isSome coordinate gamma.rep
         gamma.rep_mk)
@@ -620,7 +620,7 @@ theorem coordinates?_sound (gamma a : AlgebraicNumber)
     (powers : Array AlgebraicNumber) {coordinate : QAdjoin gamma.p gamma.x}
     (h : coordinates? gamma a powers = some coordinate) :
     QAdjoin.toComplex coordinate gamma.rep gamma.rep_mk = a.toComplex := by
-  letI : ZPoly.CheckedIrreducible gamma.p := gamma.checked
+  let : ZPoly.CheckedIrreducible gamma.p := gamma.checked
   unfold coordinates? at h
   split at h
   next hzero =>

--- a/HexNumberFieldMathlib/Exact.lean
+++ b/HexNumberFieldMathlib/Exact.lean
@@ -53,7 +53,7 @@ theorem ofNormalized?_isSome
           (xs := isolations) (f := DyadicRootIsolation.toRefined?)
           (fun iso hiso => by
             unfold DyadicRootIsolation.toRefined?
-            rw [dif_pos (HexRootsMathlib.isolate_refined p squarefree
+            rw [dite_eq_left (HexRootsMathlib.isolate_refined p squarefree
               (separationDepth p : Int) .nkThenPellet hrun iso hiso)]
             rfl)
         cases hmap : isolations.mapM DyadicRootIsolation.toRefined? with
@@ -170,8 +170,8 @@ theorem exactFactor?_isSome (a : AlgebraicRoot) (q : ZPoly)
     (hroot : (HexRootsMathlib.toPolyℂ q).IsRoot a.toComplex) :
     (a.exactFactor? q).isSome := by
   unfold AlgebraicRoot.exactFactor?
-  rw [dif_pos hprim, dif_pos hpos, dif_pos hdegree, dif_pos hirred,
-    dif_pos hsimple]
+  rw [dite_eq_left hprim, dite_eq_left hpos, dite_eq_left hdegree, dite_eq_left hirred,
+    dite_eq_left hsimple]
   have hqne : q ≠ 0 := by
     intro hq
     rw [hq] at hdegree
@@ -185,7 +185,7 @@ theorem exactFactor?_isSome (a : AlgebraicRoot) (q : ZPoly)
         (xs := isolations) (f := DyadicRootIsolation.toRefined?)
         (fun iso hiso => by
           unfold DyadicRootIsolation.toRefined?
-          rw [dif_pos (HexRootsMathlib.isolate_refined q hsimple
+          rw [dite_eq_left (HexRootsMathlib.isolate_refined q hsimple
             (separationDepth q : Int) .nkThenPellet hrun iso hiso)]
           rfl)
       cases hmap : isolations.mapM DyadicRootIsolation.toRefined? with
@@ -610,7 +610,7 @@ private theorem relationAt?_isSome_of_linear [ZPoly.CheckedIrreducible p]
       ⟨coeffs, hcoords⟩
   unfold relationAt?
   dsimp only
-  rw [dif_pos hk]
+  rw [dite_eq_left hk]
   cases hspan : Matrix.spanCoeffs previous target with
   | none => exact (hnotnone hspan).elim
   | some found => simp
@@ -901,7 +901,7 @@ private theorem minpoly?_certificates [ZPoly.CheckedIrreducible p]
   have hrelation' := hrelation
   unfold relationAt? at hrelation
   dsimp only at hrelation
-  rw [dif_pos (by omega : i + 1 ≤ p.degree?.getD 0)] at hrelation
+  rw [dite_eq_left (by omega : i + 1 ≤ p.degree?.getD 0)] at hrelation
   obtain ⟨coeffs, _hspan, rfl⟩ := Option.map_eq_some_iff.mp hrelation
   have hrelationNe : relationPoly coeffs ≠ 0 := by
     intro hzero
@@ -1225,8 +1225,8 @@ theorem toAlgebraicNumber?_isSome [ZPoly.CheckedIrreducible p]
         minpoly?_certificates a hq
       unfold QAdjoin.toAlgebraicNumber?
       simp only [hq, Option.bind_eq_bind, Option.bind_some]
-      rw [dif_pos hprim, dif_pos hpos, dif_pos hdegree,
-        dif_pos hirred, dif_pos hsimple]
+      rw [dite_eq_left hprim, dite_eq_left hpos, dite_eq_left hdegree,
+        dite_eq_left hirred, dite_eq_left hsimple]
       have hqne : q ≠ 0 := by
         intro hzero
         rw [hzero] at hdegree
@@ -1240,7 +1240,7 @@ theorem toAlgebraicNumber?_isSome [ZPoly.CheckedIrreducible p]
             (xs := isolations) (f := DyadicRootIsolation.toRefined?)
             (fun iso hiso => by
               unfold DyadicRootIsolation.toRefined?
-              rw [dif_pos (HexRootsMathlib.isolate_refined q hsimple
+              rw [dite_eq_left (HexRootsMathlib.isolate_refined q hsimple
                 (separationDepth q : Int) .nkThenPellet hrun iso hiso)]
               rfl)
           cases hmap : isolations.mapM DyadicRootIsolation.toRefined? with

--- a/HexNumberFieldMathlib/Exact.lean
+++ b/HexNumberFieldMathlib/Exact.lean
@@ -402,7 +402,7 @@ theorem exact?_isSome (a : AlgebraicRoot) :
     (Hex.ZPoly.isIrreducible_iff
       entry.1).mpr hirredProp
   let checked : ZPoly.CheckedIrreducible entry.1 := ⟨hirred, hdegree⟩
-  letI : ZPoly.CheckedIrreducible entry.1 := checked
+  let : ZPoly.CheckedIrreducible entry.1 := checked
   have hentryNe : entry.1 ≠ 0 := by
     intro hq
     rw [hq] at hdegree
@@ -622,9 +622,9 @@ private theorem minpoly_relation [ZPoly.CheckedIrreducible p]
     0 < d ∧ d ≤ p.degree?.getD 0 ∧
       (a.relationAt? a.krylovOrbit d).isSome := by
   let b : AdjoinRoot (definingPolynomial p) := toAdjoinRoot a
-  letI : Module.Free Rat (AdjoinRoot (definingPolynomial p)) :=
+  let : Module.Free Rat (AdjoinRoot (definingPolynomial p)) :=
     (definingPolynomial_monic p).free_adjoinRoot
-  letI : Module.Finite Rat (AdjoinRoot (definingPolynomial p)) :=
+  let : Module.Finite Rat (AdjoinRoot (definingPolynomial p)) :=
     (definingPolynomial_monic p).finite_adjoinRoot
   have hbint : IsIntegral Rat b := IsIntegral.of_finite Rat b
   let m : Polynomial Rat := minpoly Rat b
@@ -845,9 +845,9 @@ private theorem minpoly?_natDegree [ZPoly.CheckedIrreducible p]
     (HexPolyZMathlib.toPolyℚ q).natDegree = (minpoly Rat b).natDegree := by
   let b : AdjoinRoot (definingPolynomial p) := toAdjoinRoot a
   let d := (minpoly Rat b).natDegree
-  letI : Module.Free Rat (AdjoinRoot (definingPolynomial p)) :=
+  let : Module.Free Rat (AdjoinRoot (definingPolynomial p)) :=
     (definingPolynomial_monic p).free_adjoinRoot
-  letI : Module.Finite Rat (AdjoinRoot (definingPolynomial p)) :=
+  let : Module.Finite Rat (AdjoinRoot (definingPolynomial p)) :=
     (definingPolynomial_monic p).finite_adjoinRoot
   have hbint : IsIntegral Rat b := IsIntegral.of_finite Rat b
   unfold minpoly? at hq
@@ -932,9 +932,9 @@ private theorem minpoly?_certificates [ZPoly.CheckedIrreducible p]
     ZPoly.ratPolyPrimitivePart_primitive (relationPoly coeffs) hcontentNe
   let q := ZPoly.ratPolyPrimitivePart (relationPoly coeffs)
   let b : AdjoinRoot (definingPolynomial p) := toAdjoinRoot a
-  letI : Module.Free Rat (AdjoinRoot (definingPolynomial p)) :=
+  let : Module.Free Rat (AdjoinRoot (definingPolynomial p)) :=
     (definingPolynomial_monic p).free_adjoinRoot
-  letI : Module.Finite Rat (AdjoinRoot (definingPolynomial p)) :=
+  let : Module.Finite Rat (AdjoinRoot (definingPolynomial p)) :=
     (definingPolynomial_monic p).finite_adjoinRoot
   have hbint : IsIntegral Rat b := IsIntegral.of_finite Rat b
   let E := adjoinRootAlgEquiv (p := p) (x := x)
@@ -978,7 +978,7 @@ private theorem minpoly?_certificates [ZPoly.CheckedIrreducible p]
       hirredProp
   let checked : ZPoly.CheckedIrreducible q := ⟨hirred, by
     simpa [q] using hdegree⟩
-  letI : ZPoly.CheckedIrreducible q := checked
+  let : ZPoly.CheckedIrreducible q := checked
   have hsimple : HasOnlySimpleRoots q :=
     (HexRootsMathlib.hasOnlySimpleRoots_iff_separable q (by simpa [q] using hqne)).mpr
       (ZPoly.CheckedIrreducible.separable q)

--- a/HexNumberFieldMathlib/Field.lean
+++ b/HexNumberFieldMathlib/Field.lean
@@ -53,12 +53,12 @@ theorem natPow_toComplex (a : AlgebraicNumber) (n : Nat) :
             Nat.div_lt_self (Nat.succ_pos n) (by decide : 1 < 2)
           rw [natPow]
           by_cases heven : (n + 1) % 2 = 0
-          · rw [if_pos heven, mul_toComplex, ih ((n + 1) / 2) hlt,
+          · rw [ite_eq_left heven, mul_toComplex, ih ((n + 1) / 2) hlt,
               ← pow_add]
             have hdecomp := Nat.mod_add_div (n + 1) 2
             congr 1
             omega
-          · rw [if_neg heven, mul_toComplex, mul_toComplex,
+          · rw [ite_eq_right heven, mul_toComplex, mul_toComplex,
               ih ((n + 1) / 2) hlt, ← pow_add, ← pow_succ]
             have hdecomp := Nat.mod_add_div (n + 1) 2
             have hmod := Nat.mod_two_eq_zero_or_one (n + 1)

--- a/HexNumberFieldMathlib/Lazy.lean
+++ b/HexNumberFieldMathlib/Lazy.lean
@@ -395,7 +395,7 @@ private theorem ZPoly.reciprocal_isRoot {p : ZPoly} {z : ℂ}
     (hroot : (HexRootsMathlib.toPolyℂ p).IsRoot z) :
     (HexRootsMathlib.toPolyℂ p.reciprocal).IsRoot z⁻¹ := by
   rw [ZPoly.toPolyℂ_reciprocal p hp]
-  letI : Invertible z := invertibleOfNonzero hz
+  let : Invertible z := invertibleOfNonzero hz
   change ((HexRootsMathlib.toPolyℂ p).reverse).eval z⁻¹ = 0
   change (HexRootsMathlib.toPolyℂ p).eval z = 0 at hroot
   have hreverse :=

--- a/HexNumberFieldMathlib/Lazy.lean
+++ b/HexNumberFieldMathlib/Lazy.lean
@@ -132,8 +132,8 @@ private theorem ZPoly.coeff_mulSubstitute (q : ZPoly) (j : Nat) :
   rw [DensePoly.coeff_ofList,
     HexPolyMathlib.list_getD_map_range_zero]
   split <;> rename_i h
-  · rw [if_pos (by omega)]
-  · rw [if_neg (by omega)]
+  · rw [ite_eq_left (by omega)]
+  · rw [ite_eq_right (by omega)]
     rfl
 
 private theorem evalZPoly_X (t : ℂ) : evalZPoly t ZPoly.X = t := by
@@ -158,7 +158,7 @@ private theorem ZPoly.map_mulSubstitute (q : ZPoly) (t : ℂ) :
   rw [← Polynomial.lcoeff_apply, map_sum]
   simp only [Polynomial.lcoeff_apply]
   by_cases hj : j ≤ q.degree?.getD 0
-  · rw [if_pos hj, evalZPoly_monomial]
+  · rw [ite_eq_left hj, evalZPoly_monomial]
     rw [Finset.sum_eq_single j]
     · simp
     · intro b hb hbj
@@ -166,7 +166,7 @@ private theorem ZPoly.map_mulSubstitute (q : ZPoly) (t : ℂ) :
         ((q.coeff (q.degree?.getD 0 - b) : ℂ) *
           t ^ (q.degree?.getD 0 - b)) hbj.symm
     · simp [hj]
-  · rw [if_neg hj, map_zero]
+  · rw [ite_eq_right hj, map_zero]
     symm
     exact Finset.sum_eq_zero
       (s := Finset.range (q.degree?.getD 0 + 1)) fun b hb =>
@@ -220,7 +220,7 @@ private theorem ZPoly.natDegree_map_mulSubstitute (q : ZPoly) (hq : q ≠ 0)
       DensePoly.monomial (q.degree?.getD 0)
         (q.coeff (q.degree?.getD 0)) := by
     dsimp only [g]
-    rw [ZPoly.coeff_mulSubstitute, if_pos (Nat.zero_le _), Nat.sub_zero]
+    rw [ZPoly.coeff_mulSubstitute, ite_eq_left (Nat.zero_le _), Nat.sub_zero]
   have hgcoeff0ne : g.coeff 0 ≠ 0 := by
     rw [hgcoeff0]
     exact DensePoly.monomial_ne_zero_of_ne_zero hqtop
@@ -238,13 +238,13 @@ private theorem ZPoly.natDegree_map_mulSubstitute (q : ZPoly) (hq : q ≠ 0)
     intro hzero
     apply hgLast
     dsimp only [g]
-    rw [ZPoly.coeff_mulSubstitute, if_pos hdle, hzero]
+    rw [ZPoly.coeff_mulSubstitute, ite_eq_left hdle, hzero]
     simp
   apply Polynomial.natDegree_map_of_leadingCoeff_ne_zero
   rw [HexPolyMathlib.leadingCoeff_toPolynomial,
     DensePoly.leadingCoeff_eq_coeff_last g hgpos]
   dsimp only [g]
-  rw [ZPoly.coeff_mulSubstitute, if_pos hdle, evalZPoly_monomial]
+  rw [ZPoly.coeff_mulSubstitute, ite_eq_left hdle, evalZPoly_monomial]
   have htPow :
       t ^ (q.degree?.getD 0 - (g.size - 1)) ≠ 0 :=
     _root_.pow_ne_zero _ ht
@@ -287,7 +287,7 @@ private theorem toPolynomial_ofList_eq_X_pow_dropWhile (l : List Int) :
         obtain ⟨k, hk⟩ := ih
         refine ⟨k + 1, ?_⟩
         rw [toPolynomial_ofList_zero_cons, hk]
-        simp only [List.dropWhile_cons, beq_self_eq_true, if_true]
+        simp only [List.dropWhile_cons, beq_self_eq_true, ite_true]
         rw [pow_succ]
         ring
       · refine ⟨0, ?_⟩
@@ -334,10 +334,10 @@ private theorem ZPoly.coeff_reciprocal (p : ZPoly) (j : Nat) :
   unfold ZPoly.reciprocal
   rw [DensePoly.coeff_ofCoeffs, Array.getD_eq_getD_getElem?]
   by_cases hj : j < p.size
-  · rw [if_pos hj, Array.getElem?_reverse (by simpa using hj)]
+  · rw [ite_eq_left hj, Array.getElem?_reverse (by simpa using hj)]
     rw [← Array.getD_eq_getD_getElem?, DensePoly.toArray_getD]
     rw [DensePoly.toArray_size]
-  · rw [if_neg hj, Array.getElem?_eq_none (by simpa using
+  · rw [ite_eq_right hj, Array.getElem?_eq_none (by simpa using
       (Nat.le_of_not_gt hj))]
     rfl
 
@@ -354,8 +354,8 @@ private theorem ZPoly.toPolynomial_reciprocal (p : ZPoly) (hp : p ≠ 0) :
   rw [HexPolyMathlib.coeff_toPolynomial, ZPoly.coeff_reciprocal,
     Polynomial.coeff_reverse, hdegree, HexPolyMathlib.coeff_toPolynomial]
   by_cases hj : j < p.size
-  · rw [if_pos hj, Polynomial.revAt_le (by omega)]
-  · rw [if_neg hj, Polynomial.revAt_eq_self_of_lt (by omega)]
+  · rw [ite_eq_left hj, Polynomial.revAt_le (by omega)]
+  · rw [ite_eq_right hj, Polynomial.revAt_eq_self_of_lt (by omega)]
     exact (DensePoly.coeff_eq_zero_of_size_le p
       (Nat.le_of_not_gt hj)).symm
 
@@ -386,7 +386,7 @@ private theorem ZPoly.reciprocal_ne_zero {p : ZPoly} (hp : p ≠ 0) :
   have hlast := DensePoly.coeff_last_ne_zero_of_pos_size p hpos
   intro hzero
   have hcoeff := congrArg (fun q : ZPoly => q.coeff 0) hzero
-  rw [ZPoly.coeff_reciprocal, if_pos hpos, Nat.sub_zero] at hcoeff
+  rw [ZPoly.coeff_reciprocal, ite_eq_left hpos, Nat.sub_zero] at hcoeff
   simp at hcoeff
   exact hlast hcoeff
 
@@ -984,7 +984,7 @@ theorem AlgebraicRoot.ofEliminant?_isSome
       (ZPoly.squareFreeCore raw) hsize hn z hpRoot
   unfold AlgebraicRoot.ofEliminant?
   dsimp only
-  rw [dif_pos hprim, dif_pos hpos, dif_pos hdegree, dif_pos hsimple]
+  rw [dite_eq_left hprim, dite_eq_left hpos, dite_eq_left hdegree, dite_eq_left hsimple]
   rw [hballAt]
   have hisolateSome := HexRootsMathlib.isolate_isSome
     (ZPoly.squareFreeCore raw) hsimple hpne
@@ -998,7 +998,7 @@ theorem AlgebraicRoot.ofEliminant?_isSome
         (xs := isolations) (f := DyadicRootIsolation.toRefined?)
         (fun iso hiso => by
           unfold DyadicRootIsolation.toRefined?
-          rw [dif_pos (HexRootsMathlib.isolate_refined
+          rw [dite_eq_left (HexRootsMathlib.isolate_refined
             (ZPoly.squareFreeCore raw) hsimple
             (separationDepth (ZPoly.squareFreeCore raw) : Int)
             .nkThenPellet hisolate iso hiso)]

--- a/HexNumberFieldMathlib/Primitive.lean
+++ b/HexNumberFieldMathlib/Primitive.lean
@@ -134,7 +134,7 @@ private theorem shift_degree_le (theta alpha candidate : AlgebraicNumber)
   let alphaK : K := IntermediateField.AdjoinPair.gen₂
     Rat theta.toComplex alpha.toComplex
   let candidateK : K := thetaK + (c : Rat) • alphaK
-  letI : FiniteDimensional Rat K :=
+  let : FiniteDimensional Rat K :=
     IntermediateField.finiteDimensional_adjoin_pair
       (isIntegral_toComplex theta) (isIntegral_toComplex alpha)
   have hvalue : candidate.toComplex = (candidateK : ℂ) := by
@@ -159,7 +159,7 @@ private theorem exists_shift_degree_eq (theta alpha : AlgebraicNumber) :
     Rat theta.toComplex alpha.toComplex
   let alphaK : K := IntermediateField.AdjoinPair.gen₂
     Rat theta.toComplex alpha.toComplex
-  letI : FiniteDimensional Rat K :=
+  let : FiniteDimensional Rat K :=
     IntermediateField.finiteDimensional_adjoin_pair
       (isIntegral_toComplex theta) (isIntegral_toComplex alpha)
   have hgen : ∀ phi psi : K →ₐ[Rat] ℂ,
@@ -372,7 +372,7 @@ theorem extend?_field (theta alpha gamma : AlgebraicNumber)
           Rat theta.toComplex alpha.toComplex
   have hle : Rat⟮gamma.toComplex⟯ ≤ K :=
     IntermediateField.adjoin_simple_le_iff.mpr hmember
-  letI : FiniteDimensional Rat K :=
+  let : FiniteDimensional Rat K :=
     IntermediateField.finiteDimensional_adjoin_pair
       (isIntegral_toComplex theta) (isIntegral_toComplex alpha)
   apply IntermediateField.eq_of_le_of_finrank_eq hle

--- a/HexNumberFieldMathlib/Roots.lean
+++ b/HexNumberFieldMathlib/Roots.lean
@@ -271,7 +271,7 @@ theorem componentRoots?_isSome [ZPoly.CheckedIrreducible p]
     simp at hdegree
   unfold componentRoots?
   dsimp only
-  rw [dif_pos hprim, dif_pos hpos, dif_pos hdegree, dif_pos hsimple]
+  rw [dite_eq_left hprim, dite_eq_left hpos, dite_eq_left hdegree, dite_eq_left hsimple]
   have hisolateSome := HexRootsMathlib.isolate_isSome eliminant hsimple
     heliminant (separationDepth eliminant : Int) .nkThenPellet
   cases hisolate : isolate eliminant hsimple
@@ -283,7 +283,7 @@ theorem componentRoots?_isSome [ZPoly.CheckedIrreducible p]
         (xs := isolations) (f := DyadicRootIsolation.toRefined?)
         (fun iso hiso => by
           unfold DyadicRootIsolation.toRefined?
-          rw [dif_pos (HexRootsMathlib.isolate_refined eliminant hsimple
+          rw [dite_eq_left (HexRootsMathlib.isolate_refined eliminant hsimple
             (separationDepth eliminant : Int) .nkThenPellet
             hisolate iso hiso)]
           rfl)
@@ -1241,7 +1241,7 @@ private theorem evalShifted_map_eval [ZPoly.CheckedIrreducible p]
         List.getElem?_map, List.getElem?_range hj]
       simp only [Option.map_some, Option.getD_some]
       by_cases hij : i = 0 && j = 0
-      · rw [if_pos hij, if_pos hij]
+      · rw [ite_eq_left hij, ite_eq_left hij]
         change Polynomial.eval₂ (Int.castRingHom ℂ) s
             (HexPolyMathlib.toPolynomial
               (DensePoly.ofCoeffs
@@ -1258,7 +1258,7 @@ private theorem evalShifted_map_eval [ZPoly.CheckedIrreducible p]
           | 0 => simp [Array.getD]
           | 1 => simp [Array.getD]
           | k + 2 =>
-              rw [if_neg (by omega), if_neg (by omega)]
+              rw [ite_eq_right (by omega), ite_eq_right (by omega)]
               rw [Array.getD_eq_getD_getElem?,
                 Array.getElem?_eq_none (by simp), Option.getD_none, add_zero]
               rfl
@@ -1266,7 +1266,7 @@ private theorem evalShifted_map_eval [ZPoly.CheckedIrreducible p]
         simp only [Int.coe_castRingHom]
         push_cast
         ring
-      · rw [if_neg hij, if_neg hij]
+      · rw [ite_eq_right hij, ite_eq_right hij]
         change Polynomial.eval₂ (Int.castRingHom ℂ) s
             (HexPolyMathlib.toPolynomial
               (DensePoly.C (-clearRat den ((f.coeff i).coeffs.coeff j)))) = _
@@ -1288,11 +1288,11 @@ private theorem evalShifted_map_eval [ZPoly.CheckedIrreducible p]
     simp only [sub_mul, Finset.sum_sub_distrib]
     congr 1
     rcases Nat.eq_zero_or_pos i with rfl | hipos
-    · rw [if_pos rfl]
+    · rw [ite_eq_left rfl]
       rw [Finset.sum_eq_single 0 (fun b _ hb => by simp [hb])
         (fun h0 => absurd (Finset.mem_range.mpr hd) h0)]
       simp
-    · rw [if_neg (by omega)]
+    · rw [ite_eq_right (by omega)]
       apply Finset.sum_eq_zero
       intro j _
       simp [hipos.ne']
@@ -1630,8 +1630,8 @@ theorem size_pos_of_core_degree [ZPoly.CheckedIrreducible p]
     unfold DensePoly.resultant
     rw [hliftZero]
     simp only [Bool.false_eq_true, ↓reduceIte]
-    rw [if_pos (show DensePoly.isZero (0 : DensePoly ZPoly) = true from rfl),
-      if_neg (by omega)]
+    rw [ite_eq_left (show DensePoly.isZero (0 : DensePoly ZPoly) = true from rfl),
+      ite_eq_right (by omega)]
   rw [hnorm] at hdegree
   have hcore : (ZPoly.squareFreeCore 0).degree?.getD 0 = 0 := by decide
   omega
@@ -1873,7 +1873,7 @@ theorem roots?_isSome [ZPoly.CheckedIrreducible p]
       intro out component hcomponent
       obtain ⟨hdegree, hMultiplicity⟩ :=
         Roots.yun_positive f component hcomponent
-      rw [dif_pos hMultiplicity]
+      rw [dite_eq_left hMultiplicity]
       obtain ⟨found, hfound⟩ := Option.isSome_iff_exists.mp
         (Roots.componentRoots?_total_of_degree component.1 component.2
           hMultiplicity rep h hdegree)

--- a/HexNumberFieldMathlib/Roots.lean
+++ b/HexNumberFieldMathlib/Roots.lean
@@ -702,7 +702,7 @@ private theorem conjugateEmbedding_apply [ZPoly.CheckedIrreducible p]
 private theorem conjugateEmbedding_injective [ZPoly.CheckedIrreducible p]
     (y : ℂ) (hy : (HexRootsMathlib.toPolyℂ p).eval y = 0) :
     Function.Injective (conjugateEmbedding (x := x) y hy) := by
-  letI : Fact (_root_.Irreducible (definingPolynomial p)) :=
+  let : Fact (_root_.Irreducible (definingPolynomial p)) :=
     ⟨definingPolynomial_irreducible p⟩
   exact (AdjoinRoot.lift (algebraMap Rat ℂ) y
     (definingPolynomial_isRoot hy)).injective.comp
@@ -904,7 +904,7 @@ theorem normEliminant_ne_zero [ZPoly.CheckedIrreducible p]
     simp at hdegree
   have hPne : P ≠ 0 := by
     exact HexRootsMathlib.toPolyℂ_ne_zero p hpSize
-  letI : Fintype (P.rootSet ℂ) :=
+  let : Fintype (P.rootSet ℂ) :=
     (Polynomial.rootSet_finite P ℂ).fintype
   let H (y : P.rootSet ℂ) : Polynomial ℂ :=
     Q.map (conjugateEmbedding y.1 (by

--- a/HexNumberFieldMathlib/Yun.lean
+++ b/HexNumberFieldMathlib/Yun.lean
@@ -732,9 +732,9 @@ private theorem yunAux_complete [ZPoly.CheckedIrreducible p]
           simpa only [Polynomial.C_1] using
             Polynomial.rootMultiplicity_C (1 : K) z
         simp only [toPolynomialMap, HexPolyMathlib.toPolynomial_one,
-          Polynomial.map_one, if_pos hindex] at hmultiplicity
+          Polynomial.map_one, ite_eq_left hindex] at hmultiplicity
         omega
-      rw [yunAux, if_neg hnotOne]
+      rw [yunAux, ite_eq_right hnotOne]
       dsimp only
       let shared := monic (DensePoly.gcd w repeated)
       let component := monic (w / shared)
@@ -758,7 +758,7 @@ private theorem yunAux_complete [ZPoly.CheckedIrreducible p]
           (Polynomial.rootMultiplicity_pos hcomponentNe).mp hpositive
         have hdegree : 0 < component.degree?.getD 0 :=
           degree_pos_of_map_root embedding component hcomponentNe hroot
-        rw [if_pos hdegree]
+        rw [ite_eq_left hdegree]
         refine ⟨(component, k), ?_, hroot, heq⟩
         apply mem_yunAux_of_mem
         simp [component, shared]
@@ -796,7 +796,7 @@ theorem yun_sound [ZPoly.CheckedIrreducible p]
       distinct repeated :=
     YunInvariant.init embedding f hf hnatDegree z
   unfold yun at hentry
-  rw [if_neg (by omega)] at hentry
+  rw [ite_eq_right (by omega)] at hentry
   exact yunAux_sound embedding z
     ((toPolynomialMap embedding f).rootMultiplicity z)
     distinct repeated 1 (f.size + 1) #[] invariant (by simp)
@@ -844,7 +844,7 @@ theorem yun_complete [ZPoly.CheckedIrreducible p]
   have hcomplete := yunAux_complete embedding z r distinct repeated 1
     (f.size + 1) #[] invariant hindex hfuel
   unfold yun
-  rw [if_neg (by omega)]
+  rw [ite_eq_right (by omega)]
   exact hcomplete
 
 end Hex.QAdjoin.Roots

--- a/HexNumberFieldTower/Arithmetic.lean
+++ b/HexNumberFieldTower/Arithmetic.lean
@@ -150,7 +150,7 @@ theorem sub_eq_add_neg {T : NumberTower} (a b : Elem T) :
   congr 1
   funext i
   simpa only [Array.getD_eq_getD_getElem?, Array.getElem?_ofFn,
-    dif_pos i.isLt, Option.getD_some] using Rat.sub_eq_add_neg
+    dite_eq_left i.isLt, Option.getD_some] using Rat.sub_eq_add_neg
       ((coeffs a).getD i 0) ((coeffs b).getD i 0)
 
 /-- Coordinatewise negation is an additive inverse. -/

--- a/HexNumberFieldTower/Basic.lean
+++ b/HexNumberFieldTower/Basic.lean
@@ -277,11 +277,11 @@ theorem positiveAssociate_primitive (p : ZPoly)
     simp at hpos
   have hdegree : p.degree?.getD 0 ≠ 0 := Nat.ne_of_gt checked.pos_degree
   have hirred := checked.is_true
-  rw [ZPoly.isIrreducible, if_neg hpne, if_neg hdegree] at hirred
+  rw [ZPoly.isIrreducible, ite_eq_right hpne, ite_eq_right hdegree] at hirred
   simp only [Bool.and_eq_true, decide_eq_true_eq] at hirred
   have hscalar : (ZPoly.factorize p).scalar.natAbs = 1 := by
     exact hirred.1.1
-  rw [factorize_scalar, if_neg hpne] at hscalar
+  rw [factorize_scalar, ite_eq_right hpne] at hscalar
   have hcontentAbs : (ZPoly.content p).natAbs = 1 := by
     by_cases hlead : p.leadingCoeff < 0
     · simpa [hlead] using hscalar

--- a/HexNumberFieldTower/RawArithmetic.lean
+++ b/HexNumberFieldTower/RawArithmetic.lean
@@ -102,7 +102,7 @@ theorem block_one (count width index : Nat) (hindex : index < count) :
       rcases i with _ | i
       · simp [block, fixedCoeffs, Array.getD, Nat.ne_of_gt htotal]
       · simp [block, fixedCoeffs, Array.getD]
-  · simp only [if_neg hindex0]
+  · simp only [ite_eq_right hindex0]
     apply Array.ext
     · simp [block, fixedCoeffs]
     · intro i hi₁ hi₂

--- a/HexNumberFieldTowerMathlib/Adjoin.lean
+++ b/HexNumberFieldTowerMathlib/Adjoin.lean
@@ -263,7 +263,7 @@ private theorem vanishing_factor_unique {T : NumberTower} {f : Poly T}
       (T.toPolynomial b.1) = 0) :
     a = b := by
   by_contra hab
-  letI : Std.Symm (fun x y : Poly T × Nat => x.1 ≠ y.1) :=
+  let : Std.Symm (fun x y : Poly T × Nat => x.1 ≠ y.1) :=
     ⟨fun _ _ h => h.symm⟩
   have hfactorNe : a.1 ≠ b.1 :=
     (factor_fsts_pairwise r hsound).forall ha hb hab

--- a/HexNumberFieldTowerMathlib/ArithmeticCore/Basic.lean
+++ b/HexNumberFieldTowerMathlib/ArithmeticCore/Basic.lean
@@ -1389,7 +1389,7 @@ theorem denseMap_eq_denseEval (lower : List Level) (x : ℂ)
       coeffField lower hvalid hinjective hinv
     denseMap lower x hvalid hinjective hinv f =
       denseEval lower x degree f := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffField lower hvalid hinjective hinv
   rw [denseMap,
     Polynomial.eval₂_eq_sum_range'
@@ -1409,7 +1409,7 @@ theorem denseMap_mul (lower : List Level) (x : ℂ)
     denseMap lower x hvalid hinjective hinv (f * g) =
       denseMap lower x hvalid hinjective hinv f *
         denseMap lower x hvalid hinjective hinv g := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffField lower hvalid hinjective hinv
   simp [denseMap, HexPolyMathlib.toPolynomial_mul, Polynomial.eval₂_mul]
 
@@ -1424,7 +1424,7 @@ theorem denseMap_add (lower : List Level) (x : ℂ)
     denseMap lower x hvalid hinjective hinv (f + g) =
       denseMap lower x hvalid hinjective hinv f +
         denseMap lower x hvalid hinjective hinv g := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffField lower hvalid hinjective hinv
   simp [denseMap, HexPolyMathlib.toPolynomial_add, Polynomial.eval₂_add]
 
@@ -1439,7 +1439,7 @@ theorem denseMap_scale (lower : List Level) (x : ℂ)
       coeffField lower hvalid hinjective hinv
     denseMap lower x hvalid hinjective hinv (DensePoly.scale c f) =
       coeffDenote lower c * denseMap lower x hvalid hinjective hinv f := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffField lower hvalid hinjective hinv
   simp [denseMap, HexPolyMathlib.toPolynomial_scale, Polynomial.eval₂_mul,
     coeffHom]
@@ -1454,7 +1454,7 @@ theorem denseMap_C (lower : List Level) (x : ℂ)
       coeffField lower hvalid hinjective hinv
     denseMap lower x hvalid hinjective hinv (DensePoly.C c) =
       coeffDenote lower c := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffField lower hvalid hinjective hinv
   simp [denseMap, coeffHom]
 

--- a/HexNumberFieldTowerMathlib/ArithmeticCore/Basic.lean
+++ b/HexNumberFieldTowerMathlib/ArithmeticCore/Basic.lean
@@ -1048,7 +1048,7 @@ theorem denote_mul (levels : List Level) (hvalid : LevelsValid levels)
       have hmul : ∀ u v, denote lower (Arithmetic.mulCoords lower u v) =
           denote lower u * denote lower v := fun u v => ih hlower u v
       simp only [Arithmetic.mulCoords]
-      rw [if_neg (Nat.ne_of_gt hdegree)]
+      rw [ite_eq_right (Nat.ne_of_gt hdegree)]
       rw [denote_flatten]
       change evalUpTo lower level.root.toComplex level.degree
           (Arithmetic.reduce level.degree (levelsDim lower) level.defining
@@ -1083,7 +1083,7 @@ theorem evalAt_mul (level : Level) (lower : List Level)
         denote lower u * denote lower v :=
     denote_mul lower hvalid.2.2
   simp only [Arithmetic.mulCoords]
-  rw [if_neg (Nat.ne_of_gt hdegree)]
+  rw [ite_eq_right (Nat.ne_of_gt hdegree)]
   rw [evalAt_flatten]
   change evalUpTo lower x level.degree
       (Arithmetic.reduce level.degree (levelsDim lower) level.defining

--- a/HexNumberFieldTowerMathlib/ArithmeticCore/Field.lean
+++ b/HexNumberFieldTowerMathlib/ArithmeticCore/Field.lean
@@ -22,7 +22,7 @@ theorem denseMap_zero (lower : List Level) (x : ℂ)
     letI : Field (Arithmetic.Coeff lower) :=
       coeffField lower hvalid hinjective hinv
     denseMap lower x hvalid hinjective hinv 0 = 0 := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffField lower hvalid hinjective hinv
   simp [denseMap]
 
@@ -335,12 +335,12 @@ theorem separates_of_irreducible (level : Level) (lower : List Level)
     Irreducible (HexPolyMathlib.toPolynomial
       (Arithmetic.Coeff.relation level lower)) →
       Separates level lower := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffField lower hvalid.2.2 hlowerInjective hlowerInv
   intro hirreducible
   let ι : Arithmetic.Coeff lower →+* ℂ :=
     coeffHom lower hvalid.2.2 hlowerInjective hlowerInv
-  letI : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
+  let : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
   let relation := Arithmetic.Coeff.relation level lower
   let p := HexPolyMathlib.toPolynomial relation
   have hpMonic : p.Monic := by
@@ -412,13 +412,13 @@ theorem relation_irreducible_of_injective (level : Level)
       coeffField lower hvalid.2.2 hlowerInjective hlowerInv
     Irreducible (HexPolyMathlib.toPolynomial
       (Arithmetic.Coeff.relation level lower)) := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffField lower hvalid.2.2 hlowerInjective hlowerInv
   let relation := Arithmetic.Coeff.relation level lower
   let p := HexPolyMathlib.toPolynomial relation
   let ι : Arithmetic.Coeff lower →+* ℂ :=
     coeffHom lower hvalid.2.2 hlowerInjective hlowerInv
-  letI : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
+  let : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
   have hpMonic : p.Monic := by
     rw [Polynomial.Monic.def]
     change (HexPolyMathlib.toPolynomial relation).leadingCoeff = 1
@@ -489,7 +489,7 @@ theorem xgcdLeft_size_one (level : Level) (lower : List Level)
       coeffField lower hvalid.2.2 hlowerInjective hinv
     (DensePoly.xgcdLeft (Arithmetic.Coeff.value level lower a)
       (Arithmetic.Coeff.relation level lower)).gcd.size = 1 := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffField lower hvalid.2.2 hlowerInjective hinv
   let value := Arithmetic.Coeff.value level lower a
   let relation := Arithmetic.Coeff.relation level lower
@@ -630,7 +630,7 @@ theorem denote_xgcd_inverse (level : Level) (lower : List Level)
           (((List.range level.degree).map fun i =>
             (normalized.coeff i).data).toArray)) =
       (denote (level :: lower) a)⁻¹ := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffField lower hvalid.2.2 hlowerInjective hinv
   let value := Arithmetic.Coeff.value level lower a
   let relation := Arithmetic.Coeff.relation level lower
@@ -836,7 +836,7 @@ theorem denote_invCoords (levels : List Level) (hvalid : LevelsValid levels)
           (denote lower b.data)⁻¹
         rw [denote_fixed]
         exact ih hvalid.2.2 hlowerInjective b.data
-      letI : Field (Arithmetic.Coeff lower) :=
+      let : Field (Arithmetic.Coeff lower) :=
         coeffField lower hvalid.2.2 hlowerInjective hlowerInv
       let zeroTest :=
         (Arithmetic.fixedCoeffs
@@ -1003,7 +1003,7 @@ from raw data reads off its first entry. -/
 theorem coeffRatEquiv_ofData (data : Array Rat) :
     letI : Field (Arithmetic.Coeff []) := coeffFieldNil
     coeffRatEquiv (Arithmetic.Coeff.ofData [] data) = data.getD 0 0 := by
-  letI : Field (Arithmetic.Coeff []) := coeffFieldNil
+  let : Field (Arithmetic.Coeff []) := coeffFieldNil
   change (Arithmetic.fixedCoeffs (levelsDim []) data).getD 0 0 =
     data.getD 0 0
   simp [Arithmetic.fixedCoeffs, levelsDim, Array.getD]
@@ -1015,7 +1015,7 @@ theorem map_rawPoly_nil (f : Array (Array Rat)) :
     (HexPolyMathlib.toPolynomial (Factor.rawPoly [] f)).map
         coeffRatEquiv.toRingHom =
       HexPolyMathlib.toPolynomial (Factor.toRatPoly f) := by
-  letI : Field (Arithmetic.Coeff []) := coeffFieldNil
+  let : Field (Arithmetic.Coeff []) := coeffFieldNil
   ext n
   rw [Polynomial.coeff_map, HexPolyMathlib.coeff_toPolynomial,
     HexPolyMathlib.coeff_toPolynomial]
@@ -1032,7 +1032,7 @@ theorem isIrreducible_nil_toMathlib (f : Array (Array Rat))
     (hcheck : Factor.isIrreducible [] f = true) :
     letI : Field (Arithmetic.Coeff []) := coeffFieldNil
     Irreducible (HexPolyMathlib.toPolynomial (Factor.rawPoly [] f)) := by
-  letI : Field (Arithmetic.Coeff []) := coeffFieldNil
+  let : Field (Arithmetic.Coeff []) := coeffFieldNil
   simp only [Factor.isIrreducible, Bool.and_eq_true] at hcheck
   have hdegree := hcheck.1.1.1
   have hirreducible := hcheck.2
@@ -1112,7 +1112,7 @@ theorem map_relation_nil (level : Level) (hstruct : level.Structural 1) :
         coeffRatEquiv.toRingHom =
       HexPolyMathlib.toPolynomial
         (Factor.toRatPoly (level.polynomial [])) := by
-  letI : Field (Arithmetic.Coeff []) := coeffFieldNil
+  let : Field (Arithmetic.Coeff []) := coeffFieldNil
   ext n
   rw [Polynomial.coeff_map, HexPolyMathlib.coeff_toPolynomial,
     HexPolyMathlib.coeff_toPolynomial]
@@ -1189,9 +1189,9 @@ theorem relation_irreducible_rational (level : Level)
     letI : Field (Arithmetic.Coeff []) := coeffFieldNil
     Irreducible (HexPolyMathlib.toPolynomial
       (Arithmetic.Coeff.relation level [])) := by
-  letI : Field (Arithmetic.Coeff []) := coeffFieldNil
+  let : Field (Arithmetic.Coeff []) := coeffFieldNil
   obtain ⟨_, original, checked, hp, hraw⟩ := hrelation
-  letI : ZPoly.CheckedIrreducible original := checked
+  let : ZPoly.CheckedIrreducible original := checked
   have hirrOriginal :
       Irreducible (HexPolyZMathlib.toPolyℚ original) :=
     ZPoly.CheckedIrreducible.irreducibleRat original
@@ -1236,7 +1236,7 @@ associate; relative certificates over the rational base use the recursive
 factor checker base case. -/
 theorem DenoteInjective.singleton (level : Level)
     (hvalid : LevelsValid [level]) : DenoteInjective [level] := by
-  letI : Field (Arithmetic.Coeff []) := coeffFieldNil
+  let : Field (Arithmetic.Coeff []) := coeffFieldNil
   have hrelation : Irreducible (HexPolyMathlib.toPolynomial
       (Arithmetic.Coeff.relation level [])) := by
     cases hvalid.2.1 with

--- a/HexNumberFieldTowerMathlib/ArithmeticCore/Field.lean
+++ b/HexNumberFieldTowerMathlib/ArithmeticCore/Field.lean
@@ -53,7 +53,7 @@ private theorem eq_C_leadingCoeff_of_size_one {R : Type*} [Zero R]
   · subst n
     rw [DensePoly.leadingCoeff_eq_coeff_last f (by omega), hsize]
     rfl
-  · rw [if_neg hn]
+  · rw [ite_eq_right hn]
     exact DensePoly.coeff_eq_zero_of_size_le f (by omega)
 
 /-- The first prescribed coefficient range of a dense polynomial, exposed as
@@ -855,7 +855,7 @@ theorem denote_invCoords (levels : List Level) (hvalid : LevelsValid levels)
         rw [show (Arithmetic.fixedCoeffs
             (level.degree * levelsDim lower) a).all (fun q => q = 0) = true by
           simpa [zeroTest] using hzero]
-        simp only [if_true]
+        simp only [ite_true]
         rw [hrep, denote_zero, hdenote]
         simp
       · have ha : denote (level :: lower) a ≠ 0 := by
@@ -875,8 +875,8 @@ theorem denote_invCoords (levels : List Level) (hvalid : LevelsValid levels)
         rw [show (Arithmetic.fixedCoeffs
             (level.degree * levelsDim lower) a).all (fun q => q = 0) = false by
           exact Bool.eq_false_of_not_eq_true hzero]
-        simp only [Bool.false_eq_true, if_false]
-        rw [if_pos hgcdSize, if_neg hcNe]
+        simp only [Bool.false_eq_true, ite_false]
+        rw [ite_eq_left hgcdSize, ite_eq_right hcNe]
         exact denote_xgcd_inverse level lower hvalid hinjective
           hlowerInjective hlowerInv a ha
 

--- a/HexNumberFieldTowerMathlib/Factor.lean
+++ b/HexNumberFieldTowerMathlib/Factor.lean
@@ -466,16 +466,16 @@ private theorem toPolynomial_rawPow (levels : List Level)
       by_cases hn : n = 0
       · subst n
         simp [Factor.polyPow]
-      · rw [Factor.polyPow, if_neg hn]
+      · rw [Factor.polyPow, ite_eq_right hn]
         have hhalf : n / 2 < n := Nat.div_lt_self (Nat.pos_of_ne_zero hn) (by omega)
         dsimp only
         by_cases heven : n % 2 = 0
-        · rw [if_pos heven, HexPolyMathlib.toPolynomial_mul,
+        · rw [ite_eq_left heven, HexPolyMathlib.toPolynomial_mul,
             ih (n / 2) hhalf]
           rw [← pow_add]
           congr 1
           omega
-        · rw [if_neg heven, HexPolyMathlib.toPolynomial_mul,
+        · rw [ite_eq_right heven, HexPolyMathlib.toPolynomial_mul,
             HexPolyMathlib.toPolynomial_mul, ih (n / 2) hhalf]
           rw [← pow_add, ← pow_succ]
           congr 1

--- a/HexNumberFieldTowerMathlib/Factor.lean
+++ b/HexNumberFieldTowerMathlib/Factor.lean
@@ -142,7 +142,7 @@ private theorem map_rawPoly (T : NumberTower) (f : Poly T) :
         (coeffEquiv T).toRingHom = HexPolyMathlib.toPolynomial f := by
   let hinjective := coeffDenote_injective T
   let hinv := LevelSemantics.coeffDenote_inv T.levels.toList T.valid hinjective
-  letI : Field (Arithmetic.Coeff T.levels.toList) :=
+  let : Field (Arithmetic.Coeff T.levels.toList) :=
     Norm.coeffFieldPoly T.levels.toList T.valid hinjective hinv
   apply Polynomial.ext
   intro n
@@ -187,7 +187,7 @@ theorem rawPolynomial_rawPoly (T : NumberTower) (f : Poly T) :
       T.toPolynomial f := by
   let hinjective := coeffDenote_injective T
   let hinv := LevelSemantics.coeffDenote_inv T.levels.toList T.valid hinjective
-  letI : Field (Arithmetic.Coeff T.levels.toList) :=
+  let : Field (Arithmetic.Coeff T.levels.toList) :=
     Norm.coeffFieldPoly T.levels.toList T.valid hinjective hinv
   rw [Norm.rawPolynomial_eq_map T.levels.toList T.valid hinjective hinv,
     toPolynomial_eq_map, ← map_rawPoly T f, Polynomial.map_map]
@@ -205,7 +205,7 @@ theorem polyCoords_rawPoly (T : NumberTower) (f : Poly T) :
       f.toArray.map coeffs := by
   let hinjective := coeffDenote_injective T
   let hinv := LevelSemantics.coeffDenote_inv T.levels.toList T.valid hinjective
-  letI : Field (Arithmetic.Coeff T.levels.toList) :=
+  let : Field (Arithmetic.Coeff T.levels.toList) :=
     Norm.coeffFieldPoly T.levels.toList T.valid hinjective hinv
   let q := Factor.rawPoly T.levels.toList (f.toArray.map coeffs)
   have hmap : (HexPolyMathlib.toPolynomial q).map
@@ -280,7 +280,7 @@ private theorem toPolynomial_of_polyCoords (T : NumberTower)
       (HexPolyMathlib.toPolynomial p).map (coeffEquiv T).toRingHom := by
   let hinjective := coeffDenote_injective T
   let hinv := LevelSemantics.coeffDenote_inv T.levels.toList T.valid hinjective
-  letI : Field (Arithmetic.Coeff T.levels.toList) :=
+  let : Field (Arithmetic.Coeff T.levels.toList) :=
     Norm.coeffFieldPoly T.levels.toList T.valid hinjective hinv
   dsimp only
   apply Polynomial.ext
@@ -319,7 +319,7 @@ private theorem publicCoords_of_canonical (T : NumberTower)
       factor := by
   let hinjective := coeffDenote_injective T
   let hinv := LevelSemantics.coeffDenote_inv T.levels.toList T.valid hinjective
-  letI : Field (Arithmetic.Coeff T.levels.toList) :=
+  let : Field (Arithmetic.Coeff T.levels.toList) :=
     Norm.coeffFieldPoly T.levels.toList T.valid hinjective hinv
   let p := Factor.rawPoly T.levels.toList factor
   let g : Poly T := DensePoly.ofCoeffs (factor.map (ofCoeffs T))
@@ -459,7 +459,7 @@ private theorem toPolynomial_rawPow (levels : List Level)
       Norm.coeffFieldPoly levels hvalid hinjective hinv
     HexPolyMathlib.toPolynomial (Factor.polyPow f n) =
       HexPolyMathlib.toPolynomial f ^ n := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   induction n using Nat.strong_induction_on with
   | h n ih =>
@@ -558,7 +558,7 @@ private theorem map_factorFold (T : NumberTower)
           product * Factorization.polyPow factor.1 factor.2) publicInit) := by
   let hinjective := coeffDenote_injective T
   let hinv := LevelSemantics.coeffDenote_inv T.levels.toList T.valid hinjective
-  letI : Field (Arithmetic.Coeff T.levels.toList) :=
+  let : Field (Arithmetic.Coeff T.levels.toList) :=
     Norm.coeffFieldPoly T.levels.toList T.valid hinjective hinv
   dsimp only
   induction factors generalizing rawInit publicInit with
@@ -583,7 +583,7 @@ theorem isIrreducible_iff (T : NumberTower) (f : Poly T) :
         f.leadingCoeff = 1 ∧ PolynomialIrreducible T f := by
   let hinjective := coeffDenote_injective T
   let hinv := LevelSemantics.coeffDenote_inv T.levels.toList T.valid hinjective
-  letI : Field (Arithmetic.Coeff T.levels.toList) :=
+  let : Field (Arithmetic.Coeff T.levels.toList) :=
     Norm.coeffFieldPoly T.levels.toList T.valid hinjective hinv
   let raw := Factor.rawPoly T.levels.toList (f.toArray.map coeffs)
   have hmap : (HexPolyMathlib.toPolynomial raw).map
@@ -648,7 +648,7 @@ theorem factor?_sound (T : NumberTower) (f : Poly T)
   simp only [checkFactorization, Factor.check, Bool.and_eq_true] at hcheck
   let hinjective := coeffDenote_injective T
   let hinv := LevelSemantics.coeffDenote_inv T.levels.toList T.valid hinjective
-  letI : Field (Arithmetic.Coeff T.levels.toList) :=
+  let : Field (Arithmetic.Coeff T.levels.toList) :=
     Norm.coeffFieldPoly T.levels.toList T.valid hinjective hinv
   have hscalar : coeffEquiv T
       (Arithmetic.Coeff.ofData T.levels.toList (coeffs r.scalar)) =

--- a/HexNumberFieldTowerMathlib/FactorGeneric/Complete.lean
+++ b/HexNumberFieldTowerMathlib/FactorGeneric/Complete.lean
@@ -171,7 +171,7 @@ theorem factorSquarefree_isSome :
         simp
       have hresult : Factor.factorSquarefree? (level :: lower) f =
           some factors := by
-        simp only [Factor.factorSquarefree?, hcheck, if_true]
+        simp only [Factor.factorSquarefree?, hcheck, ite_true]
         rw [hfind]
         change (do
           let lowerFactors ← Factor.factorSquarefree? lower norm
@@ -227,21 +227,21 @@ private theorem ratListLess_iff : ∀ a b : List Rat,
       | nil => simp [Factor.ratListLess, List.lt_iff_lex_lt]
       | cons b bs =>
           by_cases hab : a < b
-          · rw [Factor.ratListLess, if_pos hab]
+          · rw [Factor.ratListLess, ite_eq_left hab]
             constructor
             · intro _
               exact List.Lex.rel hab
             · intro _
               rfl
-          · rw [Factor.ratListLess, if_neg hab]
+          · rw [Factor.ratListLess, ite_eq_right hab]
             by_cases hba : b < a
-            · rw [if_pos hba]
+            · rw [ite_eq_left hba]
               constructor
               · intro hfalse
                 contradiction
               · intro hlt
                 exact ((not_le_of_gt hba) (List.head_le_of_lt hlt)).elim
-            · rw [if_neg hba]
+            · rw [ite_eq_right hba]
               have heq : a = b :=
                 le_antisymm (le_of_not_gt hba) (le_of_not_gt hab)
               subst b
@@ -335,20 +335,20 @@ private theorem insertFactor_fst_mem
   | cons head tail ih =>
       intro hentry
       by_cases hfactor : Factor.factorLess factor.1 head.1 = true
-      · rw [Factor.insertFactor, if_pos hfactor] at hentry
+      · rw [Factor.insertFactor, ite_eq_left hfactor] at hentry
         rcases List.mem_cons.mp hentry with rfl | hentry
         · exact Or.inl rfl
         · exact Or.inr ⟨entry, hentry, rfl⟩
-      · rw [Factor.insertFactor, if_neg hfactor] at hentry
+      · rw [Factor.insertFactor, ite_eq_right hfactor] at hentry
         by_cases hhead : Factor.factorLess head.1 factor.1 = true
-        · rw [if_pos hhead] at hentry
+        · rw [ite_eq_left hhead] at hentry
           rcases List.mem_cons.mp hentry with hentryHead | hentry
           · subst entry
             exact Or.inr ⟨head, by simp, rfl⟩
           · rcases ih hentry with hfactorEq | ⟨original, horiginal, heq⟩
             · exact Or.inl hfactorEq
             · exact Or.inr ⟨original, by simp [horiginal], heq⟩
-        · rw [if_neg hhead] at hentry
+        · rw [ite_eq_right hhead] at hentry
           rcases List.mem_cons.mp hentry with hentry | hentry
           · subst entry
             exact Or.inr ⟨head, by simp, rfl⟩
@@ -367,16 +367,16 @@ private theorem insertFactor_pairwise
       have hhead := (List.pairwise_cons.mp hsorted).1
       have htail := (List.pairwise_cons.mp hsorted).2
       by_cases hfactor : Factor.factorLess factor.1 head.1 = true
-      · rw [Factor.insertFactor, if_pos hfactor,
+      · rw [Factor.insertFactor, ite_eq_left hfactor,
           List.pairwise_cons]
         refine ⟨?_, hsorted⟩
         intro other hother
         rcases List.mem_cons.mp hother with rfl | hother
         · exact hfactor
         · exact factorLess_trans hfactor (hhead other hother)
-      · rw [Factor.insertFactor, if_neg hfactor]
+      · rw [Factor.insertFactor, ite_eq_right hfactor]
         by_cases hheadFactor : Factor.factorLess head.1 factor.1 = true
-        · rw [if_pos hheadFactor, List.pairwise_cons]
+        · rw [ite_eq_left hheadFactor, List.pairwise_cons]
           refine ⟨?_, ih htail⟩
           intro other hother
           rcases insertFactor_fst_mem factor other tail hother with
@@ -387,7 +387,7 @@ private theorem insertFactor_pairwise
           · unfold FactorEntryLess
             rw [horiginalEq]
             exact hhead original horiginal
-        · rw [if_neg hheadFactor, List.pairwise_cons]
+        · rw [ite_eq_right hheadFactor, List.pairwise_cons]
           refine ⟨?_, htail⟩
           intro other hother
           exact hhead other hother
@@ -473,17 +473,17 @@ private theorem insertFactor_positive
         intro original horiginal
         exact hfactors original (by simp [horiginal])
       by_cases hfactorHead : Factor.factorLess factor.1 head.1 = true
-      · rw [Factor.insertFactor, if_pos hfactorHead] at hentry
+      · rw [Factor.insertFactor, ite_eq_left hfactorHead] at hentry
         rcases List.mem_cons.mp hentry with rfl | hentry
         · exact hfactor
         · exact hfactors entry hentry
-      · rw [Factor.insertFactor, if_neg hfactorHead] at hentry
+      · rw [Factor.insertFactor, ite_eq_right hfactorHead] at hentry
         by_cases hheadFactor : Factor.factorLess head.1 factor.1 = true
-        · rw [if_pos hheadFactor] at hentry
+        · rw [ite_eq_left hheadFactor] at hentry
           rcases List.mem_cons.mp hentry with rfl | hentry
           · exact hhead
           · exact ih htail entry hentry
-        · rw [if_neg hheadFactor] at hentry
+        · rw [ite_eq_right hheadFactor] at hentry
           rcases List.mem_cons.mp hentry with hentry | hentry
           · subst entry
             omega
@@ -1173,17 +1173,17 @@ private theorem toPolynomial_polyPow (levels : List Level)
       by_cases hn : n = 0
       · subst n
         simp [Factor.polyPow]
-      · rw [Factor.polyPow, if_neg hn]
+      · rw [Factor.polyPow, ite_eq_right hn]
         have hhalf : n / 2 < n :=
           Nat.div_lt_self (Nat.pos_of_ne_zero hn) (by omega)
         dsimp only
         by_cases heven : n % 2 = 0
-        · rw [if_pos heven, HexPolyMathlib.toPolynomial_mul,
+        · rw [ite_eq_left heven, HexPolyMathlib.toPolynomial_mul,
             ih (n / 2) hhalf]
           rw [← pow_add]
           congr 1
           omega
-        · rw [if_neg heven, HexPolyMathlib.toPolynomial_mul,
+        · rw [ite_eq_right heven, HexPolyMathlib.toPolynomial_mul,
             HexPolyMathlib.toPolynomial_mul, ih (n / 2) hhalf]
           rw [← pow_add, ← pow_succ]
           congr 1

--- a/HexNumberFieldTowerMathlib/FactorGeneric/Complete.lean
+++ b/HexNumberFieldTowerMathlib/FactorGeneric/Complete.lean
@@ -42,13 +42,13 @@ theorem factorSquarefree_isSome :
         Subsingleton.elim _ _
       subst hvalid
       subst hinjective
-      letI : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
+      let : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
         LevelSemantics.DenoteInjective.nil
         LevelSemantics.coeffDenote_inv_nil
       let ι := LevelSemantics.coeffHom [] trivial
         LevelSemantics.DenoteInjective.nil
         LevelSemantics.coeffDenote_inv_nil
-      letI : CharZero (Arithmetic.Coeff []) :=
+      let : CharZero (Arithmetic.Coeff []) :=
         { cast_injective := by
             intro m n hmn
             apply Nat.cast_injective (R := ℂ)
@@ -69,9 +69,9 @@ theorem factorSquarefree_isSome :
         hinjectiveLower
       let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
         hinjectiveTop
-      letI : Field (Arithmetic.Coeff lower) :=
+      let : Field (Arithmetic.Coeff lower) :=
         Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-      letI : Field (Arithmetic.Coeff (level :: lower)) :=
+      let : Field (Arithmetic.Coeff (level :: lower)) :=
         Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
       have harrayDegree : 0 < f.size - 1 :=
         array_degree_pos_of_raw_degree_pos (level :: lower) f hdegree
@@ -577,7 +577,7 @@ private theorem factorRat_mem_monic (input : DensePoly Rat)
     ∀ factor ∈ factors,
       (HexPolyMathlib.toPolynomial
         (Factor.rawPoly [] factor)).Monic := by
-  letI : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
+  let : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
     LevelSemantics.DenoteInjective.nil
     LevelSemantics.coeffDenote_inv_nil
   intro factor hfactor
@@ -636,7 +636,7 @@ private theorem factorSquarefree_mem_monic
       (HexPolyMathlib.toPolynomial
         (Factor.rawPoly levels factor)).Monic := by
   let hinv := LevelSemantics.coeffDenote_inv levels hvalid hinjective
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   dsimp only
   intro factor hfactor
@@ -737,7 +737,7 @@ private theorem factorFold_sound
             HexPolyMathlib.toPolynomial
               (Factor.rawPoly levels component.1) ^ component.2).prod := by
   let hinv := LevelSemantics.coeffDenote_inv levels hvalid hinjective
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   dsimp only
   intro hstate
@@ -842,7 +842,7 @@ theorem factorRaw_isSome (levels : List Level)
     (f : Array (Array Rat)) :
     (Factor.factorRaw? levels f).isSome := by
   let hinv := LevelSemantics.coeffDenote_inv levels hvalid hinjective
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let components := Factor.yunRaw levels f
   have hcheck : Factor.checkYun levels f components :=
@@ -899,7 +899,7 @@ theorem isIrreducible_nil_iff (f : Array (Array Rat)) :
     Factor.isIrreducible [] f ↔
       (Factor.rawPoly [] f).leadingCoeff = 1 ∧
         Irreducible (HexPolyMathlib.toPolynomial (Factor.rawPoly [] f)) := by
-  letI : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
+  let : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
     LevelSemantics.DenoteInjective.nil
     LevelSemantics.coeffDenote_inv_nil
   constructor
@@ -924,7 +924,7 @@ theorem isIrreducible_nil_iff (f : Array (Array Rat)) :
       apply (Norm.isSquarefree_iff [] trivial
         LevelSemantics.DenoteInjective.nil
         LevelSemantics.coeffDenote_inv_nil f).mpr
-      letI : CharZero (Arithmetic.Coeff []) :=
+      let : CharZero (Arithmetic.Coeff []) :=
         { cast_injective := by
             intro m n hmn
             apply Nat.cast_injective (R := ℂ)
@@ -1030,7 +1030,7 @@ theorem isIrreducible_iff_of_injective (levels : List Level)
         Irreducible (HexPolyMathlib.toPolynomial
           (Factor.rawPoly levels f)) := by
   let hinv := LevelSemantics.coeffDenote_inv levels hvalid hinjective
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   cases levels with
   | nil =>
@@ -1075,7 +1075,7 @@ theorem isIrreducible_iff_of_injective (levels : List Level)
           exact Nat.pos_of_ne_zero hnatDegree
         let ι := LevelSemantics.coeffHom (level :: lower) hvalid
           hinjective hinv
-        letI : CharZero (Arithmetic.Coeff (level :: lower)) :=
+        let : CharZero (Arithmetic.Coeff (level :: lower)) :=
           { cast_injective := by
               intro m n hmn
               apply Nat.cast_injective (R := ℂ)
@@ -1166,7 +1166,7 @@ private theorem toPolynomial_polyPow (levels : List Level)
     HexPolyMathlib.toPolynomial (Factor.polyPow f n) =
       HexPolyMathlib.toPolynomial f ^ n := by
   let hinv := LevelSemantics.coeffDenote_inv levels hvalid hinjective
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   induction n using Nat.strong_induction_on with
   | h n ih =>
@@ -1206,7 +1206,7 @@ private theorem toPolynomial_factorFold (levels : List Level)
           HexPolyMathlib.toPolynomial
             (Factor.rawPoly levels entry.1) ^ entry.2).prod := by
   let hinv := LevelSemantics.coeffDenote_inv levels hvalid hinjective
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   dsimp only
   induction entries generalizing acc with
@@ -1228,7 +1228,7 @@ private theorem leadingCoeff_mul_monic (levels : List Level)
         HexPolyMathlib.toPolynomial (Norm.monic p) =
       HexPolyMathlib.toPolynomial p := by
   let hinv := LevelSemantics.coeffDenote_inv levels hvalid hinjective
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   dsimp only
   rw [Norm.monic]
@@ -1259,7 +1259,7 @@ private theorem C_leadingCoeff_eq_of_degreeZero (levels : List Level)
       Norm.coeffFieldPoly levels hvalid hinjective hinv
     DensePoly.C p.leadingCoeff = p := by
   let hinv := LevelSemantics.coeffDenote_inv levels hvalid hinjective
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   dsimp only
   apply (HexPolyMathlib.equiv
@@ -1292,7 +1292,7 @@ theorem factorRaw_check (levels : List Level)
     (hresult : Factor.factorRaw? levels f = some raw) :
     Factor.check levels f raw.scalar raw.factors = true := by
   let hinv := LevelSemantics.coeffDenote_inv levels hvalid hinjective
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let p := Factor.rawPoly levels f
   have hresult' := hresult
@@ -1467,7 +1467,7 @@ theorem denoteInjective_of_valid : ∀ (levels : List Level),
       have hinjectiveLower := ih hvalid.2.2
       let hinvLower := LevelSemantics.coeffDenote_inv lower hvalid.2.2
         hinjectiveLower
-      letI : Field (Arithmetic.Coeff lower) :=
+      let : Field (Arithmetic.Coeff lower) :=
         Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
       have hrelation : Irreducible (HexPolyMathlib.toPolynomial
           (Arithmetic.Coeff.relation level lower)) := by

--- a/HexNumberFieldTowerMathlib/FactorGeneric/Product.lean
+++ b/HexNumberFieldTowerMathlib/FactorGeneric/Product.lean
@@ -39,7 +39,7 @@ theorem rawPoly_nil_eq_zero_iff (f : Array (Array Rat)) :
       LevelSemantics.DenoteInjective.nil
       LevelSemantics.coeffDenote_inv_nil
     Factor.rawPoly [] f = 0 ↔ Factor.toRatPoly f = 0 := by
-  letI : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
+  let : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
     LevelSemantics.DenoteInjective.nil
     LevelSemantics.coeffDenote_inv_nil
   constructor
@@ -70,7 +70,7 @@ theorem map_monic_rawPoly_nil (f : Array (Array Rat)) :
       HexPolyMathlib.toPolynomial
         (let p := Factor.toRatPoly f
          if p.isZero then 0 else DensePoly.scale p.leadingCoeff⁻¹ p) := by
-  letI : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
+  let : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
     LevelSemantics.DenoteInjective.nil
     LevelSemantics.coeffDenote_inv_nil
   let raw := Factor.rawPoly [] f
@@ -155,7 +155,7 @@ theorem rawFactorFoldl (levels : List Level)
         (factors.map fun factor => HexPolyMathlib.toPolynomial
           (R := Arithmetic.Coeff levels)
           (Factor.rawPoly levels factor)).prod := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   induction factors generalizing init with
   | nil => simp
@@ -202,7 +202,7 @@ theorem factorSquarefree_product (levels : List Level)
           (Norm.monic (Factor.rawPoly levels f)) := by
   cases levels with
   | nil =>
-      letI : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
+      let : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
         LevelSemantics.DenoteInjective.nil
         LevelSemantics.coeffDenote_inv_nil
       dsimp only
@@ -276,7 +276,7 @@ theorem factorSquarefree_product (levels : List Level)
   | cons level lower =>
       let hinv := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
         hinjective
-      letI : Field (Arithmetic.Coeff (level :: lower)) :=
+      let : Field (Arithmetic.Coeff (level :: lower)) :=
         Norm.coeffFieldPoly (level :: lower) hvalid hinjective hinv
       dsimp only
       simp only [Factor.factorSquarefree?] at hresult
@@ -399,9 +399,9 @@ theorem recover_product_associated (level : Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   let delta := Arithmetic.Coeff.ofData (level :: lower) #[(shift : Rat)] *
     Factor.topGenerator level lower
@@ -576,9 +576,9 @@ theorem recover_product_monic (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   dsimp only
   intro hsound
@@ -666,9 +666,9 @@ theorem recover_product (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   dsimp only
   intro hcomponentNe hnormSquarefree hnormEq hlowerCoords hlowerProduct
@@ -693,13 +693,13 @@ theorem recover_product (level : Level) (lower : List Level)
     hinjectiveLower hinvLower
   let ιTop := LevelSemantics.coeffHom (level :: lower) hvalid
     hinjectiveTop hinvTop
-  letI : CharZero (Arithmetic.Coeff lower) :=
+  let : CharZero (Arithmetic.Coeff lower) :=
     { cast_injective := by
         intro m n hmn
         apply Nat.cast_injective (R := ℂ)
         have hmapped := congrArg ιLower hmn
         simpa only [map_natCast] using hmapped }
-  letI : CharZero (Arithmetic.Coeff (level :: lower)) :=
+  let : CharZero (Arithmetic.Coeff (level :: lower)) :=
     { cast_injective := by
         intro m n hmn
         apply Nat.cast_injective (R := ℂ)

--- a/HexNumberFieldTowerMathlib/FactorGeneric/Product.lean
+++ b/HexNumberFieldTowerMathlib/FactorGeneric/Product.lean
@@ -109,7 +109,7 @@ theorem map_monic_rawPoly_nil (f : Array (Array Rat)) :
         ← DensePoly.isZero_eq_true_iff]
       exact hrawZero
     rw [hpZero]
-    simp only [if_true]
+    simp only [ite_true]
     have hraw : raw = 0 :=
       (DensePoly.size_eq_zero_iff raw).mp
         ((DensePoly.isZero_eq_true_iff raw).mp hrawZero)
@@ -124,7 +124,7 @@ theorem map_monic_rawPoly_nil (f : Array (Array Rat)) :
           hzero, ← DensePoly.size_eq_zero_iff]
         exact hpSize
     rw [hpZero]
-    simp only [Bool.false_eq_true, if_false]
+    simp only [Bool.false_eq_true, ite_false]
     change (HexPolyMathlib.toPolynomial
         (DensePoly.scale raw.leadingCoeff⁻¹ raw)).map
           LevelSemantics.coeffRatEquiv.toRingHom =
@@ -266,7 +266,7 @@ theorem factorSquarefree_product (levels : List Level)
                 LevelSemantics.coeffRatEquiv.toRingHom
                 LevelSemantics.coeffRatEquiv.injective
               rw [polynomial_map_list_prod, hmappedList,
-                map_monic_rawPoly_nil, if_neg hinputZero]
+                map_monic_rawPoly_nil, ite_eq_right hinputZero]
               have hpoly := congrArg HexPolyMathlib.toPolynomial hproduct
               rw [← Array.foldl_toList,
                 ratFactorFoldl] at hpoly
@@ -1008,9 +1008,9 @@ theorem factorRat_isSome (input : DensePoly Rat)
   have hgcd := gcd_derivative_size_le_one_of_separable p hpSeparable
   have hproduct := factorRat_product p hpNe hpMonic
   dsimp only at hproduct
-  simp only [Factor.factorRat?, hinputZero, Bool.false_eq_true, if_false]
+  simp only [Factor.factorRat?, hinputZero, Bool.false_eq_true, ite_false]
   rw [show DensePoly.scale input.leadingCoeff⁻¹ input = p from rfl]
-  simp only [hpZero, hgcd, if_pos]
+  simp only [hpZero, hgcd, ite_eq_left]
   rw [hproduct]
   simp
 

--- a/HexNumberFieldTowerMathlib/FactorGeneric/Trager.lean
+++ b/HexNumberFieldTowerMathlib/FactorGeneric/Trager.lean
@@ -89,9 +89,9 @@ theorem ofData_lower_eq_lowerHom (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   rw [Norm.lowerHom_apply]
   apply hinjectiveTop
@@ -127,9 +127,9 @@ theorem rawPoly_embedLower_polyCoords (level : Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   rw [rawPoly_embedLower]
   apply (HexPolyMathlib.equiv
@@ -203,9 +203,9 @@ theorem toPolynomial_shiftTop (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   let delta := Arithmetic.Coeff.ofData (level :: lower) #[(c : Rat)] *
     Factor.topGenerator level lower
@@ -248,9 +248,9 @@ theorem shiftDelta_neg (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   dsimp only
   apply hinjectiveTop
@@ -291,9 +291,9 @@ theorem irreducible_shiftTop_iff (level : Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   let delta := Arithmetic.Coeff.ofData (level :: lower) #[(c : Rat)] *
     Factor.topGenerator level lower
@@ -341,9 +341,9 @@ theorem rawPoly_shiftTop_zero (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   apply (HexPolyMathlib.equiv
     (R := Arithmetic.Coeff (level :: lower))).injective
@@ -380,9 +380,9 @@ theorem toPolynomial_shiftTop_zero (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   dsimp only
   rw [toPolynomial_shiftTop level lower hvalid hinjectiveTop]
@@ -424,9 +424,9 @@ theorem tragerNorm_shiftTop (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   rw [tragerNorm, polyCoords_rawPoly_shiftTop]
   exact Norm.oneLevel_shift_zero level lower hvalid hinjectiveTop f c
@@ -452,9 +452,9 @@ theorem tragerNorm_mul (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   exact Norm.oneLevel_mul level lower hvalid hinjectiveTop a b 0
 
@@ -504,9 +504,9 @@ theorem tragerNorm_dvd (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   change (HexPolyMathlib.toPolynomial a ∣
       HexPolyMathlib.toPolynomial b) → _
@@ -547,9 +547,9 @@ theorem tragerNorm_not_isUnit (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   change ¬ IsUnit (HexPolyMathlib.toPolynomial
     (tragerNorm level lower f))
@@ -582,7 +582,7 @@ theorem toPolynomial_monic_associated (levels : List Level)
       Norm.coeffFieldPoly levels hvalid hinjective hinv
     Associated (HexPolyMathlib.toPolynomial (Norm.monic f))
       (HexPolyMathlib.toPolynomial f) := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   have hzero : f.isZero = false := by
     rw [DensePoly.isZero_eq_false_iff]
@@ -608,7 +608,7 @@ theorem toPolynomial_monic_monic (levels : List Level)
     letI : Field (Arithmetic.Coeff levels) :=
       Norm.coeffFieldPoly levels hvalid hinjective hinv
     (HexPolyMathlib.toPolynomial (Norm.monic f)).Monic := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   have hzero : f.isZero = false := by
     rw [DensePoly.isZero_eq_false_iff]
@@ -638,7 +638,7 @@ theorem monic_eq_self (levels : List Level)
     letI : Field (Arithmetic.Coeff levels) :=
       Norm.coeffFieldPoly levels hvalid hinjective hinv
     (HexPolyMathlib.toPolynomial f).Monic → Norm.monic f = f := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   intro hf
   apply (HexPolyMathlib.equiv
@@ -705,9 +705,9 @@ theorem recoveredCommon_irreducible (level : Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   let lifted := Factor.rawPoly (level :: lower)
     (Factor.embedLower level lower (Factor.polyCoords q))
@@ -865,9 +865,9 @@ theorem recoveredFactor_irreducible (level : Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   let shifted := Factor.rawPoly (level :: lower)
     (Factor.shiftTop level lower component shift)
@@ -1013,9 +1013,9 @@ theorem oneLevel_degree_pos (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   dsimp only
   intro hsquarefree
@@ -1062,11 +1062,11 @@ theorem squarefree_toPolynomial_of_check (levels : List Level)
       Norm.coeffFieldPoly levels hvalid hinjective hinv
     Squarefree (HexPolyMathlib.toPolynomial
       (Factor.rawPoly levels f)) := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let P := HexPolyMathlib.toPolynomial (Factor.rawPoly levels f)
   let φ := LevelSemantics.coeffHom levels hvalid hinjective hinv
-  letI : CharZero (Arithmetic.Coeff levels) :=
+  let : CharZero (Arithmetic.Coeff levels) :=
     { cast_injective := by
         intro m n hmn
         apply CharZero.cast_injective (R := ℂ)
@@ -1253,9 +1253,9 @@ theorem recover_mem_sound (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   let shifted := Factor.rawPoly (level :: lower)
     (Factor.shiftTop level lower component shift)
@@ -1291,7 +1291,7 @@ theorem polyCoords_rawPoly_ofRatPoly (f : DensePoly Rat)
     (hf : f ≠ 0) :
     Factor.polyCoords (Factor.rawPoly [] (Factor.ofRatPoly f)) =
       Factor.ofRatPoly f := by
-  letI : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
+  let : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
     LevelSemantics.DenoteInjective.nil
     LevelSemantics.coeffDenote_inv_nil
   let q := Factor.rawPoly [] (Factor.ofRatPoly f)
@@ -1548,7 +1548,7 @@ theorem rawRatFactor_irreducible (integer : ZPoly)
       entry.1.toRatPoly
     Irreducible (HexPolyMathlib.toPolynomial
       (Factor.rawPoly [] (Factor.ofRatPoly q))) := by
-  letI : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
+  let : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
     LevelSemantics.DenoteInjective.nil
     LevelSemantics.coeffDenote_inv_nil
   let q := DensePoly.scale entry.1.toRatPoly.leadingCoeff⁻¹
@@ -1581,7 +1581,7 @@ theorem generatedRatFactors_sound (integer : ZPoly)
       Factor.polyCoords (Factor.rawPoly [] factor) = factor ∧
         Irreducible (HexPolyMathlib.toPolynomial
           (Factor.rawPoly [] factor)) := by
-  letI : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
+  let : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
     LevelSemantics.DenoteInjective.nil
     LevelSemantics.coeffDenote_inv_nil
   let rawFactors := (ZPoly.factorize integer).factors.flatMap fun entry =>
@@ -1633,7 +1633,7 @@ theorem factorRat_mem_sound (input : DensePoly Rat)
       Factor.polyCoords (Factor.rawPoly [] factor) = factor ∧
         Irreducible (HexPolyMathlib.toPolynomial
           (Factor.rawPoly [] factor)) := by
-  letI : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
+  let : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
     LevelSemantics.DenoteInjective.nil
     LevelSemantics.coeffDenote_inv_nil
   intro factor hfactor
@@ -1694,7 +1694,7 @@ theorem factorSquarefree_mem_sound :
   | nil =>
       intro hvalid hinjective f factors hresult
       let hinv := LevelSemantics.coeffDenote_inv [] hvalid hinjective
-      letI : Field (Arithmetic.Coeff []) :=
+      let : Field (Arithmetic.Coeff []) :=
         Norm.coeffFieldPoly [] hvalid hinjective hinv
       have hvalidEq : hvalid = (trivial : LevelsValid []) :=
         Subsingleton.elim _ _
@@ -1710,9 +1710,9 @@ theorem factorSquarefree_mem_sound :
         hinjectiveLower
       let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
         hinjectiveTop
-      letI : Field (Arithmetic.Coeff lower) :=
+      let : Field (Arithmetic.Coeff lower) :=
         Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-      letI : Field (Arithmetic.Coeff (level :: lower)) :=
+      let : Field (Arithmetic.Coeff (level :: lower)) :=
         Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
       dsimp only
       simp only [Factor.factorSquarefree?] at hresult

--- a/HexNumberFieldTowerMathlib/FactorGeneric/Trager.lean
+++ b/HexNumberFieldTowerMathlib/FactorGeneric/Trager.lean
@@ -589,7 +589,7 @@ theorem toPolynomial_monic_associated (levels : List Level)
     exact Nat.pos_of_ne_zero fun hsize =>
       hf ((DensePoly.size_eq_zero_iff f).mp hsize)
   rw [Norm.monic, hzero]
-  simp only [Bool.false_eq_true, if_false]
+  simp only [Bool.false_eq_true, ite_false]
   rw [HexPolyMathlib.toPolynomial_scale]
   exact associated_unit_mul_left _ _
     (Polynomial.isUnit_C.mpr
@@ -621,7 +621,7 @@ theorem toPolynomial_monic_monic (levels : List Level)
       (R := Arithmetic.Coeff levels)).injective
     simpa using h
   rw [Norm.monic, hzero]
-  simp only [Bool.false_eq_true, if_false]
+  simp only [Bool.false_eq_true, ite_false]
   rw [HexPolyMathlib.toPolynomial_scale, mul_comm]
   simpa only [HexPolyMathlib.leadingCoeff_toPolynomial] using
     Polynomial.monic_mul_leadingCoeff_inv hpolyNe
@@ -1101,11 +1101,11 @@ theorem mem_foldl_push_if {α β : Type*}
       simp only [List.foldl_cons] at hx
       rcases ih _ x hx with hxinit | ⟨source, hsource, hpass, rfl⟩
       · by_cases hitem : p item
-        · rw [if_pos hitem] at hxinit
+        · rw [ite_eq_left hitem] at hxinit
           rcases Array.mem_push.mp hxinit with hxold | rfl
           · exact Or.inl hxold
           · exact Or.inr ⟨item, by simp, hitem, rfl⟩
-        · rw [if_neg hitem] at hxinit
+        · rw [ite_eq_right hitem] at hxinit
           exact Or.inl hxinit
       · exact Or.inr ⟨source, List.mem_cons_of_mem item hsource,
           hpass, rfl⟩
@@ -1127,9 +1127,9 @@ theorem foldl_push_if_toList {α β : Type*}
       intro init
       simp only [List.foldl_cons]
       by_cases hitem : p item
-      · rw [if_pos hitem, ih]
+      · rw [ite_eq_left hitem, ih]
         simp [hitem]
-      · rw [if_neg hitem, ih]
+      · rw [ite_eq_right hitem, ih]
         simp [hitem]
 
 /-- Dropping unit contributions preserves the product up to a unit: if

--- a/HexNumberFieldTowerMathlib/FactorGeneric/Yun.lean
+++ b/HexNumberFieldTowerMathlib/FactorGeneric/Yun.lean
@@ -39,7 +39,7 @@ theorem rawPolynomial_monic_associated
     (hf : Norm.rawPolynomial levels f ≠ 0) :
     Associated (Norm.rawPolynomial levels (Norm.monic f))
       (Norm.rawPolynomial levels f) := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let ι := LevelSemantics.coeffHom levels hvalid hinjective hinv
   have hfSource : HexPolyMathlib.toPolynomial f ≠ 0 := by
@@ -101,7 +101,7 @@ theorem monicGcd_dvd
       Norm.coeffFieldPoly levels hvalid hinjective hinv
     Norm.monic (DensePoly.gcd f g) ∣ f ∧
       Norm.monic (DensePoly.gcd f g) ∣ g := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let raw := HexPolyMathlib.toPolynomial (DensePoly.gcd f g)
   let normalized := EuclideanDomain.gcd
@@ -139,7 +139,7 @@ theorem rawPolynomial_monicGcd_ne_zero
     (f g : DensePoly (Arithmetic.Coeff levels))
     (hf : Norm.rawPolynomial levels f ≠ 0) :
     Norm.rawPolynomial levels (Norm.monic (DensePoly.gcd f g)) ≠ 0 := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   have hfSource : HexPolyMathlib.toPolynomial f ≠ 0 := by
     intro hzero
@@ -185,7 +185,7 @@ theorem rootMultiplicity_monicGcd
       (Norm.monic (DensePoly.gcd f g))).rootMultiplicity z =
       min ((Norm.rawPolynomial levels f).rootMultiplicity z)
         ((Norm.rawPolynomial levels g).rootMultiplicity z) := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let sourceGcd := EuclideanDomain.gcd
     (HexPolyMathlib.toPolynomial f) (HexPolyMathlib.toPolynomial g)
@@ -257,7 +257,7 @@ theorem rawPolynomial_div_mul
     Norm.rawPolynomial levels (dividend / divisor) *
         Norm.rawPolynomial levels divisor =
       Norm.rawPolynomial levels dividend := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   have hmod : dividend % divisor = 0 :=
     DensePoly.mod_eq_zero_of_dvd dividend divisor hdivisor
@@ -284,7 +284,7 @@ theorem rawPolynomial_div_ne_zero
     (hdivisor : divisor ∣ dividend)
     (hdividend : Norm.rawPolynomial levels dividend ≠ 0) :
     Norm.rawPolynomial levels (dividend / divisor) ≠ 0 := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   intro hquotient
   have hreconstruct := rawPolynomial_div_mul hvalid hinjective hinv
@@ -303,7 +303,7 @@ theorem rootMultiplicity_monicDiv
       (Norm.monic (dividend / divisor))).rootMultiplicity z =
       (Norm.rawPolynomial levels dividend).rootMultiplicity z -
         (Norm.rawPolynomial levels divisor).rootMultiplicity z := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   have hquotient := rawPolynomial_div_ne_zero hvalid hinjective hinv
     dividend divisor hdivisor hdividend
@@ -325,7 +325,7 @@ theorem rawPolynomial_monicDiv_ne_zero
     (hdivisor : divisor ∣ dividend)
     (hdividend : Norm.rawPolynomial levels dividend ≠ 0) :
     Norm.rawPolynomial levels (Norm.monic (dividend / divisor)) ≠ 0 := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   have hquotient := rawPolynomial_div_ne_zero hvalid hinjective hinv
     dividend divisor hdivisor hdividend
@@ -354,7 +354,7 @@ theorem YunInvariant.step (z : ℂ) (r k : Nat)
     let shared := Norm.monic (DensePoly.gcd w repeated)
     let nextRepeated := Norm.monic (repeated / shared)
     YunInvariant z r (k + 1) shared nextRepeated := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let shared := Norm.monic (DensePoly.gcd w repeated)
   let nextRepeated := Norm.monic (repeated / shared)
@@ -401,7 +401,7 @@ theorem YunInvariant.component (z : ℂ) (r k : Nat)
     let component := Norm.monic (w / shared)
     (Norm.rawPolynomial levels component).rootMultiplicity z =
       if k = r then 1 else 0 := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let shared := Norm.monic (DensePoly.gcd w repeated)
   let component := Norm.monic (w / shared)
@@ -440,7 +440,7 @@ theorem YunInvariant.init
     YunInvariant z
       ((Norm.rawPolynomial levels f).rootMultiplicity z) 1
       distinct repeated := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let normalized := Norm.monic f
   let repeated := Norm.monic
@@ -510,7 +510,7 @@ re-elaborating the coefficient-field construction at every induction step. -/
 theorem natDegree_rawPolynomial
     (f : DensePoly (Arithmetic.Coeff levels)) :
     (Norm.rawPolynomial levels f).natDegree = f.degree?.getD 0 := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   rw [← Norm.rawPolynomialHom_apply levels hvalid hinjective hinv]
   change ((HexPolyMathlib.toPolynomial f).map
@@ -528,7 +528,7 @@ theorem rawPolynomial_eq_map
     Norm.rawPolynomial levels f =
       (HexPolyMathlib.toPolynomial f).map
         (LevelSemantics.coeffHom levels hvalid hinjective hinv) := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   rw [← Norm.rawPolynomialHom_apply levels hvalid hinjective hinv]
   rfl
@@ -540,7 +540,7 @@ theorem degree_pos_of_rawPolynomial_root
     (hf : Norm.rawPolynomial levels f ≠ 0) {z : ℂ}
     (hroot : (Norm.rawPolynomial levels f).IsRoot z) :
     0 < f.degree?.getD 0 := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   have hdegree := Polynomial.degree_pos_of_root hf hroot
   have hnatDegree : 0 < (Norm.rawPolynomial levels f).natDegree :=
@@ -581,7 +581,7 @@ theorem yunAux_sound (z : ℂ) (r : Nat)
     ∀ entry ∈ (Factor.yunAux levels w repeated k fuel out).toList,
       (Norm.rawPolynomial levels
         (Factor.rawPoly levels entry.1)).IsRoot z → entry.2 = r := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   induction fuel generalizing w repeated k out with
   | zero => simpa [Factor.yunAux] using hOut
@@ -643,7 +643,7 @@ theorem yunAux_rootMultiplicity_le_one (z : ℂ) (r : Nat)
     ∀ entry ∈ (Factor.yunAux levels w repeated k fuel out).toList,
       (Norm.rawPolynomial levels
         (Factor.rawPoly levels entry.1)).rootMultiplicity z ≤ 1 := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   induction fuel generalizing w repeated k out with
   | zero => simpa [Factor.yunAux] using hOut
@@ -684,7 +684,7 @@ theorem yunAux_complete (z : ℂ) (r : Nat)
     ∃ entry ∈ (Factor.yunAux levels w repeated k fuel out).toList,
       (Norm.rawPolynomial levels
         (Factor.rawPoly levels entry.1)).IsRoot z ∧ entry.2 = r := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   induction fuel generalizing w repeated k out with
   | zero => omega
@@ -854,7 +854,7 @@ theorem yunAux_monic
     ∀ entry ∈
       (Factor.yunAux levels w repeated multiplicity fuel out).toList,
       (Factor.rawPoly levels entry.1).leadingCoeff = 1 := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   induction fuel generalizing w repeated multiplicity out with
   | zero => simpa [Factor.yunAux] using hOut
@@ -912,7 +912,7 @@ theorem yun_sound
       (Factor.rawPoly levels entry.1)).IsRoot z) :
     entry.2 = (Norm.rawPolynomial levels
       (Factor.rawPoly levels f)).rootMultiplicity z := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let p := Factor.rawPoly levels f
   have hdegreeP : 0 < p.degree?.getD 0 := hdegree
@@ -951,7 +951,7 @@ theorem yun_complete
         (Factor.rawPoly levels entry.1)).IsRoot z ∧
       entry.2 = (Norm.rawPolynomial levels
         (Factor.rawPoly levels f)).rootMultiplicity z := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let p := Factor.rawPoly levels f
   have hdegreeP : 0 < p.degree?.getD 0 := hdegree
@@ -1001,7 +1001,7 @@ theorem yun_rootMultiplicity_le_one
     (hentry : entry ∈ (Factor.yunRaw levels f).toList) (z : ℂ) :
     (Norm.rawPolynomial levels
       (Factor.rawPoly levels entry.1)).rootMultiplicity z ≤ 1 := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let p := Factor.rawPoly levels f
   have hdegreeP : 0 < p.degree?.getD 0 := hdegree
@@ -1069,7 +1069,7 @@ theorem yun_squarefree
     (component : Array (Array Rat) × Nat)
     (hcomponent : component ∈ (Factor.yunRaw levels f).toList) :
     Norm.isSquarefree levels component.1 := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let P := Norm.rawPolynomial levels
     (Factor.rawPoly levels component.1)
@@ -1104,7 +1104,7 @@ theorem yun_coprime
     (hmultiplicity : a.2 < b.2) :
     (DensePoly.gcd (Factor.rawPoly levels a.1)
       (Factor.rawPoly levels b.1)).size ≤ 1 := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let pa := Factor.rawPoly levels a.1
   let pb := Factor.rawPoly levels b.1
@@ -1198,7 +1198,7 @@ theorem rawPolynomial_polyPow
     (f : DensePoly (Arithmetic.Coeff levels)) (n : Nat) :
     Norm.rawPolynomial levels (Factor.polyPow f n) =
       Norm.rawPolynomial levels f ^ n := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   induction n using Nat.strong_induction_on with
   | h n ih =>
@@ -1238,7 +1238,7 @@ theorem rawPolynomial_yunFold
         Norm.rawPolynomial levels
           (Factor.rawPoly levels component.1) ^ component.2).prod *
         Norm.rawPolynomial levels acc := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   induction components generalizing acc with
   | nil => simp
@@ -1271,7 +1271,7 @@ theorem yunMultiplicity_sum
         (Factor.rawPoly levels entry.1)).rootMultiplicity z).sum =
       (Norm.rawPolynomial levels
         (Factor.rawPoly levels f)).rootMultiplicity z := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let input := Norm.rawPolynomial levels (Factor.rawPoly levels f)
   have hinputNe : input ≠ 0 := by
@@ -1379,7 +1379,7 @@ theorem yun_rawPolynomial_monic
     (hentry : entry ∈ (Factor.yunRaw levels f).toList) :
     (Norm.rawPolynomial levels
       (Factor.rawPoly levels entry.1)).Monic := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   have hsource : (HexPolyMathlib.toPolynomial
       (Factor.rawPoly levels entry.1)).Monic := by
@@ -1396,7 +1396,7 @@ theorem yun_product
     (hdegree : 0 < (Factor.rawPoly levels f).degree?.getD 0) :
     Factor.yunProduct levels (Factor.yunRaw levels f) =
       Factor.polyCoords (Norm.monic (Factor.rawPoly levels f)) := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let p := Factor.rawPoly levels f
   let components := (Factor.yunRaw levels f).toList
@@ -1507,7 +1507,7 @@ certificate check. -/
 theorem checkYun_yunRaw
     (f : Array (Array Rat)) :
     Factor.checkYun levels f (Factor.yunRaw levels f) := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let p := Factor.rawPoly levels f
   by_cases hdegreeZero : p.degree?.getD 0 = 0

--- a/HexNumberFieldTowerMathlib/FactorGeneric/Yun.lean
+++ b/HexNumberFieldTowerMathlib/FactorGeneric/Yun.lean
@@ -693,13 +693,13 @@ theorem yunAux_complete (z : ℂ) (r : Nat)
         intro hone
         have hmultiplicity := invariant.w_multiplicity
         rw [hone, Norm.rawPolynomial_one levels hvalid hinjective hinv,
-          if_pos hindex] at hmultiplicity
+          ite_eq_left hindex] at hmultiplicity
         have honeMultiplicity :
             Polynomial.rootMultiplicity z (1 : Polynomial ℂ) = 0 := by
           simpa only [Polynomial.C_1] using
             Polynomial.rootMultiplicity_C (1 : ℂ) z
         omega
-      rw [Factor.yunAux, if_neg hnotOne]
+      rw [Factor.yunAux, ite_eq_right hnotOne]
       dsimp only
       let shared := Norm.monic (DensePoly.gcd w repeated)
       let component := Norm.monic (w / shared)
@@ -727,7 +727,7 @@ theorem yunAux_complete (z : ℂ) (r : Nat)
         have hdegree : 0 < component.degree?.getD 0 :=
           degree_pos_of_rawPolynomial_root hvalid hinjective hinv component
             hcomponentNe hroot
-        rw [if_pos hdegree]
+        rw [ite_eq_left hdegree]
         refine ⟨(Factor.polyCoords component, k), ?_, ?_, heq⟩
         · apply mem_yunAux_of_mem hvalid hinjective hinv
           simp [component, shared]
@@ -932,7 +932,7 @@ theorem yun_sound
       distinct repeated :=
     YunInvariant.init hvalid hinjective hinv p hpNe hnatDegree z
   unfold Factor.yunRaw at hentry
-  rw [if_neg (by omega : p.degree?.getD 0 ≠ 0)] at hentry
+  rw [ite_eq_right (by omega : p.degree?.getD 0 ≠ 0)] at hentry
   exact yunAux_sound hvalid hinjective hinv z
     ((Norm.rawPolynomial levels p).rootMultiplicity z)
     distinct repeated 1 (p.size + 1) #[] invariant (by simp)
@@ -990,7 +990,7 @@ theorem yun_complete
   have hcomplete := yunAux_complete hvalid hinjective hinv z r
     distinct repeated 1 (p.size + 1) #[] invariant hindex hfuel
   unfold Factor.yunRaw
-  rw [if_neg (by omega : p.degree?.getD 0 ≠ 0)]
+  rw [ite_eq_right (by omega : p.degree?.getD 0 ≠ 0)]
   exact hcomplete
 
 /-- Every emitted Yun component has only simple roots over `ℂ`. -/
@@ -1020,7 +1020,7 @@ theorem yun_rootMultiplicity_le_one
   have invariant : YunInvariant z r 1 distinct repeated :=
     YunInvariant.init hvalid hinjective hinv p hpNe hnatDegree z
   unfold Factor.yunRaw at hentry
-  rw [if_neg (by omega : p.degree?.getD 0 ≠ 0)] at hentry
+  rw [ite_eq_right (by omega : p.degree?.getD 0 ≠ 0)] at hentry
   exact yunAux_rootMultiplicity_le_one hvalid hinjective hinv z r
     distinct repeated 1 (p.size + 1) #[] invariant (by simp)
     entry hentry
@@ -1206,18 +1206,18 @@ theorem rawPolynomial_polyPow
       · subst n
         simp [Factor.polyPow, Norm.rawPolynomial_one levels hvalid
           hinjective hinv]
-      · rw [Factor.polyPow, if_neg hn]
+      · rw [Factor.polyPow, ite_eq_right hn]
         have hhalf : n / 2 < n :=
           Nat.div_lt_self (Nat.pos_of_ne_zero hn) (by omega)
         dsimp only
         by_cases heven : n % 2 = 0
-        · rw [if_pos heven,
+        · rw [ite_eq_left heven,
             Norm.rawPolynomial_mul levels hvalid hinjective hinv,
             ih (n / 2) hhalf]
           rw [← pow_add]
           congr 1
           omega
-        · rw [if_neg heven,
+        · rw [ite_eq_right heven,
             Norm.rawPolynomial_mul levels hvalid hinjective hinv,
             Norm.rawPolynomial_mul levels hvalid hinjective hinv,
             ih (n / 2) hhalf]
@@ -1572,7 +1572,7 @@ theorem checkYun_yunRaw
     have hproduct : Factor.yunProduct levels components =
         Factor.polyCoords (Norm.monic p) :=
       yun_product hvalid hinjective hinv f hdegree
-    simp only [Factor.checkYun, p, hdegreeZero, if_false,
+    simp only [Factor.checkYun, p, hdegreeZero, ite_false,
       Bool.and_eq_true]
     exact ⟨⟨⟨⟨hmultiplicities, hpositiveMonic⟩, hcoprime⟩,
       hsquarefree⟩, decide_eq_true hproduct⟩

--- a/HexNumberFieldTowerMathlib/Flatten.lean
+++ b/HexNumberFieldTowerMathlib/Flatten.lean
@@ -739,7 +739,7 @@ private theorem checkCoordinate?_sound (target gamma : AlgebraicNumber)
     (coordinate out : QAdjoin gamma.p gamma.x)
     (h : checkCoordinate? target gamma coordinate = some out) :
     QAdjoin.toComplex out gamma.rep gamma.rep_mk = target.toComplex := by
-  letI : ZPoly.CheckedIrreducible gamma.p := gamma.checked
+  let : ZPoly.CheckedIrreducible gamma.p := gamma.checked
   unfold checkCoordinate? at h
   obtain ⟨recovered, hrecovered, h⟩ := Option.bind_eq_some_iff.mp h
   by_cases heq : recovered == target
@@ -780,7 +780,7 @@ private theorem recoverPairFast?_sound (theta alpha gamma : AlgebraicNumber)
   by_cases hshift : shift = 0
   · simp [hshift] at h
   · simp only [hshift, ↓reduceIte] at h
-    letI : ZPoly.CheckedIrreducible gamma.p := gamma.checked
+    let : ZPoly.CheckedIrreducible gamma.p := gamma.checked
     let gammaCoordinate := gamma.toQAdjoin
     let affine : DensePoly (QAdjoin gamma.p gamma.x) :=
       DensePoly.ofList
@@ -1671,7 +1671,7 @@ private theorem fold_unit_range {p : ZPoly} {x : SimpleRoot p}
     (List.range count).foldl (fun value i =>
       if index = i then value + (1 : Rat) • values i else value) 0 =
         if index < count then values index else 0 := by
-  letI : Field (QAdjoin p x) := QAdjoin.field p x
+  let : Field (QAdjoin p x) := QAdjoin.field p x
   induction count with
   | zero => simp
   | succ count ih =>
@@ -1717,7 +1717,7 @@ private theorem basisImages_complex (T : NumberTower)
         (basisImages generators candidate.coordinates |>.getD index 0)
         candidate.root.rep candidate.root.rep_mk =
       T.toComplex (T.ofCoeffs (unitCoords T.dim index)) := by
-  letI : ZPoly.CheckedIrreducible candidate.root.p := candidate.root.checked
+  let : ZPoly.CheckedIrreducible candidate.root.p := candidate.root.checked
   have hgeneratorShape := generators?_shape T hgenerators
   have hcandidateShape := candidate?_shape T generators hcandidate
   have hcoordinates := candidate?_represents T generators hcandidate
@@ -1771,7 +1771,7 @@ private theorem constructed_basis_roundtrip (T : NumberTower)
         (toPrimitiveWith (basisImages generators candidate.coordinates)
           (T.ofCoeffs (unitCoords T.dim index))) =
       T.ofCoeffs (unitCoords T.dim index) := by
-  letI : ZPoly.CheckedIrreducible candidate.root.p := candidate.root.checked
+  let : ZPoly.CheckedIrreducible candidate.root.p := candidate.root.checked
   rw [toPrimitiveWith_unit _ index hindex]
   apply toComplex_injective T
   rw [fromPrimitiveWith_complex candidate.value candidate.root.rep
@@ -1815,12 +1815,12 @@ theorem flatten?_sound (T : NumberTower) {F : Flattening T}
     have hgeneratorsSound := Flatten.generators?_sound T hgenerators
     have hcandidateSound := Flatten.candidate?_matches T generators
       hgeneratorsSound hcandidate
-    letI : ZPoly.CheckedIrreducible candidate.root.p :=
+    let : ZPoly.CheckedIrreducible candidate.root.p :=
       candidate.root.checked
     let rep := candidate.root.rep
     have hrep : SimpleRoot.mk rep = candidate.root.x :=
       candidate.root.rep_mk
-    letI : Field (Elem T) := elemField T
+    let : Field (Elem T) := elemField T
     let towerAdd : Elem T →+ ℂ :=
       { toFun := T.toComplex
         map_zero' := by
@@ -1830,7 +1830,7 @@ theorem flatten?_sound (T : NumberTower) {F : Flattening T}
           intro a b
           change T.toComplex (a + b) = T.toComplex a + T.toComplex b
           exact map_add T a b }
-    letI : Module Rat (Elem T) :=
+    let : Module Rat (Elem T) :=
       Function.Injective.module Rat towerAdd (toComplex_injective T)
         (fun q a => by
           change T.toComplex (q • a) = q • T.toComplex a
@@ -1998,7 +1998,7 @@ theorem flatten_toComplex (T : NumberTower) {F : Flattening T}
     (h : T.flatten? = some F) (a : Elem T) :
     QAdjoin.toComplex (F.toPrimitive a) F.root.rep F.root.rep_mk =
       T.toComplex a := by
-  letI : ZPoly.CheckedIrreducible F.root.p := F.root.checked
+  let : ZPoly.CheckedIrreducible F.root.p := F.root.checked
   exact (flatten?_sound T h).2.2.1 a
 
 /-- The inverse primitive coordinate map preserves the fixed complex value. -/
@@ -2006,7 +2006,7 @@ theorem flatten_fromComplex (T : NumberTower) {F : Flattening T}
     (h : T.flatten? = some F) (a : QAdjoin F.root.p F.root.x) :
     T.toComplex (F.fromPrimitive a) =
       QAdjoin.toComplex a F.root.rep F.root.rep_mk := by
-  letI : ZPoly.CheckedIrreducible F.root.p := F.root.checked
+  let : ZPoly.CheckedIrreducible F.root.p := F.root.checked
   exact (flatten?_sound T h).2.2.2.1 a
 
 end Hex.NumberTower

--- a/HexNumberFieldTowerMathlib/Flatten.lean
+++ b/HexNumberFieldTowerMathlib/Flatten.lean
@@ -535,9 +535,9 @@ private theorem toPrimitiveFold_complex {T : NumberTower}
   | cons i indices ih =>
       simp only [List.foldl_cons, List.map_cons, List.sum_cons]
       by_cases hzero : (coeffs a).getD i 0 = 0
-      · rw [if_pos hzero]
+      · rw [ite_eq_left hzero]
         simpa [hzero] using ih initial
-      · rw [if_neg hzero, ih, QAdjoin.map_add, QAdjoin.map_smul]
+      · rw [ite_eq_right hzero, ih, QAdjoin.map_add, QAdjoin.map_smul]
         ring
 
 private theorem toPrimitiveWith_complex {T : NumberTower}
@@ -1427,7 +1427,7 @@ private theorem block_unitCoords (degree width index exponent : Nat)
       Vector.getElem_ofFn]
     rw [unitCoords_getD]
     by_cases heq : exponent = index / width
-    · simp only [if_pos heq] at hright ⊢
+    · simp only [ite_eq_left heq] at hright ⊢
       rw [unitCoords_getElem width (index % width) offset hoffset]
       by_cases hsame : index % width = offset
       · have hposition := (blockIndex_iff index exponent width offset
@@ -1438,7 +1438,7 @@ private theorem block_unitCoords (degree width index exponent : Nat)
           exact hsame ((blockIndex_iff index exponent width offset
             hwidth hoffset).mp hposition).2
         simp [hglobal, hposition, hsame]
-    · simp only [if_neg heq] at hright ⊢
+    · simp only [ite_eq_right heq] at hright ⊢
       simp only [Arithmetic.fixedCoeffs, Vector.getElem_toArray,
         Vector.getElem_ofFn, Array.getD, Array.size_empty,
         Nat.not_lt_zero, ↓reduceIte]
@@ -1513,7 +1513,7 @@ private theorem levelBasis_get (levels : List Level) (hvalid : LevelsValid level
             exponent width) * level.root.toComplex ^ exponent = 0
         rw [block_unitCoords level.degree width index exponent hwidth
           (by simpa [width, levelsDim] using hindex) hexponent']
-        rw [if_neg hne]
+        rw [ite_eq_right hne]
         change LevelSemantics.denote lower
           (Arithmetic.fixedCoeffs (levelsDim lower) #[]) *
             level.root.toComplex ^ exponent = 0

--- a/HexNumberFieldTowerMathlib/NormCore/Basic.lean
+++ b/HexNumberFieldTowerMathlib/NormCore/Basic.lean
@@ -337,9 +337,9 @@ theorem rawPolynomialHom_apply (levels : List Level)
     letI : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
     rawPolynomialHom levels hvalid hinjective hinv f =
       rawPolynomial levels f := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     coeffFieldPoly levels hvalid hinjective hinv
-  letI : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
   ext n
   rw [coeff_rawPolynomial, rawToComplex_eq_denote]
   simp [rawPolynomialHom, LevelSemantics.coeffHom,
@@ -359,7 +359,7 @@ theorem rawPolynomial_eq_map (levels : List Level)
     rawPolynomial levels f =
       (HexPolyMathlib.toPolynomial f).map
         (LevelSemantics.coeffHom levels hvalid hinjective hinv) := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     coeffFieldPoly levels hvalid hinjective hinv
   rw [← rawPolynomialHom_apply levels hvalid hinjective hinv]
   rfl
@@ -373,9 +373,9 @@ theorem rawPolynomial_injective (levels : List Level)
       LevelSemantics.coeffDenote levels a⁻¹ =
         (LevelSemantics.coeffDenote levels a)⁻¹) :
     Function.Injective (rawPolynomial levels) := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     coeffFieldPoly levels hvalid hinjective hinv
-  letI : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
   intro f g h
   apply (HexPolyMathlib.equiv
     (R := Arithmetic.Coeff levels)).injective
@@ -399,9 +399,9 @@ theorem rawPolynomial_one (levels : List Level)
       LevelSemantics.coeffDenote levels a⁻¹ =
         (LevelSemantics.coeffDenote levels a)⁻¹) :
     rawPolynomial levels 1 = 1 := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     coeffFieldPoly levels hvalid hinjective hinv
-  letI : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
   rw [← rawPolynomialHom_apply levels hvalid hinjective hinv]
   exact (rawPolynomialHom levels hvalid hinjective hinv).map_one
 
@@ -417,9 +417,9 @@ theorem rawPolynomial_mul (levels : List Level)
     (f g : DensePoly (Arithmetic.Coeff levels)) :
     rawPolynomial levels (f * g) =
       rawPolynomial levels f * rawPolynomial levels g := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     coeffFieldPoly levels hvalid hinjective hinv
-  letI : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
   let φ := rawPolynomialHom levels hvalid hinjective hinv
   calc
     rawPolynomial levels (f * g) = φ (f * g) :=
@@ -441,9 +441,9 @@ theorem rawPolynomial_C (levels : List Level)
     (a : Arithmetic.Coeff levels) :
     rawPolynomial levels (DensePoly.C a) =
       Polynomial.C (LevelSemantics.coeffDenote levels a) := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     coeffFieldPoly levels hvalid hinjective hinv
-  letI : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
   rw [← rawPolynomialHom_apply levels hvalid hinjective hinv]
   simp [rawPolynomialHom, HexPolyMathlib.toPolynomial_C,
     LevelSemantics.coeffHom]
@@ -556,7 +556,7 @@ theorem conjugatePolynomial_eq_map (level : Level) (lower : List Level)
       (HexPolyMathlib.toPolynomial
         (Factor.rawPoly (level :: lower) f)).map
           (conjugateMap level lower hvalid hinjective x hrelation) := by
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     coeffFieldPoly (level :: lower) hvalid hinjective
       (LevelSemantics.coeffDenote_inv (level :: lower) hvalid hinjective)
   ext n
@@ -641,9 +641,9 @@ theorem derivative_eq (levels : List Level)
     letI : Field (Arithmetic.Coeff levels) :=
       coeffFieldPoly levels hvalid hinjective hinv
     derivative levels f = DensePoly.derivative f := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     coeffFieldPoly levels hvalid hinjective hinv
-  letI : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
   apply rawPolynomial_injective levels hvalid hinjective hinv
   rw [rawPolynomial_derivative]
   have hmap (g : DensePoly (Arithmetic.Coeff levels)) :
@@ -666,9 +666,9 @@ theorem isSquarefree_iff (levels : List Level)
     (f : Array (Array Rat)) :
     Norm.isSquarefree levels f ↔
       Squarefree (rawPolynomial levels (Factor.rawPoly levels f)) := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     coeffFieldPoly levels hvalid hinjective hinv
-  letI : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
   let p := Factor.rawPoly levels f
   let P := HexPolyMathlib.toPolynomial p
   let d := DensePoly.derivative p
@@ -798,9 +798,9 @@ theorem rawOuter_eq_map (levels : List Level)
     letI : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
     rawOuter levels f = (HexPolyMathlib.toPolynomial f).map
       (rawPolynomialHom levels hvalid hinjective hinv) := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     coeffFieldPoly levels hvalid hinjective hinv
-  letI : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
   ext n
   rw [coeff_rawOuter, Polynomial.coeff_map,
     HexPolyMathlib.coeff_toPolynomial,
@@ -926,11 +926,11 @@ theorem outerEval_map (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
   let topHom := LevelSemantics.coeffHom (level :: lower) hvalid
     hinjectiveTop hinvTop
   let lowerPolyHom : DensePoly (Arithmetic.Coeff lower) →+*
@@ -990,9 +990,9 @@ theorem eval_liftCoefficient (level : Level) (lower : List Level)
     (rawOuter lower (liftCoefficient level lower a)).eval
         (Polynomial.C x) =
       Polynomial.C (LevelSemantics.evalAt level lower x a) := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjective hinv
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
   let lifted := liftCoefficient level lower a
   have hsize : lifted.size ≤ level.degree := by
     exact (DensePoly.size_ofCoeffs_le _).trans (by simp [lifted,
@@ -1039,9 +1039,9 @@ theorem eval_shiftBase (lower : List Level)
         DensePoly.C (Arithmetic.Coeff.ofData lower #[(-(c : Rat))])]
     (rawOuter lower base).eval (Polynomial.C x) =
       Polynomial.X - Polynomial.C ((c : ℂ) * x) := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid hinjective hinv
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
   let base : DensePoly (DensePoly (Arithmetic.Coeff lower)) :=
     DensePoly.ofCoeffs #[DensePoly.monomial 1 1,
       DensePoly.C (Arithmetic.Coeff.ofData lower #[(-(c : Rat))])]
@@ -1085,9 +1085,9 @@ theorem eval_shiftedOuter (level : Level) (lower : List Level)
         (Polynomial.C x) =
       (conjugatePolynomial level lower x f).comp
         (Polynomial.X - Polynomial.C ((c : ℂ) * x)) := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjective hinv
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
   let ψ (g : DensePoly (DensePoly (Arithmetic.Coeff lower))) :
       Polynomial ℂ := (rawOuter lower g).eval (Polynomial.C x)
   let q := Polynomial.X - Polynomial.C ((c : ℂ) * x)
@@ -1190,9 +1190,9 @@ theorem rawOuter_defining (level : Level) (lower : List Level)
     change Arithmetic.Coeff.ofData lower #[] =
       Arithmetic.Coeff.ofData lower #[]
     rfl
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjective hinv
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
   apply Polynomial.ext
   intro n
   by_cases hn : n ≤ level.degree
@@ -1231,11 +1231,11 @@ theorem outerEval_defining (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
   let topHom := LevelSemantics.coeffHom (level :: lower) hvalid
     hinjectiveTop hinvTop
   apply Polynomial.map_injective topHom topHom.injective
@@ -1301,7 +1301,7 @@ theorem conjugatePolynomial_shiftTop (level : Level)
         (Polynomial.X - Polynomial.C ((c : ℂ) * x)) := by
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   let conjugate := conjugateMap level lower hvalid hinjectiveTop x hrelation
   have hsource : conjugatePolynomial level lower x f =
@@ -1394,11 +1394,11 @@ theorem outerEval_shifted (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
   let topHom := LevelSemantics.coeffHom (level :: lower) hvalid
     hinjectiveTop hinvTop
   have hrelation :

--- a/HexNumberFieldTowerMathlib/NormCore/Basic.lean
+++ b/HexNumberFieldTowerMathlib/NormCore/Basic.lean
@@ -295,7 +295,7 @@ theorem topGenerator_evalAt (level : Level) (lower : List Level)
       have := hvalid.1.1
       omega
     unfold Factor.topGenerator
-    rw [if_neg hdegree]
+    rw [ite_eq_right hdegree]
     change LevelSemantics.evalAt level lower x
         (Arithmetic.fixedCoeffs (level.degree * levelsDim lower)
           ((Array.replicate (levelsDim lower) 0).push 1)) = x
@@ -571,7 +571,7 @@ theorem conjugatePolynomial_eq_map (level : Level) (lower : List Level)
     have hright : (f.map
         (Arithmetic.Coeff.ofData (level :: lower))).getD n 0 =
           Arithmetic.Coeff.ofData (level :: lower) f[n] := by
-      rw [Array.getD, dif_pos hnmap]
+      rw [Array.getD, dite_eq_left hnmap]
       simp
     rw [hleft]
     calc
@@ -591,7 +591,7 @@ theorem conjugatePolynomial_eq_map (level : Level) (lower : List Level)
       simp [Array.getD, hn]
     have hright : (f.map
         (Arithmetic.Coeff.ofData (level :: lower))).getD n 0 = 0 := by
-      rw [Array.getD, dif_neg hnmap]
+      rw [Array.getD, dite_eq_right hnmap]
     rw [hleft]
     calc
       LevelSemantics.evalAt level lower x #[] =

--- a/HexNumberFieldTowerMathlib/NormCore/Trager.lean
+++ b/HexNumberFieldTowerMathlib/NormCore/Trager.lean
@@ -33,11 +33,11 @@ private theorem relation_sum_of_mem_rootSet (level : Level)
     (∑ j ∈ Finset.range level.degree,
         LevelSemantics.denote lower (level.defining.getD j #[]) * x ^ j) +
       x ^ level.degree = 0 := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjective hinv
   let ι : Arithmetic.Coeff lower →+* ℂ :=
     LevelSemantics.coeffHom lower hvalid.2.2 hinjective hinv
-  letI : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
+  let : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
   change x ∈ (HexPolyMathlib.toPolynomial
     (Arithmetic.Coeff.relation level lower)).rootSet ℂ → _
   intro hx
@@ -113,10 +113,10 @@ theorem oneLevel_resultant (level : Level) (lower : List Level)
         (rawOuter lower (shiftedOuter level lower f c))
         (m := (definingOuter level lower).degree?.getD 0)
         (n := (shiftedOuter level lower f c).degree?.getD 0) := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hlower hinjective hinv
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
-  letI : IsDomain (DensePoly (Arithmetic.Coeff lower)) :=
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : IsDomain (DensePoly (Arithmetic.Coeff lower)) :=
     (HexPolyMathlib.equiv
       (R := Arithmetic.Coeff lower)).toMulEquiv.isDomain
         (Polynomial (Arithmetic.Coeff lower))
@@ -170,14 +170,14 @@ theorem oneLevel_shift_zero (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
   let ι : Arithmetic.Coeff lower →+* ℂ :=
     LevelSemantics.coeffHom lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
+  let : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
   let relation := Arithmetic.Coeff.relation level lower
   let p := HexPolyMathlib.toPolynomial relation
   let shifted := Factor.shiftTop level lower f c
@@ -309,12 +309,12 @@ theorem shifted_dvd_norm (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
-  letI : IsDomain (DensePoly (Arithmetic.Coeff lower)) :=
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : IsDomain (DensePoly (Arithmetic.Coeff lower)) :=
     (HexPolyMathlib.equiv
       (R := Arithmetic.Coeff lower)).toMulEquiv.isDomain
         (Polynomial (Arithmetic.Coeff lower))
@@ -385,14 +385,14 @@ theorem oneLevel_ne_zero (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
   let ι : Arithmetic.Coeff lower →+* ℂ :=
     LevelSemantics.coeffHom lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
+  let : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
   let relation := Arithmetic.Coeff.relation level lower
   let p := HexPolyMathlib.toPolynomial relation
   have hpDegree : p.natDegree = level.degree := by
@@ -545,14 +545,14 @@ theorem oneLevel_mul (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
   let ι : Arithmetic.Coeff lower →+* ℂ :=
     LevelSemantics.coeffHom lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
+  let : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
   let relation := Arithmetic.Coeff.relation level lower
   let p := HexPolyMathlib.toPolynomial relation
   let M := rawOuter lower (definingOuter level lower)
@@ -698,17 +698,17 @@ theorem oneLevel_lift (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
   let lifted := HexPolyMathlib.ofPolynomial
     ((HexPolyMathlib.toPolynomial q).map
       (lowerHom level lower hvalid hinjectiveTop))
   let ι : Arithmetic.Coeff lower →+* ℂ :=
     LevelSemantics.coeffHom lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
+  let : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
   let relation := Arithmetic.Coeff.relation level lower
   let p := HexPolyMathlib.toPolynomial relation
   let M := rawOuter lower (definingOuter level lower)
@@ -980,16 +980,16 @@ theorem findSquarefreeShift_isSome_of_injective
     hinjectiveTop.tail level lower hvalid.1.1
   let hinvLower := LevelSemantics.coeffDenote_inv lower hvalid.2.2
     hinjectiveLower
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
   let ι : Arithmetic.Coeff lower →+* ℂ :=
     LevelSemantics.coeffHom lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : CharZero (Arithmetic.Coeff lower) :=
+  let : CharZero (Arithmetic.Coeff lower) :=
     { cast_injective := fun m n h => by
         apply CharZero.cast_injective (R := ℂ)
         simpa only [map_natCast] using congrArg ι h }
-  letI : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
+  let : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
   let relation := Arithmetic.Coeff.relation level lower
   let p := HexPolyMathlib.toPolynomial relation
   have hpIrreducible : Irreducible p := by
@@ -1013,7 +1013,7 @@ theorem findSquarefreeShift_isSome_of_injective
       (IsAlgClosed.splits _), hpDegree]
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   let P := HexPolyMathlib.toPolynomial
     (Factor.rawPoly (level :: lower) f)

--- a/HexNumberFieldTowerMathlib/Split.lean
+++ b/HexNumberFieldTowerMathlib/Split.lean
@@ -367,7 +367,7 @@ theorem factorRoot?_isSome (T : NumberTower) (f : Poly T)
       (factorEliminant T f) hcoreSize hnot z hcoreRoot
   unfold factorRoot?
   dsimp only
-  rw [dif_pos hprim, dif_pos hpos, dif_pos hdegree, dif_pos hsimple]
+  rw [dite_eq_left hprim, dite_eq_left hpos, dite_eq_left hdegree, dite_eq_left hsimple]
   have hisolateSome := HexRootsMathlib.isolate_isSome
     (factorEliminant T f) hsimple hcoreNe
     (separationDepth (factorEliminant T f) : Int) .nkThenPellet
@@ -380,7 +380,7 @@ theorem factorRoot?_isSome (T : NumberTower) (f : Poly T)
         (xs := isolations) (f := DyadicRootIsolation.toRefined?)
         (fun iso hiso => by
           unfold DyadicRootIsolation.toRefined?
-          rw [dif_pos (HexRootsMathlib.isolate_refined
+          rw [dite_eq_left (HexRootsMathlib.isolate_refined
             (factorEliminant T f) hsimple
             (separationDepth (factorEliminant T f) : Int)
             .nkThenPellet hisolate iso hiso)]

--- a/HexNumberFieldTowerMathlib/Split.lean
+++ b/HexNumberFieldTowerMathlib/Split.lean
@@ -35,11 +35,11 @@ private theorem oneLevel_isRoot (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
   have hdvd := shifted_dvd_norm level lower hvalid hinjectiveTop f 0
   have hdvdComplex := Polynomial.map_dvd
     (LevelSemantics.coeffHom (level :: lower) hvalid hinjectiveTop hinvTop)
@@ -80,7 +80,7 @@ private theorem basePolynomial (f : Array (Array Rat)) :
     rawPolynomial [] (Factor.rawPoly [] f) =
       (HexPolyMathlib.toPolynomial (Factor.toRatPoly f)).map
         (algebraMap Rat ℂ) := by
-  letI : Field (Arithmetic.Coeff []) := LevelSemantics.coeffFieldNil
+  let : Field (Arithmetic.Coeff []) := LevelSemantics.coeffFieldNil
   have hvalidNil : LevelsValid [] := by exact trivial
   have hhom :
       (algebraMap Rat ℂ).comp LevelSemantics.coeffRatEquiv.toRingHom =
@@ -117,7 +117,7 @@ theorem iterated_isRoot_toRat (T : NumberTower) (f : Poly T) (z : ℂ)
 
 private theorem toRatPoly_ne_zero (f : Array (Array Rat))
     (hf : Factor.rawPoly [] f ≠ 0) : Factor.toRatPoly f ≠ 0 := by
-  letI : Field (Arithmetic.Coeff []) := LevelSemantics.coeffFieldNil
+  let : Field (Arithmetic.Coeff []) := LevelSemantics.coeffFieldNil
   intro hzero
   have hmap := LevelSemantics.map_rawPoly_nil f
   rw [hzero, HexPolyMathlib.toPolynomial_zero] at hmap

--- a/HexPolyFp/Compose.lean
+++ b/HexPolyFp/Compose.lean
@@ -82,7 +82,7 @@ composition. -/
     DensePoly.compose (FpPoly.X : FpPoly p) q = q := by
   unfold DensePoly.compose DensePoly.toList DensePoly.toArray FpPoly.X DensePoly.monomial
   have h1 : (1 : ZMod64 p) ≠ (Zero.zero : ZMod64 p) := one_ne_zero_of_prime
-  rw [dif_neg h1]
+  rw [dite_eq_right h1]
   show ((0 : FpPoly p) * q + DensePoly.C (1 : ZMod64 p)) * q +
       DensePoly.C (Zero.zero : ZMod64 p) = q
   have hstep1 : ((0 : FpPoly p) * q + DensePoly.C (1 : ZMod64 p)) = (1 : FpPoly p) := by
@@ -250,7 +250,7 @@ private theorem monomial_one_toList_eq
   show ((DensePoly.monomial k (1 : ZMod64 p) : FpPoly p).coeffs.toList :
     List (ZMod64 p)) = _
   unfold DensePoly.monomial
-  rw [dif_neg h1]
+  rw [dite_eq_right h1]
   show ((Array.replicate k (Zero.zero : ZMod64 p)).push (1 : ZMod64 p)).toList =
     List.replicate k (Zero.zero : ZMod64 p) ++ [(1 : ZMod64 p)]
   rw [Array.toList_push, Array.toList_replicate]
@@ -295,7 +295,7 @@ private theorem monomial_toList_eq (k : Nat) {c : ZMod64 p}
       List.replicate k (Zero.zero : ZMod64 p) ++ [c] := by
   show ((DensePoly.monomial k c : FpPoly p).coeffs.toList : List (ZMod64 p)) = _
   unfold DensePoly.monomial
-  rw [dif_neg hc]
+  rw [dite_eq_right hc]
   show ((Array.replicate k (Zero.zero : ZMod64 p)).push c).toList =
     List.replicate k (Zero.zero : ZMod64 p) ++ [c]
   rw [Array.toList_push, Array.toList_replicate]
@@ -313,7 +313,7 @@ theorem compose_monomial [ZMod64.PrimeModulus p] (w : FpPoly p) (k : Nat)
   · subst hc
     have hzero : (DensePoly.monomial k (Zero.zero : ZMod64 p) : FpPoly p) = 0 := by
       unfold DensePoly.monomial
-      rw [dif_pos rfl]
+      rw [dite_eq_left rfl]
     have hCz : (DensePoly.C (Zero.zero : ZMod64 p) : FpPoly p) = 0 := C_zero_eq_zero
     rw [hzero, compose_zero, hCz, FpPoly.zero_mul]
   · rw [compose_eq_powerSum, monomial_toList_eq k hc,
@@ -632,7 +632,7 @@ private theorem composeScalarCoeffList_trim
       unfold DensePoly.trimTrailingZerosList
       by_cases htrim :
           DensePoly.trimTrailingZerosList cs = [] ∧ c = (Zero.zero : ZMod64 p)
-      · rw [if_pos htrim]
+      · rw [ite_eq_left htrim]
         have htail : DensePoly.trimTrailingZerosList cs = [] := htrim.1
         have hc : c = (Zero.zero : ZMod64 p) := htrim.2
         have hih := composeScalarCoeffList_trim q cs
@@ -654,7 +654,7 @@ private theorem composeScalarCoeffList_trim
         rw [show (DensePoly.C (Zero.zero : ZMod64 p) : FpPoly p) = 0 from
           fp_C_zero]
         rw [FpPoly.mul_zero, FpPoly.zero_add]
-      · rw [if_neg htrim]
+      · rw [ite_eq_right htrim]
         simp only [DensePoly.composeScalarCoeffList]
         rw [composeScalarCoeffList_trim q cs]
 
@@ -949,7 +949,7 @@ private theorem composeCoeffPowerSumUpTo_X_coeff
       simp only [composeCoeffPowerSumUpTo]
       rw [DensePoly.coeff_zero]
       have hneg : ¬ (base ≤ k ∧ k < base + 0) := by intro ⟨_, h⟩; omega
-      rw [if_neg hneg]
+      rw [ite_eq_right hneg]
       rfl
   | n + 1, base, k => by
       simp only [composeCoeffPowerSumUpTo]
@@ -970,31 +970,31 @@ private theorem composeCoeffPowerSumUpTo_X_coeff
       have hzz_add : (Zero.zero : ZMod64 p) + Zero.zero = Zero.zero := by
         grind
       by_cases hk_base : k = base
-      · rw [if_pos hk_base]
+      · rw [ite_eq_left hk_base]
         have hneg' : ¬ (base + 1 ≤ k ∧ k < base + 1 + n) := by
           intro ⟨h, _⟩; omega
-        rw [if_neg hneg']
+        rw [ite_eq_right hneg']
         have hpos : base ≤ k ∧ k < base + (n + 1) := by
           refine ⟨?_, ?_⟩ <;> omega
-        rw [if_pos hpos]
+        rw [ite_eq_left hpos]
         have hmul_one : coeff base * (1 : ZMod64 p) = coeff k := by
           rw [hk_base]; grind
         rw [hmul_one]
         show coeff k + (Zero.zero : ZMod64 p) = coeff k
         rw [hzz]; grind
-      · rw [if_neg hk_base]
+      · rw [ite_eq_right hk_base]
         rw [hmul_zero]
         by_cases hkb : base ≤ k
         · have hk1 : base + 1 ≤ k := by omega
           by_cases hcond : k < base + (n + 1)
           · have hcond' : k < base + 1 + n := by omega
-            rw [if_pos ⟨hk1, hcond'⟩, if_pos ⟨hkb, hcond⟩]
+            rw [ite_eq_left ⟨hk1, hcond'⟩, ite_eq_left ⟨hkb, hcond⟩]
             rw [hzz]; grind
-          · rw [if_neg (fun ⟨_, h⟩ => hcond (by omega))]
-            rw [if_neg (fun ⟨_, h⟩ => hcond h)]
+          · rw [ite_eq_right (fun ⟨_, h⟩ => hcond (by omega))]
+            rw [ite_eq_right (fun ⟨_, h⟩ => hcond h)]
             exact hzz_add
         · have hk1 : ¬ (base + 1 ≤ k) := by omega
-          rw [if_neg (fun ⟨h, _⟩ => hk1 h), if_neg (fun ⟨h, _⟩ => hkb h)]
+          rw [ite_eq_right (fun ⟨h, _⟩ => hk1 h), ite_eq_right (fun ⟨h, _⟩ => hkb h)]
           exact hzz_add
 
 private theorem composeCoeffPowerSumUpTo_self_X_eq_self
@@ -1006,7 +1006,7 @@ private theorem composeCoeffPowerSumUpTo_self_X_eq_self
   by_cases hk : k < w.size
   · simp [hk]
   · have hk' : w.size ≤ k := Nat.le_of_not_gt hk
-    rw [if_neg (by intro ⟨_, h⟩; omega : ¬ (0 ≤ k ∧ k < 0 + w.size))]
+    rw [ite_eq_right (by intro ⟨_, h⟩; omega : ¬ (0 ≤ k ∧ k < 0 + w.size))]
     exact (DensePoly.coeff_eq_zero_of_size_le w hk').symm
 
 /-- Substituting the polynomial indeterminate into `w` returns `w`.

--- a/HexPolyFp/Enumeration.lean
+++ b/HexPolyFp/Enumeration.lean
@@ -244,7 +244,7 @@ theorem of_first_coeffs_eq_of_degree_getD_lt {f : FpPoly p} {d : Nat}
   · simp [hn]
   · have hsize_le : f.size ≤ d := size_le_of_degree_getD_lt hdeg
     have hn_size : f.size ≤ n := Nat.le_trans hsize_le (Nat.le_of_not_gt hn)
-    rw [if_neg hn]
+    rw [ite_eq_right hn]
     exact (DensePoly.coeff_eq_zero_of_size_le f hn_size).symm
 
 /-- Every polynomial with degree below `d` appears in the bounded-degree list. -/

--- a/HexPolyFp/Frobenius.lean
+++ b/HexPolyFp/Frobenius.lean
@@ -350,7 +350,7 @@ private theorem powModMonicAux_mod_eq
               DensePoly.modByMonic_eq_mod _ _ hmonic]
         rcases Nat.mod_two_eq_zero_or_one (m + 1) with hmod | hmod
         · -- (m + 1) is even
-          rw [if_pos hmod]
+          rw [ite_eq_left hmod]
           have hk : 2 * ((m + 1) / 2) = m + 1 := by
             have h := Nat.mod_add_div (m + 1) 2
             omega
@@ -369,7 +369,7 @@ private theorem powModMonicAux_mod_eq
                   rw [powLinear_double]
             _ = (acc * powLinear base (m + 1)) % f := by rw [hk]
         · -- (m + 1) is odd
-          rw [if_neg (by omega)]
+          rw [ite_eq_right (by omega)]
           rw [show modByMonic f (acc * base) hmonic = (acc * base) % f from
                 DensePoly.modByMonic_eq_mod _ _ hmonic]
           have hk : 2 * ((m + 1) / 2) + 1 = m + 1 := by
@@ -416,7 +416,7 @@ private theorem powModMonicAux_pos_self_mod
             have h := Nat.mod_add_div (k + 1) 2
             omega
           subst hkz
-          rw [if_neg (by decide : ¬ ((1 : Nat)) % 2 = 0)]
+          rw [ite_eq_right (by decide : ¬ ((1 : Nat)) % 2 = 0)]
           rw [modByMonic_eq_mod_swap f (acc * base) hmonic,
               DensePoly.mod_mod (acc * base) f]
         · -- Recurse via IH with strictly smaller fuel.

--- a/HexPolyFp/Packed.lean
+++ b/HexPolyFp/Packed.lean
@@ -224,12 +224,12 @@ theorem arrayDegreeAuxPacked_eq (a : Array (ZMod64 p)) (ceil : Nat) :
       by_cases h : a.getD ceil (Zero.zero : ZMod64 p) = (Zero.zero : ZMod64 p)
       · have hp : (toWords a).getD ceil (0 : UInt64) = 0 := by
           rw [toWords_getD, h, ZMod64.val_zero]
-        rw [if_pos hp, if_pos h, ih]
+        rw [ite_eq_left hp, ite_eq_left h, ih]
       · have hp : ¬ (toWords a).getD ceil (0 : UInt64) = 0 := by
           rw [toWords_getD]
           intro hc
           exact h ((ZMod64.val_eq_zero_iff _).mp hc)
-        rw [if_neg hp, if_neg h]
+        rw [ite_eq_right hp, ite_eq_right h]
 
 /-- Packed degree agrees with the reference degree on packed input. -/
 theorem arrayDegreePacked?_eq (a : Array (ZMod64 p)) :
@@ -283,8 +283,8 @@ theorem divModArrayAuxPacked_eq (q : Array (ZMod64 p)) (qDegree : Nat) (fuel : N
       | none => rfl
       | some rd =>
           by_cases hlt : rd < qDegree
-          · simp only [dif_pos hlt]
-          · simp only [dif_neg hlt, toWords_getD, toWords_set!, subtractScaledShiftPacked_eq]
+          · simp only [dite_eq_left hlt]
+          · simp only [dite_eq_right hlt, toWords_getD, toWords_set!, subtractScaledShiftPacked_eq]
             exact ih (quot.set! (rd - qDegree) (rem.getD rd (Zero.zero : ZMod64 p)))
               (DensePoly.subtractScaledShift rem q (rd - qDegree)
                 (rem.getD rd (Zero.zero : ZMod64 p)))
@@ -297,7 +297,7 @@ theorem modByMonicPacked_eq (f g : FpPoly p) (hmonic : DensePoly.Monic f) :
   unfold modByMonicPacked
   by_cases hz : f.isZero
   · simp [hz]
-  · rw [if_neg hz, if_neg hz]
+  · rw [ite_eq_right hz, ite_eq_right hz]
     dsimp only
     rw [← toWords_replicate (p := p) (g.size - (f.size - 1))]
     simp only [divModArrayAuxPacked_eq, ofWords_toWords]

--- a/HexPolyFp/PackedMul.lean
+++ b/HexPolyFp/PackedMul.lean
@@ -44,12 +44,12 @@ theorem foldl_add_toNat_mod {p : Nat} [ZMod64.Bounds p]
   | cons x xs ih =>
       simp only [List.foldl_cons]
       by_cases hP : P x
-      · rw [if_pos hP, if_pos hP]
+      · rw [ite_eq_left hP, ite_eq_left hP]
         refine ih (init + f x) (initN + g x) ?_
         have h1 : (init + f x).toNat = (init.toNat + (f x).toNat) % p :=
           ZMod64.toNat_add init (f x)
         rw [h1, hinit, hfg, ← Nat.add_mod]
-      · rw [if_neg hP, if_neg hP]
+      · rw [ite_eq_right hP, ite_eq_right hP]
         exact ih init initN hinit
 
 namespace FpPoly
@@ -145,7 +145,7 @@ private theorem foldl_if_false {α β : Type} (l : List α) (P : α → Prop) [D
   induction l generalizing init with
   | nil => rfl
   | cons x xs ih =>
-      rw [List.foldl_cons, if_neg (h x (List.mem_cons_self)), ih init
+      rw [List.foldl_cons, ite_eq_right (h x (List.mem_cons_self)), ih init
         (fun i hi => h i (List.mem_cons_of_mem x hi))]
 
 /-- The word-level per-coefficient `Nat` sum, over packed words. -/
@@ -165,7 +165,7 @@ private theorem convGetD_mod (a b : FpPoly p) (k : Nat) :
   have hpsize : p < UInt64.word := ZMod64.Bounds.pLtWord p
   by_cases hab : (toWords a.toArray).size = 0 ∨ (toWords b.toArray).size = 0
   · have hconv : fpConvolve (toWords a.toArray) (toWords b.toArray) (UInt64.ofNat p) = #[] := by
-      unfold fpConvolve; rw [if_pos hab]
+      unfold fpConvolve; rw [ite_eq_left hab]
     have hzero : natFoldW a b k = 0 := by
       unfold natFoldW
       rcases hab with hA | hB
@@ -179,11 +179,11 @@ private theorem convGetD_mod (a b : FpPoly p) (k : Nat) :
     · have hconv : (fpConvolve (toWords a.toArray) (toWords b.toArray) (UInt64.ofNat p)).getD k 0 =
           convolveCoeff (toWords a.toArray) (toWords b.toArray) (UInt64.ofNat p) k := by
         unfold fpConvolve
-        rw [if_neg (not_or.mpr ⟨hA, hB⟩)]
+        rw [ite_eq_right (not_or.mpr ⟨hA, hB⟩)]
         simp only [Array.getD_eq_getD_getElem?, Array.getElem?_map, Array.getElem?_range]
         have hk' : k < (toWords a.toArray).size + (toWords b.toArray).size - 1 := hk
         simp only [toWords_size, DensePoly.toArray_size] at hk' ⊢
-        rw [if_pos hk']
+        rw [ite_eq_left hk']
         rfl
       rw [hconv]
       unfold convolveCoeff natFoldW
@@ -191,9 +191,9 @@ private theorem convGetD_mod (a b : FpPoly p) (k : Nat) :
         Nat.mod_eq_of_lt (Nat.lt_of_lt_of_le (Nat.mod_lt _ hp0) (Nat.le_of_lt hpsize)), Nat.mod_mod]
     · have hget : (fpConvolve (toWords a.toArray) (toWords b.toArray) (UInt64.ofNat p)).getD k 0 = 0 := by
         unfold fpConvolve
-        rw [if_neg (not_or.mpr ⟨hA, hB⟩)]
+        rw [ite_eq_right (not_or.mpr ⟨hA, hB⟩)]
         simp only [Array.getD_eq_getD_getElem?, Array.getElem?_map, Array.getElem?_range]
-        rw [if_neg (by omega)]
+        rw [ite_eq_right (by omega)]
         rfl
       have hzero : natFoldW a b k = 0 :=
         foldl_if_false _ _ _ _ (fun i hi => by

--- a/HexPolyFp/Quotient.lean
+++ b/HexPolyFp/Quotient.lean
@@ -1038,10 +1038,10 @@ theorem eval_monomial (n : Nat) (c : ZMod64 p)
           (DensePoly.C (0 : ZMod64 p)) *
         β ^ n
     unfold DensePoly.monomial
-    rw [dif_pos (show (0 : ZMod64 p) = Zero.zero from rfl), eval_zero, reduce_C_zero, zero_mul]
+    rw [dite_eq_left (show (0 : ZMod64 p) = Zero.zero from rfl), eval_zero, reduce_C_zero, zero_mul]
   · unfold eval DensePoly.toList DensePoly.toArray DensePoly.monomial
     have hc0 : ¬ c = (Zero.zero : ZMod64 p) := hc
-    rw [dif_neg hc0]
+    rw [dite_eq_right hc0]
     simp only [Array.toList_push, Array.toList_replicate, List.reverse_append,
       List.reverse_cons, List.reverse_nil, List.nil_append, List.singleton_append,
       List.foldl_cons]
@@ -1528,7 +1528,7 @@ private theorem fpPoly_one_ne_zero :
   have hcoeff := congrArg (fun f : FpPoly p => f.coeff 0) hone
   change (DensePoly.C (1 : ZMod64 p)).coeff 0 = (0 : FpPoly p).coeff 0 at hcoeff
   rw [DensePoly.coeff_C, DensePoly.coeff_zero] at hcoeff
-  simp only [if_true] at hcoeff
+  simp only [ite_true] at hcoeff
   exact zmod64_one_ne_zero hcoeff
 
 /-- The quotient is nontrivial: `1` and `0` are distinct quotient elements

--- a/HexPolyFp/Quotient/Ring.lean
+++ b/HexPolyFp/Quotient/Ring.lean
@@ -957,7 +957,7 @@ theorem mul_mod_inverseCandidate_eq_one_of_irreducible
           DensePoly.coeff_eq_zero_of_size_le d (by omega)
         rw [hd_coeff]
         have hkne : k + 1 ≠ 0 := Nat.succ_ne_zero k
-        rw [if_neg hkne]
+        rw [ite_eq_right hkne]
         exact hzero_mul
   have hkey : L * a + R * g = (1 : FpPoly p) := by
     show DensePoly.scale dlc⁻¹ xres.left * a +

--- a/HexPolyFp/QuotientFrobenius.lean
+++ b/HexPolyFp/QuotientFrobenius.lean
@@ -278,10 +278,10 @@ theorem reduce_monomial_eq (m : Nat) (c : ZMod64 p) :
     from FpPoly.C_mul_eq_scale c _]
   rw [DensePoly.coeff_scale c _ k hzero, DensePoly.coeff_monomial m (1 : ZMod64 p) k]
   by_cases hk : k = m
-  · simp only [hk, if_true]
+  · simp only [hk, ite_true]
     show c = c * (1 : ZMod64 p)
     grind
-  · simp only [hk, if_false]
+  · simp only [hk, ite_false]
     exact hzero.symm
 
 private def quotMonoSum (f : FpPoly p)
@@ -305,7 +305,7 @@ private theorem coeff_fpPolyMonoSum (f : FpPoly p) (m k : Nat) :
       show (0 : FpPoly p).coeff k = if k < 0 then f.coeff k else 0
       rw [DensePoly.coeff_zero]
       have hk : ¬ k < 0 := Nat.not_lt_zero k
-      rw [if_neg hk]
+      rw [ite_eq_right hk]
       rfl
   | succ m ih =>
       show (fpPolyMonoSum f m + DensePoly.monomial m (f.coeff m)).coeff k =
@@ -314,18 +314,18 @@ private theorem coeff_fpPolyMonoSum (f : FpPoly p) (m k : Nat) :
       by_cases hk_lt_m : k < m
       · have hk_lt_succ : k < m + 1 := Nat.lt_succ_of_lt hk_lt_m
         have hk_ne_m : k ≠ m := Nat.ne_of_lt hk_lt_m
-        simp only [hk_lt_m, if_true, hk_lt_succ, hk_ne_m, if_false]
+        simp only [hk_lt_m, ite_true, hk_lt_succ, hk_ne_m, ite_false]
         show f.coeff k + 0 = f.coeff k
         grind
       · by_cases hk_eq_m : k = m
         · subst hk_eq_m
           have hk_lt_succ : k < k + 1 := Nat.lt_succ_self k
           have hk_lt_self : ¬ k < k := Nat.lt_irrefl k
-          simp only [hk_lt_self, if_false, hk_lt_succ, if_true]
+          simp only [hk_lt_self, ite_false, hk_lt_succ, ite_true]
           show 0 + f.coeff k = f.coeff k
           grind
         · have hk_not_lt_succ : ¬ k < m + 1 := by omega
-          simp only [hk_lt_m, hk_eq_m, hk_not_lt_succ, if_false]
+          simp only [hk_lt_m, hk_eq_m, hk_not_lt_succ, ite_false]
           show 0 + 0 = (0 : ZMod64 p)
           grind
 

--- a/HexPolyFp/Ring.lean
+++ b/HexPolyFp/Ring.lean
@@ -113,7 +113,7 @@ theorem eval_X [ZMod64.PrimeModulus p] (x : ZMod64 p) :
         show ((0 : ZMod64 p).toNat) = 0 from ZMod64.toNat_zero,
         Nat.mod_eq_of_lt (by omega : 1 < p)] at htoNat
     exact absurd htoNat (by omega)
-  rw [dif_neg h1]
+  rw [dite_eq_right h1]
   change (((0 : ZMod64 p) * x + 1) * x + 0 = x)
   rw [zmod_zero_mul, zmod_zero_add, zmod_one_mul, zmod_add_zero]
 
@@ -1457,13 +1457,13 @@ private theorem fold_add_single_range
           intro i hi
           have hi' : i < n + 1 := List.mem_range.mp hi
           have hne : i ≠ n + 1 := by omega
-          rw [if_neg hne]
-        rw [hzero, if_pos rfl]
+          rw [ite_eq_right hne]
+        rw [hzero, ite_eq_left rfl]
         exact zmod_zero_add a
       · have ht' : t < n + 1 := by omega
         rw [ih ht']
         have hne : n + 1 ≠ t := by omega
-        rw [if_neg hne]
+        rw [ite_eq_right hne]
         exact zmod_add_zero a
 
 /-- Multiplying `f` by the scaled monomial `c · Xⁱ` shifts each coefficient up
@@ -1490,7 +1490,7 @@ theorem coeff_mul_shift_scale_one
             unfold mulCoeffTerm
             by_cases hnj : n < j
             · have hne : j ≠ n - i := by omega
-              rw [if_pos hnj, if_neg hne]
+              rw [ite_eq_left hnj, ite_eq_right hne]
             · simp [hnj, -DensePoly.coeff_shift]
               have hzero : c * (0 : ZMod64 p) = 0 := by grind
               rw [DensePoly.coeff_shift_scale i c (1 : FpPoly p) (n - j) hzero]
@@ -1502,19 +1502,19 @@ theorem coeff_mul_shift_scale_one
                     rw [Nat.sub_sub_self hin]
                     omega
                   exact hnot hlt
-                rw [if_neg hne]
+                rw [ite_eq_right hne]
                 simp [hlt]
                 exact zmod_mul_zero (f.coeff j)
               · by_cases hji : j = n - i
                 · subst j
-                  rw [if_pos rfl]
+                  rw [ite_eq_left rfl]
                   simp [hlt]
                   rw [coeff_one]
                   have hsub : n - (n - i) - i = 0 := by
                     rw [Nat.sub_sub_self hin]
                     simp
                   simp [hsub]
-                · rw [if_neg hji]
+                · rw [ite_eq_right hji]
                   simp [hlt]
                   rw [coeff_one]
                   have hsub : n - j - i ≠ 0 := by omega
@@ -1522,7 +1522,7 @@ theorem coeff_mul_shift_scale_one
       _ = f.coeff (n - i) * c := by
             exact fold_add_single_range n (n - i) (f.coeff (n - i) * c) (by omega)
       _ = if i ≤ n then f.coeff (n - i) * c else 0 := by
-            rw [if_pos hin]
+            rw [ite_eq_left hin]
   · have hzero :
         (List.range (n + 1)).foldl
             (fun acc j =>
@@ -1540,7 +1540,7 @@ theorem coeff_mul_shift_scale_one
         have hlt : n - j < i := by omega
         simp [hlt]
         exact zmod_mul_zero (f.coeff j)
-    rw [hzero, if_neg hin]
+    rw [hzero, ite_eq_right hin]
 
 /-- Expands the degree-`n` coefficient of `(f * g) * h` into a left-associated
 triple fold: the outer sum over `i` pairs the `i`-th coefficient of `f * g`

--- a/HexPolyFp/SquareFree/Algebra.lean
+++ b/HexPolyFp/SquareFree/Algebra.lean
@@ -149,7 +149,7 @@ private theorem pow_go_eq_mul_powLinear (acc base : FpPoly p) (k : Nat) :
       rw [pow.go.eq_def]
       by_cases hk : k = 0
       · simp [hk, powLinear]
-      · rw [dif_neg hk]
+      · rw [dite_eq_right hk]
         have hlt : k / 2 < k :=
           Nat.div_lt_self (Nat.pos_of_ne_zero hk) (by decide : 1 < 2)
         cases Nat.mod_two_eq_zero_or_one k with
@@ -160,7 +160,7 @@ private theorem pow_go_eq_mul_powLinear (acc base : FpPoly p) (k : Nat) :
             have hnot : ¬k % 2 = 1 := by omega
             have hdiv : 2 * (k / 2) / 2 = k / 2 :=
               Nat.mul_div_right (k / 2) (by decide : 0 < 2)
-            rw [if_neg hnot]
+            rw [ite_eq_right hnot]
             calc
               pow.go acc (base * base) (k / 2)
                   = acc * powLinear (base * base) (k / 2) := by
@@ -171,7 +171,7 @@ private theorem pow_go_eq_mul_powLinear (acc base : FpPoly p) (k : Nat) :
             have hk_eq : k = 2 * (k / 2) + 1 := by
               have h := Nat.mod_add_div k 2
               omega
-            rw [if_pos hmod1]
+            rw [ite_eq_left hmod1]
             calc
               pow.go (acc * base) (base * base) (k / 2)
                   = (acc * base) * powLinear (base * base) (k / 2) := by
@@ -700,11 +700,11 @@ private theorem coeffTerm_coeff (g : FpPoly p) (i n : Nat) :
   have hzero : g.coeff i * (0 : ZMod64 p) = 0 := by grind
   rw [DensePoly.coeff_shift_scale i (g.coeff i) (1 : FpPoly p) n hzero]
   by_cases hlt : n < i
-  · simp only [hlt, if_true]
+  · simp only [hlt, ite_true]
     have hne : n ≠ i := by omega
     simp [hne]
     rfl
-  · simp only [hlt, if_false]
+  · simp only [hlt, ite_false]
     change g.coeff i * (DensePoly.C (1 : ZMod64 p)).coeff (n - i) =
       if n = i then g.coeff i else 0
     rw [DensePoly.coeff_C]
@@ -736,14 +736,14 @@ private theorem powLinear_coeffTerm_coeff (g : FpPoly p) (i k n : Nat) :
         if n = (k + 1) * i then (g.coeff i) ^ (k + 1) else 0
       rw [coeff_mul_shift_scale_one]
       by_cases hin : i ≤ n
-      · rw [if_pos hin, ih]
+      · rw [ite_eq_left hin, ih]
         by_cases hprev : n - i = k * i
         · have hn : n = (k + 1) * i := by
             calc
               n = n - i + i := (Nat.sub_add_cancel hin).symm
               _ = k * i + i := by rw [hprev]
               _ = (k + 1) * i := by rw [Nat.succ_mul]
-          rw [if_pos hprev, if_pos hn]
+          rw [ite_eq_left hprev, ite_eq_left hn]
           exact (Lean.Grind.Semiring.pow_succ (g.coeff i) k).symm
         · have hn : n ≠ (k + 1) * i := by
             intro hn
@@ -751,7 +751,7 @@ private theorem powLinear_coeffTerm_coeff (g : FpPoly p) (i k n : Nat) :
             calc
               n - i = (k + 1) * i - i := by rw [hn]
               _ = k * i := by rw [Nat.succ_mul]; omega
-          rw [if_neg hprev, if_neg hn]
+          rw [ite_eq_right hprev, ite_eq_right hn]
           grind
       · have hn : n ≠ (k + 1) * i := by
           intro hn
@@ -759,7 +759,7 @@ private theorem powLinear_coeffTerm_coeff (g : FpPoly p) (i k n : Nat) :
             rw [Nat.succ_mul]
             omega
           omega
-        rw [if_neg hin, if_neg hn]
+        rw [ite_eq_right hin, ite_eq_right hn]
 
 /-- Coefficient projection for the bounded finite coefficient fold. -/
 private theorem coeffFold_coeff (g : FpPoly p) (m n : Nat) :
@@ -782,16 +782,16 @@ private theorem coeffFold_coeff (g : FpPoly p) (m n : Nat) :
         if n < m + 1 then g.coeff n else 0
       rw [ih, coeffTerm_coeff]
       by_cases hlt : n < m
-      · rw [if_pos hlt]
+      · rw [ite_eq_left hlt]
         have hne : n ≠ m := by omega
-        rw [if_neg hne, if_pos (by omega : n < m + 1)]
+        rw [ite_eq_right hne, ite_eq_left (by omega : n < m + 1)]
         exact zmod64_add_zero_coeff (g.coeff n)
       · by_cases heq : n = m
-        · rw [if_neg hlt]
-          rw [if_pos heq, if_pos (by omega : n < m + 1), heq]
+        · rw [ite_eq_right hlt]
+          rw [ite_eq_left heq, ite_eq_left (by omega : n < m + 1), heq]
           exact zmod64_zero_add_coeff (g.coeff m)
         · have hsucc : ¬n < m + 1 := by omega
-          rw [if_neg hlt, if_neg heq, if_neg hsucc]
+          rw [ite_eq_right hlt, ite_eq_right heq, ite_eq_right hsucc]
           exact zmod64_add_zero_zero_coeff
 
 /-- Any coefficient fold whose bound reaches `g.size` reconstructs `g`. -/
@@ -916,8 +916,8 @@ private theorem coeffFoldPowerCoeff_prime_coeff
       rw [hpow_zero_p_coeff]
       have hne : ¬ n / p < 0 := Nat.not_lt_zero _
       by_cases hmod : n % p = 0
-      · rw [if_pos hmod, if_neg hne]
-      · rw [if_neg hmod]
+      · rw [ite_eq_left hmod, ite_eq_right hne]
+      · rw [ite_eq_right hmod]
   | succ m ih =>
       have hsucc : coeffFold g (m + 1) = coeffFold g m + coeffTerm g m := by
         unfold coeffFold
@@ -927,45 +927,45 @@ private theorem coeffFoldPowerCoeff_prime_coeff
         DensePoly.coeff_add_semiring,
         ih, powLinear_coeffTerm_coeff]
       by_cases hmod : n % p = 0
-      · rw [if_pos hmod, if_pos hmod]
+      · rw [ite_eq_left hmod, ite_eq_left hmod]
         have hn_eq : n = p * (n / p) := by
           have hdiv := Nat.div_add_mod n p
           omega
         by_cases hlt : n / p < m
-        · rw [if_pos hlt]
+        · rw [ite_eq_left hlt]
           have hne : n ≠ p * m := by
             intro heq
             have hmul : p * (n / p) = p * m := by rw [← hn_eq]; exact heq
             have hdivm : n / p = m := Nat.eq_of_mul_eq_mul_left hp_pos hmul
             omega
-          rw [if_neg hne]
+          rw [ite_eq_right hne]
           have hltsucc : n / p < m + 1 := by omega
-          rw [if_pos hltsucc]
+          rw [ite_eq_left hltsucc]
           exact zmod64_add_zero_coeff (g.coeff (n / p) ^ p)
-        · rw [if_neg hlt]
+        · rw [ite_eq_right hlt]
           by_cases heq : n / p = m
           · have hnm : n = p * m := by rw [hn_eq, heq]
-            rw [if_pos hnm]
+            rw [ite_eq_left hnm]
             have hltsucc : n / p < m + 1 := by omega
-            rw [if_pos hltsucc, heq]
+            rw [ite_eq_left hltsucc, heq]
             exact zmod64_zero_add_coeff (g.coeff m ^ p)
           · have hne : n ≠ p * m := by
               intro habs
               have hmul : p * (n / p) = p * m := by rw [← hn_eq]; exact habs
               have hdivm : n / p = m := Nat.eq_of_mul_eq_mul_left hp_pos hmul
               exact heq hdivm
-            rw [if_neg hne]
+            rw [ite_eq_right hne]
             have hltsucc : ¬ n / p < m + 1 := by omega
-            rw [if_neg hltsucc]
+            rw [ite_eq_right hltsucc]
             exact zmod64_add_zero_zero_coeff
-      · rw [if_neg hmod, if_neg hmod]
+      · rw [ite_eq_right hmod, ite_eq_right hmod]
         have hne : n ≠ p * m := by
           intro heq
           have hmodzero : n % p = 0 := by
             rw [heq]
             exact Nat.mul_mod_right p m
           exact hmod hmodzero
-        rw [if_neg hne]
+        rw [ite_eq_right hne]
         exact zmod64_add_zero_zero_coeff
 
 /-- Freshman's-dream coefficient of `(coeffFold g m)^p`: nonzero only at `p`-divisible degrees, where it is `(g.coeff (n/p))^p`. -/
@@ -1001,17 +1001,17 @@ private theorem powLinear_prime_coeff
             exact powLinear_coeffFold_prime_coeff hp g g.size n
     _ = if n % p = 0 then g.coeff (n / p) ^ p else 0 := by
           by_cases hn : n % p = 0
-          · rw [if_pos hn]
+          · rw [ite_eq_left hn]
             by_cases hsize : n / p < g.size
-            · rw [if_pos hsize]
-              rw [if_pos hn]
-            · rw [if_neg hsize]
+            · rw [ite_eq_left hsize]
+              rw [ite_eq_left hn]
+            · rw [ite_eq_right hsize]
               have hcoeff : g.coeff (n / p) = 0 :=
                 DensePoly.coeff_eq_zero_of_size_le g (by omega)
-              rw [hcoeff, if_pos hn]
+              rw [hcoeff, ite_eq_left hn]
               exact (ZMod64.pow_prime hp (0 : ZMod64 p)).symm
-          · rw [if_neg hn]
-            rw [if_neg hn]
+          · rw [ite_eq_right hn]
+            rw [ite_eq_right hn]
 
 /--
 Coefficient form of the prime-field Frobenius law for the formal `p`-th root:

--- a/HexPolyFp/SquareFree/YunCorrect.lean
+++ b/HexPolyFp/SquareFree/YunCorrect.lean
@@ -82,7 +82,7 @@ private theorem squareFreeAuxRevContribution_derivative_active_pow_obligation
             (pthRoot loop.2) (multiplicity * p) fuel) := by
     have h := _hresidual
     simp only [squareFreeAuxRevResidualSatisfied] at h
-    rw [if_neg (by simp [hzero]), if_neg (by simp [hdf])] at h
+    rw [ite_eq_right (by simp [hzero]), ite_eq_right (by simp [hdf])] at h
     simpa [c, g, Nat.mul_one] using h
   have hloop_eq :
       (yunFactorsWithLevel c g multiplicity 1 fuel []).2 = contribution.2 := by
@@ -90,7 +90,7 @@ private theorem squareFreeAuxRevContribution_derivative_active_pow_obligation
       yunFactorsWithLevel_reconstruction_invariant c g multiplicity 1 fuel []
     simpa [contribution] using hrec.1
   simp only [squareFreeAuxRevContribution]
-  rw [if_neg (by simp [hzero]), if_neg (by simp [hdf])]
+  rw [ite_eq_right (by simp [hzero]), ite_eq_right (by simp [hdf])]
   by_cases hone : isOne contribution.2 = true
   · have hcontribution_eq_one : contribution.2 = 1 :=
       eq_one_of_isOne_true contribution.2 hone
@@ -222,7 +222,7 @@ private theorem squareFreeAuxRevContribution_correct_pow_of_nonzero
                     squareFreeAuxRevResidualSatisfied (pthRoot f) (multiplicity * p) fuel := by
                   have h := hresidual
                   simp only [squareFreeAuxRevResidualSatisfied] at h
-                  rw [if_neg (by simp [hzero]), if_pos hdf] at h
+                  rw [ite_eq_right (by simp [hzero]), ite_eq_left hdf] at h
                   exact h
                 exact ih (pthRoot f) (multiplicity * p)
                   hmultiplicity_root hroot_fuel hroot_zero hroot_reachable hroot_residual)
@@ -681,14 +681,14 @@ private theorem squareFreeAuxRev_factor_dvd_input
           cases h : g.isZero
           · rfl
           · exact False.elim (hzero h)
-        rw [if_neg (by simp [hzero_false])] at hb
+        rw [ite_eq_right (by simp [hzero_false])] at hb
         by_cases hdf : (DensePoly.derivative g).isZero = true
-        · rw [if_pos hdf] at hb
+        · rw [ite_eq_left hdf] at hb
           have hres_pth :
               squareFreeAuxRevResidualSatisfied (pthRoot g) (m * p) fuel := by
             have h := hresidual
             simp only [squareFreeAuxRevResidualSatisfied] at h
-            rw [if_neg (by simp [hzero_false]), if_pos hdf] at h
+            rw [ite_eq_right (by simp [hzero_false]), ite_eq_left hdf] at h
             exact h
           have hb_pth : b.factor ∣ pthRoot g :=
             ih (pthRoot g) (m * p) hres_pth b hb
@@ -699,7 +699,7 @@ private theorem squareFreeAuxRev_factor_dvd_input
             cases h : (DensePoly.derivative g).isZero
             · rfl
             · exact False.elim (hdf h)
-          rw [if_neg (by simp [hdf_false])] at hb
+          rw [ite_eq_right (by simp [hdf_false])] at hb
           let g_inner := monicGcd g (DensePoly.derivative g)
           let c_inner := g / g_inner
           let loop := yunFactorsWithLevel c_inner g_inner m 1 fuel []
@@ -710,7 +710,7 @@ private theorem squareFreeAuxRev_factor_dvd_input
                     (pthRoot loop.2) (m * p) fuel) := by
             have h := hresidual
             simp only [squareFreeAuxRevResidualSatisfied] at h
-            rw [if_neg (by simp [hzero_false]), if_neg (by simp [hdf_false])] at h
+            rw [ite_eq_right (by simp [hzero_false]), ite_eq_right (by simp [hdf_false])] at h
             exact h
           have hg_inner_dvd_g : g_inner ∣ g :=
             monicGcd_dvd_left hp g (DensePoly.derivative g)
@@ -874,7 +874,7 @@ private theorem squareFreeAuxRevResidualSatisfied_one
         rw [DensePoly.isZero_eq_true_iff]
         have h := DensePoly.size_derivative_le (1 : FpPoly p)
         omega
-      rw [if_neg (by simp [hone_ne]), if_pos hdf_one, pthRoot_one hp]
+      rw [ite_eq_right (by simp [hone_ne]), ite_eq_left hdf_one, pthRoot_one hp]
       exact ih (m * p)
 
 private theorem yunFactorsWithLevel_squareFreeAuxRev_tail_cross_coprime
@@ -998,7 +998,7 @@ private theorem squareFreeAuxRev_eq_nil_of_size_le_one
           omega
         have hdf : (DensePoly.derivative f).isZero = true :=
           derivative_isZero_true_of_size_one f hsize_one
-        simp only [hzero, Bool.false_eq_true, if_false, hdf, if_true]
+        simp only [hzero, Bool.false_eq_true, ite_false, hdf, ite_true]
         apply ih
         have h := pthRoot_size_of_derivative_zero hp f hzero_false hdf
         rw [hsize_one, Nat.sub_self, Nat.zero_div] at h
@@ -1079,8 +1079,8 @@ private theorem squareFreeAuxRev_pairwise_coprime_nil_of_yun_invariant
                   squareFreeAuxRevResidualSatisfied f multiplicity (fuel + 1) :=
                 squareFreeAuxRevResidualSatisfied_of_size_lt hp f multiplicity (fuel + 1) hfuel
               simp only [squareFreeAuxRevResidualSatisfied] at hres_full
-              rw [if_neg (by simp [hzero_false]),
-                  if_neg (by simp [hdf_false])] at hres_full
+              rw [ite_eq_right (by simp [hzero_false]),
+                  ite_eq_right (by simp [hdf_false])] at hres_full
               refine ⟨?_, ?_⟩
               · simpa [c, g, Nat.mul_one] using hres_full.1
               · intro hone_false

--- a/HexPolyFp/SquareFree/YunMeasure.lean
+++ b/HexPolyFp/SquareFree/YunMeasure.lean
@@ -1248,7 +1248,7 @@ private theorem squareFreeAuxRevResidualSatisfied_of_size_le_one
   | succ fuel ih =>
       by_cases hzero : f.isZero = true
       · simp only [squareFreeAuxRevResidualSatisfied]
-        rw [if_pos hzero]; exact trivial
+        rw [ite_eq_left hzero]; exact trivial
       · have hzero_false : f.isZero = false := by
           cases h : f.isZero
           · rfl
@@ -1259,7 +1259,7 @@ private theorem squareFreeAuxRevResidualSatisfied_of_size_le_one
         have hdf : (DensePoly.derivative f).isZero = true :=
           derivative_isZero_true_of_size_one f hsize_one
         simp only [squareFreeAuxRevResidualSatisfied]
-        rw [if_neg (by simp [hzero_false]), if_pos hdf]
+        rw [ite_eq_right (by simp [hzero_false]), ite_eq_left hdf]
         have hroot_size : (pthRoot f).size ≤ 1 := by
           have h := pthRoot_size_of_derivative_zero hp f hzero_false hdf
           rw [hsize_one, Nat.sub_self, Nat.zero_div] at h
@@ -1283,7 +1283,7 @@ private theorem squareFreeAuxRevResidualSatisfied_of_size_lt
   | succ fuel ih =>
       by_cases hzero : f.isZero = true
       · simp only [squareFreeAuxRevResidualSatisfied]
-        rw [if_pos hzero]; exact trivial
+        rw [ite_eq_left hzero]; exact trivial
       · have hzero_false : f.isZero = false := by
           cases h : f.isZero
           · rfl
@@ -1293,7 +1293,7 @@ private theorem squareFreeAuxRevResidualSatisfied_of_size_lt
         · have hnonconst : 1 < f.size := by omega
           by_cases hdf : (DensePoly.derivative f).isZero = true
           · simp only [squareFreeAuxRevResidualSatisfied]
-            rw [if_neg (by simp [hzero_false]), if_pos hdf]
+            rw [ite_eq_right (by simp [hzero_false]), ite_eq_left hdf]
             have hroot_fuel : (pthRoot f).size < fuel :=
               pthRoot_fuel_decrease_of_derivative_zero_nonconstant hp f hbound hnonconst
             exact ih (pthRoot f) (m * p) hroot_fuel
@@ -1373,7 +1373,7 @@ private theorem squareFreeAuxRevResidualSatisfied_of_size_lt
               rw [hbridge]
               exact hderiv_impl (by rw [← hbridge]; exact hone_false)
             simp only [squareFreeAuxRevResidualSatisfied]
-            rw [if_neg (by simp [hzero_false]), if_neg (by simp [hdf_false])]
+            rw [ite_eq_right (by simp [hzero_false]), ite_eq_right (by simp [hdf_false])]
             refine ⟨?_, ?_⟩
             · by_cases hone :
                   isOne

--- a/HexPolyFpMathlib/Basic.lean
+++ b/HexPolyFpMathlib/Basic.lean
@@ -56,8 +56,8 @@ theorem coeff_fpPolyToPolynomial (f : Hex.FpPoly p) (n : Nat) :
   rw [Finset.sum_ite_eq' (Finset.range f.size) n
     (fun i => HexModArithMathlib.ZMod64.toZMod (f.coeff i))]
   by_cases hn : n ∈ Finset.range f.size
-  · rw [if_pos hn]
-  · rw [if_neg hn, Hex.DensePoly.coeff_eq_zero_of_size_le f
+  · rw [ite_eq_left hn]
+  · rw [ite_eq_right hn, Hex.DensePoly.coeff_eq_zero_of_size_le f
       (Nat.le_of_not_lt (Finset.mem_range.not.mp hn))]
     exact HexModArithMathlib.ZMod64.toZMod_zero.symm
 
@@ -82,9 +82,9 @@ private theorem toZMod_diagonalMulCoeffTerm (f g : Hex.FpPoly p) (n i : Nat) :
         HexModArithMathlib.ZMod64.toZMod (g.coeff (n - i)) := by
   unfold Hex.DensePoly.diagonalMulCoeffTerm
   by_cases hni : n < i
-  · simp only [if_pos hni]
+  · simp only [ite_eq_left hni]
     exact HexModArithMathlib.ZMod64.toZMod_zero
-  · simp only [if_neg hni, HexModArithMathlib.ZMod64.toZMod_mul]
+  · simp only [ite_eq_right hni, HexModArithMathlib.ZMod64.toZMod_mul]
 
 /-- The executable schoolbook multiplication coefficient, transported to
 `ZMod p`, is the truncated convolution sum over the support of `f`. -/
@@ -122,7 +122,7 @@ private theorem sum_ite_diagonal_eq_range_succ (f g : Hex.FpPoly p) (n : Nat) :
     simp only [hF]
     by_cases hni : n < i
     · simp [hni]
-    · simp only [hni, if_false, hterm]
+    · simp only [hni, ite_false, hterm]
       rw [Hex.DensePoly.coeff_eq_zero_of_size_le f hi]
       rw [show HexModArithMathlib.ZMod64.toZMod (Zero.zero : Hex.ZMod64 p) = 0 from
         HexModArithMathlib.ZMod64.toZMod_zero, zero_mul]
@@ -167,9 +167,9 @@ def fpPolyEquiv : Hex.FpPoly p ≃+* Polynomial (ZMod p) where
     rw [polynomialToFpPoly, Hex.DensePoly.coeff_ofList,
       HexPolyMathlib.list_getD_map_range_zero]
     by_cases hn : n < (fpPolyToPolynomial f).natDegree + 1
-    · simp only [if_pos hn, coeff_fpPolyToPolynomial,
+    · simp only [ite_eq_left hn, coeff_fpPolyToPolynomial,
         HexModArithMathlib.ZMod64.equiv_symm_apply, HexModArithMathlib.ZMod64.ofZMod_toZMod]
-    · rw [if_neg hn]
+    · rw [ite_eq_right hn]
       have hcoeff : (fpPolyToPolynomial f).coeff n = 0 :=
         Polynomial.coeff_eq_zero_of_natDegree_lt (by omega)
       rw [coeff_fpPolyToPolynomial f n] at hcoeff
@@ -185,9 +185,9 @@ def fpPolyEquiv : Hex.FpPoly p ≃+* Polynomial (ZMod p) where
     rw [coeff_fpPolyToPolynomial, polynomialToFpPoly, Hex.DensePoly.coeff_ofList,
       HexPolyMathlib.list_getD_map_range_zero]
     by_cases hn : n < P.natDegree + 1
-    · simp only [if_pos hn, HexModArithMathlib.ZMod64.equiv_symm_apply,
+    · simp only [ite_eq_left hn, HexModArithMathlib.ZMod64.equiv_symm_apply,
         HexModArithMathlib.ZMod64.toZMod_ofZMod]
-    · rw [if_neg hn, Polynomial.coeff_eq_zero_of_natDegree_lt (by omega)]
+    · rw [ite_eq_right hn, Polynomial.coeff_eq_zero_of_natDegree_lt (by omega)]
       exact HexModArithMathlib.ZMod64.toZMod_zero
   map_mul' := by
     intro f g
@@ -392,8 +392,8 @@ theorem toMathlibPolynomial_C (c : Hex.ZMod64 p) :
   intro n
   rw [coeff_toMathlibPolynomial, Hex.DensePoly.coeff_C, Polynomial.coeff_C]
   by_cases hn : n = 0
-  · subst hn; rw [if_pos rfl, if_pos rfl]
-  · rw [if_neg hn, if_neg hn]; exact HexModArithMathlib.ZMod64.toZMod_zero
+  · subst hn; rw [ite_eq_left rfl, ite_eq_left rfl]
+  · rw [ite_eq_right hn, ite_eq_right hn]; exact HexModArithMathlib.ZMod64.toZMod_zero
 
 /-- An executable monomial transports to the corresponding Mathlib monomial. -/
 @[simp, grind =]
@@ -425,8 +425,9 @@ theorem toMathlibPolynomial_X :
   intro n
   rw [coeff_toMathlibPolynomial, Hex.FpPoly.coeff_X, Polynomial.coeff_X]
   by_cases hn : n = 1
-  · subst hn; rw [if_pos rfl, if_pos rfl, HexModArithMathlib.ZMod64.toZMod_one]
-  · rw [if_neg hn, if_neg (show ¬ (1 = n) by omega), HexModArithMathlib.ZMod64.toZMod_zero]
+  · subst hn; rw [ite_eq_left rfl, ite_eq_left rfl, HexModArithMathlib.ZMod64.toZMod_one]
+  · rw [ite_eq_right hn, ite_eq_right (show ¬ (1 = n) by omega),
+      HexModArithMathlib.ZMod64.toZMod_zero]
 
 /-- Divisibility transports along the finite-field polynomial map. -/
 theorem toMathlibPolynomial_dvd {f g : Hex.FpPoly p} (h : f ∣ g) :

--- a/HexPolyFpMathlib/SquareFree.lean
+++ b/HexPolyFpMathlib/SquareFree.lean
@@ -48,16 +48,16 @@ private theorem pow_go_eq_mul_pow (acc base : Hex.FpPoly p) (k : Nat) :
       rw [Hex.FpPoly.pow.go.eq_def]
       by_cases hk : k = 0
       · simp [hk]
-      · rw [dif_neg hk]
+      · rw [dite_eq_right hk]
         have hlt : k / 2 < k := Nat.div_lt_self (Nat.pos_of_ne_zero hk) (by decide)
         show Hex.FpPoly.pow.go (if k % 2 = 1 then acc * base else acc)
           (base * base) (k / 2) = acc * base ^ k
         rcases Nat.mod_two_eq_zero_or_one k with hmod | hmod
         · have hnot : ¬ k % 2 = 1 := by omega
           have hk2 : 2 * (k / 2) = k := by omega
-          rw [if_neg hnot, ih _ hlt, ← sq, ← pow_mul, hk2]
+          rw [ite_eq_right hnot, ih _ hlt, ← sq, ← pow_mul, hk2]
         · have hk2 : 2 * (k / 2) + 1 = k := by omega
-          rw [if_pos hmod, ih _ hlt, ← sq, ← pow_mul, mul_assoc, ← pow_succ', hk2]
+          rw [ite_eq_left hmod, ih _ hlt, ← sq, ← pow_mul, mul_assoc, ← pow_succ', hk2]
 
 /-- The executable square-and-multiply power is Mathlib's monoid power, the
 sibling of `linearPow_eq_pow` for the exponentiation the compiled square-free

--- a/HexPolyFpMathlib/SquareFree.lean
+++ b/HexPolyFpMathlib/SquareFree.lean
@@ -119,7 +119,7 @@ theorem isCoprime_toMathlibPolynomial_of_normalizeMonic_gcd_eq_one
     [Fact (Nat.Prime p)] {a b : Hex.FpPoly p}
     (h : (Hex.FpPoly.normalizeMonic (Hex.DensePoly.gcd a b)).2 = 1) :
     IsCoprime (toMathlibPolynomial a) (toMathlibPolynomial b) := by
-  haveI : Hex.ZMod64.PrimeModulus p := primeModulus_of_fact p
+  have : Hex.ZMod64.PrimeModulus p := primeModulus_of_fact p
   obtain ⟨u, hu⟩ := isUnit_toMathlibPolynomial_of_normalizeMonic_eq_one h
   have hbez : (Hex.DensePoly.xgcd a b).left * a + (Hex.DensePoly.xgcd a b).right * b
       = Hex.DensePoly.gcd a b :=

--- a/HexPolyMathlib/PolynomialEquivalence.lean
+++ b/HexPolyMathlib/PolynomialEquivalence.lean
@@ -676,7 +676,7 @@ private theorem coeff_hornerList [Semiring R] : ∀ (l : List R) (n : ℕ),
       cases n with
       | zero => simp
       | succ m =>
-          rw [Polynomial.coeff_add, Polynomial.coeff_C, if_neg (Nat.succ_ne_zero m),
+          rw [Polynomial.coeff_add, Polynomial.coeff_C, ite_eq_right (Nat.succ_ne_zero m),
             Polynomial.coeff_X_mul, coeff_hornerList cs m, zero_add, List.getD_cons_succ]
 
 /-- Composition pushes through the Horner fold: substituting `M` for `X` turns

--- a/HexPolyZ/Decomposition.lean
+++ b/HexPolyZ/Decomposition.lean
@@ -80,7 +80,7 @@ private theorem normalizePrimitiveSign_C_one :
   unfold normalizePrimitiveSign
   have hlead : ¬ DensePoly.leadingCoeff (DensePoly.C (1 : Int)) < 0 := by
     simp [DensePoly.leadingCoeff, DensePoly.coeffs_C_of_ne_zero (by decide : (1 : Int) ≠ 0)]
-  rw [if_neg hlead]
+  rw [ite_eq_right hlead]
   rfl
 
 /-- Sign-normalization sends the constant `-1` to `1`: its negative leading
@@ -90,7 +90,7 @@ private theorem normalizePrimitiveSign_C_neg_one :
   unfold normalizePrimitiveSign
   have hlead : DensePoly.leadingCoeff (DensePoly.C (-1 : Int)) < 0 := by
     simp [DensePoly.leadingCoeff, DensePoly.coeffs_C_of_ne_zero (by decide : (-1 : Int) ≠ 0)]
-  rw [if_pos hlead]
+  rw [ite_eq_left hlead]
   apply DensePoly.ext_coeff
   intro n
   rw [DensePoly.coeff_scale (R := Int) (-1 : Int) (DensePoly.C (-1 : Int)) n
@@ -141,20 +141,20 @@ theorem primitiveSquareFreeDecomposition_reassembly_over_rat (f : ZPoly) :
   unfold primitiveSquareFreeDecomposition
   by_cases hzero : (primitivePart f).isZero = true
   · refine ⟨0, ?_⟩
-    rw [if_pos hzero]
+    rw [ite_eq_left hzero]
     have hprimitive_zero : primitivePart f = 0 :=
       densePoly_eq_zero_of_isZero_true (primitivePart f) hzero
     rw [hprimitive_zero, toRatPoly_zero, rat_scale_zero]
-  · rw [if_neg hzero]
+  · rw [ite_eq_right hzero]
     let ratPrimitive := toRatPoly (primitivePart f)
     let derivative := DensePoly.derivative ratPrimitive
     by_cases hderivative : derivative.isZero = true
     · rcases toRatPoly_normalizePrimitiveSign_rational_associate (primitivePart f) with
         ⟨unit, hunit⟩
       refine ⟨unit, ?_⟩
-      rw [if_pos hderivative, toRatPoly_one, DensePoly.mul_one_right_poly]
+      rw [ite_eq_left hderivative, toRatPoly_one, DensePoly.mul_one_right_poly]
       simpa [ratPrimitive] using hunit
-    · rw [if_neg hderivative]
+    · rw [ite_eq_right hderivative]
       let repeatedRat := DensePoly.gcd ratPrimitive derivative
       let quotientRat := ratPrimitive / repeatedRat
       rcases ratPolyPrimitivePart_rational_associate quotientRat with
@@ -222,11 +222,11 @@ theorem primitiveSquareFreeDecomposition_squareFreeCore
           simpa [derivative, ratPrimitive] using hderivative_eq)
       have hcore_eq : normalizePrimitiveSign p = 1 :=
         normalizePrimitiveSign_eq_one_of_primitive_size_le_one p hprimitive hsize
-      rw [if_pos hderivative]
+      rw [ite_eq_left hderivative]
       change SquareFreeRat (normalizePrimitiveSign p)
       rw [hcore_eq]
       exact squareFreeRat_one
-    · rw [if_neg hderivative]
+    · rw [ite_eq_right hderivative]
       let repeatedRat := DensePoly.gcd ratPrimitive derivative
       let quotientRat := ratPrimitive / repeatedRat
       have hp_ne : p ≠ 0 := by
@@ -339,12 +339,12 @@ theorem primitiveSquareFreeDecomposition_squareFreeCore_repeatedPart_primitive
     · exfalso
       exact hprimitive_ne (densePoly_eq_zero_of_isZero_true (primitivePart f) hzero)
   unfold primitiveSquareFreeDecomposition
-  rw [if_neg (by simpa using hprimitive_not_isZero)]
+  rw [ite_eq_right (by simpa using hprimitive_not_isZero)]
   let p := primitivePart f
   let ratPrimitive := toRatPoly p
   let derivative := DensePoly.derivative ratPrimitive
   by_cases hderivative : derivative.isZero = true
-  · rw [if_pos hderivative]
+  · rw [ite_eq_left hderivative]
     have hderivative_eq : derivative = 0 :=
       densePoly_eq_zero_of_isZero_true derivative hderivative
     have hsize : p.size ≤ 1 := by
@@ -357,7 +357,7 @@ theorem primitiveSquareFreeDecomposition_squareFreeCore_repeatedPart_primitive
     rw [hcore_eq]
     change Primitive ((1 : ZPoly) * (1 : ZPoly))
     exact primitive_mul 1 1 primitive_one primitive_one
-  · rw [if_neg hderivative]
+  · rw [ite_eq_right hderivative]
     have hp_ne : p ≠ 0 := by
       simpa [p] using hprimitive_ne
     simpa [p, ratPrimitive, derivative] using
@@ -378,7 +378,7 @@ theorem primitiveSquareFreeDecomposition_squareFreeCore_eq_one_of_degree_zero
     let ratPrimitive := toRatPoly p
     let derivative := DensePoly.derivative ratPrimitive
     by_cases hderivative : derivative.isZero = true
-    · rw [if_pos hderivative] at hcore_ne hdegree ⊢
+    · rw [ite_eq_left hderivative] at hcore_ne hdegree ⊢
       have hderivative_eq : derivative = 0 :=
         densePoly_eq_zero_of_isZero_true derivative hderivative
       have hcontent_ne : content f ≠ 0 := by
@@ -398,7 +398,7 @@ theorem primitiveSquareFreeDecomposition_squareFreeCore_eq_one_of_degree_zero
         exact size_le_one_of_toRatPoly_derivative_zero p (by
           simpa [derivative, ratPrimitive] using hderivative_eq)
       exact normalizePrimitiveSign_eq_one_of_primitive_size_le_one p hprimitive hsize
-    · rw [if_neg hderivative] at hcore_ne hdegree ⊢
+    · rw [ite_eq_right hderivative] at hcore_ne hdegree ⊢
       let repeatedRat := DensePoly.gcd ratPrimitive derivative
       let quotientRat := ratPrimitive / repeatedRat
       let core := ratPolyPrimitivePart quotientRat
@@ -437,10 +437,10 @@ theorem primitiveSquareFreeDecomposition_repeatedPart_eq_one_of_squareFreeCore_d
     let derivative := DensePoly.derivative ratPrimitive
     by_cases hderivative : derivative.isZero = true
     · -- Case 2: `repeatedPart := 1` by definition.
-      rw [if_pos hderivative]
+      rw [ite_eq_left hderivative]
     · -- Case 3: rule out via gcd-derivative degree arithmetic.
       exfalso
-      rw [if_neg hderivative] at hcore_ne hdegree
+      rw [ite_eq_right hderivative] at hcore_ne hdegree
       let repeatedRat := DensePoly.gcd ratPrimitive derivative
       let quotientRat := ratPrimitive / repeatedRat
       let core := ratPolyPrimitivePart quotientRat
@@ -563,12 +563,12 @@ theorem primitiveSquareFreeDecomposition_squareFreeCore_repeatedPart_leadingCoef
     · exfalso
       exact hprimitive_ne (densePoly_eq_zero_of_isZero_true (primitivePart f) hzero)
   unfold primitiveSquareFreeDecomposition
-  rw [if_neg (by simpa using hprimitive_not_isZero)]
+  rw [ite_eq_right (by simpa using hprimitive_not_isZero)]
   let p := primitivePart f
   let ratPrimitive := toRatPoly p
   let derivative := DensePoly.derivative ratPrimitive
   by_cases hderivative : derivative.isZero = true
-  · rw [if_pos hderivative]
+  · rw [ite_eq_left hderivative]
     have hderivative_eq : derivative = 0 :=
       densePoly_eq_zero_of_isZero_true derivative hderivative
     have hsize : p.size ≤ 1 := by
@@ -583,7 +583,7 @@ theorem primitiveSquareFreeDecomposition_squareFreeCore_repeatedPart_leadingCoef
         (by decide) (by decide)]
       exact Int.mul_pos leadingCoeff_one_pos leadingCoeff_one_pos
     simpa [p, hcore_eq] using hprod_pos
-  · rw [if_neg hderivative]
+  · rw [ite_eq_right hderivative]
     let repeatedRat := DensePoly.gcd ratPrimitive derivative
     let quotientRat := ratPrimitive / repeatedRat
     have hp_ne : p ≠ 0 := by
@@ -771,17 +771,17 @@ theorem toRatPoly_repeatedPart_dvd_derivative (f : ZPoly) :
   by_cases hzero : (primitivePart f).isZero
   · have hpz : primitivePart f = 0 :=
       densePoly_eq_zero_of_isZero_true (primitivePart f) hzero
-    simp only [hzero, if_true]
+    simp only [hzero, ite_true]
     rw [hpz]
     simp only [toRatPoly_zero, DensePoly.derivative_zero]
     exact ⟨0, (DensePoly.zero_mul 0).symm⟩
-  · simp only [hzero, Bool.false_eq_true, if_false]
+  · simp only [hzero, Bool.false_eq_true, ite_false]
     by_cases hderiv : (DensePoly.derivative (toRatPoly (primitivePart f))).isZero
-    · simp only [hderiv, if_true]
+    · simp only [hderiv, ite_true]
       rw [toRatPoly_one]
       exact ⟨DensePoly.derivative (toRatPoly (primitivePart f)),
         by rw [DensePoly.mul_comm_poly, DensePoly.mul_one_right_poly]⟩
-    · simp only [hderiv, Bool.false_eq_true, if_false]
+    · simp only [hderiv, Bool.false_eq_true, ite_false]
       exact ratPolyPrimitivePart_gcd_dvd_derivative (toRatPoly (primitivePart f))
 
 /-- A Bezout congruence witness proves that two integer polynomials are coprime
@@ -956,10 +956,10 @@ theorem primitiveSquareFreeDecomposition_repeatedPart_eq_one_of_squareFreeRat
     · rfl
     · exact absurd (densePoly_eq_zero_of_isZero_true _ hz) hprimitive_ne
   unfold primitiveSquareFreeDecomposition
-  rw [if_neg (by simpa using hnot_isZero)]
+  rw [ite_eq_right (by simpa using hnot_isZero)]
   by_cases hderiv : (DensePoly.derivative (toRatPoly (primitivePart core))).isZero = true
-  · rw [if_pos hderiv]
-  · rw [if_neg hderiv]
+  · rw [ite_eq_left hderiv]
+  · rw [ite_eq_right hderiv]
     have hratPrim_ne : toRatPoly (primitivePart core) ≠ 0 :=
       toRatPoly_ne_zero_of_ne_zero _ hprimitive_ne
     apply ratPolyPrimitivePart_eq_one_of_size_le_one
@@ -1009,7 +1009,7 @@ theorem primitiveSquareFreeDecomposition_squareFreeCore_eq_of_squareFreeRat
       rw [← hre, leadingCoeff_scale_of_nonzero (-1 : Int) _ (by decide)]
       omega
     unfold normalizePrimitiveSign
-    rw [if_pos hlead_prim_neg, ← hre, int_scale_scale]
+    rw [ite_eq_left hlead_prim_neg, ← hre, int_scale_scale]
     show (primitiveSquareFreeDecomposition core).squareFreeCore =
       DensePoly.scale (1 : Int) (primitiveSquareFreeDecomposition core).squareFreeCore
     exact (int_scale_one _).symm

--- a/HexPolyZ/IntegerPolynomial.lean
+++ b/HexPolyZ/IntegerPolynomial.lean
@@ -666,7 +666,7 @@ theorem ratPolyPrimitivePart_rational_associate (f : DensePoly Rat) :
     change f =
       DensePoly.scale (-(((content scaled : Int) : Rat) / (den : Rat)))
         (toRatPoly (normalizePrimitiveSign (primitivePart scaled)))
-    rw [normalizePrimitiveSign, if_pos hlead]
+    rw [normalizePrimitiveSign, ite_eq_left hlead]
     rw [← rat_scale_toRatPoly_neg_int (((content scaled : Int) : Rat) / (den : Rat))
       (primitivePart scaled)]
     exact hbase
@@ -675,7 +675,7 @@ theorem ratPolyPrimitivePart_rational_associate (f : DensePoly Rat) :
     change f =
       DensePoly.scale (((content scaled : Int) : Rat) / (den : Rat))
         (toRatPoly (normalizePrimitiveSign (primitivePart scaled)))
-    rw [normalizePrimitiveSign, if_neg hlead]
+    rw [normalizePrimitiveSign, ite_eq_right hlead]
     exact hbase
 
 /--
@@ -1144,10 +1144,10 @@ theorem C_mul_eq_scale (c : Int) (p : ZPoly) :
     simp only [List.range_one, List.foldl_cons, List.foldl_nil]
     rw [fold_mulCoeffStep_C_left_range]
     by_cases hn : n < p.size
-    · rw [if_pos hn]
+    · rw [ite_eq_left hn]
       change (0 : Int) + c * p.coeff n = c * p.coeff n
       omega
-    · rw [if_neg hn, DensePoly.coeff_eq_zero_of_size_le p (Nat.le_of_not_gt hn)]
+    · rw [ite_eq_right hn, DensePoly.coeff_eq_zero_of_size_le p (Nat.le_of_not_gt hn)]
       change (0 : Int) = c * 0
       rw [Int.mul_zero]
 
@@ -1239,7 +1239,7 @@ private theorem shift_size_of_ne_zero (k : Nat) {p : ZPoly} (hp : p ≠ 0) :
       rw [DensePoly.coeff_shift]
       have hnot : ¬ k + p.size - 1 < k := by omega
       have hidx : k + p.size - 1 - k = p.size - 1 := by omega
-      rw [if_neg hnot, hidx]
+      rw [ite_eq_right hnot, hidx]
       exact DensePoly.coeff_last_ne_zero_of_pos_size p hpos
     by_cases hle : k + p.size ≤ (DensePoly.shift k p).size
     · exact hle
@@ -1264,7 +1264,7 @@ theorem leadingCoeff_shift_of_nonzero (k : Nat) (p : ZPoly) (hp : p ≠ 0) :
     rw [DensePoly.coeff_shift]
     have hnot : ¬ k + p.size - 1 < k := by omega
     have hidx : k + p.size - 1 - k = p.size - 1 := by omega
-    rw [if_neg hnot, hidx, DensePoly.leadingCoeff_eq_coeff_last p hpos]
+    rw [ite_eq_right hnot, hidx, DensePoly.leadingCoeff_eq_coeff_last p hpos]
   · rw [shift_size_of_ne_zero k hp]
     omega
 

--- a/HexPolyZ/Kronecker.lean
+++ b/HexPolyZ/Kronecker.lean
@@ -61,7 +61,7 @@ theorem lt_two_pow_bitLen (n : Nat) : n < 2 ^ bitLen n := by
   unfold bitLen
   by_cases h : n = 0
   · simp [h]
-  · rw [if_neg h]
+  · rw [ite_eq_right h]
     exact Nat.lt_log2_self
 
 /-- The least `k` with `n ≤ 2 ^ k`. -/
@@ -442,9 +442,9 @@ theorem constPack_eq (b : Nat) (c : Int) :
   | _ len ih =>
       unfold constPack
       by_cases hlen : len = 0
-      · rw [if_pos hlen, hlen]
+      · rw [ite_eq_left hlen, hlen]
         rfl
-      · rw [if_neg hlen]
+      · rw [ite_eq_right hlen]
         have hh : len / 2 < len := by omega
         have hsucc : ∀ m, packSpec b (fun _ => c) (m + 1)
             = c + 2 ^ b * packSpec b (fun _ => c) m := fun _ => rfl
@@ -455,7 +455,7 @@ theorem constPack_eq (b : Nat) (c : Int) :
             have h := packSpec_add b (fun _ => c) (len / 2) (len / 2)
             rw [show len / 2 + len / 2 = len by omega] at h
             exact h
-          rw [if_pos hpar, ih _ hh, Int.shiftLeft_eq, hsplit]
+          rw [ite_eq_left hpar, ih _ hh, Int.shiftLeft_eq, hsplit]
           grind
         · have hsplit : packSpec b (fun _ => c) len
               = packSpec b (fun _ => c) (len / 2)
@@ -463,7 +463,7 @@ theorem constPack_eq (b : Nat) (c : Int) :
             have h := packSpec_add b (fun _ => c) (len / 2) (len / 2 + 1)
             rw [show len / 2 + (len / 2 + 1) = len by omega] at h
             exact h
-          rw [if_neg hpar, ih _ hh, Int.shiftLeft_eq, Int.shiftLeft_eq, hsplit, hsucc]
+          rw [ite_eq_right hpar, ih _ hh, Int.shiftLeft_eq, Int.shiftLeft_eq, hsplit, hsucc]
           grind
 
 /-! # Divide-and-conquer digit extraction -/
@@ -658,20 +658,20 @@ private theorem mul_eq_zero_of_isZero (p q : ZPoly) (h : p.isZero = true ∨ q.i
     p * q = 0 := by
   show DensePoly.mul p q = 0
   unfold DensePoly.mul
-  rcases h with h | h <;> rw [if_pos (by simp [h])]
+  rcases h with h | h <;> rw [ite_eq_left (by simp [h])]
 
 /-- The Kronecker kernel computes the schoolbook product, at every cutoff. -/
 theorem mulKroneckerAt_eq (sizeCutoff bitCutoff : Nat) (p q : ZPoly) :
     mulKroneckerAt sizeCutoff bitCutoff p q = p * q := by
   unfold mulKroneckerAt
   by_cases hz : p.isZero || q.isZero
-  · rw [if_pos hz]
+  · rw [ite_eq_left hz]
     exact (mul_eq_zero_of_isZero p q (by simpa using hz)).symm
-  rw [if_neg hz]
+  rw [ite_eq_right hz]
   by_cases hsmall : min p.size q.size < sizeCutoff
-  · rw [if_pos hsmall]
+  · rw [ite_eq_left hsmall]
     exact (DensePoly.mul_eq_mulImpl p q).symm
-  rw [if_neg hsmall]
+  rw [ite_eq_right hsmall]
   by_cases hnarrow : bitLen (max (maxAbs p) (maxAbs q)) < bitCutoff
   · simp only [hnarrow, ↓reduceIte]
     exact (DensePoly.mul_eq_mulImpl p q).symm

--- a/HexPolyZ/Mignotte.lean
+++ b/HexPolyZ/Mignotte.lean
@@ -443,7 +443,7 @@ theorem floorSqrt_sq_le (n : Nat) : floorSqrt n * floorSqrt n ≤ n := by
     simp
   · have hn_pos : 0 < n := Nat.pos_of_ne_zero hn
     unfold floorSqrt
-    rw [if_neg hn]
+    rw [ite_eq_right hn]
     exact sqrtAux_full_fuel_sq_le n hn_pos
 
 /-- Base case of `ceilSqrt`: since `floorSqrt 0 = 0` is a perfect square,
@@ -464,7 +464,7 @@ theorem le_ceilSqrt_sq (n : Nat) : n ≤ (ceilSqrt n) ^ 2 := by
   · have hn_pos : 0 < n := Nat.pos_of_ne_zero hn
     have hfloor : floorSqrt n = sqrtAux n (2 * n.log2 + 1) n := by
       unfold floorSqrt
-      rw [if_neg hn]
+      rw [ite_eq_right hn]
     have hinit : n ≤ (n + 1) ^ 2 := by
       simp [Nat.pow_two]
       grind
@@ -473,9 +473,9 @@ theorem le_ceilSqrt_sq (n : Nat) : n ≤ (ceilSqrt n) ^ 2 := by
       exact sqrtAux_upper_succ n (2 * n.log2 + 1) n hn_pos hinit
     unfold ceilSqrt
     by_cases hsq : floorSqrt n * floorSqrt n = n
-    · rw [if_pos hsq, Nat.pow_two]
+    · rw [ite_eq_left hsq, Nat.pow_two]
       omega
-    · rw [if_neg hsq]
+    · rw [ite_eq_right hsq]
       exact hub
 
 /-- Restates `coeffNormSq f` as the explicit `foldl` summing `(f.coeff i).natAbs ^ 2`
@@ -499,13 +499,13 @@ theorem coeffL2NormBound_sq_le_two_mul_coeffNormSq (f : ZPoly) :
     dsimp [r]
     exact floorSqrt_sq_le (coeffNormSq f)
   by_cases hsq : r * r = coeffNormSq f
-  · rw [if_pos hsq]
+  · rw [ite_eq_left hsq]
     rw [Nat.pow_two]
     have hsq_floor :
         floorSqrt (coeffNormSq f) * floorSqrt (coeffNormSq f) = coeffNormSq f := by
       simpa [r] using hsq
     omega
-  · rw [if_neg hsq]
+  · rw [ite_eq_right hsq]
     rw [Nat.pow_two]
     have hr_lt : r * r < coeffNormSq f := Nat.lt_of_le_of_ne hr_sq hsq
     have hsucc_le : r * r + 1 ≤ coeffNormSq f := by omega

--- a/HexPolyZ/Rational.lean
+++ b/HexPolyZ/Rational.lean
@@ -45,10 +45,10 @@ theorem leadingCoeff_normalizePrimitiveSign_nonneg (p : ZPoly) :
     0 ≤ DensePoly.leadingCoeff (normalizePrimitiveSign p) := by
   unfold normalizePrimitiveSign
   by_cases hlead : DensePoly.leadingCoeff p < 0
-  · rw [if_pos hlead]
+  · rw [ite_eq_left hlead]
     rw [leadingCoeff_scale_of_nonzero (-1 : Int) p (by decide)]
     omega
-  · rw [if_neg hlead]
+  · rw [ite_eq_right hlead]
     omega
 
 /-- A nonzero integer polynomial has nonzero leading coefficient. -/
@@ -64,7 +64,7 @@ private theorem normalizePrimitiveSign_ne_zero_of_ne_zero (p : ZPoly) (hp : p �
     normalizePrimitiveSign p ≠ 0 := by
   unfold normalizePrimitiveSign
   by_cases hlead : DensePoly.leadingCoeff p < 0
-  · rw [if_pos hlead]
+  · rw [ite_eq_left hlead]
     intro hzero
     have hsize : p.size = 0 := by
       have hscaled_size : (DensePoly.scale (-1 : Int) p).size = p.size :=
@@ -76,7 +76,7 @@ private theorem normalizePrimitiveSign_ne_zero_of_ne_zero (p : ZPoly) (hp : p �
     intro n
     rw [DensePoly.coeff_zero]
     exact DensePoly.coeff_eq_zero_of_size_le p (by omega)
-  · rw [if_neg hlead]
+  · rw [ite_eq_right hlead]
     exact hp
 
 /-- Normalizing the primitive sign of a nonzero polynomial makes the leading
@@ -96,7 +96,7 @@ private theorem normalizePrimitiveSign_eq_self_of_leadingCoeff_nonneg
     (p : ZPoly) (h : 0 ≤ DensePoly.leadingCoeff p) :
     normalizePrimitiveSign p = p := by
   unfold normalizePrimitiveSign
-  rw [if_neg (by omega)]
+  rw [ite_eq_right (by omega)]
 
 /-- The rational primitive part has nonnegative integer leading coefficient. -/
 theorem leadingCoeff_ratPolyPrimitivePart_nonneg (p : DensePoly Rat) :
@@ -159,10 +159,10 @@ private theorem normalizePrimitiveSign_primitivePart_primitive (f : ZPoly)
     rw [hpart_zero, normalizePrimitiveSign_zero]
     simp [content, DensePoly.content_zero]
   by_cases hlead : DensePoly.leadingCoeff (primitivePart f) < 0
-  · rw [normalizePrimitiveSign, if_pos hlead, Primitive, content,
+  · rw [normalizePrimitiveSign, ite_eq_left hlead, Primitive, content,
       DensePoly.content_scale_neg_one]
     simpa [Primitive, content] using primitivePart_primitive f hcontent_ne
-  · rw [normalizePrimitiveSign, if_neg hlead]
+  · rw [normalizePrimitiveSign, ite_eq_right hlead]
     exact primitivePart_primitive f hcontent_ne
 
 /-- Sign normalization preserves a primitive integer polynomial. -/
@@ -170,10 +170,10 @@ theorem primitive_normalizePrimitiveSign {p : ZPoly} (hp : Primitive p) :
     Primitive (normalizePrimitiveSign p) := by
   unfold normalizePrimitiveSign
   by_cases hlead : DensePoly.leadingCoeff p < 0
-  · rw [if_pos hlead, Primitive, content,
+  · rw [ite_eq_left hlead, Primitive, content,
       DensePoly.content_scale_neg_one]
     simpa [Primitive, content] using hp
-  · rw [if_neg hlead]
+  · rw [ite_eq_right hlead]
     exact hp
 
 /-- Sign normalization preserves the stored coefficient count. -/
@@ -435,7 +435,7 @@ theorem reflectRat_mul (p q : DensePoly Rat) :
     unfold DensePoly.diagonalMulCoeffTerm
     by_cases hni : n < i
     · simp [hni, sign]
-    · rw [if_neg hni, if_neg hni, coeff_reflectRat, coeff_reflectRat]
+    · rw [ite_eq_right hni, ite_eq_right hni, coeff_reflectRat, coeff_reflectRat]
       have hpow : (-1 : Rat) ^ i * (-1 : Rat) ^ (n - i) = sign := by
         rw [← Lean.Grind.Semiring.pow_add]
         congr 1
@@ -529,12 +529,12 @@ private theorem toRatPoly_normalizePrimitiveSign_rational_associate (p : ZPoly) 
     ∃ unit : Rat, toRatPoly p = DensePoly.scale unit (toRatPoly (normalizePrimitiveSign p)) := by
   by_cases hlead : DensePoly.leadingCoeff p < 0
   · refine ⟨-1, ?_⟩
-    rw [normalizePrimitiveSign, if_pos hlead]
+    rw [normalizePrimitiveSign, ite_eq_left hlead]
     have h := rat_scale_toRatPoly_neg_int (1 : Rat) p
     rw [rat_scale_one] at h
     simpa using h
   · refine ⟨1, ?_⟩
-    rw [normalizePrimitiveSign, if_neg hlead]
+    rw [normalizePrimitiveSign, ite_eq_right hlead]
     exact (rat_scale_one (toRatPoly p)).symm
 
 /-- Folding a step that discards each element leaves the initial accumulator `init` unchanged. -/
@@ -594,11 +594,11 @@ private theorem rat_scale_mulCoeffStep (u v : Rat) (p q : DensePoly Rat)
       (u * v) * DensePoly.mulCoeffStep p q n i a j := by
   unfold DensePoly.mulCoeffStep
   by_cases hij : i + j = n
-  · rw [if_pos hij, if_pos hij]
+  · rw [ite_eq_left hij, ite_eq_left hij]
     rw [DensePoly.coeff_scale (R := Rat) u p i (Rat.mul_zero u),
       DensePoly.coeff_scale (R := Rat) v q j (Rat.mul_zero v)]
     grind
-  · rw [if_neg hij, if_neg hij]
+  · rw [ite_eq_right hij, ite_eq_right hij]
 
 /-- `rat_scale_mulCoeffStep_fold`: the `u * v` factor pulls out through the
 inner `mulCoeffStep` fold that accumulates one output coefficient. -/
@@ -745,7 +745,7 @@ private theorem rat_divMod_spec (p q : DensePoly Rat) :
       change (0 : DensePoly Rat) * q + p = p
       rw [DensePoly.zero_mul, DensePoly.zero_add]
     · unfold DensePoly.divMod
-      rw [if_neg hlt]
+      rw [ite_eq_right hlt]
       exact DensePoly.divModArray_reconstruction p q
         (fun coeff : Rat => coeff / q.leadingCoeff) hcancel
 
@@ -760,7 +760,7 @@ private theorem rat_divMod_spec_of_not_isZero (p q : DensePoly Rat)
   by_cases hlt : p.degree?.getD 0 < q.degree?.getD 0
   · simp [hlt]
     rw [DensePoly.zero_mul, DensePoly.zero_add]
-  · rw [if_neg hlt]
+  · rw [ite_eq_right hlt]
     exact DensePoly.divModArray_reconstruction p q
       (fun coeff => coeff / q.leadingCoeff)
       (fun a => rat_div_mul_cancel_of_ne a q.leadingCoeff

--- a/HexPolyZGcd/Brown.lean
+++ b/HexPolyZGcd/Brown.lean
@@ -277,11 +277,11 @@ private theorem brownLoop_checks (f h : ZPoly)
     checkGcd f h cert = true := by
   unfold brownLoop at hfound
   by_cases hfuel : fuel = 0
-  · rw [if_pos hfuel] at hfound
+  · rw [ite_eq_left hfuel] at hfound
     contradiction
-  · rw [if_neg hfuel] at hfound
+  · rw [ite_eq_right hfuel] at hfound
     by_cases hi : index < supply.size
-    · rw [dif_pos hi] at hfound
+    · rw [dite_eq_left hi] at hfound
       dsimp only at hfound
       generalize hoffer : brownOffer f h state supply[index] = offer at hfound
       cases offer with
@@ -311,7 +311,7 @@ private theorem brownLoop_checks (f h : ZPoly)
           | none =>
               exact brownLoop_checks f h supply (index + 1) (fuel - 1)
                 (some next) hfound
-    · rw [dif_neg hi] at hfound
+    · rw [dite_eq_right hi] at hfound
       contradiction
 termination_by fuel
 decreasing_by all_goals omega
@@ -324,9 +324,9 @@ private theorem brownBatches_checks (f h : ZPoly) (remaining start : Nat)
     checkGcd f h cert = true := by
   unfold brownBatches at hcert
   by_cases hremaining : remaining = 0
-  · rw [if_pos hremaining] at hcert
+  · rw [ite_eq_left hremaining] at hcert
     contradiction
-  · rw [if_neg hremaining] at hcert
+  · rw [ite_eq_right hremaining] at hcert
     dsimp only at hcert
     let supply := (ZMod64.primesBelow start (min brownBatchSize remaining)).filter
       (fun p => 2 ^ 30 < p.m)
@@ -367,9 +367,9 @@ theorem brownCert?_checks {f h : ZPoly} {cert : GcdCert}
   | pending state =>
       dsimp only at hcert
       by_cases hbudget : brownPrimeBudget f h ≤ brownBundledSupply.size
-      · rw [if_pos hbudget] at hcert
+      · rw [ite_eq_left hbudget] at hcert
         contradiction
-      · rw [if_neg hbudget] at hcert
+      · rw [ite_eq_right hbudget] at hcert
         exact brownBatches_checks f h
           (brownPrimeBudget f h - brownBundledSupply.size) (2 ^ 31 - 1)
           state hcert

--- a/HexPolyZGcd/Cert.lean
+++ b/HexPolyZGcd/Cert.lean
@@ -111,14 +111,14 @@ private theorem foldDiagonal_extend (p : Nat) [ZMod64.Bounds p]
       · have hterm : DensePoly.diagonalMulCoeffTerm
             (reduceModP p f) (reduceModP p g) n ((reduceModP p f).size + d) = 0 := by
           unfold DensePoly.diagonalMulCoeffTerm
-          rw [if_pos hn]
+          rw [ite_eq_left hn]
           rfl
         rw [hterm]
         exact Lean.Grind.Semiring.add_zero _
       · have hterm : DensePoly.diagonalMulCoeffTerm
             (reduceModP p f) (reduceModP p g) n ((reduceModP p f).size + d) = 0 := by
           unfold DensePoly.diagonalMulCoeffTerm
-          rw [if_neg hn, hcoeff]
+          rw [ite_eq_right hn, hcoeff]
           exact Lean.Grind.Semiring.zero_mul _
         rw [hterm]
         exact Lean.Grind.Semiring.add_zero _
@@ -221,7 +221,7 @@ theorem mulEqPacked_sound {p q target : ZPoly}
     p * q = target := by
   unfold mulEqPacked at hcheck
   by_cases hz : p.isZero || q.isZero
-  · rw [if_pos hz] at hcheck
+  · rw [ite_eq_left hz] at hcheck
     have htarget : target = 0 := by
       simpa [beq_iff_eq] using hcheck
     have hz' : p.isZero = true ∨ q.isZero = true := by
@@ -235,7 +235,7 @@ theorem mulEqPacked_sound {p q target : ZPoly}
         (DensePoly.size_eq_zero_iff q).mp ((DensePoly.isZero_eq_true_iff q).mp hq)
       rw [hq0, htarget, DensePoly.mul_comm_poly]
       exact DensePoly.zero_mul p
-  · rw [if_neg hz] at hcheck
+  · rw [ite_eq_right hz] at hcheck
     dsimp only at hcheck
     have hparts :
         target.size ≤ p.size + q.size - 1 ∧
@@ -336,7 +336,7 @@ theorem mulEqPacked_complete {p q target : ZPoly}
     mulEqPacked p q target = true := by
   unfold mulEqPacked
   by_cases hz : p.isZero || q.isZero
-  · rw [if_pos hz]
+  · rw [ite_eq_left hz]
     rw [beq_iff_eq]
     rw [← hproduct]
     have hz' : p.isZero = true ∨ q.isZero = true := by
@@ -352,7 +352,7 @@ theorem mulEqPacked_complete {p q target : ZPoly}
           ((DensePoly.isZero_eq_true_iff q).mp hq)
       rw [hq0, DensePoly.mul_comm_poly]
       exact DensePoly.zero_mul p
-  · rw [if_neg hz]
+  · rw [ite_eq_right hz]
     dsimp only
     rw [Bool.and_eq_true, decide_eq_true_eq, beq_iff_eq]
     let A := max (max (maxAbs p) (maxAbs q)) (maxAbs target)

--- a/HexPolyZGcd/Gcd.lean
+++ b/HexPolyZGcd/Gcd.lean
@@ -218,7 +218,7 @@ theorem rationalGcdCandidate_of_primitive {f h : ZPoly} (hf : Primitive f) :
   change normalizePrimitiveSign (DensePoly.scale (1 : Int) primitive) = primitive
   rw [hscaleOne]
   unfold normalizePrimitiveSign
-  rw [if_neg (by
+  rw [ite_eq_right (by
     have hlead := leadingCoeff_ratPolyPrimitivePart_nonneg
       (DensePoly.gcd (toRatPoly f) (toRatPoly h))
     have hleadPrimitive : 0 ≤ DensePoly.leadingCoeff primitive := by
@@ -1041,7 +1041,7 @@ theorem rationalGcdCert_checks (f h : ZPoly) :
     have hcop :
         checkCoprime cofL cofR (rationalCoprimeWitness cofL cofR) = true :=
       rationalCoprimeWitness_checks hcofNz hcopSize
-    rw [rationalGcdCert, if_neg hzero]
+    rw [rationalGcdCert, ite_eq_right hzero]
     change checkGcd f h
       { gcd := g, cofL := cofL, cofR := cofR,
         coprime := rationalCoprimeWitness cofL cofR } = true
@@ -1057,7 +1057,7 @@ candidate in its gcd field. -/
 theorem rationalGcdCert_gcd {f h : ZPoly} (hnz : f ≠ 0 ∨ h ≠ 0) :
     (rationalGcdCert f h).gcd = rationalGcdCandidate f h := by
   unfold rationalGcdCert
-  rw [if_neg (by
+  rw [ite_eq_right (by
     intro hzero
     rcases hnz with hf | hh
     · exact hf hzero.1
@@ -1124,9 +1124,9 @@ private theorem structuralReduction?_products {f h : ZPoly}
   unfold structuralReduction? at hresult
   dsimp only at hresult
   by_cases hzero : f.isZero || h.isZero
-  · rw [if_pos hzero] at hresult
+  · rw [ite_eq_left hzero] at hresult
     contradiction
-  · rw [if_neg hzero] at hresult
+  · rw [ite_eq_right hzero] at hresult
     let commonPower := min (xOrder f) (xOrder h)
     let commonContent : Int := Int.ofNat (Int.gcd (content f) (content h))
     let factor := DensePoly.scale commonContent (xPower commonPower)
@@ -1205,12 +1205,12 @@ private theorem afterCoprime_checks (f h : ZPoly) :
     checkGcd f h (afterCoprime f h) = true := by
   unfold afterCoprime
   by_cases hsmall : max f.size h.size ≤ heuSizeLimit
-  · rw [if_pos hsmall]
+  · rw [ite_eq_left hsmall]
     generalize hheu : heuCert? f h = cert?
     cases cert? with
     | some cert => exact heuCert?_checks hheu
     | none => exact brownOrFallback_checks f h
-  · rw [if_neg hsmall]
+  · rw [ite_eq_right hsmall]
     exact brownOrFallback_checks f h
 
 /-- Routes 1--4 on inputs after structural content and `x`-power removal. -/
@@ -1237,9 +1237,9 @@ private theorem reducedGcdCert_checks (f h : ZPoly) :
   | some cert => exact differenceCert?_checks hdiff
   | none =>
       by_cases hbits : brownBitCutoff < max (maxAbs f).log2 (maxAbs h).log2
-      · rw [if_pos hbits]
+      · rw [ite_eq_left hbits]
         exact brownOrFallback_checks f h
-      · rw [if_neg hbits]
+      · rw [ite_eq_right hbits]
         generalize hcop : coprimeCert? f h = coprime?
         cases coprime? with
         | some cert => exact coprimeCert?_checks hcop
@@ -1298,7 +1298,7 @@ theorem gcdCert_checks (f h : ZPoly) :
           simp only
           let cert := reducedGcdCert reduced.left reduced.right
           by_cases hfactor : reduced.factor == 1
-          · rw [if_pos hfactor]
+          · rw [ite_eq_left hfactor]
             have hfactorEq : reduced.factor = 1 := by
               simpa only [beq_iff_eq] using hfactor
             have hproducts := structuralReduction?_products hreduction
@@ -1314,7 +1314,7 @@ theorem gcdCert_checks (f h : ZPoly) :
               exact hproducts.2
             simpa only [cert, hleft, hright] using
               reducedGcdCert_checks reduced.left reduced.right
-          · rw [if_neg hfactor]
+          · rw [ite_eq_right hfactor]
             generalize hrestore : restoreStructural? f h reduced cert = restored?
             cases restored? with
             | some restored =>

--- a/HexPolyZGcd/Heu.lean
+++ b/HexPolyZGcd/Heu.lean
@@ -105,9 +105,9 @@ private theorem heuLoop_checks (f h : ZPoly) (base remainingBits : Nat)
   unfold heuLoop at hcert
   dsimp only at hcert
   by_cases hcost : projectedBits f h base > remainingBits
-  · rw [if_pos hcost] at hcert
+  · rw [ite_eq_left hcost] at hcert
     contradiction
-  · rw [if_neg hcost] at hcert
+  · rw [ite_eq_right hcost] at hcert
     generalize hcand : checkedCandidate? f h
         (heuCandidateAt f h base hbase) = candidate? at hcert
     cases candidate? with

--- a/HexPolyZGcd/SquareFree.lean
+++ b/HexPolyZGcd/SquareFree.lean
@@ -41,13 +41,13 @@ private theorem scaleNormalize (p : ZPoly) :
       DensePoly.scale ε (normalizePrimitiveSign p) = p := by
   unfold normalizePrimitiveSign
   by_cases hnegative : p.leadingCoeff < 0
-  · rw [if_pos hnegative]
+  · rw [ite_eq_left hnegative]
     refine ⟨-1, Or.inr rfl, ?_⟩
     rw [DensePoly.scale_scale]
     have hunit : (-1 : Int) * -1 = 1 := by omega
     rw [hunit]
     exact scaleOne p
-  · rw [if_neg hnegative]
+  · rw [ite_eq_right hnegative]
     exact ⟨1, Or.inl rfl, scaleOne p⟩
 
 /-- Integer-gcd replacement for `primitiveSquareFreeDecomposition`'s rational
@@ -138,15 +138,15 @@ theorem sqfDecomp_repeatedPart (f : ZPoly)
     have hpTrue : p.isZero = true := by rw [hpZero]; rfl
     exact hpNot hpTrue
   unfold sqfDecomp
-  rw [if_neg (by simpa only [p] using hpNot)]
-  rw [if_neg (by
+  rw [ite_eq_right (by simpa only [p] using hpNot)]
+  rw [ite_eq_right (by
     intro hdTrue
     rw [hd] at hdTrue
     contradiction)]
   by_cases hsmall : p.size ≤ 8
-  · rw [if_pos hsmall]
+  · rw [ite_eq_left hsmall]
     exact (gcd_eq_rationalCandidate (Or.inl hpNe)).symm
-  · rw [if_neg hsmall]
+  · rw [ite_eq_right hsmall]
     exact (gcd_eq_cert p derivative).symm
 
 namespace Repeated
@@ -197,8 +197,8 @@ private theorem nondegenerate (f : ZPoly)
   rw [gcd_eq_rationalCandidate (Or.inl hpNe)]
   rw [rationalGcdCandidate_of_primitive hpPrimitive]
   unfold primitiveSquareFreeDecomposition
-  rw [if_neg (by simpa only [p] using hpNot)]
-  rw [if_neg (by simpa only [p] using hratNot)]
+  rw [ite_eq_right (by simpa only [p] using hpNot)]
+  rw [ite_eq_right (by simpa only [p] using hratNot)]
   rw [toRatPoly_derivative]
 
 /-- The repeated factors also agree in the derivative-zero branch. -/
@@ -222,7 +222,7 @@ private theorem eqReference (f : ZPoly)
       rw [hratDerivativeZero]
       rfl
     unfold sqfDecomp primitiveSquareFreeDecomposition
-    rw [if_neg hpNot, if_pos hd, if_neg hpNot, if_pos hratTrue]
+    rw [ite_eq_right hpNot, ite_eq_left hd, ite_eq_right hpNot, ite_eq_left hratTrue]
   · have hdFalse :
         (DensePoly.derivative (primitivePart f)).isZero = false := by
       cases hvalue : (DensePoly.derivative (primitivePart f)).isZero with
@@ -238,11 +238,11 @@ private theorem sqfDecomp_primitive (f : ZPoly) :
   let p := primitivePart f
   unfold sqfDecomp
   by_cases hp : p.isZero = true
-  · rw [if_pos (by simpa only [p] using hp)]
-  · rw [if_neg (by simpa only [p] using hp)]
+  · rw [ite_eq_left (by simpa only [p] using hp)]
+  · rw [ite_eq_right (by simpa only [p] using hp)]
     by_cases hd : (DensePoly.derivative p).isZero = true
-    · rw [if_pos (by simpa only [p] using hd)]
-    · rw [if_neg (by simpa only [p] using hd)]
+    · rw [ite_eq_left (by simpa only [p] using hd)]
+    · rw [ite_eq_right (by simpa only [p] using hd)]
       split <;> rfl
 
 /-- Scaling twice by `-1` is the identity on integer polynomials. -/
@@ -271,7 +271,7 @@ theorem sqfDecomp_reassembly_signed (f : ZPoly) :
   have hpDef : primitivePart f = p := rfl
   unfold sqfDecomp
   by_cases hp : p.isZero = true
-  · rw [if_pos (by simpa only [p] using hp)]
+  · rw [ite_eq_left (by simpa only [p] using hp)]
     have hpZero : p = 0 :=
       (DensePoly.size_eq_zero_iff p).mp
         ((DensePoly.isZero_eq_true_iff p).mp hp)
@@ -279,22 +279,22 @@ theorem sqfDecomp_reassembly_signed (f : ZPoly) :
     rw [DensePoly.zero_mul, DensePoly.scale_zero_right]
     change 0 = primitivePart f
     rw [hpDef, hpZero]
-  · rw [if_neg (by simpa only [p] using hp)]
+  · rw [ite_eq_right (by simpa only [p] using hp)]
     let derivative := DensePoly.derivative p
     by_cases hd : derivative.isZero = true
-    · rw [if_pos (by simpa only [derivative, p] using hd)]
+    · rw [ite_eq_left (by simpa only [derivative, p] using hd)]
       rcases scaleNormalize p with ⟨ε, hε, hscale⟩
       refine ⟨ε, hε, ?_⟩
       rw [DensePoly.mul_one_right_poly]
       exact hscale
-    · rw [if_neg (by simpa only [derivative, p] using hd)]
+    · rw [ite_eq_right (by simpa only [derivative, p] using hd)]
       have hpNe : p ≠ 0 := by
         intro hpZero
         apply hp
         rw [hpZero]
         rfl
       by_cases hsmall : p.size ≤ 8
-      · rw [if_pos (by simpa only [p] using hsmall)]
+      · rw [ite_eq_left (by simpa only [p] using hsmall)]
         let repeated := rationalGcdCandidate p derivative
         let quotient := (DensePoly.divMod p repeated).1
         rcases scaleNormalize quotient with ⟨ε, hε, hscale⟩
@@ -306,7 +306,7 @@ theorem sqfDecomp_reassembly_signed (f : ZPoly) :
         rw [DensePoly.scale_mul, hscale]
         rw [DensePoly.mul_comm_poly quotient repeated]
         exact hproduct
-      · rw [if_neg (by simpa only [p] using hsmall)]
+      · rw [ite_eq_right (by simpa only [p] using hsmall)]
         let cert := gcdCert p derivative
         rcases scaleNormalize cert.cofL with ⟨ε, hε, hscale⟩
         refine ⟨ε, hε, ?_⟩
@@ -330,7 +330,7 @@ theorem sqfDecomp_squareFreeCore (f : ZPoly)
     have hpTrue : (primitivePart f).isZero = true := by
       rw [hpZero]
       rfl
-    simp only [fast, sqfDecomp, hpTrue, if_pos]
+    simp only [fast, sqfDecomp, hpTrue, ite_eq_left]
   have hfNe : f ≠ 0 := by
     intro hfZero
     subst f

--- a/HexPolyZMathlib/Mignotte.lean
+++ b/HexPolyZMathlib/Mignotte.lean
@@ -210,8 +210,8 @@ private theorem foldl_binom_iter_eq_choose (n m : Nat) :
 theorem binom_eq_choose (n k : Nat) : Hex.Nat.binom n k = Nat.choose n k := by
   unfold Hex.Nat.binom
   by_cases hnk : n < k
-  · rw [if_pos hnk, Nat.choose_eq_zero_of_lt hnk]
-  · rw [if_neg hnk]
+  · rw [ite_eq_left hnk, Nat.choose_eq_zero_of_lt hnk]
+  · rw [ite_eq_right hnk]
     have hkn : k ≤ n := Nat.le_of_not_lt hnk
     by_cases hkk : k ≤ n - k
     · have hmin : min k (n - k) = k := Nat.min_eq_left hkk

--- a/HexPolyZMathlib/RobinsonForm.lean
+++ b/HexPolyZMathlib/RobinsonForm.lean
@@ -400,7 +400,7 @@ theorem mahlerMeasure_le_circleAverage_norm (p : ℂ[X]) :
       0 < ‖p.eval (circleMap 0 1 θ)‖ := by
     rw [ae_restrict_iff' measurableSet_uIoc]
     refine Set.Finite.measure_zero ?_ _
-    simp only [norm_pos_iff, ne_eq, compl_setOf, Classical.not_imp, Decidable.not_not]
+    simp only [norm_pos_iff, ne_eq, compl_ofPred, Classical.not_imp, Decidable.not_not]
     refine Finite.of_finite_image (f := circleMap 0 1) (p.roots.finite_toSet.subset ?_) ?_
     · rintro z ⟨θ, ⟨_, heval⟩, rfl⟩
       exact (mem_roots hp).mpr heval

--- a/HexRCF/Cells.lean
+++ b/HexRCF/Cells.lean
@@ -574,7 +574,7 @@ theorem meetsIoc_iff {f : ZPoly} {cert : IsolationCert}
   | «open» cut =>
       by_cases hzero : cert.intervals.size = 0
       · simp only [meetsIoc]
-        rw [dif_pos hzero]
+        rw [dite_eq_left hzero]
         constructor
         · intro _
           exact ⟨B, by simp [Sem, hzero], hab, le_rfl⟩
@@ -590,7 +590,7 @@ theorem meetsIoc_iff {f : ZPoly} {cert : IsolationCert}
         have hbound : (cmps.lower[0] == .gt) = true ↔ A < M.root first := by
           simpa [first] using eq_gt_iff hl
         simp only [meetsIoc]
-        rw [dif_neg hzero, dif_pos hleft, hbound]
+        rw [dite_eq_right hzero, dite_eq_left hleft, hbound]
         constructor
         · intro har
           obtain ⟨x, hax, hx⟩ := exists_between (lt_min hab har)
@@ -610,7 +610,7 @@ theorem meetsIoc_iff {f : ZPoly} {cert : IsolationCert}
             M.root last < B := by
           simpa [last] using eq_lt_iff hu
         simp only [meetsIoc]
-        rw [dif_neg hzero, dif_neg hleft, dif_pos hright, hbound]
+        rw [dite_eq_right hzero, dite_eq_right hleft, dite_eq_left hright, hbound]
         constructor
         · intro hrb
           obtain ⟨x, hx, hxb⟩ := exists_between (max_lt hab hrb)
@@ -639,7 +639,7 @@ theorem meetsIoc_iff {f : ZPoly} {cert : IsolationCert}
             A < M.root next := by
           simpa [next] using eq_gt_iff hl
         simp only [meetsIoc]
-        rw [dif_neg hzero, dif_neg hleft, dif_neg hright, Bool.and_eq_true,
+        rw [dite_eq_right hzero, dite_eq_right hleft, dite_eq_right hright, Bool.and_eq_true,
           hubound, hlbound]
         constructor
         · rintro ⟨hrb, har⟩

--- a/HexRCF/IsolationCheck.lean
+++ b/HexRCF/IsolationCheck.lean
@@ -61,7 +61,7 @@ theorem count_one_of_check {replay : SturmReplay} {cert : IsolationCert}
     replay.count cert.intervals[i] = 1 := by
   have hmem : i.val ∈ List.range cert.intervals.size := List.mem_range.mpr i.isLt
   have hcount := (List.all_eq_true.mp h) i.val hmem
-  simp only [i.isLt, dif_pos] at hcount
+  simp only [i.isLt, dite_eq_left] at hcount
   exact of_decide_eq_true hcount
 
 /-- Each adjacent interval pair accepted by the order walk is separated in the
@@ -72,7 +72,7 @@ theorem adjacent_of_check {cert : IsolationCert} (h : cert.checkOrder = true)
       (cert.intervals[i + 1]'hi).lower := by
   have hmem : i ∈ List.range (cert.intervals.size - 1) := List.mem_range.mpr (by omega)
   have hstep := (List.all_eq_true.mp h) i hmem
-  simp only [hi, dif_pos] at hstep
+  simp only [hi, dite_eq_left] at hstep
   exact of_decide_eq_true hstep
 
 /-- Derive non-strict dyadic order from strict dyadic order. -/

--- a/HexRCF/SeparationCheck.lean
+++ b/HexRCF/SeparationCheck.lean
@@ -60,7 +60,7 @@ theorem gap_of_check {cert : IsolationCert} (h : cert.checkGaps = true)
       (cert.intervals[i + 1]'hi).lower := by
   have hmem : i ∈ List.range (cert.intervals.size - 1) := List.mem_range.mpr (by omega)
   have hstep := (List.all_eq_true.mp h) i hmem
-  simp only [hi, dif_pos] at hstep
+  simp only [hi, dite_eq_left] at hstep
   exact of_decide_eq_true hstep
 
 /-- Transitivity of strict order on dyadic numbers. -/

--- a/HexRCF/SignMatrix.lean
+++ b/HexRCF/SignMatrix.lean
@@ -315,7 +315,7 @@ theorem signWith?_spec {sentence : Sentence} {carrier : CarrierCert}
         · refine ⟨.zero, ?_, ?_⟩
           · have hhas' : common.hasRoot isolations.intervals[↑i] = true := by
               simpa using hhas
-            simp only [signWith?, if_pos hdegree]
+            simp only [signWith?, ite_eq_left hdegree]
             rw [hfind']
             change rootSign? p common isolations i = some .zero
             unfold rootSign?
@@ -342,7 +342,7 @@ theorem signWith?_spec {sentence : Sentence} {carrier : CarrierCert}
           have hnonzero : evalSign p (isolations.openPoint i.castSucc) ≠ .zero :=
             evalSign_ne_zero p _ hnotroot
           refine ⟨evalSign p (isolations.openPoint i.castSucc), ?_, ?_⟩
-          · simp only [signWith?, if_pos hdegree]
+          · simp only [signWith?, ite_eq_left hdegree]
             rw [hfind']
             change rootSign? p common isolations i =
               some (evalSign p (isolations.openPoint i.castSucc))

--- a/HexResultant/Basic.lean
+++ b/HexResultant/Basic.lean
@@ -322,10 +322,10 @@ private theorem pseudoQuotient_coeff {S : Type u} [Zero S] [DecidableEq S]
       else 0
   rw [coeff_ofCoeffs]
   by_cases hk : k < d
-  · rw [if_pos hk]
+  · rw [ite_eq_left hk]
     have hget := pushBuild_getD d k #[] step (Zero.zero : S) hk
     simpa only [Array.size_empty, Nat.zero_add] using hget
-  · rw [if_neg hk]
+  · rw [ite_eq_right hk]
     have hsize : (pushBuild d #[] step).size ≤ k := by
       rw [pushBuild_size]
       simp only [Array.size_empty]
@@ -372,12 +372,12 @@ private theorem pseudoRemainder_coeff {S : Type u}
       else 0
   rw [coeff_ofCoeffs]
   by_cases ht : t < m
-  · rw [if_pos ht]
+  · rw [ite_eq_left ht]
     dsimp only [step]
     have hget := pushBuild_getD m t #[] step (Zero.zero : S) ht
     dsimp only [step] at hget
     simpa only [Array.size_empty, Nat.zero_add, coeff_ofCoeffs] using hget
-  · rw [if_neg ht]
+  · rw [ite_eq_right ht]
     have hsize : (pushBuild m #[] step).size ≤ t := by
       rw [pushBuild_size]
       simp only [Array.size_empty]
@@ -509,7 +509,7 @@ private theorem coeff_mul_bounded {S : Type u} [Lean.Grind.CommRing S]
   apply foldl_range_congr
   intro acc i hi
   unfold diagonalMulCoeffTerm
-  rw [if_neg (by
+  rw [ite_eq_right (by
     have himin : i < min (t + 1) bound := hi
     omega)]
 
@@ -590,7 +590,7 @@ private theorem high_convolution {S : Type u} [Lean.Grind.CommRing S]
     have hgindex : n - i - k = m + j - i := by
       dsimp only [k, j]
       omega
-    rw [hq, if_pos hk, hjindex, hgindex]
+    rw [hq, ite_eq_left hk, hjindex, hgindex]
     by_cases hoff : offset < correctionLength
     · have hj : j < i := by
         dsimp only [j, correctionLength]
@@ -844,7 +844,7 @@ theorem pseudoDivMod_reconstruct {S : Type u}
   intro t
   rw [coeff_scale_semiring, coeff_add_semiring]
   by_cases ht : t < m
-  · rw [hrcoeff t, if_pos ht, coeff_mul_bounded q g t d hqsize,
+  · rw [hrcoeff t, ite_eq_left ht, coeff_mul_bounded q g t d hqsize,
       hpowersSpec.2 d (by omega)]
     grind
   · by_cases htf : t < f.size
@@ -855,7 +855,7 @@ theorem pseudoDivMod_reconstruct {S : Type u}
       have hi : i < d := by
         dsimp only [i]
         omega
-      rw [hrcoeff t, if_neg ht, coeff_mul_bounded q g t d hqsize]
+      rw [hrcoeff t, ite_eq_right ht, coeff_mul_bounded q g t d hqsize]
       have hhigh := high_convolution g q active powers b n m d i hnd
         hmsize.symm hlc hpowersSpec.2 hqcoeff hi
       rw [← hnti, hhigh, hactiveSpec.2 i hi]
@@ -873,7 +873,7 @@ theorem pseudoDivMod_reconstruct {S : Type u}
       have hprodzero : (q * g).coeff t = 0 :=
         coeff_eq_zero_of_size_le (q * g)
           (Nat.le_trans hprodsize (Nat.le_of_not_gt htf))
-      rw [hrcoeff t, if_neg ht, hfzero, hprodzero]
+      rw [hrcoeff t, ite_eq_right ht, hfzero, hprodzero]
       simp only [Lean.Grind.Semiring.mul_zero,
         Lean.Grind.Semiring.add_zero]
 

--- a/HexResultant/BlockDeterminant.lean
+++ b/HexResultant/BlockDeterminant.lean
@@ -84,34 +84,34 @@ theorem det_swapAt {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
         funext i j
         simp only [swapAt, swapAdjacent]
         by_cases hjl : j.val = left
-        · rw [if_pos hjl]
+        · rw [ite_eq_left hjl]
           have hj : j = left'.castSucc := by
             apply Fin.ext
             exact hjl
-          rw [if_pos hj]
+          rw [ite_eq_left hj]
           apply congrArg (M i)
           apply Fin.ext
           simp [left']
-        · rw [if_neg hjl]
+        · rw [ite_eq_right hjl]
           have hjl' : j ≠ left'.castSucc := by
             intro hj
             exact hjl (congrArg Fin.val hj)
-          rw [if_neg hjl']
+          rw [ite_eq_right hjl']
           by_cases hjr : j.val = left + 1
-          · rw [if_pos hjr]
+          · rw [ite_eq_left hjr]
             have hj : j = left'.succ := by
               apply Fin.ext
               simpa [left'] using hjr
-            rw [if_pos hj]
+            rw [ite_eq_left hj]
             apply congrArg (M i)
             apply Fin.ext
             simp [left']
-          · rw [if_neg hjr]
+          · rw [ite_eq_right hjr]
             have hjr' : j ≠ left'.succ := by
               intro hj
               apply hjr
               simpa [left'] using congrArg Fin.val hj
-            rw [if_neg hjr']
+            rw [ite_eq_right hjr']
       rw [hmatrix, det_swapAdjacent]
 
 /-- Move the column at `start + count` to `start`, shifting the intervening
@@ -237,7 +237,7 @@ theorem rotateBlocks_apply {R : Type u} {n : Nat} (M : Square R n)
           apply Fin.ext
           simp [rotateIndex, hstart, shifted]
         rw [hrecIndex, hfinalIndex, moveLeft_apply]
-        rw [if_pos hstart]
+        rw [ite_eq_left hstart]
       · by_cases hfirst : start ≤ j.val ∧ j.val < start + (right + 1)
         · have hrecFirst :
               start + 1 ≤ j.val ∧ j.val < start + 1 + right := by omega
@@ -258,7 +258,7 @@ theorem rotateBlocks_apply {R : Type u} {n : Nat} (M : Square R n)
             simp [shifted]
             omega
           rw [hrecIndex, hfinalIndex, moveLeft_apply]
-          rw [if_neg hshiftStart, if_neg hshiftMiddle]
+          rw [ite_eq_right hshiftStart, ite_eq_right hshiftMiddle]
         · by_cases hsecond :
             start + (right + 1) ≤ j.val ∧
               j.val < start + (right + 1) + left
@@ -289,7 +289,7 @@ theorem rotateBlocks_apply {R : Type u} {n : Nat} (M : Square R n)
               simp [middle]
               omega
             rw [hrecIndex, hfinalIndex, moveLeft_apply]
-            rw [if_neg hmiddleStart, if_pos hlookup]
+            rw [ite_eq_right hmiddleStart, ite_eq_left hlookup]
             apply congrArg (M i)
             apply Fin.ext
             simp [middle, shifted]
@@ -435,8 +435,8 @@ theorem poly_swap (J : Nat) (f g : DensePoly R) :
   rw [coeff_scale_semiring]
   simp only [coeff_poly]
   by_cases hl : l < J + 1
-  · rw [if_pos hl, if_pos hl, coeffMinor_swap]
-  · rw [if_neg hl, if_neg hl]
+  · rw [ite_eq_left hl, ite_eq_left hl, coeffMinor_swap]
+  · rw [ite_eq_right hl, ite_eq_right hl]
     exact (Lean.Grind.Semiring.mul_zero _).symm
 
 end Swap

--- a/HexResultant/BrownTraub.lean
+++ b/HexResultant/BrownTraub.lean
@@ -81,10 +81,10 @@ theorem addProduct_apply {R : Type u} [Lean.Grind.CommRing R] [DecidableEq R]
         omega
       by_cases hj : j = dst
       · subst j
-        simp only [addProduct, addCol_apply, if_true, productCol]
-        rw [ih, if_pos rfl, ih, if_neg hsrcDst]
-      · simp only [addProduct, addCol_apply, if_neg hj]
-        rw [ih, if_neg hj]
+        simp only [addProduct, addCol_apply, ite_true, productCol]
+        rw [ih, ite_eq_left rfl, ih, ite_eq_right hsrcDst]
+      · simp only [addProduct, addCol_apply, ite_eq_right hj]
+        rw [ih, ite_eq_right hj]
 
 /-- One multiplier-column update preserves the local determinant. -/
 theorem det_addProduct {R : Type u} [Lean.Grind.CommRing R] [DecidableEq R]
@@ -167,12 +167,12 @@ theorem productCols_apply {R : Type u} [Lean.Grind.CommRing R] [DecidableEq R]
       by_cases hold : split ≤ j.val ∧ j.val < split + right
       · have hnew : split ≤ j.val ∧ j.val < split + (right + 1) := by
           omega
-        rw [dif_pos hold, dif_pos hnew]
+        rw [dite_eq_left hold, dite_eq_left hnew]
         apply productCol_congr M' M j db (j.val - split) (by omega) b i
           (db + 1) (Nat.le_refl _)
         · dsimp only [M']
           rw [addProduct_apply]
-          rw [if_neg (by
+          rw [ite_eq_right (by
             intro heq
             have hval := congrArg Fin.val heq
             simp [dst] at hval
@@ -180,7 +180,7 @@ theorem productCols_apply {R : Type u} [Lean.Grind.CommRing R] [DecidableEq R]
         · intro k hk
           dsimp only [M']
           rw [addProduct_apply]
-          rw [if_neg (by
+          rw [ite_eq_right (by
             intro heq
             have hval := congrArg Fin.val heq
             simp [dst] at hval
@@ -188,17 +188,17 @@ theorem productCols_apply {R : Type u} [Lean.Grind.CommRing R] [DecidableEq R]
       · by_cases hlast : j.val = split + right
         · have hnew : split ≤ j.val ∧ j.val < split + (right + 1) := by
             omega
-          rw [dif_neg hold, dif_pos hnew]
+          rw [dite_eq_right hold, dite_eq_left hnew]
           have hjdst : j = dst := Fin.ext hlast
           subst j
-          rw [addProduct_apply, if_pos rfl]
+          rw [addProduct_apply, ite_eq_left rfl]
           congr 3
           simp [dst]
         · have hnew : ¬(split ≤ j.val ∧ j.val < split + (right + 1)) := by
             omega
-          rw [dif_neg hold, dif_neg hnew]
+          rw [dite_eq_right hold, dite_eq_right hnew]
           rw [addProduct_apply]
-          rw [if_neg (by
+          rw [ite_eq_right (by
             intro heq
             have hval := congrArg Fin.val heq
             simp at hval
@@ -288,23 +288,23 @@ private theorem coeffInt_sub_nat {R : Type u} [Zero R] [DecidableEq R]
       if k ≤ t.toNat then p.coeff (t.toNat - k) else 0 := by
   have htCast : (t.toNat : Int) = t := Int.toNat_of_nonneg ht
   by_cases hk : k ≤ t.toNat
-  · rw [if_pos hk]
+  · rw [ite_eq_left hk]
     have hkInt : (k : Int) ≤ t := by
       rw [← htCast]
       exact Int.ofNat_le.mpr hk
     unfold coeffInt
-    rw [if_neg (by
+    rw [ite_eq_right (by
       have hk0 := Int.natCast_nonneg k
       omega)]
     congr 1
     apply Int.natCast_inj.mp
     rw [Int.toNat_sub_of_le hkInt, Int.ofNat_sub hk, htCast]
-  · rw [if_neg hk]
+  · rw [ite_eq_right hk]
     have hkInt : t < (k : Int) := by
       rw [← htCast]
       exact Int.ofNat_lt.mpr (by omega)
     unfold coeffInt
-    rw [if_pos (by omega)]
+    rw [ite_eq_left (by omega)]
 
 /-- The full integer-indexed coefficient fold is the corresponding product
 coefficient. -/
@@ -315,7 +315,7 @@ theorem coeffFold_eq_mul {R : Type u} [Lean.Grind.CommRing R] [DecidableEq R]
   · have hterm (k : Nat) : coeffInt g (t - (k : Int)) = 0 := by
       have hk0 := Int.natCast_nonneg k
       unfold coeffInt
-      rw [if_pos (by omega)]
+      rw [ite_eq_left (by omega)]
     have hfold (xs : List Nat) (init : R) :
         xs.foldl
           (fun acc k => acc + b.coeff k * coeffInt g (t - (k : Int))) init =
@@ -330,7 +330,7 @@ theorem coeffFold_eq_mul {R : Type u} [Lean.Grind.CommRing R] [DecidableEq R]
     unfold coeffFold
     rw [hfold]
     unfold coeffInt
-    rw [if_pos ht]
+    rw [ite_eq_left ht]
   · have ht0 : 0 ≤ t := by omega
     have hstep (acc : R) (k : Nat) :
         acc + b.coeff k * coeffInt g (t - (k : Int)) =
@@ -339,14 +339,14 @@ theorem coeffFold_eq_mul {R : Type u} [Lean.Grind.CommRing R] [DecidableEq R]
           else acc := by
       rw [coeffInt_sub_nat g t ht0 k]
       by_cases hk : k ≤ t.toNat
-      · rw [if_pos hk]
+      · rw [ite_eq_left hk]
         by_cases hgk : t.toNat - k < g.size
-        · rw [if_pos ⟨hk, hgk⟩]
-        · rw [if_neg (by omega)]
+        · rw [ite_eq_left ⟨hk, hgk⟩]
+        · rw [ite_eq_right (by omega)]
           rw [coeff_eq_zero_of_size_le g (by omega)]
           rw [show (Zero.zero : R) = 0 from rfl,
             Lean.Grind.Semiring.mul_zero, Lean.Grind.Semiring.add_zero]
-      · rw [if_neg hk, if_neg (by omega)]
+      · rw [ite_eq_right hk, ite_eq_right (by omega)]
         rw [Lean.Grind.Semiring.mul_zero, Lean.Grind.Semiring.add_zero]
     have hfold (xs : List Nat) (init : R) :
         xs.foldl
@@ -364,7 +364,7 @@ theorem coeffFold_eq_mul {R : Type u} [Lean.Grind.CommRing R] [DecidableEq R]
     unfold coeffFold
     rw [hfold]
     unfold coeffInt
-    rw [if_neg ht]
+    rw [ite_eq_right ht]
     rw [coeff_mul, mulCoeffSum_eq_singleFold]
     rfl
 
@@ -404,7 +404,7 @@ private theorem productCol_addMul {R : Type u}
       intro k hk
       unfold coeffMatrixAt
       simp only
-      rw [if_pos (by omega), if_pos (by omega)]
+      rw [ite_eq_left (by omega), ite_eq_left (by omega)]
       congr 1
       simp only [t, Int.ofNat_eq_natCast]
       rw [Int.ofNat_sub (by omega : k ≤ db + d)]
@@ -429,7 +429,7 @@ private theorem productCol_addMul {R : Type u}
       intro k hk
       unfold coeffMatrixAt
       simp only
-      rw [if_pos (by omega), if_neg (by omega)]
+      rw [ite_eq_left (by omega), ite_eq_right (by omega)]
       congr 1
       simp only [t, Int.ofNat_eq_natCast]
       rw [Int.ofNat_sub (by omega : k ≤ db + d)]
@@ -458,14 +458,14 @@ theorem productCols_addMul {R : Type u}
   funext i j
   rw [SubresultantMinor.productCols_apply]
   by_cases hj : df - J ≤ j.val ∧ j.val < df - J + (dg - J)
-  · rw [dif_pos hj]
+  · rw [dite_eq_left hj]
     let d := j.val - (df - J)
     have hd : d < dg - J := by
       simp [d]
       omega
     exact productCol_addMul df dg db J l f g b h hJ hdeg hb hh
       d hd i j (by simp [d]; omega)
-  · rw [dif_neg hj]
+  · rw [dite_eq_right hj]
     have hjleft : j.val < df - J := by
       have := j.isLt
       omega
@@ -537,7 +537,7 @@ theorem coeffMinorAt_succRight {R : Type u}
         omega
       simp only [M, row, SubresultantMinor.castSquare, coeffMatrixAt,
         Fin.cast]
-      rw [if_pos hleft, if_neg hnotLast]
+      rw [ite_eq_left hleft, ite_eq_right hnotLast]
       rw [show Int.ofNat dg - Int.ofNat 0 + Int.ofNat j.val =
           ((dg + j.val : Nat) : Int) by
         simp [Int.ofNat_eq_natCast, Int.natCast_add]]
@@ -549,7 +549,7 @@ theorem coeffMinorAt_succRight {R : Type u}
         omega
       simp only [M, row, SubresultantMinor.castSquare, coeffMatrixAt,
         Fin.cast]
-      rw [if_neg hleft, if_neg hnotLast]
+      rw [ite_eq_right hleft, ite_eq_right hnotLast]
       rw [show Int.ofNat (dh + 1) - Int.ofNat 0 + Int.ofNat jj =
           ((dh + 1 + jj : Nat) : Int) by
         simp [Int.ofNat_eq_natCast, Int.natCast_add]]
@@ -563,21 +563,21 @@ theorem coeffMinorAt_succRight {R : Type u}
       coeffMatrixAt dg dh J l g h i j
     simp only [coeffMatrixAt]
     by_cases hleft : j.val < dh - J
-    · rw [if_pos (by omega), if_pos hleft]
+    · rw [ite_eq_left (by omega), ite_eq_left hleft]
       by_cases hlast : i.val = n - 1
-      · rw [if_pos (by omega), if_pos hlast]
+      · rw [ite_eq_left (by omega), ite_eq_left hlast]
         congr 1
         simp [n]
         omega
-      · rw [if_neg (by omega), if_neg hlast]
+      · rw [ite_eq_right (by omega), ite_eq_right hlast]
         congr 1
         simp [Int.ofNat_eq_natCast, Int.natCast_add] <;> omega
-    · rw [if_neg (by omega), if_neg hleft]
+    · rw [ite_eq_right (by omega), ite_eq_right hleft]
       by_cases hlast : i.val = n - 1
-      · rw [if_pos (by omega), if_pos hlast]
+      · rw [ite_eq_left (by omega), ite_eq_left hlast]
         congr 1
         simp [Int.ofNat_eq_natCast] <;> omega
-      · rw [if_neg (by omega), if_neg hlast]
+      · rw [ite_eq_right (by omega), ite_eq_right hlast]
         congr 1
         simp [Int.ofNat_eq_natCast, Int.natCast_add] <;> omega
   unfold coeffMinorAt
@@ -649,7 +649,7 @@ theorem coeffMinorAt_leftSucc {R : Type u}
     coeffMinorAt (dh + 1) dh dh l g h = h.coeff l := by
   rw [coeffMinorAt_swap]
   simp only [Nat.sub_self, Nat.mul_zero, SubresultantMinor.sign]
-  rw [if_pos (by decide), Lean.Grind.Semiring.one_mul,
+  rw [ite_eq_left (by decide), Lean.Grind.Semiring.one_mul,
     coeffMinorAt_rightDegree_ignore, coeffMinorAt_unitRight]
 
 /-- The subresultant immediately below the divisor degree is the signed
@@ -714,7 +714,7 @@ theorem poly_prem {R : Type u}
   rw [coeff_scale_semiring]
   simp only [coeff_poly]
   by_cases hl : l < J + 1
-  · rw [if_pos hl]
+  · rw [ite_eq_left hl]
     unfold coeffMinor
     rw [hff, hgg]
     have hscale := coeffMinorAt_scale_left df dg J l a f g
@@ -744,7 +744,7 @@ theorem poly_prem {R : Type u}
     rw [hpow, hunit, hsign] at hscale
     apply ExactDivLaws.mul_right_cancel ha
     grind
-  · rw [if_neg hl]
+  · rw [ite_eq_right hl]
     have hrzero : r.coeff l = 0 :=
       coeff_eq_zero_of_size_le r (by omega)
     rw [hrzero, Lean.Grind.Semiring.mul_zero]
@@ -760,7 +760,7 @@ theorem coeffMinorAt_rightDegree {R : Type u}
       h.leadingCoeff ^ (dg - dh - 1) * h.coeff l := by
   rw [coeffMinorAt_swap]
   simp only [Nat.sub_self, Nat.mul_zero, SubresultantMinor.sign]
-  rw [if_pos (by decide)]
+  rw [ite_eq_left (by decide)]
   rw [Lean.Grind.Semiring.one_mul,
     coeffMinorAt_rightDegree_ignore dg dh l h g]
   have hsum : dh + 1 + (dg - (dh + 1)) = dg := by omega
@@ -806,11 +806,11 @@ theorem poly_rightDegree {R : Type u}
   rw [coeff_scale_semiring]
   simp only [coeff_poly]
   by_cases hl : l < dh + 1
-  · rw [if_pos hl]
+  · rw [ite_eq_left hl]
     unfold coeffMinor
     rw [hfg, hfh]
     exact coeffMinorAt_rightDegree dg dh l g h hdh hh
-  · rw [if_neg hl, coeff_eq_zero_of_size_le h (by omega)]
+  · rw [ite_eq_right hl, coeff_eq_zero_of_size_le h (by omega)]
     change (0 : R) = h.leadingCoeff ^ (dg - dh - 1) * (0 : R)
     rw [Lean.Grind.Semiring.mul_zero]
 
@@ -836,13 +836,13 @@ theorem poly_brownTraub {R : Type u}
   rw [coeff_scale_semiring]
   simp only [coeff_poly]
   by_cases hl : l < J + 1
-  · rw [if_pos hl, if_pos hl]
+  · rw [ite_eq_left hl, ite_eq_left hl]
     unfold coeffMinor
     rw [hff, hfg, hfh]
     rw [coeffMinorAt_brownTraub df dg db dh J l f g b h hJh hdh hdeg
       hg hb (by omega) hh]
     grind
-  · rw [if_neg hl, if_neg hl]
+  · rw [ite_eq_right hl, ite_eq_right hl]
     change (0 : R) =
       (SubresultantMinor.sign (R := R) ((df - J) * (dg - J)) *
         g.leadingCoeff ^ (df - dh)) * (0 : R)

--- a/HexResultant/DeterminantAlgebra.lean
+++ b/HexResultant/DeterminantAlgebra.lean
@@ -659,8 +659,8 @@ theorem det_toMatrix {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
             Matrix.cofactorSign (R := R) row j := by
           unfold sign Matrix.cofactorSign
           by_cases h : j.val % 2 = 0
-          · rw [if_pos h, if_pos (by simpa [row] using h)]
-          · rw [if_neg h, if_neg (by simpa [row] using h)]
+          · rw [ite_eq_left h, ite_eq_left (by simpa [row] using h)]
+          · rw [ite_eq_right h, ite_eq_right (by simpa [row] using h)]
             grind
         unfold Matrix.cofactor
         rw [hminor, ← ih, ← hsign]
@@ -846,7 +846,7 @@ theorem det_scaleRange {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
       have hmatrix : scaleRange M start 0 c = M := by
         funext i j
         unfold scaleRange
-        rw [if_neg (by omega)]
+        rw [ite_eq_right (by omega)]
       rw [hmatrix]
       rw [Lean.Grind.Semiring.pow_zero]
       grind
@@ -865,9 +865,9 @@ theorem det_scaleRange {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
           have hnew : start ≤ dst.val ∧ dst.val < start + (count + 1) := by
             simp [dst]
           simp only [setCol]
-          simp only [if_true]
+          simp only [ite_true]
           unfold scaleRange
-          rw [if_pos hnew, if_neg hold]
+          rw [ite_eq_left hnew, ite_eq_right hold]
         · have hvalne : j.val ≠ start + count := by
             intro h
             exact hj (Fin.ext h)
@@ -891,12 +891,12 @@ theorem sign_succ {R : Type u} [Lean.Grind.CommRing R] (j : Nat) :
   by_cases hj : j % 2 = 0
   · have hnext : (j + 1) % 2 ≠ 0 := by
       omega
-    rw [if_pos hj, if_neg hnext]
+    rw [ite_eq_left hj, ite_eq_right hnext]
   · have hjone : j % 2 = 1 := by
       omega
     have hnext : (j + 1) % 2 = 0 := by
       omega
-    rw [if_neg hj, if_pos hnext]
+    rw [ite_eq_right hj, ite_eq_left hnext]
     grind
 
 /-- Alternating signs turn addition of exponents into multiplication. -/
@@ -1226,9 +1226,9 @@ theorem coeffInt_scale (c : R) (p : DensePoly R) (i : Int) :
     coeffInt (scale c p) i = c * coeffInt p i := by
   unfold coeffInt
   by_cases h : i < 0
-  · rw [if_pos h, if_pos h]
+  · rw [ite_eq_left h, ite_eq_left h]
     grind
-  · rw [if_neg h, if_neg h]
+  · rw [ite_eq_right h, ite_eq_right h]
     exact coeff_scale_semiring c p i.toNat
 
 /-- Scaling the left polynomial scales exactly the left Sylvester block. -/
@@ -1242,13 +1242,13 @@ theorem coeffMatrixAt_scale_left (df dg J l : Nat) (c : R)
   by_cases hj : j.val < dg - J
   · have hscaled : 0 ≤ j.val ∧ j.val < 0 + (dg - J) := by
       omega
-    simp only [if_pos hj, if_pos hscaled]
+    simp only [ite_eq_left hj, ite_eq_left hscaled]
     by_cases hi : i.val = (df - J) + (dg - J) - 1
-    · simp only [if_pos hi, coeffInt_scale]
-    · simp only [if_neg hi, coeffInt_scale]
+    · simp only [ite_eq_left hi, coeffInt_scale]
+    · simp only [ite_eq_right hi, coeffInt_scale]
   · have hscaled : ¬(0 ≤ j.val ∧ j.val < 0 + (dg - J)) := by
       omega
-    simp only [if_neg hj, if_neg hscaled]
+    simp only [ite_eq_right hj, ite_eq_right hscaled]
 
 /-- Scaling the right polynomial scales exactly the right Sylvester block. -/
 theorem coeffMatrixAt_scale_right (df dg J l : Nat) (c : R)
@@ -1261,17 +1261,17 @@ theorem coeffMatrixAt_scale_right (df dg J l : Nat) (c : R)
   by_cases hj : j.val < dg - J
   · have hscaled : ¬(dg - J ≤ j.val ∧ j.val < dg - J + (df - J)) := by
       omega
-    simp only [if_pos hj, if_neg hscaled]
+    simp only [ite_eq_left hj, ite_eq_right hscaled]
   · have hlower : dg - J ≤ j.val := by omega
     have hupper : j.val < dg - J + (df - J) := by
       have hjbound := j.isLt
       omega
     have hscaled : dg - J ≤ j.val ∧ j.val < dg - J + (df - J) :=
       ⟨hlower, hupper⟩
-    simp only [if_neg hj, if_pos hscaled]
+    simp only [ite_eq_right hj, ite_eq_left hscaled]
     by_cases hi : i.val = (df - J) + (dg - J) - 1
-    · simp only [if_pos hi, coeffInt_scale]
-    · simp only [if_neg hi, coeffInt_scale]
+    · simp only [ite_eq_left hi, coeffInt_scale]
+    · simp only [ite_eq_right hi, coeffInt_scale]
 
 /-- Fixed-degree coefficient minors are homogeneous in the left polynomial. -/
 theorem coeffMinorAt_scale_left (df dg J l : Nat) (c : R)
@@ -1328,8 +1328,8 @@ theorem poly_scale_left {c : R} (hc : c ≠ 0) (J : Nat)
   rw [coeff_scale_semiring]
   simp only [coeff_poly]
   by_cases hl : l < J + 1
-  · rw [if_pos hl, if_pos hl, coeffMinor_scale_left hc]
-  · rw [if_neg hl, if_neg hl]
+  · rw [ite_eq_left hl, ite_eq_left hl, coeffMinor_scale_left hc]
+  · rw [ite_eq_right hl, ite_eq_right hl]
     exact (Lean.Grind.Semiring.mul_zero _).symm
 
 /-- Generalized subresultants are homogeneous in the right polynomial. -/
@@ -1342,8 +1342,8 @@ theorem poly_scale_right {c : R} (hc : c ≠ 0) (J : Nat)
   rw [coeff_scale_semiring]
   simp only [coeff_poly]
   by_cases hl : l < J + 1
-  · rw [if_pos hl, if_pos hl, coeffMinor_scale_right hc]
-  · rw [if_neg hl, if_neg hl]
+  · rw [ite_eq_left hl, ite_eq_left hl, coeffMinor_scale_right hc]
+  · rw [ite_eq_right hl, ite_eq_right hl]
     exact (Lean.Grind.Semiring.mul_zero _).symm
 
 end Scale

--- a/HexResultant/ExactDiv.lean
+++ b/HexResultant/ExactDiv.lean
@@ -96,16 +96,16 @@ theorem powNat_eq_pow {S : Type u} [Lean.Grind.Semiring S]
       by_cases hn : n = 0
       · subst n
         simp [Lean.Grind.Semiring.pow_zero]
-      · rw [if_neg hn]
+      · rw [ite_eq_right hn]
         have hlt : n / 2 < n :=
           Nat.div_lt_self (Nat.pos_of_ne_zero hn) (by decide : 1 < 2)
         rw [ih (n / 2) hlt (x * x)]
         have hdiv := Nat.mod_add_div n 2
         by_cases heven : n % 2 = 0
-        · rw [if_pos heven, ← Lean.Grind.Semiring.pow_two, ← pow_mul]
+        · rw [ite_eq_left heven, ← Lean.Grind.Semiring.pow_two, ← pow_mul]
           congr 1
           omega
-        · rw [if_neg heven, ← Lean.Grind.Semiring.pow_two, ← pow_mul,
+        · rw [ite_eq_right heven, ← Lean.Grind.Semiring.pow_two, ← pow_mul,
             ← Lean.Grind.Semiring.pow_succ]
           congr 1
           have hmod := Nat.mod_lt n (by decide : 0 < 2)
@@ -190,8 +190,8 @@ theorem divScalar_eq_divScalarImpl [Zero R] [DecidableEq R] [Div R]
     (p : DensePoly R) (b : R) : divScalar p b = divScalarImpl p b := by
   unfold divScalar divScalarImpl ofList
   by_cases hb : b = 0
-  · rw [if_pos hb, if_pos hb]
-  · rw [if_neg hb, if_neg hb]
+  · rw [ite_eq_left hb, ite_eq_left hb]
+  · rw [ite_eq_right hb, ite_eq_right hb]
     congr 1
     show ((p.toArray.toList).map (fun a => a / b)).toArray = _
     rw [← Array.toList_map, Array.toArray_toList]
@@ -202,7 +202,7 @@ theorem size_divScalarImpl_le [Zero R] [DecidableEq R] [Div R]
   unfold divScalarImpl
   by_cases hb : b = 0
   · simp [hb]
-  · rw [if_neg hb]
+  · rw [ite_eq_right hb]
     exact Nat.le_trans (size_ofCoeffs_le _) (by simp)
 
 /-- Register the array pass as the compiled scalar-division implementation. -/
@@ -230,7 +230,7 @@ theorem coeff_divScalar [Lean.Grind.CommRing R] [DecidableEq R] [Div R]
     [ExactDivLaws R] (p : DensePoly R) {b : R} (hb : b ≠ 0) (n : Nat) :
     (divScalar p b).coeff n = p.coeff n / b := by
   unfold divScalar
-  rw [if_neg hb, coeff_ofList]
+  rw [ite_eq_right hb, coeff_ofList]
   have hzero : (0 : R) / b = 0 := by
     simpa [Lean.Grind.Semiring.zero_mul] using
       (ExactDivLaws.mul_div_cancel_right (0 : R) b hb)

--- a/HexResultant/Fraction.lean
+++ b/HexResultant/Fraction.lean
@@ -534,7 +534,7 @@ private theorem invRep_rel {a b : Fraction.Rep R}
       intro hb
       exact ha ((num_eq_zero_iff hab).mpr hb)
     unfold invRep
-    rw [dif_neg ha, dif_neg hb]
+    rw [dite_eq_right ha, dite_eq_right hb]
     apply rep_eq
     unfold Fraction.Rep.Rel at hab ⊢
     grind
@@ -620,7 +620,7 @@ theorem inv_inv (a : Fraction R) : a⁻¹⁻¹ = a := by
       · rw [show invRep a = ofRep ⟨a.den, a.num, hnum⟩ by simp [invRep, hnum],
           inv_ofRep]
         unfold invRep
-        rw [dif_neg a.den_ne]
+        rw [dite_eq_right a.den_ne]
 
 /-- The inverse of one is one. -/
 theorem inv_one : (1 : Fraction R)⁻¹ = 1 := by

--- a/HexResultant/FractionPoly.lean
+++ b/HexResultant/FractionPoly.lean
@@ -131,7 +131,7 @@ theorem map_C (a : R) : map (C a) = C (Hex.Fraction.ofCoeff a) := by
   rw [coeff_map, coeff_C, coeff_C]
   by_cases hn : n = 0
   · simp [hn]
-  · simp only [hn, if_false]
+  · simp only [hn, ite_false]
     exact Hex.Fraction.ofCoeff_zero
 
 /-- Fraction embedding preserves addition. -/
@@ -168,9 +168,9 @@ private theorem step_map (p q : DensePoly R) (n i j : Nat) (acc : R) :
       mulCoeffStep (map p) (map q) n i (Hex.Fraction.ofCoeff acc) j := by
   unfold mulCoeffStep
   by_cases h : i + j = n
-  · simp only [h, if_true, coeff_map, Hex.Fraction.ofCoeff_add,
+  · simp only [h, ite_true, coeff_map, Hex.Fraction.ofCoeff_add,
       Hex.Fraction.ofCoeff_mul]
-  · simp only [h, if_false]
+  · simp only [h, ite_false]
 
 private theorem inner_map (p q : DensePoly R) (n i : Nat) (xs : List Nat)
     (acc : R) :

--- a/HexResultant/Subresultant.lean
+++ b/HexResultant/Subresultant.lean
@@ -131,7 +131,7 @@ private theorem sign_prem_cancel {S : Type u} [Lean.Grind.CommRing S]
       rw [Nat.mul_mod, hu]
       omega
   unfold SubresultantMinor.sign
-  rw [if_pos hmod]
+  rw [ite_eq_left hmod]
 
 /-- The invariant identifies the next Brown scale with the leading principal
 coefficient of the original-pair subresultant and proves its exact quotient
@@ -965,12 +965,12 @@ private theorem subresultantAux_terminal {S : Type u}
           simp only [subresultantAux, p, hpzero, ↓reduceIte]
           rw [hlast]
           by_cases hconst : curr.size = 1
-          · rw [if_pos hconst]
+          · rw [ite_eq_left hconst]
             have hscale0 :
                 hCurr = Subresultant.coeffMinor 0 0 f g := by
               simpa [hconst, Subresultant.coeff_poly] using hscale
             simpa only [hCurr, delta, hconst] using hscale0
-          · rw [if_neg hconst]
+          · rw [ite_eq_right hconst]
             have hcurrPos := size_pos_of_ne_zero curr hcurr
             have hcurrBig : 2 ≤ curr.size := by omega
             have hlocal := Subresultant.coeffMinor_zero_of_prem_zero
@@ -1366,7 +1366,7 @@ theorem resultantOrdered_eq_coeffMinor {S : Type u}
       simp only [p, hpzero, ↓reduceIte]
       rw [hlast]
       by_cases hconst : g.size = 1
-      · rw [if_pos hconst]
+      · rw [ite_eq_left hconst]
         by_cases hfconst : f.size = 1
         · rw [show powNat g.leadingCoeff (f.size - g.size) = 1 by
             simp [hfconst, hconst, powNat]]
@@ -1390,7 +1390,7 @@ theorem resultantOrdered_eq_coeffMinor {S : Type u}
           rw [← Lean.Grind.Semiring.pow_succ]
           congr 1
           omega
-      · rw [if_neg hconst]
+      · rw [ite_eq_right hconst]
         have hgBig : 2 ≤ g.size := by omega
         have hzero := Subresultant.coeffMinor_zero_of_prem_zero
           f g hg hgf hgBig hp

--- a/HexResultant/SubresultantCofactor.lean
+++ b/HexResultant/SubresultantCofactor.lean
@@ -179,11 +179,11 @@ theorem cofactorCols_mul (df dg J : Nat) (f g : DensePoly R)
       by_cases hj : j.val < dg - J
       · have hj' : ¬dg - J ≤ j.val := by omega
         simp only [cofactorUCols, cofactorVCols, cofactorRowCols,
-          if_pos hj, if_neg hj']
+          ite_eq_left hj, ite_eq_right hj']
         rw [mul_add_left_poly, add_assoc_poly, ih]
       · have hj' : dg - J ≤ j.val := by omega
         simp only [cofactorUCols, cofactorVCols, cofactorRowCols,
-          if_neg hj, if_pos hj']
+          ite_eq_right hj, ite_eq_left hj']
         rw [mul_add_left_poly]
         calc
           cofactorUCols df dg J f g js * f +
@@ -231,13 +231,13 @@ private theorem coeff_monomial_mul (e : Nat) (c : R) (p : DensePoly R)
   by_cases hle : l < e
   · have hneg : Int.ofNat l - Int.ofNat e < 0 :=
       Int.sub_neg_of_lt (Int.ofNat_lt.mpr hle)
-    rw [if_pos hle, if_pos hneg, Lean.Grind.Semiring.mul_zero]
+    rw [ite_eq_left hle, ite_eq_left hneg, Lean.Grind.Semiring.mul_zero]
     rfl
   · have hleInt : Int.ofNat e ≤ Int.ofNat l :=
       Int.ofNat_le.mpr (Nat.le_of_not_gt hle)
     have hnneg : ¬Int.ofNat l - Int.ofNat e < 0 :=
       Int.not_lt.mpr (Int.sub_nonneg_of_le hleInt)
-    rw [if_neg hle, if_neg hnneg]
+    rw [ite_eq_right hle, ite_eq_right hnneg]
     have hnat := Int.toNat_sub l e
     change (Int.ofNat l - Int.ofNat e).toNat = l - e at hnat
     rw [hnat]
@@ -275,12 +275,12 @@ private theorem coeff_blockCols (start count total : Nat) (p : DensePoly R)
       simp only [blockCols, List.foldr_cons]
       rw [coeff_add_semiring, ih]
       by_cases hj : start ≤ j.val ∧ j.val < start + count
-      · rw [if_pos hj, if_pos hj, coeff_monomial]
+      · rw [ite_eq_left hj, ite_eq_left hj, coeff_monomial]
         by_cases hk : k = count - 1 - (j.val - start)
-        · rw [if_pos hk, if_pos hk]
-        · rw [if_neg hk, if_neg hk]
+        · rw [ite_eq_left hk, ite_eq_left hk]
+        · rw [ite_eq_right hk, ite_eq_right hk]
           rfl
-      · rw [if_neg hj, if_neg hj, coeff_zero]
+      · rw [ite_eq_right hj, ite_eq_right hj, coeff_zero]
 
 /-- A full interval of reversed coefficient columns reconstructs the bounded
 polynomial. -/
@@ -316,13 +316,13 @@ theorem blockCols_finRange (start count total : Nat) (p : DensePoly R)
               by_cases hjq : j = ⟨start + (count - 1 - k), by omega⟩
               · subst j
                 simp only [reduceIte]
-                rw [if_pos (by omega), if_pos (by omega)]
+                rw [ite_eq_left (by omega), ite_eq_left (by omega)]
                 congr 1
                 omega
-              · rw [if_neg hjq]
+              · rw [ite_eq_right hjq]
                 by_cases hjblock : start ≤ j.val ∧ j.val < start + count
-                · rw [if_pos hjblock]
-                  rw [if_neg]
+                · rw [ite_eq_left hjblock]
+                  rw [ite_eq_right]
                   intro heq
                   apply hjq
                   apply Fin.ext
@@ -336,7 +336,7 @@ theorem blockCols_finRange (start count total : Nat) (p : DensePoly R)
                     _ = start + (j.val - start) := by
                       rw [Nat.sub_sub_self hdle]
                     _ = j.val := hsplit
-                · rw [if_neg hjblock]
+                · rw [ite_eq_right hjblock]
       _ = 0 + p.coeff k := by
         exact List.foldl_add_single (List.finRange total) 0 q
           (fun _ => p.coeff k) (List.mem_finRange q) (List.nodup_finRange total)
@@ -347,8 +347,8 @@ theorem blockCols_finRange (start count total : Nat) (p : DensePoly R)
       intro j _hj
       dsimp only [term]
       by_cases hjblock : start ≤ j.val ∧ j.val < start + count
-      · rw [if_pos hjblock, if_neg (by omega)]
-      · rw [if_neg hjblock]
+      · rw [ite_eq_left hjblock, ite_eq_right (by omega)]
+      · rw [ite_eq_right hjblock]
     rw [List.foldl_add_eq_self _ term 0 hterm, hpzero]
 
 /-- The two reconstructed coefficient blocks multiply to their per-column
@@ -367,8 +367,8 @@ theorem blockCols_mul (df dg J : Nat) (u v f g : DensePoly R)
       · have hleft : 0 ≤ j.val ∧ j.val < 0 + (dg - J) := by omega
         have hright : ¬(dg - J ≤ j.val ∧ j.val < dg - J + (df - J)) := by
           omega
-        simp only [blockCols, bezoutCols, if_pos hj, if_pos hleft,
-          if_neg hright]
+        simp only [blockCols, bezoutCols, ite_eq_left hj, ite_eq_left hleft,
+          ite_eq_right hright]
         rw [add_comm_poly (0 : DensePoly R), add_zero_poly]
         rw [mul_add_left_poly, add_assoc_poly, ih]
         simp only [Nat.sub_zero]
@@ -377,8 +377,8 @@ theorem blockCols_mul (df dg J : Nat) (u v f g : DensePoly R)
             j.val < dg - J + (df - J) := by
           have hjfin := j.isLt
           omega
-        simp only [blockCols, bezoutCols, if_neg hj, if_neg hleft,
-          if_pos hright]
+        simp only [blockCols, bezoutCols, ite_eq_right hj, ite_eq_right hleft,
+          ite_eq_left hright]
         rw [add_comm_poly (0 : DensePoly R)
           (blockCols 0 (dg - J) (df - J + (dg - J)) u js), add_zero_poly,
           mul_add_left_poly]
@@ -428,14 +428,14 @@ theorem coeff_bezoutCols (df dg J l : Nat) (u v f g : DensePoly R)
       unfold coeffMatrixAt bezoutVector
       simp only [Fin.getElem_fin, Vector.getElem_ofFn]
       by_cases hj : j.val < dg - J
-      · simp only [if_pos hj, if_pos True.intro, coeff_monomial_mul]
+      · simp only [ite_eq_left hj, ite_eq_left True.intro, coeff_monomial_mul]
         have hle : j.val ≤ dg - J - 1 := by omega
         have hcast : Int.ofNat (dg - J - 1 - j.val) =
             Int.ofNat (dg - J - 1) - Int.ofNat j.val :=
           Int.ofNat_sub hle
         rw [hcast]
         grind
-      · simp only [if_neg hj, if_pos True.intro, coeff_monomial_mul]
+      · simp only [ite_eq_right hj, ite_eq_left True.intro, coeff_monomial_mul]
         have hbound : j.val - (dg - J) ≤ df - J - 1 := by
           have hjfin := j.isLt
           omega
@@ -465,14 +465,14 @@ private theorem coeffMatrixAt_row_eq_last (df dg J ell : Nat)
   by_cases hi : i.val = (df - J) + (dg - J) - 1
   · have hieq : i = last := Fin.ext hi
     subst i
-    simp only [if_pos hi]
+    simp only [ite_eq_left hi]
     intro j
     rfl
-  · simp only [if_neg hi]
+  · simp only [ite_eq_right hi]
     intro j
     unfold coeffMatrixAt
     by_cases hj : j.val < dg - J
-    · simp only [if_pos hj, if_neg hi, if_pos True.intro]
+    · simp only [ite_eq_left hj, ite_eq_right hi, ite_eq_left True.intro]
       congr 2
       have hleft : 0 < dg - J := by omega
       have hibound : i.val ≤ df + (dg - J) - 1 := by
@@ -487,7 +487,7 @@ private theorem coeffMatrixAt_row_eq_last (df dg J ell : Nat)
           Int.ofNat df + Int.ofNat (dg - J - 1) := Int.natCast_add _ _
       rw [hsub, hsplit, hadd]
       grind
-    · simp only [if_neg hj, if_neg hi, if_pos True.intro]
+    · simp only [ite_eq_right hj, ite_eq_right hi, ite_eq_left True.intro]
       congr 2
       have hright : 0 < df - J := by
         have hiFin := j.isLt
@@ -591,7 +591,7 @@ theorem bounded_bezout_unique [Div R] [ExactDivLaws R]
       have hj := hkernel j
       unfold bezoutVector at hj
       simp only [Fin.getElem_fin, Vector.getElem_ofFn] at hj
-      rw [if_pos (by dsimp [j]; omega)] at hj
+      rw [ite_eq_left (by dsimp [j]; omega)] at hj
       have hle : k ≤ dg - J - 1 := by omega
       have hindex : dg - J - 1 - (dg - J - 1 - k) = k :=
         Nat.sub_sub_self hle
@@ -606,7 +606,7 @@ theorem bounded_bezout_unique [Div R] [ExactDivLaws R]
       have hj := hkernel j
       unfold bezoutVector at hj
       simp only [Fin.getElem_fin, Vector.getElem_ofFn] at hj
-      rw [if_neg (by dsimp [j]; omega)] at hj
+      rw [ite_eq_right (by dsimp [j]; omega)] at hj
       have hle : k ≤ df - J - 1 := by omega
       have hindex :
           df - J - 1 -
@@ -653,12 +653,12 @@ private theorem cofactorUCols_size_le (df dg J : Nat) (f g : DensePoly R)
   | cons j js ih =>
       simp only [cofactorUCols]
       by_cases hj : j.val < dg - J
-      · rw [if_pos hj, coeff_add_semiring, coeff_monomial, ih]
-        rw [if_neg (by omega)]
+      · rw [ite_eq_left hj, coeff_add_semiring, coeff_monomial, ih]
+        rw [ite_eq_right (by omega)]
         have hzero : (Zero.zero : R) = 0 := rfl
         rw [hzero]
         grind
-      · rw [if_neg hj]
+      · rw [ite_eq_right hj]
         exact ih
 
 /-- The `g`-side cofactor accumulates only monomials below `df - J`, so it
@@ -673,12 +673,12 @@ private theorem cofactorVCols_size_le (df dg J : Nat) (f g : DensePoly R)
   | cons j js ih =>
       simp only [cofactorVCols]
       by_cases hj : dg - J ≤ j.val
-      · rw [if_pos hj, coeff_add_semiring, coeff_monomial, ih]
-        rw [if_neg (by omega)]
+      · rw [ite_eq_left hj, coeff_add_semiring, coeff_monomial, ih]
+        rw [ite_eq_right (by omega)]
         have hzero : (Zero.zero : R) = 0 := rfl
         rw [hzero]
         grind
-      · rw [if_neg hj]
+      · rw [ite_eq_right hj]
         exact ih
 
 /-- Degree bound for the left determinantal cofactor block at explicit formal
@@ -718,7 +718,7 @@ theorem coeff_cofactorRowCols (df dg J l : Nat) (f g : DensePoly R)
       simp only [cofactorRowCols, cofactorScalarCols]
       rw [coeff_add_semiring, ih]
       by_cases hj : j.val < dg - J
-      · rw [if_pos hj, if_pos hj, coeff_monomial_mul]
+      · rw [ite_eq_left hj, ite_eq_left hj, coeff_monomial_mul]
         have hle : j.val ≤ dg - J - 1 := by omega
         have hcast : Int.ofNat (dg - J - 1 - j.val) =
             Int.ofNat (dg - J - 1) - Int.ofNat j.val :=
@@ -726,7 +726,7 @@ theorem coeff_cofactorRowCols (df dg J l : Nat) (f g : DensePoly R)
         rw [hcast]
         grind
       · have hj' : dg - J ≤ j.val := by omega
-        rw [if_neg hj, if_neg hj, coeff_monomial_mul]
+        rw [ite_eq_right hj, ite_eq_right hj, coeff_monomial_mul]
         have hbound : j.val - (dg - J) ≤ df - J - 1 := by
           have hjfin := j.isLt
           omega
@@ -758,10 +758,10 @@ theorem cofactorScalarCols_eq_laplace (df dg J l : Nat)
       rw [← columnCofactorAt_eq df dg J l f g j]
       unfold coeffMatrixAt
       by_cases hj : j.val < dg - J
-      · simp only [if_pos hj]
-        rw [if_pos True.intro]
-      · simp only [if_neg hj]
-        rw [if_pos True.intro]
+      · simp only [ite_eq_left hj]
+        rw [ite_eq_left True.intro]
+      · simp only [ite_eq_right hj]
+        rw [ite_eq_left True.intro]
 
 /-- At positive matrix dimension, the full scalar cofactor sum is the
 corresponding generalized coefficient minor. -/
@@ -805,7 +805,7 @@ private theorem coeffInt_eq_zero_of_size_le (p : DensePoly R) (k : Int)
       unfold coeffInt
       by_cases hneg : Int.ofNat n < 0
       · exact False.elim (Int.not_ofNat_neg n hneg)
-      rw [if_neg hneg]
+      rw [ite_eq_right hneg]
       apply coeff_eq_zero_of_size_le
       exact Int.ofNat_le.mp h
   | negSucc n =>
@@ -840,11 +840,11 @@ theorem coeffMinorAt_eq_zero_of_lt (df dg J l : Nat) (f g : DensePoly R)
       have hdst : dst.val = (df - J) + (dg - J) - 1 := by rfl
       unfold coeffMatrixAt
       by_cases hj : j.val < dg - J
-      · simp only [if_pos hj, if_neg hsrc, if_pos hdst]
+      · simp only [ite_eq_left hj, ite_eq_right hsrc, ite_eq_left hdst]
         congr 2
         dsimp [src, dst]
         omega
-      · simp only [if_neg hj, if_neg hsrc, if_pos hdst]
+      · simp only [ite_eq_right hj, ite_eq_right hsrc, ite_eq_left hdst]
         congr 2
         dsimp [src, dst]
         omega
@@ -853,7 +853,7 @@ theorem coeffMinorAt_eq_zero_of_lt (df dg J l : Nat) (f g : DensePoly R)
     intro j
     unfold coeffMatrixAt
     by_cases hj : j.val < dg - J
-    · simp only [if_pos hj, if_pos True.intro]
+    · simp only [ite_eq_left hj, ite_eq_left True.intro]
       apply coeffInt_eq_zero_of_size_le
       have hbase : dg - J - 1 ≤ l := by omega
       have hnat : f.size ≤ l - (dg - J - 1) + j.val := by omega
@@ -868,7 +868,7 @@ theorem coeffMinorAt_eq_zero_of_lt (df dg J l : Nat) (f g : DensePoly R)
               Int.ofNat l - Int.ofNat (dg - J - 1) :=
             Int.ofNat_sub hbase
           exact hadd.trans (congrArg (fun z => z + Int.ofNat j.val) hsub)
-    · simp only [if_neg hj, if_pos True.intro]
+    · simp only [ite_eq_right hj, ite_eq_left True.intro]
       apply coeffInt_eq_zero_of_size_le
       have hbase : df - J - 1 ≤ l := by omega
       have hnat : g.size ≤
@@ -904,9 +904,9 @@ theorem cofactor_bezout (J : Nat) (f g : DensePoly R)
   unfold cofactorU cofactorV
   rw [coeff_cofactorAt_mul df dg J l f g hcount, coeff_poly]
   by_cases hl : l < J + 1
-  · rw [if_pos hl]
+  · rw [ite_eq_left hl]
     rfl
-  · rw [if_neg hl]
+  · rw [ite_eq_right hl]
     apply coeffMinorAt_eq_zero_of_lt
     · exact hJ
     · exact hdg
@@ -941,7 +941,7 @@ theorem eq_scaled_cofactor [Div R] [ExactDivLaws R]
     omega
   have hminor : coeffMinorAt df dg J ell f g ≠ 0 := by
     have hc := coeff_last_ne_zero_of_pos_size (poly J f g) hrootPos
-    rw [coeff_poly, if_pos hell] at hc
+    rw [coeff_poly, ite_eq_left hell] at hc
     have hzero : (Zero.zero : R) = 0 := rfl
     change coeffMinorAt df dg J ell f g ≠ (Zero.zero : R)
     simpa only [df, dg, ell, coeffMinor] using hc

--- a/HexResultant/SubresultantMinor.lean
+++ b/HexResultant/SubresultantMinor.lean
@@ -75,9 +75,9 @@ private theorem sign_map (j : Nat) :
       sign (R := Hex.Fraction R) j := by
   unfold sign
   by_cases h : j % 2 = 0
-  · rw [if_pos h, if_pos h]
+  · rw [ite_eq_left h, ite_eq_left h]
     exact Hex.Fraction.ofCoeff_one
-  · rw [if_neg h, if_neg h, Hex.Fraction.ofCoeff_sub]
+  · rw [ite_eq_right h, ite_eq_right h, Hex.Fraction.ofCoeff_sub]
     change Hex.Fraction.ofCoeff (Zero.zero : R) -
         Hex.Fraction.ofCoeff (One.one : R) =
       (Zero.zero : Hex.Fraction R) - (One.one : Hex.Fraction R)
@@ -158,10 +158,10 @@ theorem coeffInt_add {S : Type u} [Lean.Grind.CommRing S] [DecidableEq S]
     coeffInt (p + q) t = coeffInt p t + coeffInt q t := by
   by_cases ht : t < 0
   · unfold coeffInt
-    rw [if_pos ht, if_pos ht, if_pos ht]
+    rw [ite_eq_left ht, ite_eq_left ht, ite_eq_left ht]
     grind
   · unfold coeffInt
-    rw [if_neg ht, if_neg ht, if_neg ht, coeff_add_semiring]
+    rw [ite_eq_right ht, ite_eq_right ht, ite_eq_right ht, coeff_add_semiring]
 
 /-- Default formal degree: zero and nonzero constants both have degree zero. -/
 @[expose]
@@ -244,7 +244,7 @@ theorem coeffInt_map (p : DensePoly R) (i : Int) :
       Hex.Fraction.ofCoeff (coeffInt p i) := by
   unfold coeffInt
   by_cases h : i < 0
-  · rw [if_pos h, if_pos h]
+  · rw [ite_eq_left h, ite_eq_left h]
     exact Hex.Fraction.ofCoeff_zero.symm
   · simp [h, DensePoly.Fraction.coeff_map]
 
@@ -289,8 +289,8 @@ theorem poly_map (J : Nat) (f g : DensePoly R) :
   intro l
   simp only [coeff_poly, DensePoly.Fraction.coeff_map]
   by_cases h : l < J + 1
-  · rw [if_pos h, if_pos h, coeffMinor_map]
-  · rw [if_neg h, if_neg h]
+  · rw [ite_eq_left h, ite_eq_left h, coeffMinor_map]
+  · rw [ite_eq_right h, ite_eq_right h]
     exact Hex.Fraction.ofCoeff_zero.symm
 
 /-- Coefficients of mapped generalized subresultants lie in the coefficient

--- a/HexResultantMathlib/Basic.lean
+++ b/HexResultantMathlib/Basic.lean
@@ -69,7 +69,7 @@ theorem eval_toPolynomial [CommSemiring R] [DecidableEq R]
   intro i hi
   have hil : i < p.size := Finset.mem_range.mp hi
   rw [← length_toList p] at hil
-  rw [dif_pos hil, List.get_eq_getElem,
+  rw [dite_eq_left hil, List.get_eq_getElem,
     List.getElem_eq_getD (l := p.toList) (i := i) (h := hil) (Zero.zero : R),
     toList_getD_eq_coeff]
   rfl

--- a/HexResultantMathlib/Discriminant.lean
+++ b/HexResultantMathlib/Discriminant.lean
@@ -28,7 +28,7 @@ theorem toPolynomial_disc [CommRing R] [DecidableEq R]
   let F := HexPolyMathlib.toPolynomial f
   by_cases hsmall : f.size ≤ 1
   · unfold disc
-    rw [if_pos hsmall]
+    rw [ite_eq_left hsmall]
     have hdeg : F.natDegree = 0 := by
       rw [show F.natDegree = f.degree?.getD 0 by
         simpa only [F] using HexPolyMathlib.natDegree_toPolynomial f]
@@ -92,7 +92,7 @@ theorem toPolynomial_disc [CommRing R] [DecidableEq R]
     rw [hFn] at hformal
     rw [hlc] at hformal
     unfold disc
-    rw [if_neg hsmall]
+    rw [ite_eq_right hsmall]
     change
       negOnePow (R := R) (n * (n - 1) / 2) *
           exactDiv (powNat f.leadingCoeff gap * resultant f d)

--- a/HexResultantMathlib/Specialize.lean
+++ b/HexResultantMathlib/Specialize.lean
@@ -116,7 +116,7 @@ theorem eval_resultant [CommRing R] [DecidableEq R]
       unfold resultant
       rw [hz]
       simp only [↓reduceIte]
-      rw [if_pos hgsmall, specialize_zero, hzdeg, hgdeg,
+      rw [ite_eq_left hgsmall, specialize_zero, hzdeg, hgdeg,
         eval_toPolynomial, HexPolyMathlib.toPolynomial_one]
       simp [Polynomial.resultant]
     · have hgdeg : 0 < g.degree?.getD 0 := by
@@ -126,7 +126,7 @@ theorem eval_resultant [CommRing R] [DecidableEq R]
       unfold resultant
       rw [hz]
       simp only [↓reduceIte]
-      rw [if_neg hgsmall, specialize_zero, hzdeg,
+      rw [ite_eq_right hgsmall, specialize_zero, hzdeg,
         eval_toPolynomial, HexPolyMathlib.toPolynomial_zero,
         Polynomial.eval_zero, Polynomial.resultant_zero_left]
       simp [hgdeg.ne']
@@ -148,7 +148,7 @@ theorem eval_resultant [CommRing R] [DecidableEq R]
         unfold resultant
         rw [hfz, hz]
         simp only [Bool.false_eq_true, ↓reduceIte]
-        rw [if_pos hfsmall, specialize_zero, hzdeg, hfdeg,
+        rw [ite_eq_left hfsmall, specialize_zero, hzdeg, hfdeg,
           eval_toPolynomial, HexPolyMathlib.toPolynomial_one]
         simp [Polynomial.resultant]
       · have hfdeg : 0 < f.degree?.getD 0 := by
@@ -157,7 +157,7 @@ theorem eval_resultant [CommRing R] [DecidableEq R]
         unfold resultant
         rw [hfz, hz]
         simp only [Bool.false_eq_true, ↓reduceIte]
-        rw [if_neg hfsmall, specialize_zero, hzdeg,
+        rw [ite_eq_right hfsmall, specialize_zero, hzdeg,
           eval_toPolynomial, HexPolyMathlib.toPolynomial_zero,
           Polynomial.eval_zero, Polynomial.resultant_zero_right]
         simp [hfdeg.ne']
@@ -187,7 +187,7 @@ theorem eval_resultant [CommRing R] [DecidableEq R]
       unfold resultant
       simp only [hfz, hgz, Bool.false_eq_true, ↓reduceIte]
       by_cases hfg : f.size < g.size
-      · rw [if_pos hfg]
+      · rw [ite_eq_left hfg]
         rw [resultantOrdered_eq_coeffMinor g f hg hf (by omega),
           negOnePow_eq_sign]
         have hswap := Subresultant.coeffMinor_swap 0 0 f g
@@ -195,7 +195,7 @@ theorem eval_resultant [CommRing R] [DecidableEq R]
         rw [← hswap]
         unfold Subresultant.coeffMinor
         exact eval_coeffMinorAt_zero _ _ f g a hfBound hgBound
-      · rw [if_neg hfg]
+      · rw [ite_eq_right hfg]
         rw [resultantOrdered_eq_coeffMinor f g hf hg (by omega)]
         unfold Subresultant.coeffMinor
         exact eval_coeffMinorAt_zero _ _ f g a hfBound hgBound

--- a/HexResultantMathlib/Sylvester.lean
+++ b/HexResultantMathlib/Sylvester.lean
@@ -116,16 +116,16 @@ private theorem coeffInt_eq_ite [CommRing R] [DecidableEq R]
       if j ≤ i ∧ i ≤ d + j then p.coeff (d + j - i) else 0 := by
   unfold coeffInt
   by_cases hnonneg : 0 ≤ (d : Int) - (i : Int) + (j : Int)
-  · rw [if_neg (by omega)]
+  · rw [ite_eq_right (by omega)]
     have hnat : ((d : Int) - (i : Int) + (j : Int)).toNat = d + j - i := by
       omega
     rw [hnat]
     by_cases hji : j ≤ i
     · have hidj : i ≤ d + j := by omega
-      rw [if_pos ⟨hji, hidj⟩]
-    · rw [if_neg (by omega)]
+      rw [ite_eq_left ⟨hji, hidj⟩]
+    · rw [ite_eq_right (by omega)]
       exact coeff_eq_zero_of_size_le p (by omega)
-  · rw [if_pos (by omega), if_neg (by omega)]
+  · rw [ite_eq_left (by omega), ite_eq_right (by omega)]
 
 /-- At index zero, the generalized coefficient matrix is Mathlib's
 Sylvester matrix with both axes reversed. -/
@@ -143,7 +143,7 @@ private theorem coeffMatrixAt_zero_eq_sylvester [CommRing R] [DecidableEq R]
   simp only [Nat.sub_zero, _root_.Matrix.of_apply, HexPolyMathlib.coeff_toPolynomial,
     Int.ofNat_eq_natCast, Int.natCast_zero]
   by_cases hj : j.val < dg
-  · rw [if_pos hj]
+  · rw [ite_eq_left hj]
     have hiBound : i.val < df + dg := by simp
     have hrow :
         (if i.val = df + dg - 1 then
@@ -151,31 +151,31 @@ private theorem coeffMatrixAt_zero_eq_sylvester [CommRing R] [DecidableEq R]
           else coeffInt f ((df : Int) - i.val + j.val)) =
           coeffInt f ((df : Int) - i.val + j.val) := by
       by_cases hi : i.val = df + dg - 1
-      · rw [if_pos hi]
+      · rw [ite_eq_left hi]
         congr 1
         omega
-      · rw [if_neg hi]
+      · rw [ite_eq_right hi]
     rw [hrow, coeffInt_eq_ite f df i.val j.val hf]
     have hjrev : ¬(Fin.rev j).val < df := by
       simp [Fin.rev]
       omega
-    rw [dif_neg hjrev]
+    rw [dite_eq_right hjrev]
     by_cases hji : j.val ≤ i.val ∧ i.val ≤ df + j.val
-    · rw [if_pos hji]
+    · rw [ite_eq_left hji]
       have hraw :
           (Fin.rev j).val - df ≤ (Fin.rev i).val ∧
             (Fin.rev i).val ≤ (Fin.rev j).val - df + df := by
         simp [Fin.rev]
         omega
-      rw [if_pos hraw]
+      rw [ite_eq_left hraw]
       congr 1
       simp [Fin.rev]
       omega
-    · rw [if_neg hji]
-      rw [if_neg]
+    · rw [ite_eq_right hji]
+      rw [ite_eq_right]
       simp [Fin.rev] at hji ⊢
       omega
-  · rw [if_neg hj]
+  · rw [ite_eq_right hj]
     have hiBound : i.val < df + dg := by simp
     have hrow :
         (if i.val = df + dg - 1 then
@@ -186,28 +186,28 @@ private theorem coeffMatrixAt_zero_eq_sylvester [CommRing R] [DecidableEq R]
           coeffInt g
             ((dg : Int) - i.val + ((j.val - dg : Nat) : Int)) := by
       by_cases hi : i.val = df + dg - 1
-      · rw [if_pos hi]
+      · rw [ite_eq_left hi]
         congr 1
         omega
-      · rw [if_neg hi]
+      · rw [ite_eq_right hi]
     rw [hrow, coeffInt_eq_ite g dg i.val (j.val - dg) hg]
     have hjrev : (Fin.rev j).val < df := by
       simp [Fin.rev]
       omega
-    rw [dif_pos hjrev]
+    rw [dite_eq_left hjrev]
     by_cases hji : j.val - dg ≤ i.val ∧ i.val ≤ dg + (j.val - dg)
-    · rw [if_pos hji]
+    · rw [ite_eq_left hji]
       have hraw :
           (Fin.rev j).val ≤ (Fin.rev i).val ∧
             (Fin.rev i).val ≤ (Fin.rev j).val + dg := by
         simp [Fin.rev]
         omega
-      rw [if_pos hraw]
+      rw [ite_eq_left hraw]
       congr 1
       simp [Fin.rev]
       omega
-    · rw [if_neg hji]
-      rw [if_neg]
+    · rw [ite_eq_right hji]
+      rw [ite_eq_right]
       simp [Fin.rev] at hji ⊢
       omega
 
@@ -271,7 +271,7 @@ theorem toPolynomial_resultant [CommRing R] [DecidableEq R]
       unfold resultant
       rw [hz]
       simp only [↓reduceIte]
-      rw [if_pos hgsmall, HexPolyMathlib.toPolynomial_zero, hzdeg, hgdeg]
+      rw [ite_eq_left hgsmall, HexPolyMathlib.toPolynomial_zero, hzdeg, hgdeg]
       simp [Polynomial.resultant]
     · have hgdeg : 0 < g.degree?.getD 0 := by
         have hgpos : 0 < g.size := by omega
@@ -280,7 +280,7 @@ theorem toPolynomial_resultant [CommRing R] [DecidableEq R]
       unfold resultant
       rw [hz]
       simp only [↓reduceIte]
-      rw [if_neg hgsmall, HexPolyMathlib.toPolynomial_zero, hzdeg,
+      rw [ite_eq_right hgsmall, HexPolyMathlib.toPolynomial_zero, hzdeg,
         Polynomial.resultant_zero_left]
       simp [hgdeg.ne']
   · by_cases hg : g = 0
@@ -300,7 +300,7 @@ theorem toPolynomial_resultant [CommRing R] [DecidableEq R]
         unfold resultant
         rw [hfz, hz]
         simp only [Bool.false_eq_true, ↓reduceIte]
-        rw [if_pos hfsmall, HexPolyMathlib.toPolynomial_zero, hzdeg, hfdeg]
+        rw [ite_eq_left hfsmall, HexPolyMathlib.toPolynomial_zero, hzdeg, hfdeg]
         simp [Polynomial.resultant]
       · have hfdeg : 0 < f.degree?.getD 0 := by
           rw [degree?_eq_some_of_pos_size f hfpos, Option.getD_some]
@@ -308,7 +308,7 @@ theorem toPolynomial_resultant [CommRing R] [DecidableEq R]
         unfold resultant
         rw [hfz, hz]
         simp only [Bool.false_eq_true, ↓reduceIte]
-        rw [if_neg hfsmall, HexPolyMathlib.toPolynomial_zero, hzdeg,
+        rw [ite_eq_right hfsmall, HexPolyMathlib.toPolynomial_zero, hzdeg,
           Polynomial.resultant_zero_right]
         simp [hfdeg.ne']
     · have hfpos : 0 < f.size := by
@@ -330,7 +330,7 @@ theorem toPolynomial_resultant [CommRing R] [DecidableEq R]
       unfold resultant
       simp only [hfz, hgz, Bool.false_eq_true, ↓reduceIte]
       by_cases hfg : f.size < g.size
-      · rw [if_pos hfg]
+      · rw [ite_eq_left hfg]
         rw [resultantOrdered_eq_coeffMinor g f hg hf (by omega)]
         rw [Subresultant.coeffMinor_zero_eq_resultant]
         rw [hdf, hdg]
@@ -339,7 +339,7 @@ theorem toPolynomial_resultant [CommRing R] [DecidableEq R]
         exact (Polynomial.resultant_comm
           (HexPolyMathlib.toPolynomial f) (HexPolyMathlib.toPolynomial g)
           (Subresultant.formalDegree f) (Subresultant.formalDegree g)).symm
-      · rw [if_neg hfg]
+      · rw [ite_eq_right hfg]
         rw [resultantOrdered_eq_coeffMinor f g hf hg (by omega)]
         rw [Subresultant.coeffMinor_zero_eq_resultant, hdf, hdg]
 

--- a/HexRootsMathlib/ArgumentPrinciple.lean
+++ b/HexRootsMathlib/ArgumentPrinciple.lean
@@ -67,10 +67,10 @@ theorem integral_logDeriv_eq_rootCount {p : ℂ[X]} (hp : p ≠ 0)
           fun b hb => hnone b (Multiset.mem_cons_of_mem hb)
         rw [Multiset.map_cons, Multiset.sum_cons, Multiset.countP_cons, ih htail]
         by_cases hin : a ∈ ball c R
-        · rw [if_pos hin, integral_subInv_inside hin]
+        · rw [ite_eq_left hin, integral_subInv_inside hin]
           push_cast
           ring
-        · rw [if_neg hin, integral_subInv_outside_of_not_mem hR ha hin]
+        · rw [ite_eq_right hin, integral_subInv_outside_of_not_mem hR ha hin]
           simp
   simpa only [rootsInDisc] using hsum p.roots hroot
 

--- a/HexRootsMathlib/ArgumentTopology.lean
+++ b/HexRootsMathlib/ArgumentTopology.lean
@@ -63,7 +63,7 @@ theorem continuousOn_circleIntegral_div {X : Type*} [TopologicalSpace X]
     (hg : ContinuousOn (fun q : X × ℝ => g q.1 (circleMap c R q.2)) (s ×ˢ univ))
     (hzero : ∀ x ∈ s, ∀ θ : ℝ, g x (circleMap c R θ) ≠ 0) :
     ContinuousOn (fun x => ∮ z in C(c, R), f x z / g x z) s := by
-  rw [continuousOn_iff_continuous_restrict]
+  rw [continuousOn_iff_continuous_domRestrict]
   apply continuous_circleIntegral_div c R
   · simpa only [Function.comp_def] using hf.comp_continuous
       (show Continuous (fun q : s × ℝ => ((q.1 : X), q.2)) by fun_prop)

--- a/HexRootsMathlib/Basic.lean
+++ b/HexRootsMathlib/Basic.lean
@@ -47,9 +47,9 @@ theorem natDegree_toPolyℂ (p : Hex.ZPoly) :
 theorem le_two_pow_ceilLog2 (m : Nat) : m ≤ 2 ^ Hex.ceilLog2 m := by
   unfold Hex.ceilLog2
   by_cases hm : m ≤ 1
-  · rw [if_pos hm]
+  · rw [ite_eq_left hm]
     simpa using hm
-  · rw [if_neg hm]
+  · rw [ite_eq_right hm]
     have hm2 : 2 ≤ m := by omega
     have hne : m - 1 ≠ 0 := by omega
     have hlog := (Nat.log2_lt hne).1 (Nat.lt_succ_self (m - 1).log2)
@@ -250,7 +250,7 @@ theorem toReal_le_two_pow_ceilLog2 (x : _root_.Dyadic) (hx : 0 < toReal x) :
       have hcl : Hex.Dyadic.ceilLog2 (_root_.Dyadic.ofOdd n k hn) =
           (Hex.ceilLog2 n.toNat : Int) - k := by
         show (if n < 0 then (0 : Int) else (Hex.ceilLog2 n.toNat : Int) - k) = _
-        rw [if_neg (by omega)]
+        rw [ite_eq_right (by omega)]
       have hnle : (n : ℝ) ≤ (2 : ℝ) ^ Hex.ceilLog2 n.toNat := by
         have hnat := le_two_pow_ceilLog2 n.toNat
         have hcast : (n.toNat : ℝ) ≤ (2 : ℝ) ^ Hex.ceilLog2 n.toNat := by
@@ -285,7 +285,7 @@ theorem two_pow_ceilLog2_lt_two_mul_toReal (x : _root_.Dyadic)
       have hceil : Hex.Dyadic.ceilLog2 (_root_.Dyadic.ofOdd n k hn) =
           (Hex.ceilLog2 n.toNat : Int) - k := by
         show (if n < 0 then (0 : Int) else (Hex.ceilLog2 n.toNat : Int) - k) = _
-        rw [if_neg (by omega)]
+        rw [ite_eq_right (by omega)]
       rw [hceil, show (Hex.ceilLog2 n.toNat : Int) - k =
           (Hex.ceilLog2 n.toNat : Int) + (-k) by ring,
         zpow_add₀ (by norm_num : (2 : ℝ) ≠ 0), zpow_natCast]

--- a/HexRootsMathlib/Cauchy.lean
+++ b/HexRootsMathlib/Cauchy.lean
@@ -124,7 +124,7 @@ theorem cauchyBound_le_two_pow (p : Hex.ZPoly) (h : 0 < p.degree?.getD 0) :
     _ ≤ (Q : ℝ) := hratio
     _ ≤ (2 : ℝ) ^ Hex.ceilLog2 Q := hQ
     _ = (2 : ℝ) ^ Hex.cauchyExp p := by
-      simp only [Hex.cauchyExp, L, M, Q, if_neg (Nat.ne_of_gt hL)]
+      simp only [Hex.cauchyExp, L, M, Q, ite_eq_right (Nat.ne_of_gt hL)]
 
 /-- Every root of the complex cast lies in the closed square stored in the
 executable initial component. -/

--- a/HexRootsMathlib/Certificate.lean
+++ b/HexRootsMathlib/Certificate.lean
@@ -167,7 +167,7 @@ theorem sound {p : Hex.ZPoly} (iso : Hex.DyadicRootIsolation p) :
       · simp only [openRegion, Hex.AtomCertificate.isNK]
         rw [openRegion] at hzopen
         by_cases hkind : certificate.isNK = true
-        · simp only [hkind, if_true] at hzopen ⊢
+        · simp only [hkind, ite_true] at hzopen ⊢
           exact DyadicSquare.openSquare_neg.mpr hzopen
         · simp only [hkind] at hzopen ⊢
           exact DyadicSquare.disc_neg.mpr hzopen
@@ -181,7 +181,7 @@ theorem sound {p : Hex.ZPoly} (iso : Hex.DyadicRootIsolation p) :
             DyadicRootIsolation.region ⟨s, certificate⟩ := by
           simp only [region, Hex.AtomCertificate.isNK] at hwregion ⊢
           by_cases hkind : certificate.isNK = true
-          · simp only [hkind, if_true] at hwregion ⊢
+          · simp only [hkind, ite_true] at hwregion ⊢
             have hiff := DyadicSquare.closedSquare_neg (s := s) (z := -w)
             simp only [neg_neg] at hiff
             exact hiff.mp hwregion
@@ -481,11 +481,11 @@ theorem certifyPelletAtShift_preserves {p : Hex.ZPoly} {c : Hex.Component}
           · have hr : r = .atom (cl'.atomize hk1) :=
               (Option.some.inj hcert).symm
             subst r
-            simpa only [dif_pos hk1] using
+            simpa only [dite_eq_left hk1] using
               candidatePellet_mem hk hw₀ hins hw₀' hzroot hzbase
           · have hr : r = .cluster cl' := (Option.some.inj hcert).symm
             subst r
-            simpa only [dif_neg hk1] using
+            simpa only [dite_eq_right hk1] using
               candidatePellet_mem hk hw₀ hins hw₀' hzroot hzbase
         · have hr : r = base := (Option.some.inj hcert).symm
           subst r
@@ -529,11 +529,11 @@ theorem certifyPelletExactAt_preserves {p : Hex.ZPoly} {c : Hex.Component}
           · have hr : r = .atom (cl'.atomize hk1) :=
               (Option.some.inj hcert).symm
             subst r
-            simpa only [dif_pos hk1] using
+            simpa only [dite_eq_left hk1] using
               candidatePellet_mem hk hw₀ hins hw₀' hzroot hzbase
           · have hr : r = .cluster cl' := (Option.some.inj hcert).symm
             subst r
-            simpa only [dif_neg hk1] using
+            simpa only [dite_eq_right hk1] using
               candidatePellet_mem hk hw₀ hins hw₀' hzroot hzbase
         · have hr : r = base := (Option.some.inj hcert).symm
           subst r
@@ -577,15 +577,15 @@ theorem certifyPelletSoft_preserves {p : Hex.ZPoly} {c : Hex.Component}
           simp [Hex.TaylorShift.combinedWitnessCheck, hprec, hsCached]
       let cl : Hex.DyadicRootCluster p := ⟨c.squares, k, hs.1, hw⟩
       by_cases hk1 : k = 1
-      · rw [dif_pos hk1] at hcert
+      · rw [dite_eq_left hk1] at hcert
         have hr : r = .atom (cl.atomize hk1) := (Option.some.inj hcert).symm
         subst r
-        simpa only [dif_pos hk1] using
+        simpa only [dite_eq_left hk1] using
           basePellet_mem hs.1 hw hzsquare
-      · rw [dif_neg hk1] at hcert
+      · rw [dite_eq_right hk1] at hcert
         have hr : r = .cluster cl := (Option.some.inj hcert).symm
         subst r
-        simpa only [dif_neg hk1] using
+        simpa only [dite_eq_right hk1] using
           basePellet_mem hs.1 hw hzsquare
   · simp at hcert
 

--- a/HexRootsMathlib/Completeness/DriverCompleteness.lean
+++ b/HexRootsMathlib/Completeness/DriverCompleteness.lean
@@ -1315,13 +1315,13 @@ theorem isolate_exists (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
       (le_max_right _ _) strategy hd
     obtain ⟨atoms, hmap⟩ := array_mapM_atoms rs hatoms
     refine ⟨atoms, ?_⟩
-    rw [Hex.isolate, dif_pos hd]
+    rw [Hex.isolate, dite_eq_left hd]
     change (Hex.isolateAll? p target #[Hex.Component.cauchy p hd] strategy).bind
       (fun rs => rs.mapM Hex.Certified.asAtom?) = some atoms
     rw [hall]
     exact hmap
   · refine ⟨#[], ?_⟩
-    rw [Hex.isolate, dif_neg hd]
+    rw [Hex.isolate, dite_eq_right hd]
     simp [hpSize]
 
 /-- A nonzero squarefree polynomial has a successful isolation whose atoms

--- a/HexRootsMathlib/Completeness/PelletDyadic.lean
+++ b/HexRootsMathlib/Completeness/PelletDyadic.lean
@@ -37,7 +37,7 @@ theorem pelletAt_of_bound {cs : Array Hex.GaussDyadic} {k : ℕ}
           Dyadic.toReal rlo ^ k) :
     Hex.pelletAt cs k rlo rhi = true := by
   unfold Hex.pelletAt
-  rw [if_pos hk]
+  rw [ite_eq_left hk]
   apply decide_eq_true
   apply Dyadic.toReal_lt_toReal_iff.mp
   let result := (List.range cs.size).foldl

--- a/HexRootsMathlib/Completeness/RootFreeConverse.lean
+++ b/HexRootsMathlib/Completeness/RootFreeConverse.lean
@@ -557,7 +557,7 @@ theorem adjacent_of_supDist_lt {s t : Hex.DyadicSquare}
     (hprec : s.prec = t.prec)
     (hdist : supDist (center s) (center t) < 4 * halfWidth s) :
     Hex.DyadicSquare.adjacent s t = true := by
-  rw [Hex.DyadicSquare.adjacent, if_pos hprec]
+  rw [Hex.DyadicSquare.adjacent, ite_eq_left hprec]
   let fourH : _root_.Dyadic := .ofIntWithPrec 1 (s.prec - 2)
   have hfour : Dyadic.toReal fourH = 4 * halfWidth s := by
     dsimp [fourH]

--- a/HexRootsMathlib/Geometry.lean
+++ b/HexRootsMathlib/Geometry.lean
@@ -259,7 +259,7 @@ theorem closedSquare_eq_supClosedBall (s : Hex.DyadicSquare) :
 
 /-- The centre belongs to its closed square. -/
 theorem center_mem_closedSquare (s : Hex.DyadicSquare) : center s ∈ closedSquare s := by
-  rw [closedSquare, supClosedBall, Set.mem_setOf_eq, supDist, sub_self, supNorm]
+  rw [closedSquare, supClosedBall, Set.mem_ofPred_eq, supDist, sub_self, supNorm]
   simp only [Complex.zero_re, abs_zero, Complex.zero_im, max_self]
   rw [halfWidth_eq]
   exact (zpow_pos (by norm_num) _).le
@@ -270,7 +270,7 @@ theorem mem_closedSquare_iff_re_im (s : Hex.DyadicSquare) (z : ℂ) :
     z ∈ closedSquare s ↔
       |z.re - Dyadic.toReal s.re| ≤ halfWidth s ∧
       |z.im - Dyadic.toReal s.im| ≤ halfWidth s := by
-  rw [closedSquare, supClosedBall, Set.mem_setOf_eq, supDist, supNorm,
+  rw [closedSquare, supClosedBall, Set.mem_ofPred_eq, supDist, supNorm,
     max_le_iff]
   simp [center, Hex.DyadicSquare.center]
 
@@ -690,7 +690,7 @@ theorem closedSquare_subset_encSquare {squares : Array Hex.DyadicSquare}
 theorem closedSquare_subset_closedDisc (s : Hex.DyadicSquare) :
     closedSquare s ⊆ closedDisc s := by
   intro z hz
-  rw [closedSquare, supClosedBall, Set.mem_setOf_eq] at hz
+  rw [closedSquare, supClosedBall, Set.mem_ofPred_eq] at hz
   rw [closedDisc, Metric.mem_closedBall, Complex.dist_eq]
   calc
     ‖z - center s‖ ≤ √2 * supNorm (z - center s) :=

--- a/HexRootsMathlib/Glue.lean
+++ b/HexRootsMathlib/Glue.lean
@@ -35,7 +35,7 @@ theorem linked_symm {s t : Hex.DyadicSquare} : Linked s t → Linked t s := Or.s
 
 /-- Executable adjacency is reflexive: a square is adjacent to itself. -/
 theorem edge_refl (s : Hex.DyadicSquare) : Edge s s := by
-  rw [Edge, Hex.DyadicSquare.adjacent, if_pos rfl]
+  rw [Edge, Hex.DyadicSquare.adjacent, ite_eq_left rfl]
   have hpos : (0 : _root_.Dyadic) < .ofIntWithPrec 1 (s.prec - 2) := by
     apply Dyadic.toReal_lt_toReal_iff.mp
     rw [Dyadic.toReal_zero, Dyadic.toReal_ofIntWithPrec]

--- a/HexRootsMathlib/Isolate.lean
+++ b/HexRootsMathlib/Isolate.lean
@@ -106,7 +106,7 @@ theorem isolate_run (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
       ∀ (i : Nat) (hi : i < rs.size) (hj : i < atoms.size),
         rs[i] = .atom atoms[i] := by
   have hrun' := hrun
-  rw [Hex.isolate, dif_pos hdegree] at hrun'
+  rw [Hex.isolate, dite_eq_left hdegree] at hrun'
   let target := max atomPrec (Hex.separationDepth p : Int)
   cases hall : Hex.isolateAll? p target
       #[Hex.Component.cauchy p hdegree] strategy with
@@ -163,7 +163,7 @@ theorem isolate_nonpositive (p : Hex.ZPoly)
     (hrun : Hex.isolate p h atomPrec strategy = some atoms) :
     p.size ≠ 0 ∧ atoms = #[] := by
   have hrun' := hrun
-  rw [Hex.isolate, dif_neg hdegree] at hrun'
+  rw [Hex.isolate, dite_eq_right hdegree] at hrun'
   by_cases hp : p.size = 0
   · simp [hp] at hrun'
   · have hatoms : atoms = #[] := by

--- a/HexRootsMathlib/Loop.lean
+++ b/HexRootsMathlib/Loop.lean
@@ -220,7 +220,7 @@ theorem mem_next_of_hold {p : Hex.ZPoly} {target : Int}
     (hdisjoint : Hex.IsolationLoop.overlaps tried i r = false) :
     c ∈ Hex.IsolationLoop.next p target tried := by
   rw [Hex.IsolationLoop.next]
-  simp only [hdepth, if_true]
+  simp only [hdepth, ite_true]
   apply Array.mem_flatMap_of_mem (by simp [hi] : i ∈ Array.range tried.size)
   rw [Hex.IsolationLoop.step]
   have hgetD : tried.getD i (⟨#[], 0⟩, none) = (c, some r) := by
@@ -242,7 +242,7 @@ theorem mem_next_of_adopt {p : Hex.ZPoly} {target : Int}
     (hfiner : c.prec < r.toComponent.prec) :
     r.toComponent ∈ Hex.IsolationLoop.next p target tried := by
   rw [Hex.IsolationLoop.next]
-  simp only [hdepth, if_true]
+  simp only [hdepth, ite_true]
   apply Array.mem_flatMap_of_mem (by simp [hi] : i ∈ Array.range tried.size)
   rw [Hex.IsolationLoop.step]
   have hgetD : tried.getD i (⟨#[], 0⟩, none) = (c, some r) := by

--- a/HexRootsMathlib/NKDriver.lean
+++ b/HexRootsMathlib/NKDriver.lean
@@ -152,7 +152,7 @@ theorem isolate_nk_run (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
         rs[i] = .atom atoms[i] ∧ Hex.nkWitness p atoms[i].square ∧
           atoms[i].witness.isNK = true := by
   have hrun' := hrun
-  rw [Hex.isolate, dif_pos hdegree] at hrun'
+  rw [Hex.isolate, dite_eq_left hdegree] at hrun'
   let target := max atomPrec (Hex.separationDepth p : Int)
   cases hall : Hex.isolateAll? p target
       #[Hex.Component.cauchy p hdegree] .nk with
@@ -246,7 +246,7 @@ theorem isolate_nk_covers_once_of_pos (p : Hex.ZPoly)
   have hzri : z ∈ Certified.region rs[i] := by simpa only [hir'] using hzr
   have hzsq : z ∈ DyadicSquare.closedSquare atoms[i].square := by
     rw [hri] at hzri
-    simpa only [Certified.region, DyadicRootIsolation.region, if_pos hkind]
+    simpa only [Certified.region, DyadicRootIsolation.region, ite_eq_left hkind]
       using hzri
   let fi : Fin atoms.size := ⟨i, by simpa [← hsize] using hi⟩
   refine ⟨fi, hzsq, ?_⟩
@@ -291,7 +291,7 @@ theorem isolate_nk_nonpositive (p : Hex.ZPoly)
     (hrun : Hex.isolate p h atomPrec .nk = some atoms) :
     p.size ≠ 0 ∧ atoms = #[] := by
   have hrun' := hrun
-  rw [Hex.isolate, dif_neg hdegree] at hrun'
+  rw [Hex.isolate, dite_eq_right hdegree] at hrun'
   by_cases hp : p.size = 0
   · simp [hp] at hrun'
   · have hatoms : atoms = #[] := by

--- a/HexRootsMathlib/NKWitness.lean
+++ b/HexRootsMathlib/NKWitness.lean
@@ -103,14 +103,14 @@ theorem witness_iff (p : Hex.ZPoly) (s : Hex.DyadicSquare) :
     coeffs, c1, normSq, invPrec, inverse, residual, y,
     z1, z2Sum, z2, radius, halfRadiusSq]
   by_cases hsize : 2 ≤ (Hex.TaylorShift.compute p s.center).coeffs.size
-  · rw [if_pos hsize]
+  · rw [ite_eq_left hsize]
     simp only [Bool.and_eq_true, decide_eq_true_eq]
     constructor
     · rintro ⟨⟨h0, h1⟩, h2⟩
       exact ⟨hsize, h0, h1, h2⟩
     · rintro ⟨_, h0, h1, h2⟩
       exact ⟨⟨h0, h1⟩, h2⟩
-  · rw [if_neg hsize]
+  · rw [ite_eq_right hsize]
     simp [hsize]
 
 /-- Casting the fold accumulator gives its mathematical partial sum and the
@@ -306,7 +306,7 @@ theorem deriv_sub_center (p : Hex.ZPoly) (s : Hex.DyadicSquare)
   rw [shifted_coeff]
   by_cases hk2 : 2 ≤ k
   · have hk1 : 0 < k - 1 := by omega
-    rw [if_pos hk2, zero_pow (Nat.ne_of_gt hk1)]
+    rw [ite_eq_left hk2, zero_pow (Nat.ne_of_gt hk1)]
     simp only [mul_zero, sub_zero]
     ring
   · have hk0 : k = 0 ∨ k = 1 := by omega

--- a/HexRootsMathlib/Pellet.lean
+++ b/HexRootsMathlib/Pellet.lean
@@ -270,7 +270,7 @@ theorem pelletAt_size {cs : Array Hex.GaussDyadic} {k : ℕ}
     k < cs.size := by
   unfold Hex.pelletAt at h
   by_contra hk
-  rw [if_neg (by omega)] at h
+  rw [ite_eq_right (by omega)] at h
   contradiction
 
 /-- A successful executable Pellet check exposes its strict real
@@ -284,7 +284,7 @@ theorem pelletAt_bound {cs : Array Hex.GaussDyadic} {k : ℕ}
         Dyadic.toReal rlo ^ k := by
   have hk := pelletAt_size h
   unfold Hex.pelletAt at h
-  rw [if_pos hk] at h
+  rw [ite_eq_left hk] at h
   let result := (List.range cs.size).foldl
       (fun acc i =>
         let acc' := if i = k then acc.1
@@ -453,7 +453,7 @@ theorem rootsInDisc_localPoly (p : Hex.ZPoly) (s : Hex.DyadicSquare) (r : ℝ) :
       by_cases hz : dist z c < h * r
       · simp [hz, hequiv.mpr hz]
       · have hz' : ¬h⁻¹ * dist z c < r := fun h' => hz (hequiv.mp h')
-        rw [if_neg hz', if_neg hz]
+        rw [ite_eq_right hz', ite_eq_right hz]
 
 /-- The executable check excludes roots from the corresponding circle about
 the original Taylor centre. -/
@@ -774,7 +774,7 @@ theorem witness_cases {p : Hex.ZPoly} {s : Hex.DyadicSquare} {k : Nat}
         (Hex.TaylorShift.compute p s.center) k = true := by
   unfold Hex.witness Hex.witnessCheck Hex.TaylorShift.combinedWitnessCheck at h
   by_cases hprec : s.prec < 32
-  · rw [if_pos hprec] at h
+  · rw [ite_eq_left hprec] at h
     rw [Hex.TaylorShift.softWitnessCheck_eq] at h
     have hor : Hex.TaylorShift.witnessCheck s
         (Hex.TaylorShift.compute p s.center) k = true ∨
@@ -783,7 +783,7 @@ theorem witness_cases {p : Hex.ZPoly} {s : Hex.DyadicSquare} {k : Nat}
     rcases hor with hexact | hsoft
     · exact Or.inr hexact
     · exact Or.inl hsoft
-  · rw [if_neg hprec] at h
+  · rw [ite_eq_right hprec] at h
     rw [Hex.TaylorShift.softWitnessCheck_eq] at h
     simpa only [Bool.or_eq_true] using h
 

--- a/HexRootsMathlib/RootFree.lean
+++ b/HexRootsMathlib/RootFree.lean
@@ -53,11 +53,11 @@ theorem pelletFold (cs : Array Hex.GaussDyadic) (k : Nat)
       simp only [List.range_succ, List.foldl_append, List.foldl_cons, List.foldl_nil]
       constructor
       · by_cases hnk : n = k
-        · rw [if_pos hnk, ih.1, Finset.sum_range_succ]
-          simp only [hnk, if_pos, add_zero]
-        · rw [if_neg hnk, Dyadic.toReal_add, Dyadic.toReal_mul, ih.1, ih.2,
+        · rw [ite_eq_left hnk, ih.1, Finset.sum_range_succ]
+          simp only [hnk, ite_eq_left, add_zero]
+        · rw [ite_eq_right hnk, Dyadic.toReal_add, Dyadic.toReal_mul, ih.1, ih.2,
             Finset.sum_range_succ]
-          simp only [hnk, if_false]
+          simp only [hnk, ite_false]
       · rw [Dyadic.toReal_mul, ih.2, pow_succ]
 
 /-- A polynomial cannot vanish where its constant coefficient strictly
@@ -74,7 +74,7 @@ private theorem eval_ne_zero_of_dominates {q : Polynomial ℂ} {z : ℂ} {n : Na
   rw [Polynomial.eval_eq_sum_range' hn, Finset.sum_range_succ'] at hz
   simp only [pow_zero, mul_one] at hz
   rw [Finset.sum_range_succ'] at hdom
-  simp only [if_pos, pow_zero, mul_one, Nat.succ_ne_zero, if_false, add_zero] at hdom
+  simp only [ite_eq_left, pow_zero, mul_one, Nat.succ_ne_zero, ite_false, add_zero] at hdom
   have hcoeff : ‖q.coeff 0‖ ≤
       ∑ i ∈ Finset.range m, ‖q.coeff (i + 1)‖ * ‖z‖ ^ (i + 1) := by
     calc
@@ -96,7 +96,7 @@ theorem exactRootFree_size_pos {p : Hex.ZPoly} {s : Hex.DyadicSquare}
   unfold Hex.exactRootFree Hex.pelletAt at h
   rw [Hex.taylor_size] at h
   by_contra hp
-  rw [if_neg (by omega)] at h
+  rw [ite_eq_right (by omega)] at h
   contradiction
 
 /-- A nonempty polynomial's shift has degree strictly below its executable
@@ -123,7 +123,7 @@ theorem exactRootFree_bound {p : Hex.ZPoly} {s : Hex.DyadicSquare}
   have hsize : 0 < p.size := exactRootFree_size_pos h
   unfold Hex.exactRootFree Hex.pelletAt at h
   rw [Hex.taylor_size] at h
-  rw [if_pos hsize] at h
+  rw [ite_eq_left hsize] at h
   simp only [_root_.Dyadic.pow_zero, _root_.Dyadic.mul_one] at h
   let result := (List.range p.size).foldl
       (fun acc i =>
@@ -173,7 +173,7 @@ private theorem exactRootFree_ne_zero {p : Hex.ZPoly} {s : Hex.DyadicSquare}
         intro i hi
         by_cases hi0 : i = 0
         · simp [hi0]
-        · simp only [hi0, if_false]
+        · simp only [hi0, ite_false]
           have hcoeff : ‖q.coeff i‖ ≤ Dyadic.toReal
               (Hex.GaussDyadic.hi ((Hex.taylor p s.center).getD i (0, 0))) := by
             rw [show q.coeff i =
@@ -228,7 +228,7 @@ private theorem softPelletZero_eval {cs : Array Hex.CoeffBall} {q : ℂ[X]}
         intro i _
         by_cases hi : i = 0
         · simp [hi]
-        · simp only [hi, if_false]
+        · simp only [hi, ite_false]
           gcongr
       _ < ‖q.coeff 0‖ := hdomR'
   exact eval_ne_zero_of_dominates henclose.degree_lt hdomZ

--- a/HexRootsMathlib/SoftPellet.lean
+++ b/HexRootsMathlib/SoftPellet.lean
@@ -58,7 +58,7 @@ private theorem coeff_expand_even (p : ℂ[X]) (k : Nat) :
 
 private theorem coeff_expand_even_odd (p : ℂ[X]) (k : Nat) :
     (expand ℂ 2 (graeffeEvenPart p)).coeff (2 * k + 1) = 0 := by
-  rw [coeff_expand (by omega), if_neg]
+  rw [coeff_expand (by omega), ite_eq_right]
   omega
 
 private theorem coeff_expand_odd (p : ℂ[X]) (k : Nat) :
@@ -73,7 +73,7 @@ private theorem coeff_expand_odd (p : ℂ[X]) (k : Nat) :
 
 private theorem coeff_expand_odd_odd (p : ℂ[X]) (k : Nat) :
     (expand ℂ 2 (graeffeOddPart p)).coeff (2 * k + 1) = 0 := by
-  rw [coeff_expand (by omega), if_neg]
+  rw [coeff_expand (by omega), ite_eq_right]
   omega
 
 /-- Recombining the contracted even and odd parts recovers the polynomial. -/
@@ -210,9 +210,9 @@ theorem rootsInDisc_graeffePoly {p : ℂ[X]} (hp : p ≠ 0) (r : ℝ) (hr : 0 �
       congr 1
       simp only [Metric.mem_ball, dist_zero_right, norm_pow]
       by_cases hz : ‖z‖ < r
-      · rw [if_pos hz, if_pos]
+      · rw [ite_eq_left hz, ite_eq_left]
         nlinarith [norm_nonneg z]
-      · rw [if_neg hz, if_neg]
+      · rw [ite_eq_right hz, ite_eq_right]
         nlinarith [norm_nonneg z]
 
 /-! # Coefficient-ball arithmetic -/
@@ -747,7 +747,7 @@ theorem graeffe_enclosePoly {cs : Array Hex.CoeffBall} {q : ℂ[X]}
     · have he := graeffeEven_encloses h bits k
       have ho := graeffeOdd_encloses h bits (k - 1)
       have hs := CoeffBall.sub_encloses he ho bits
-      rw [if_neg hk0]
+      rw [ite_eq_right hk0]
       have hx : (X * graeffeOddPart q ^ 2).coeff k =
           (graeffeOddPart q ^ 2).coeff (k - 1) := by
         let n := k - 1
@@ -810,11 +810,11 @@ private theorem softPelletFold (cs : Array Hex.CoeffBall) (k : Nat)
       simp only [List.range_succ, List.foldl_append, List.foldl_cons, List.foldl_nil]
       constructor
       · by_cases hnk : n = k
-        · rw [if_pos hnk, ih.1, Finset.sum_range_succ]
-          simp only [hnk, if_pos, add_zero]
-        · rw [if_neg hnk, Dyadic.toReal_add, Dyadic.toReal_mul, ih.1, ih.2,
+        · rw [ite_eq_left hnk, ih.1, Finset.sum_range_succ]
+          simp only [hnk, ite_eq_left, add_zero]
+        · rw [ite_eq_right hnk, Dyadic.toReal_add, Dyadic.toReal_mul, ih.1, ih.2,
             Finset.sum_range_succ]
-          simp only [hnk, if_false]
+          simp only [hnk, ite_false]
       · rw [Dyadic.toReal_mul, ih.2, pow_succ]
 
 /-- A successful soft comparison names a stored coefficient. -/
@@ -823,7 +823,7 @@ theorem softPelletAt_size {cs : Array Hex.CoeffBall} {k : ℕ}
     k < cs.size := by
   unfold Hex.softPelletAt at h
   by_contra hk
-  rw [if_neg (by omega)] at h
+  rw [ite_eq_right (by omega)] at h
   contradiction
 
 /-- A successful three-radius comparison names a stored coefficient. -/
@@ -865,7 +865,7 @@ theorem softPelletAt_bound {cs : Array Hex.CoeffBall} {k : ℕ}
         Dyadic.toReal rlo ^ k := by
   have hk := softPelletAt_size h
   unfold Hex.softPelletAt at h
-  rw [if_pos hk] at h
+  rw [ite_eq_left hk] at h
   let result := (List.range cs.size).foldl
       (fun acc i =>
         let acc' := if i = k then acc.1

--- a/HexRootsMathlib/Taylor.lean
+++ b/HexRootsMathlib/Taylor.lean
@@ -116,8 +116,8 @@ theorem taylor_coeff (p : Hex.ZPoly) (z : Hex.GaussDyadic) (k : Nat) :
       ((toPolyℂ p).comp (X + C (GaussDyadic.toComplex z))).coeff k := by
   rw [Hex.taylor_getD]
   by_cases hk : k < p.size
-  · rw [if_pos hk, toComplex_taylorCoeff, coeff_shift]
-  · rw [if_neg hk, coeff_shift,
+  · rw [ite_eq_left hk, toComplex_taylorCoeff, coeff_shift]
+  · rw [ite_eq_right hk, coeff_shift,
       Nat.sub_eq_zero_of_le (Nat.le_of_not_gt hk)]
     simp only [Finset.range_zero, Finset.sum_empty]
     apply Complex.ext <;> simp [GaussDyadic.toComplex]

--- a/HexRowReduce/Api.lean
+++ b/HexRowReduce/Api.lean
@@ -115,7 +115,7 @@ theorem rowReduce_rank_eq_n_of_rightInverse [Lean.Grind.Field R] [DecidableEq R]
       rw [Vector.get_eq_getElem, Vector.getElem_zero]
     have hu : (Vector.unit R i).get i = 1 := by
       unfold Vector.unit
-      rw [Vector.get_ofFn, if_pos rfl]
+      rw [Vector.get_ofFn, ite_eq_left rfl]
       rfl
     have huRow : (Matrix.row (Matrix.identity (R := R) n) i).get i = 1 := by
       rw [Matrix.row_identity]
@@ -189,7 +189,7 @@ theorem rowReduce_takeRows_echelon_eq_identity [Lean.Grind.Field R] [DecidableEq
   have hpj : D.pivotCols.get jj = j := hpivot j
   by_cases hijv : i.val = j.val
   · have hij : i = j := Fin.ext hijv
-    rw [if_pos hij]
+    rw [ite_eq_left hij]
     have hone := E.pivot_one ii
     have hcol : D.pivotCols.get ii = j := hpi.trans hij
     change (rowReduce M).pivotCols.get ii = j at hcol
@@ -203,7 +203,7 @@ theorem rowReduce_takeRows_echelon_eq_identity [Lean.Grind.Field R] [DecidableEq
     change (Matrix.row (rowReduce M).echelon iN).get j = 1
     exact hentry.symm.trans hone
   · have hij : i ≠ j := fun h => hijv (congrArg Fin.val h)
-    rw [if_neg hij]
+    rw [ite_eq_right hij]
     cases Nat.lt_or_gt_of_ne hijv with
     | inl hijv =>
         rw [← hpj]
@@ -248,9 +248,9 @@ theorem rowReduce_rank_le_of_eq_mul [Lean.Grind.Field R] [DecidableEq R]
         simp only [P, Matrix.getElem_takeRows]
         by_cases hij : i = j
         · subst j
-          rw [if_pos rfl]
+          rw [ite_eq_left rfl]
           simpa [P, Matrix.IsEchelonForm.pivotRow] using E.pivot_one i
-        · rw [if_neg hij]
+        · rw [ite_eq_right hij]
           cases Nat.lt_or_gt_of_ne (fun h => hij (Fin.ext h)) with
           | inl hijv =>
               simpa [Matrix.IsEchelonForm.pivotRow] using
@@ -328,7 +328,7 @@ private theorem pad_identity_mul [Lean.Grind.Field R] [DecidableEq R]
       change (Matrix.pad (Matrix.identity (R := R) k) n k)[i][tt] =
         (Matrix.identity (R := R) k)[ii][tt]
       rw [Matrix.getElem_pad,
-        dif_pos (⟨hi, tt.isLt⟩ : i.val < k ∧ tt.val < k),
+        dite_eq_left (⟨hi, tt.isLt⟩ : i.val < k ∧ tt.val < k),
         Matrix.getElem_pair_eq_nested]
     calc
       (Matrix.pad (Matrix.identity (R := R) k) n k * P)[i][j] =
@@ -336,14 +336,14 @@ private theorem pad_identity_mul [Lean.Grind.Field R] [DecidableEq R]
         rw [Matrix.getElem_mul, Matrix.getElem_mul, hrow]
       _ = P[ii][j] := by rw [Matrix.identity_mul]
       _ = (Matrix.pad P n m)[i][j] := by
-        rw [Matrix.getElem_pad, dif_pos (⟨hi, j.isLt⟩ : i.val < k ∧ j.val < m),
+        rw [Matrix.getElem_pad, dite_eq_left (⟨hi, j.isLt⟩ : i.val < k ∧ j.val < m),
           Matrix.getElem_pair_eq_nested]
   · have hrow : Matrix.row (Matrix.pad (Matrix.identity (R := R) k) n k) i = 0 := by
       ext t ht
       let tt : Fin k := ⟨t, ht⟩
       change (Matrix.pad (Matrix.identity (R := R) k) n k)[i][tt] =
         (0 : Vector R k)[tt]
-      rw [Matrix.getElem_pad, dif_neg (by simp [hi])]
+      rw [Matrix.getElem_pad, dite_eq_right (by simp [hi])]
       change (0 : R) = (0 : Vector R k)[tt.val]
       rw [Vector.getElem_zero]
     have hz := Matrix.row_mul_eq_zero
@@ -352,7 +352,7 @@ private theorem pad_identity_mul [Lean.Grind.Field R] [DecidableEq R]
     change (Matrix.pad (Matrix.identity (R := R) k) n k * P)[i][j] =
       (0 : Vector R m)[j.val] at hentry
     rw [Vector.getElem_zero] at hentry
-    rw [Matrix.getElem_pad, dif_neg (by simp [hi])]
+    rw [Matrix.getElem_pad, dite_eq_right (by simp [hi])]
     exact hentry
 
 /-- The computed rank supplies an explicit factorization through that many
@@ -374,9 +374,9 @@ theorem rowReduce_rank_factorization [Lean.Grind.Field R] [DecidableEq R]
     intro i j
     rw [Matrix.getElem_pad]
     by_cases hi : i.val < d
-    · rw [dif_pos (⟨hi, j.isLt⟩ : i.val < d ∧ j.val < m),
+    · rw [dite_eq_left (⟨hi, j.isLt⟩ : i.val < d ∧ j.val < m),
         Matrix.getElem_pair_eq_nested, Matrix.getElem_takeRows]
-    · rw [dif_neg (by simp [hi])]
+    · rw [dite_eq_right (by simp [hi])]
       have hrow := E.toIsEchelonForm.zero_row i (Nat.le_of_not_gt hi)
       have hentry := congrArg (fun v : Vector R m => v[j]) hrow
       change D.echelon[i][j] = (0 : Vector R m)[j.val] at hentry

--- a/HexRowReduce/Loop.lean
+++ b/HexRowReduce/Loop.lean
@@ -251,9 +251,9 @@ private theorem rowReduceLoop_shape :
       intro col state h
       unfold rowReduceLoop
       by_cases hRow : state.row < n
-      · rw [dif_pos hRow]
+      · rw [dite_eq_left hRow]
         by_cases hCol : col < m
-        · rw [dif_pos hCol]
+        · rw [dite_eq_left hCol]
           cases hpivot : findPivot? state.echelon ⟨col, hCol⟩ state.row with
           | none =>
               simpa [hpivot, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using
@@ -279,9 +279,9 @@ private theorem rowReduceLoop_shape :
               simpa [hpivot, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm, nextState, colFin, target,
                 swappedEchelon, swappedTransform, pivotVal, scaledEchelon, scaledTransform,
                 eliminated] using ih (col + 1) nextState hnext
-        · rw [dif_neg hCol]
+        · rw [dite_eq_right hCol]
           exact h.mono_col (by omega)
-      · rw [dif_neg hRow]
+      · rw [dite_eq_right hRow]
         exact h.mono_col (by omega)
 
 omit [DecidableEq R] in
@@ -334,9 +334,9 @@ private theorem rowReduceLoop_canonical :
       intro col state hshape hcanon
       unfold rowReduceLoop
       by_cases hRow : state.row < n
-      · rw [dif_pos hRow]
+      · rw [dite_eq_left hRow]
         by_cases hCol : col < m
-        · rw [dif_pos hCol]
+        · rw [dite_eq_left hCol]
           cases hpivot : findPivot? state.echelon ⟨col, hCol⟩ state.row with
           | none =>
               simpa [hpivot] using
@@ -372,9 +372,9 @@ private theorem rowReduceLoop_canonical :
                 swappedTransform, pivotVal, scaledEchelon, scaledTransform,
                 eliminated] using
                 ih (col + 1) nextState hnext_shape hnext_canon
-        · rw [dif_neg hCol]
+        · rw [dite_eq_right hCol]
           exact hcanon
-      · rw [dif_neg hRow]
+      · rw [dite_eq_right hRow]
         exact hcanon
 
 /-- `rowReduce_final_canonical`: the matrix produced by the full `rowReduceLoop` run over
@@ -402,11 +402,11 @@ private theorem rowSwap_zero_column_preserve {M : Matrix R n m}
   intro r hr
   rw [getElem_rowSwap]
   by_cases hrj : r = j
-  · subst r; rw [if_pos rfl]; exact h i hi
-  · rw [if_neg hrj]
+  · subst r; rw [ite_eq_left rfl]; exact h i hi
+  · rw [ite_eq_right hrj]
     by_cases hri : r = i
-    · subst r; rw [if_pos rfl]; exact h j hj
-    · rw [if_neg hri]; exact h r hr
+    · subst r; rw [ite_eq_left rfl]; exact h j hj
+    · rw [ite_eq_right hri]; exact h r hr
 
 omit [DecidableEq R] in
 /-- Scaling row `i` by `c` preserves any zero-column property on rows from
@@ -420,9 +420,9 @@ private theorem rowScale_zero_column_preserve {M : Matrix R n m}
   rw [getElem_rowScale]
   by_cases hri : r = i
   · subst r
-    rw [if_pos rfl, h i hr]
+    rw [ite_eq_left rfl, h i hr]
     grind
-  · rw [if_neg hri]; exact h r hr
+  · rw [ite_eq_right hri]; exact h r hr
 
 /-- Folding `eliminateColumn`'s step function over any list preserves every
 row's entry at column `k`, provided the pivot row is zero at column `k`. -/
@@ -455,11 +455,11 @@ private theorem eliminateColumn_foldl_other_column
         exact hs
       rw [ih _ r hstep_pivot]
       by_cases hxp : x = pivotRow
-      · rw [dif_pos hxp]
-      · rw [dif_neg hxp]
+      · rw [dite_eq_left hxp]
+      · rw [dite_eq_right hxp]
         by_cases hcoeff : -s.1[x][col] = 0
-        · rw [if_pos hcoeff]
-        · rw [if_neg hcoeff]
+        · rw [ite_eq_left hcoeff]
+        · rw [ite_eq_right hcoeff]
           by_cases hrx : r = x
           · subst r
             rw [rowAdd_get_dst, hs]
@@ -536,9 +536,9 @@ private theorem rowReduceLoop_no_pivot_zero :
       intro col state h
       unfold rowReduceLoop
       by_cases hRow : state.row < n
-      · rw [dif_pos hRow]
+      · rw [dite_eq_left hRow]
         by_cases hCol : col < m
-        · rw [dif_pos hCol]
+        · rw [dite_eq_left hCol]
           cases hpivot : findPivot? state.echelon ⟨col, hCol⟩ state.row with
           | none =>
               have hnext : RowReduceNoPivotZero (R := R) (n := n) (m := m) (col + 1) state := by
@@ -614,9 +614,9 @@ private theorem rowReduceLoop_no_pivot_zero :
                 pivotVal, scaledEchelon, scaledTransform, eliminated, nextState,
                 Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using
                 ih (col + 1) nextState hnext
-        · rw [dif_neg hCol]
+        · rw [dite_eq_right hCol]
           exact h.widen_col_at_m (by omega)
-      · rw [dif_neg hRow]
+      · rw [dite_eq_right hRow]
         exact h.widen_col_at_n (by omega)
 
 /-- `rowReduce_final_no_pivot_zero`: the matrix produced by the full `rowReduceLoop` run
@@ -754,9 +754,9 @@ private theorem rowReduceLoop_transform_preserve (M : Matrix R n m) :
       intro state h
       unfold rowReduceLoop
       by_cases hRow : state.row < n
-      · rw [dif_pos hRow]
+      · rw [dite_eq_left hRow]
         by_cases hCol : col < m
-        · rw [dif_pos hCol]
+        · rw [dite_eq_left hCol]
           let colFin : Fin m := ⟨col, hCol⟩
           cases hp : findPivot? state.echelon colFin state.row with
           | none =>
@@ -786,9 +786,9 @@ private theorem rowReduceLoop_transform_preserve (M : Matrix R n m) :
               simpa [colFin, hp, target, swappedEchelon, swappedTransform, pivotVal,
                 scaledEchelon, scaledTransform, eliminated]
                 using hnext
-        · rw [dif_neg hCol]
+        · rw [dite_eq_right hCol]
           exact h
-      · rw [dif_neg hRow]
+      · rw [dite_eq_right hRow]
         exact h
 
 /-- Reduced row echelon form data computed by Gauss-Jordan elimination. -/

--- a/HexRowReduce/Nullspace.lean
+++ b/HexRowReduce/Nullspace.lean
@@ -71,13 +71,13 @@ private theorem pivotIndexAux_pivot (E : IsEchelonForm M D) (i : Fin D.rank) :
       let s : Fin D.rank := ⟨start, hstartRank⟩
       by_cases hsi : s = i
       · have hcols : D.pivotCols.get s = D.pivotCols.get i := by rw [hsi]
-        rw [if_pos hcols]
+        rw [ite_eq_left hcols]
         change some s = some i
         exact congrArg some hsi
       · have hcols : D.pivotCols.get s ≠ D.pivotCols.get i := by
           intro hcols
           exact hsi (E.pivotCols_injective hcols)
-        rw [if_neg hcols]
+        rw [ite_eq_right hcols]
         apply ih (start := start + 1)
         · have hslt : start < i.val := by
             have hsne : start ≠ i.val := by
@@ -523,15 +523,15 @@ private theorem pivot_column_entry_pivotRow {R : Type u} [Lean.Grind.Field R]
   have h := pivot_column_entry E i' (E.toIsEchelonForm.pivotRow i)
   by_cases hii : i' = i
   · subst i'
-    rw [if_pos rfl, h, if_pos rfl]
-  · rw [if_neg hii]
+    rw [ite_eq_left rfl, h, ite_eq_left rfl]
+  · rw [ite_eq_right hii]
     rw [h]
     have hrow_ne : E.toIsEchelonForm.pivotRow i' ≠ E.toIsEchelonForm.pivotRow i := by
       intro heq
       apply hii
       apply Fin.ext
       simpa [IsEchelonForm.pivotRow] using congrArg Fin.val heq
-    rw [if_neg hrow_ne]
+    rw [ite_eq_right hrow_ne]
 
 omit [Mul R] [Add R] [OfNat R 0] [OfNat R 1] in
 /-- The row of `D.echelon * v` at `pivotRow i`, expanded as a foldl, is the
@@ -608,7 +608,7 @@ private theorem freeSum_eq_neg_pivot {R : Type u} [Lean.Grind.Field R] {n m : Na
       · subst i'
         rfl
       · have hii' : i ≠ i' := fun h => hii h.symm
-        rw [if_neg hii, if_neg hii']
+        rw [ite_eq_right hii, ite_eq_right hii']
     rw [hrewrite]
     rw [foldl_indicator_mul_unique (List.finRange D.rank) i
       (fun i' => v[D.pivotCols.get i'])
@@ -772,9 +772,9 @@ theorem nullspace_complete {R : Type u} [Lean.Grind.Field R] {n m : Nat}
         rw [hcEntry k]
         by_cases hkl : k = l
         · subst k
-          rw [nullspaceMatrix_free E l, if_pos rfl]
+          rw [nullspaceMatrix_free E l, ite_eq_left rfl]
         · have hlk : l ≠ k := fun heq => hkl heq.symm
-          rw [nullspaceMatrix_free_ne E (k := k) (l := l) hkl, if_neg hlk]
+          rw [nullspaceMatrix_free_ne E (k := k) (l := l) hkl, ite_eq_right hlk]
       rw [hcongr]
       rw [foldl_indicator_mul_unique (List.finRange (m - D.rank)) l
         (fun k => v[E.toIsEchelonForm.freeCols.get k])

--- a/HexRowReduce/Pivot.lean
+++ b/HexRowReduce/Pivot.lean
@@ -89,15 +89,15 @@ private theorem findPivotAux_some_ge (M : Matrix R n m) (col : Fin m) :
       unfold findPivotAux at h
       simp only [getElem_pair_eq_nested] at h
       by_cases hstart : start < n
-      · rw [dif_pos hstart] at h
+      · rw [dite_eq_left hstart] at h
         by_cases hzero : M[(⟨start, hstart⟩ : Fin n)][col] = 0
-        · rw [if_pos hzero] at h
+        · rw [ite_eq_left hzero] at h
           exact Nat.le_of_succ_le (ih h)
-        · rw [if_neg hzero] at h
+        · rw [ite_eq_right hzero] at h
           injection h with hi
           subst hi
           exact Nat.le_refl _
-      · rw [dif_neg hstart] at h
+      · rw [dite_eq_right hstart] at h
         contradiction
 
 /-- The result of a successful pivot search is a nonzero entry. -/
@@ -114,15 +114,15 @@ private theorem findPivotAux_some_nonzero (M : Matrix R n m) (col : Fin m) :
       unfold findPivotAux at h
       simp only [getElem_pair_eq_nested] at h
       by_cases hstart : start < n
-      · rw [dif_pos hstart] at h
+      · rw [dite_eq_left hstart] at h
         by_cases hzero : M[(⟨start, hstart⟩ : Fin n)][col] = 0
-        · rw [if_pos hzero] at h
+        · rw [ite_eq_left hzero] at h
           exact ih h
-        · rw [if_neg hzero] at h
+        · rw [ite_eq_right hzero] at h
           injection h with hi
           subst hi
           exact hzero
-      · rw [dif_neg hstart] at h
+      · rw [dite_eq_right hstart] at h
         contradiction
 
 /-- All rows below the pivot search start that precede the returned index are zero. -/
@@ -140,9 +140,9 @@ private theorem findPivotAux_some_above (M : Matrix R n m) (col : Fin m) :
       unfold findPivotAux at h
       simp only [getElem_pair_eq_nested] at h
       by_cases hstart : start < n
-      · rw [dif_pos hstart] at h
+      · rw [dite_eq_left hstart] at h
         by_cases hzero : M[(⟨start, hstart⟩ : Fin n)][col] = 0
-        · rw [if_pos hzero] at h
+        · rw [ite_eq_left hzero] at h
           rcases Nat.lt_or_ge start (k.val + 1) with hgt | hle
           · -- start < k.val + 1, so start ≤ k.val and start < k.val + 1
             -- combined with hge gives start ≤ k.val
@@ -155,7 +155,7 @@ private theorem findPivotAux_some_above (M : Matrix R n m) (col : Fin m) :
               exact hzero
           · -- k.val + 1 ≤ start, contradicts hge
             omega
-        · rw [if_neg hzero] at h
+        · rw [ite_eq_right hzero] at h
           injection h with hi
           -- hi : ⟨start, hstart⟩ = i
           have hival : i.val = start := by
@@ -163,7 +163,7 @@ private theorem findPivotAux_some_above (M : Matrix R n m) (col : Fin m) :
             exact hi.symm
           exfalso
           omega
-      · rw [dif_neg hstart] at h
+      · rw [dite_eq_right hstart] at h
         contradiction
 
 /-- Failed pivot search means every searched row is zero in this column. -/
@@ -181,15 +181,15 @@ private theorem findPivotAux_none (M : Matrix R n m) (col : Fin m) :
       unfold findPivotAux at h
       simp only [getElem_pair_eq_nested] at h
       by_cases hstart : start < n
-      · rw [dif_pos hstart] at h
+      · rw [dite_eq_left hstart] at h
         by_cases hzero : M[(⟨start, hstart⟩ : Fin n)][col] = 0
-        · rw [if_pos hzero] at h
+        · rw [ite_eq_left hzero] at h
           rcases Nat.lt_or_eq_of_le hge with hgt | heq
           · exact ih h k hgt (by omega)
           · have hk_eq : k = ⟨start, hstart⟩ := Fin.ext heq.symm
             rw [hk_eq]
             exact hzero
-        · rw [if_neg hzero] at h
+        · rw [ite_eq_right hzero] at h
           contradiction
       · exact absurd k.isLt (by omega)
 
@@ -225,14 +225,14 @@ omit [DecidableEq R] in
 private theorem rowAdd_get_dst (M : Matrix R n m) (src dst : Fin n) (c : R)
     (k : Fin m) :
     (rowAdd M src dst c)[dst][k] = M[dst][k] + c * M[src][k] := by
-  rw [getElem_rowAdd, if_pos rfl]
+  rw [getElem_rowAdd, ite_eq_left rfl]
 
 omit [DecidableEq R] in
 /-- Entry of `rowAdd M src dst c` at any row other than `dst`. -/
 private theorem rowAdd_get_other (M : Matrix R n m) (src dst : Fin n) (c : R)
     {r : Fin n} (hne : r ≠ dst) (k : Fin m) :
     (rowAdd M src dst c)[r][k] = M[r][k] := by
-  rw [getElem_rowAdd, if_neg hne]
+  rw [getElem_rowAdd, ite_eq_right hne]
 
 /-- One step of `eliminateColumn`'s fold preserves the entry at the pivot row. -/
 private theorem eliminateColumn_step_pivotRow_unchanged
@@ -245,11 +245,11 @@ private theorem eliminateColumn_step_pivotRow_unchanged
        else (rowAdd s.1 pivotRow x coeff, rowAdd s.2 pivotRow x coeff)).1[pivotRow][k]
       = s.1[pivotRow][k] := by
   by_cases hxp : x = pivotRow
-  · rw [dif_pos hxp]
-  · rw [dif_neg hxp]
+  · rw [dite_eq_left hxp]
+  · rw [dite_eq_right hxp]
     by_cases hcoeff : -s.1[x][col] = 0
-    · rw [if_pos hcoeff]
-    · rw [if_neg hcoeff]
+    · rw [ite_eq_left hcoeff]
+    · rw [ite_eq_right hcoeff]
       exact rowAdd_get_other s.1 pivotRow x _ (fun h => hxp h.symm) k
 
 /-- One step of `eliminateColumn`'s fold preserves the entry at any row other
@@ -264,11 +264,11 @@ private theorem eliminateColumn_step_other_unchanged
        else (rowAdd s.1 pivotRow x coeff, rowAdd s.2 pivotRow x coeff)).1[r][col]
       = s.1[r][col] := by
   by_cases hxp : x = pivotRow
-  · rw [dif_pos hxp]
-  · rw [dif_neg hxp]
+  · rw [dite_eq_left hxp]
+  · rw [dite_eq_right hxp]
     by_cases hcoeff : -s.1[x][col] = 0
-    · rw [if_pos hcoeff]
-    · rw [if_neg hcoeff]
+    · rw [ite_eq_left hcoeff]
+    · rw [ite_eq_right hcoeff]
       exact rowAdd_get_other s.1 pivotRow x _ hrx col
 
 /-- One step of `eliminateColumn`'s fold zeros the entry at row `x` (the row
@@ -283,11 +283,11 @@ private theorem eliminateColumn_step_zero_at_x
        if coeff = 0 then s
        else (rowAdd s.1 pivotRow x coeff, rowAdd s.2 pivotRow x coeff)).1[x][col]
       = 0 := by
-  rw [dif_neg hxp]
+  rw [dite_eq_right hxp]
   by_cases hcoeff : -s.1[x][col] = 0
-  · rw [if_pos hcoeff]
+  · rw [ite_eq_left hcoeff]
     grind
-  · rw [if_neg hcoeff]
+  · rw [ite_eq_right hcoeff]
     show (rowAdd s.1 pivotRow x (-s.1[x][col]))[x][col] = 0
     rw [rowAdd_get_dst s.1 pivotRow x (-s.1[x][col]) col, hpivot]
     grind
@@ -409,11 +409,11 @@ private theorem eliminateColumn_step_transform_preserve
             if coeff = 0 then s
             else (rowAdd s.1 pivotRow x coeff, rowAdd s.2 pivotRow x coeff)).1 := by
   by_cases hx : x = pivotRow
-  · rw [dif_pos hx]; exact h
-  · rw [dif_neg hx]
+  · rw [dite_eq_left hx]; exact h
+  · rw [dite_eq_right hx]
     by_cases hcoeff : -s.1[x][col] = 0
-    · rw [if_pos hcoeff]; exact h
-    · rw [if_neg hcoeff]
+    · rw [ite_eq_left hcoeff]; exact h
+    · rw [ite_eq_right hcoeff]
       exact rowAdd_transform_mul_preserve pivotRow x (-s.1[x][col]) h
 
 /-- Folding `eliminateColumn`'s step function over any list preserves the
@@ -468,13 +468,13 @@ private theorem eliminateColumn_step_left_inverse_preserve
            if coeff = 0 then s
            else (rowAdd s.1 pivotRow x coeff, rowAdd s.2 pivotRow x coeff)).2 = (Matrix.identity (R := R) n) := by
   by_cases hx : x = pivotRow
-  · rw [dif_pos hx]
+  · rw [dite_eq_left hx]
     exact h
-  · rw [dif_neg hx]
+  · rw [dite_eq_right hx]
     by_cases hcoeff : -s.1[x][col] = 0
-    · rw [if_pos hcoeff]
+    · rw [ite_eq_left hcoeff]
       exact h
-    · rw [if_neg hcoeff]
+    · rw [ite_eq_right hcoeff]
       exact rowAdd_left_inverse_preserve s.2 (-s.1[x][col])
         (fun hpivotx => hx hpivotx.symm) h
 
@@ -491,13 +491,13 @@ private theorem eliminateColumn_step_right_inverse_preserve
          else (rowAdd s.1 pivotRow x coeff, rowAdd s.2 pivotRow x coeff)).2 *
         Tinv' = (Matrix.identity (R := R) n) := by
   by_cases hx : x = pivotRow
-  · rw [dif_pos hx]
+  · rw [dite_eq_left hx]
     exact h
-  · rw [dif_neg hx]
+  · rw [dite_eq_right hx]
     by_cases hcoeff : -s.1[x][col] = 0
-    · rw [if_pos hcoeff]
+    · rw [ite_eq_left hcoeff]
       exact h
-    · rw [if_neg hcoeff]
+    · rw [ite_eq_right hcoeff]
       exact rowAdd_right_inverse_preserve s.2 (-s.1[x][col])
         (fun hpivotx => hx hpivotx.symm) h
 
@@ -625,7 +625,7 @@ private theorem rowScale_preserve_canonical_column
     rw [getElem_rowScale]
     by_cases hrTarget : r = target
     · subst r
-      rw [if_pos rfl, hTarget]
+      rw [ite_eq_left rfl, hTarget]
       grind
     · simpa [hrTarget] using hzero r hr
 
@@ -643,14 +643,14 @@ private theorem rowAdd_preserve_canonical_column
   · rw [getElem_rowAdd]
     by_cases hrowDst : pivotRow = dst
     · subst dst
-      rw [if_pos rfl, hpivotRow, hSrc]
+      rw [ite_eq_left rfl, hpivotRow, hSrc]
       grind
     · simpa [hrowDst] using hpivotRow
   · intro r hr
     rw [getElem_rowAdd]
     by_cases hrDst : r = dst
     · subst dst
-      rw [if_pos rfl, hzero r hr, hSrc]
+      rw [ite_eq_left rfl, hzero r hr, hSrc]
       grind
     · simpa [hrDst] using hzero r hr
 
@@ -696,9 +696,9 @@ private theorem eliminateColumn_preserve_canonical_column
       simp only [List.foldl_cons]
       simp only [getElem_pair_eq_nested] at ih ⊢
       by_cases hx : x = newPivot
-      · simp only [dif_pos hx]; exact ih s hSrc hOld hzero
+      · simp only [dite_eq_left hx]; exact ih s hSrc hOld hzero
       · by_cases hcoeff : -s.1[x][newCol] = 0
-        · simp only [dif_neg hx, hcoeff, if_pos]; exact ih s hSrc hOld hzero
+        · simp only [dite_eq_right hx, hcoeff, ite_eq_left]; exact ih s hSrc hOld hzero
         · let next : Matrix R n m × Matrix R n n :=
             (rowAdd s.1 newPivot x (-s.1[x][newCol]), rowAdd s.2 newPivot x (-s.1[x][newCol]))
           have hcanon :
@@ -709,7 +709,8 @@ private theorem eliminateColumn_preserve_canonical_column
                 (-s.1[x][newCol]) hSrc hOld hzero
           have hSrcNext : next.1[newPivot][oldCol] = 0 :=
             hcanon.2 newPivot (fun h => hOldNew h.symm)
-          simp only [dif_neg hx, if_neg hcoeff]; exact ih next hSrcNext hcanon.1 hcanon.2
+          simp only [dite_eq_right hx, ite_eq_right hcoeff]
+          exact ih next hSrcNext hcanon.1 hcanon.2
 
 /-- Process columns left-to-right, performing Gauss-Jordan elimination. -/
 def rowReduceLoop (col fuel : Nat) (state : RowReduceState R n m) : RowReduceState R n m :=

--- a/HexRowReduce/RowEchelon/Contracts.lean
+++ b/HexRowReduce/RowEchelon/Contracts.lean
@@ -165,14 +165,14 @@ private theorem sortedComplement_eq_filter [DecidableEq α]
             intro h
             subst y
             exact hnot (by simp)
-          rw [sortedComplement, if_neg hxy]
+          rw [sortedComplement, ite_eq_right hxy]
           rw [ih (List.nodup_cons.mp hnodup).2]
           rw [List.filter_cons]
           have hp : (decide (x ∉ y :: ys) : Bool) = true := decide_eq_true hnot
           rw [hp]
           simp
   | @cons_cons pivots cols x hsub ih =>
-      rw [sortedComplement, if_pos rfl, List.filter_cons_of_neg (by simp)]
+      rw [sortedComplement, ite_eq_left rfl, List.filter_cons_of_neg (by simp)]
       rw [ih (List.nodup_cons.mp hnodup).2]
       apply List.filter_congr
       intro z hz

--- a/HexRowReduce/Span.lean
+++ b/HexRowReduce/Span.lean
@@ -183,15 +183,15 @@ private theorem foldl_indicator_mul_unique {R : Type u} [Lean.Grind.Ring R]
             ∀ y ∈ xs, (if x = y then (1 : R) else 0) * f y = 0 := by
           intro y hy
           have hxy : x ≠ y := fun heq => (List.nodup_cons.mp hnodup).1 (heq ▸ hy)
-          rw [if_neg hxy]
+          rw [ite_eq_right hxy]
           grind
-        rw [if_pos rfl, List.foldl_add_eq_self xs _ _ hxs_zero]
+        rw [ite_eq_left rfl, List.foldl_add_eq_self xs _ _ hxs_zero]
         grind
       · have hxi : i ≠ x := by
           intro heq
           rw [← heq] at hnodup
           exact (List.nodup_cons.mp hnodup).1 hitail
-        rw [if_neg hxi]
+        rw [ite_eq_right hxi]
         have hzero : (0 : R) * f x = 0 := by grind
         rw [hzero]
         have hacc : acc + (0 : R) = acc := by grind
@@ -225,7 +225,7 @@ theorem vecMul_single {R : Type u} [Lean.Grind.CommRing R]
     rw [getElem_col, hind]
     by_cases hil : i = l
     · simp [hil, Lean.Grind.CommSemiring.mul_comm]
-    · rw [if_neg hil]
+    · rw [ite_eq_right hil]
       grind
   rw [hbody]
   have hpick := foldl_indicator_mul_unique (R := R) (List.finRange n) i
@@ -246,7 +246,7 @@ private theorem pivot_column_entry [Lean.Grind.Field R] (E : IsRowReduced M D)
       have hip : E.toIsEchelonForm.pivotRow p = i := by
         apply Fin.ext
         simpa [IsEchelonForm.pivotRow] using congrArg Fin.val hpq
-      rw [if_pos hip]
+      rw [ite_eq_left hip]
       subst p
       simpa [IsEchelonForm.pivotRow] using E.pivot_one ⟨i.val, hi⟩
     · have hrow_ne : E.toIsEchelonForm.pivotRow p ≠ i := by
@@ -254,7 +254,7 @@ private theorem pivot_column_entry [Lean.Grind.Field R] (E : IsRowReduced M D)
         apply hpq
         apply Fin.ext
         simpa [IsEchelonForm.pivotRow] using congrArg Fin.val hrow
-      rw [if_neg hrow_ne]
+      rw [ite_eq_right hrow_ne]
       have hne : i.val ≠ p.val := by
         intro hval
         apply hpq
@@ -270,7 +270,7 @@ private theorem pivot_column_entry [Lean.Grind.Field R] (E : IsRowReduced M D)
       apply hi
       rw [← Fin.ext_iff.mp hrow]
       exact p.isLt
-    rw [if_neg hrow_ne]
+    rw [ite_eq_right hrow_ne]
     have hzero := E.toIsEchelonForm.zero_row i (by omega)
     simpa using congrArg (fun row => row[D.pivotCols.get p]) hzero
 

--- a/HexSmith/Correct/Complete.lean
+++ b/HexSmith/Correct/Complete.lean
@@ -394,7 +394,7 @@ private theorem reduceFuel_inverses (pivotRow : Fin n) (pivotCol : Fin m)
                 let normalized := Matrix.rowScale s.matrix pivotRow (-1)
                 have hzero' : normalized[pivotRow][q.2] = 0 := by
                   dsimp only [normalized]
-                  rw [Matrix.getElem_rowScale, if_pos rfl]
+                  rw [Matrix.getElem_rowScale, ite_eq_left rfl]
                   have hz : s.matrix[pivotRow][q.2] = 0 := by
                     simpa only [Matrix.getElem_pair_eq_nested] using hzero
                   rw [hz]
@@ -407,7 +407,7 @@ private theorem reduceFuel_inverses (pivotRow : Fin n) (pivotCol : Fin m)
                 have hb : repairedMatrix[(pivotRow, q.2)] ≠ 0 := by
                   dsimp only [repairedMatrix]
                   rw [Matrix.getElem_pair_eq_nested, Matrix.getElem_rowAdd,
-                    if_pos rfl, hzero']
+                    ite_eq_left rfl, hzero']
                   simpa using hsource
                 exact ih (repair_inverses hneg pivotRow q.1 pivotCol q.2
                   hrowNe hcolNe hb)
@@ -431,7 +431,7 @@ private theorem reduceFuel_inverses (pivotRow : Fin n) (pivotCol : Fin m)
                   rw [hz, Int.zero_emod] at hs
                   exact hs.2.2 rfl
                 have hb : (Matrix.rowAdd s.matrix q.1 pivotRow 1)[(pivotRow, q.2)] ≠ 0 := by
-                  rw [Matrix.getElem_pair_eq_nested, Matrix.getElem_rowAdd, if_pos rfl, hzero']
+                  rw [Matrix.getElem_pair_eq_nested, Matrix.getElem_rowAdd, ite_eq_left rfl, hzero']
                   simpa using hsource
                 exact ih (repair_inverses h pivotRow q.1 pivotCol q.2
                   hrowNe hcolNe hb)
@@ -556,9 +556,9 @@ private theorem Diagonal.Compact.swap_agrees (ops : Accumulator α r r)
   subst denseAcc
   simp only [Diagonal.Compact.swap, Diagonal.swap, swapRows, swapCols]
   by_cases hij : i = j
-  · simp only [if_pos hij]
+  · simp only [ite_eq_left hij]
     exact ⟨rfl, rfl⟩
-  · simp only [if_neg hij]
+  · simp only [ite_eq_right hij]
     exact ⟨diagMatrix_swap values i j, rfl⟩
 
 private theorem Diagonal.findNonzero?_diag (values : Vector Int r)
@@ -583,7 +583,7 @@ private theorem Diagonal.Compact.normalizeFuel_agrees
   | succ fuel ih =>
       rw [Diagonal.Compact.normalizeFuel, Diagonal.normalizeFuel]
       by_cases ht : target < r
-      · rw [dif_pos ht, dif_pos ht]
+      · rw [dite_eq_left ht, dite_eq_left ht]
         rw [h.matrix, Diagonal.findNonzero?_diag]
         cases hf : Diagonal.Compact.findNonzero? compact.values target with
         | none => simp only [hf]; exact h
@@ -600,7 +600,7 @@ private theorem Diagonal.Compact.normalizeFuel_agrees
             · have hp' : (Diagonal.swap ops dense pivot found).matrix[(pivot, pivot)] < 0 := by
                 rw [hpivot]
                 exact hp
-              rw [if_pos hp, if_pos hp']
+              rw [ite_eq_left hp, ite_eq_left hp']
               apply ih
               exact ⟨(congrArg (fun M => Matrix.rowScale M pivot (-1))
                 hmoved.matrix).trans (diagMatrix_negate _ pivot),
@@ -608,9 +608,9 @@ private theorem Diagonal.Compact.normalizeFuel_agrees
             · have hp' : ¬ (Diagonal.swap ops dense pivot found).matrix[(pivot, pivot)] < 0 := by
                 rw [hpivot]
                 exact hp
-              rw [if_neg hp, if_neg hp']
+              rw [ite_eq_right hp, ite_eq_right hp']
               exact ih (target + 1) hmoved
-      · rw [dif_neg ht, dif_neg ht]
+      · rw [dite_eq_right ht, dite_eq_right ht]
         exact h
 
 private def Diagonal.Compact.NonnegTo (s : Diagonal.Compact.Result α r)
@@ -631,7 +631,7 @@ private theorem Diagonal.Compact.normalizeFuel_nonneg
   | succ fuel ih =>
       rw [Diagonal.Compact.normalizeFuel]
       have ht : target < r := by omega
-      rw [dif_pos ht]
+      rw [dite_eq_left ht]
       cases hf : Diagonal.Compact.findNonzero? s.values target with
       | none =>
           intro i
@@ -679,7 +679,7 @@ private theorem Diagonal.Compact.normalizeFuel_nonneg
                 simp [next, Vector.getElem_set, hip, hip']
                 exact hmoved i (by simp [pivot] at hip; omega)
             have hout := ih (target + 1) next hnext (by omega)
-            simpa only [moved, pivot, p, if_pos hneg, next] using hout
+            simpa only [moved, pivot, p, ite_eq_left hneg, next] using hout
           · have hnext : Diagonal.Compact.NonnegTo moved (target + 1) := by
               intro i hi
               by_cases hip : i.val = pivot.val
@@ -688,7 +688,7 @@ private theorem Diagonal.Compact.normalizeFuel_nonneg
                 exact Int.le_of_not_gt hneg
               · exact hmoved i (by simp [pivot] at hip; omega)
             have hout := ih (target + 1) moved hnext (by omega)
-            simpa only [moved, pivot, p, if_neg hneg] using hout
+            simpa only [moved, pivot, p, ite_eq_right hneg] using hout
 
 private theorem Diagonal.Compact.normalize_nonneg
     (ops : Accumulator α r r) (s : Diagonal.Compact.Result α r) :
@@ -785,11 +785,11 @@ private theorem Diagonal.Compact.pairStep_model
   have hji : j.val ≠ i.val := Ne.symm hij
   rw [Diagonal.Compact.pairStep]
   by_cases ha0 : a = 0
-  · rw [if_pos ha0]
+  · rw [ite_eq_left ha0]
     have hai : s.values[i] = 0 := by simpa [a] using ha0
     have hai' : s.values[i.val] = 0 := hai
     by_cases hb0 : b = 0
-    · rw [if_pos hb0]
+    · rw [ite_eq_left hb0]
       have hbj : s.values[j] = 0 := by simpa [b] using hb0
       have hbj' : s.values[j.val] = 0 := hbj
       apply Vector.ext
@@ -808,7 +808,7 @@ private theorem Diagonal.Compact.pairStep_model
             hik, hjk, hij, hji, hcastNat k hk]
           exact (hcastNat k hk).symm
 
-    · rw [if_neg hb0]
+    · rw [ite_eq_right hb0]
       apply Vector.ext
       intro k hk
       by_cases hki : k = i.val
@@ -827,9 +827,9 @@ private theorem Diagonal.Compact.pairStep_model
             Vector.getElem_set, Vector.getElem_swap, hki, hkj, hik, hjk, hne,
             hij, hji, hcastNat k hk]
           exact (hcastNat k hk).symm
-  · rw [if_neg ha0]
+  · rw [ite_eq_right ha0]
     by_cases hb0 : b = 0
-    · rw [if_pos hb0]
+    · rw [ite_eq_left hb0]
       have hbj : s.values[j] = 0 := by simpa [b] using hb0
       have hbj' : s.values[j.val] = 0 := hbj
       apply Vector.ext
@@ -848,9 +848,9 @@ private theorem Diagonal.Compact.pairStep_model
           simp [Diagonal.Bubble.vectorStep, Vector.getElem_set, hki, hkj,
             hik, hjk, hij, hji, hcastNat k hk]
           exact (hcastNat k hk).symm
-    · rw [if_neg hb0]
+    · rw [ite_eq_right hb0]
       by_cases hab : a = b
-      · rw [if_pos hab]
+      · rw [ite_eq_left hab]
         have habv : s.values[i.val] = s.values[j.val] := by
           simpa [a, b] using hab
         apply Vector.ext
@@ -873,7 +873,7 @@ private theorem Diagonal.Compact.pairStep_model
               Vector.getElem_set, hki, hkj, hik, hjk, hij, hji,
               hcastNat k hk]
             exact (hcastNat k hk).symm
-      · rw [if_neg hab]
+      · rw [ite_eq_right hab]
         rcases he : HexArith.Int.extGcd a b with ⟨g, u, v⟩
         have hg : g = Nat.gcd a.natAbs b.natAbs := by
           have := HexArith.Int.extGcd_fst a b
@@ -931,7 +931,7 @@ private theorem Diagonal.Compact.passFuel_model
   | succ fuel ih =>
       rw [Diagonal.Compact.passFuel, Diagonal.Bubble.vectorPassFuel]
       by_cases hi : index + 1 < r
-      · rw [dif_pos hi, dif_pos hi]
+      · rw [dite_eq_left hi, dite_eq_left hi]
         let i : Fin r := ⟨index, by omega⟩
         let j : Fin r := ⟨index + 1, hi⟩
         let next := Diagonal.Compact.pairStep ops s i j
@@ -946,7 +946,7 @@ private theorem Diagonal.Compact.passFuel_model
           intro k hk
           simp
         rw [habs]
-      · rw [dif_neg hi, dif_neg hi]
+      · rw [dite_eq_right hi, dite_eq_right hi]
         apply Vector.ext
         intro k hk
         simp
@@ -1051,8 +1051,8 @@ private theorem Diagonal.Compact.takeWhile_abs (xs : List Int)
       by_cases ha0 : a = 0
       · subst a
         simp [Diagonal.Bubble.nonzeros]
-      · rw [List.takeWhile_cons, if_pos (by simpa)]
-        rw [List.map_cons, Diagonal.Bubble.nonzeros, if_neg (by simpa [ha0])]
+      · rw [List.takeWhile_cons, ite_eq_left (by simpa)]
+        rw [List.map_cons, Diagonal.Bubble.nonzeros, ite_eq_right (by simpa [ha0])]
         simp only [List.map_cons, List.cons.injEq]
         exact ⟨(cast_natAbs a ha).symm, ih (by
           intro x hx
@@ -1121,13 +1121,13 @@ private theorem Diagonal.Compact.diagMatrix_split
   · have hij' : i = j := Fin.ext hij
     subst j
     by_cases hi : i.val < xs.length
-    · rw [dif_pos ⟨rfl, i.isLt⟩, dif_pos ⟨rfl, hi⟩]
+    · rw [dite_eq_left ⟨rfl, i.isLt⟩, dite_eq_left ⟨rfl, hi⟩]
       change values.toList[i.val] = xs.toArray[i.val]
       rw [List.getElem_toArray]
       simp [hsplit, List.getElem_append, hi]
     · have hv : values.toList[i.val] = 0 := by
         simp [hsplit, List.getElem_append, hi]
-      simp only [Fin.getElem_fin, hi, and_self, dif_neg, i.isLt, dif_pos]
+      simp only [Fin.getElem_fin, hi, and_self, dite_eq_right, i.isLt, dite_eq_left]
       rw [Vector.getElem_toList] at hv
       exact hv
   · simp [hij]
@@ -1315,21 +1315,21 @@ private theorem Diagonal.Compact.pairStep_agrees (ops : Accumulator α r r)
     exact diagMatrix_apply_diag values j j rfl j.isLt
   rw [Diagonal.Compact.pairStep, Diagonal.pairStep, hii, hjj]
   by_cases ha : values[i] = 0
-  · rw [if_pos ha, if_pos ha]
+  · rw [ite_eq_left ha, ite_eq_left ha]
     by_cases hb : values[j] = 0
-    · rw [if_pos hb, if_pos hb]
+    · rw [ite_eq_left hb, ite_eq_left hb]
       exact ⟨rfl, rfl⟩
-    · rw [if_neg hb, if_neg hb]
+    · rw [ite_eq_right hb, ite_eq_right hb]
       exact swap_agrees ops ⟨rfl, rfl⟩ i j
-  · rw [if_neg ha, if_neg ha]
+  · rw [ite_eq_right ha, ite_eq_right ha]
     by_cases hb : values[j] = 0
-    · rw [if_pos hb, if_pos hb]
+    · rw [ite_eq_left hb, ite_eq_left hb]
       exact ⟨rfl, rfl⟩
-    · rw [if_neg hb, if_neg hb]
+    · rw [ite_eq_right hb, ite_eq_right hb]
       by_cases hab : values[i] = values[j]
-      · rw [if_pos hab, if_pos hab]
+      · rw [ite_eq_left hab, ite_eq_left hab]
         exact ⟨rfl, rfl⟩
-      · rw [if_neg hab, if_neg hab]
+      · rw [ite_eq_right hab, ite_eq_right hab]
         exact ⟨Diagonal.Compact.pair_matrix values i j hne ha hb, rfl⟩
 
 private theorem Diagonal.Compact.passFuel_agrees (ops : Accumulator α r r)
@@ -1342,10 +1342,10 @@ private theorem Diagonal.Compact.passFuel_agrees (ops : Accumulator α r r)
   | succ fuel ih =>
       rw [Diagonal.Compact.passFuel, Diagonal.passFuel]
       by_cases hi : index + 1 < r
-      · rw [dif_pos hi, dif_pos hi]
+      · rw [dite_eq_left hi, dite_eq_left hi]
         exact ih (index + 1) (pairStep_agrees ops h
           ⟨index, by omega⟩ ⟨index + 1, hi⟩ (by simp))
-      · rw [dif_neg hi, dif_neg hi]
+      · rw [dite_eq_right hi, dite_eq_right hi]
         exact h
 
 private theorem Diagonal.Compact.pass_agrees (ops : Accumulator α r r)
@@ -1453,10 +1453,10 @@ private theorem Diagonal.passFuel_transforms (A : Matrix Int r r)
   | succ fuel ih =>
       rw [Diagonal.passFuel]
       by_cases hi : index + 1 < r
-      · rw [dif_pos hi]
+      · rw [dite_eq_left hi]
         exact ih (index + 1) (Diagonal.pairStep_transforms A h
           ⟨index, by omega⟩ ⟨index + 1, hi⟩)
-      · rw [dif_neg hi]
+      · rw [dite_eq_right hi]
         exact h
 
 private theorem Diagonal.pass_transforms (A : Matrix Int r r)
@@ -1612,14 +1612,14 @@ private theorem Diagonal.passFuel_inverses (fuel index : Nat)
   | succ fuel ih =>
       rw [Diagonal.passFuel]
       by_cases hi : index + 1 < r
-      · rw [dif_pos hi]
+      · rw [dite_eq_left hi]
         exact ih (index + 1) (Diagonal.pairStep_inverses h
           ⟨index, by omega⟩ ⟨index + 1, hi⟩ (by
             intro heq
             have := congrArg Fin.val heq
             simp only at this
             omega))
-      · rw [dif_neg hi]
+      · rw [dite_eq_right hi]
         exact h
 
 private theorem Diagonal.pass_inverses

--- a/HexSmith/Correct/Core.lean
+++ b/HexSmith/Correct/Core.lean
@@ -32,14 +32,14 @@ private theorem clearColumn_spec (ops : Accumulator α n m)
   · dsimp only [p, b] at hdiv ⊢
     have hdiv' : s.matrix[row][pivotCol] % s.matrix[pivotRow][pivotCol] = 0 := by
       simpa only [Matrix.getElem_pair_eq_nested] using hdiv
-    rw [clearColumn, if_pos hdiv]
+    rw [clearColumn, ite_eq_left hdiv]
     dsimp only
     constructor
     · simp only [Matrix.getElem_pair_eq_nested]
-      rw [Matrix.getElem_rowAdd, if_neg hne]
-      rw [if_pos hdiv']
+      rw [Matrix.getElem_rowAdd, ite_eq_right hne]
+      rw [ite_eq_left hdiv']
     · simp only [Matrix.getElem_pair_eq_nested]
-      rw [Matrix.getElem_rowAdd, if_pos rfl]
+      rw [Matrix.getElem_rowAdd, ite_eq_left rfl]
       have hdvd : p ∣ b := Int.dvd_of_emod_eq_zero hdiv
       have hquot : HexArith.Int.exactDiv b p * p = b := by
         simpa [HexArith.Int.exactDiv] using Int.ediv_mul_cancel hdvd
@@ -50,7 +50,7 @@ private theorem clearColumn_spec (ops : Accumulator α n m)
   · dsimp only [p, b] at hdiv ⊢
     have hdiv' : s.matrix[row][pivotCol] % s.matrix[pivotRow][pivotCol] ≠ 0 := by
       simpa only [Matrix.getElem_pair_eq_nested] using hdiv
-    rw [clearColumn, if_neg hdiv]
+    rw [clearColumn, ite_eq_right hdiv]
     rcases hc : Hermite.gcdCoeffs p b with ⟨x, y, z, w⟩
     have hpivot := Hermite.gcdCoeffs_pivot p b
     have happly := Hermite.gcdCoeffs_apply (a := p) (b := b) hb
@@ -59,11 +59,11 @@ private theorem clearColumn_spec (ops : Accumulator α n m)
     simp only [Matrix.getElem_pair_eq_nested] at hpivot happly
     constructor
     · simp only [Matrix.getElem_pair_eq_nested, Hermite.getElem_combineRows,
-        if_pos]
-      rw [if_neg hdiv']
+        ite_eq_left]
+      rw [ite_eq_right hdiv']
       exact hpivot
     · simp only [Matrix.getElem_pair_eq_nested, Hermite.getElem_combineRows,
-        if_neg (Ne.symm hne), if_pos]
+        ite_eq_right (Ne.symm hne), ite_eq_left]
       exact happly.2
 
 private theorem clearRow_spec (ops : Accumulator α n m)
@@ -81,13 +81,13 @@ private theorem clearRow_spec (ops : Accumulator α n m)
   · dsimp only [p, b] at hdiv ⊢
     have hdiv' : s.matrix[pivotRow][col] % s.matrix[pivotRow][pivotCol] = 0 := by
       simpa only [Matrix.getElem_pair_eq_nested] using hdiv
-    rw [clearRow, if_pos hdiv]
+    rw [clearRow, ite_eq_left hdiv]
     dsimp only
     constructor
     · simp only [Matrix.getElem_pair_eq_nested]
-      rw [Matrix.getElem_colAdd, if_neg hne, if_pos hdiv']
+      rw [Matrix.getElem_colAdd, ite_eq_right hne, ite_eq_left hdiv']
     · simp only [Matrix.getElem_pair_eq_nested]
-      rw [Matrix.getElem_colAdd, if_pos rfl]
+      rw [Matrix.getElem_colAdd, ite_eq_left rfl]
       have hdvd : p ∣ b := Int.dvd_of_emod_eq_zero hdiv
       have hquot : HexArith.Int.exactDiv b p * p = b := by
         simpa [HexArith.Int.exactDiv] using Int.ediv_mul_cancel hdvd
@@ -98,7 +98,7 @@ private theorem clearRow_spec (ops : Accumulator α n m)
   · dsimp only [p, b] at hdiv ⊢
     have hdiv' : s.matrix[pivotRow][col] % s.matrix[pivotRow][pivotCol] ≠ 0 := by
       simpa only [Matrix.getElem_pair_eq_nested] using hdiv
-    rw [clearRow, if_neg hdiv]
+    rw [clearRow, ite_eq_right hdiv]
     rcases hc : Hermite.gcdCoeffs p b with ⟨x, y, z, w⟩
     have hpivot := Hermite.gcdCoeffs_pivot p b
     have happly := Hermite.gcdCoeffs_apply (a := p) (b := b) hb
@@ -107,11 +107,11 @@ private theorem clearRow_spec (ops : Accumulator α n m)
     simp only [Matrix.getElem_pair_eq_nested] at hpivot happly
     constructor
     · simp only [Matrix.getElem_pair_eq_nested, Hermite.getElem_combineCols,
-        if_pos]
-      rw [if_neg hdiv']
+        ite_eq_left]
+      rw [ite_eq_right hdiv']
       exact hpivot
     · simp only [Matrix.getElem_pair_eq_nested, Hermite.getElem_combineCols,
-        if_neg (Ne.symm hne), if_pos]
+        ite_eq_right (Ne.symm hne), ite_eq_left]
       exact happly.2
 
 private theorem gcd_lt_natAbs {p b : Int} (hp : p ≠ 0) (hmod : b % p ≠ 0) :
@@ -135,7 +135,7 @@ private theorem clearColumn_pivot_lt (ops : Accumulator α n m)
       s.matrix[(pivotRow, pivotCol)].natAbs := by
   have hs := clearColumn_spec ops s pivotRow row pivotCol hne hb
   dsimp only at hs
-  rw [if_neg hmod] at hs
+  rw [ite_eq_right hmod] at hs
   rw [hs.1]
   exact gcd_lt_natAbs hp hmod
 
@@ -148,7 +148,7 @@ private theorem clearRow_pivot_lt (ops : Accumulator α n m)
       s.matrix[(pivotRow, pivotCol)].natAbs := by
   have hs := clearRow_spec ops s pivotRow pivotCol col hne hb
   dsimp only at hs
-  rw [if_neg hmod] at hs
+  rw [ite_eq_right hmod] at hs
   rw [hs.1]
   exact gcd_lt_natAbs hp hmod
 
@@ -220,7 +220,7 @@ private theorem crossCount_clearColumn (ops : Accumulator α n m)
     omega
   have hs := clearColumn_spec ops s pivotRow row pivotCol hne hb
   dsimp only at hs
-  rw [if_pos hdiv] at hs
+  rw [ite_eq_left hdiv] at hs
   have hb' : s.matrix[row][pivotCol] ≠ 0 := by
     simpa only [Matrix.getElem_pair_eq_nested] using hb
   have hsZero :
@@ -239,7 +239,7 @@ private theorem crossCount_clearColumn (ops : Accumulator α n m)
   have hold := foldl_remove_one (List.finRange n) row oldCol
     (List.mem_finRange row) (List.nodup_finRange n) (by
       unfold oldCol
-      rw [if_pos ⟨hr, hb⟩])
+      rw [ite_eq_left ⟨hr, hb⟩])
   have hcol : (List.finRange n).foldl (fun total r => total + newCol r) 0 =
       (List.finRange n).foldl
         (fun total r => total + if r = row then 0 else oldCol r) 0 := by
@@ -248,15 +248,15 @@ private theorem crossCount_clearColumn (ops : Accumulator α n m)
     by_cases hrr : r = row
     · subst r
       unfold newCol
-      rw [if_neg (by intro hbad; exact hbad.2 hs.2)]
+      rw [ite_eq_right (by intro hbad; exact hbad.2 hs.2)]
       simp
     · have hentry :
           (clearColumn ops s pivotRow row pivotCol).matrix[(r, pivotCol)] =
             s.matrix[(r, pivotCol)] := by
-        rw [clearColumn, if_pos hdiv]
+        rw [clearColumn, ite_eq_left hdiv]
         dsimp only
         simp only [Matrix.getElem_pair_eq_nested]
-        rw [Matrix.getElem_rowAdd, if_neg hrr]
+        rw [Matrix.getElem_rowAdd, ite_eq_right hrr]
       unfold newCol oldCol
       rw [hentry]
       simp [hrr]
@@ -267,10 +267,10 @@ private theorem crossCount_clearColumn (ops : Accumulator α n m)
     have hentry :
         (clearColumn ops s pivotRow row pivotCol).matrix[(pivotRow, c)] =
           s.matrix[(pivotRow, c)] := by
-      rw [clearColumn, if_pos hdiv]
+      rw [clearColumn, ite_eq_left hdiv]
       dsimp only
       simp only [Matrix.getElem_pair_eq_nested]
-      rw [Matrix.getElem_rowAdd, if_neg hne]
+      rw [Matrix.getElem_rowAdd, ite_eq_right hne]
     unfold newRow oldRow
     rw [hentry]
   unfold crossCount
@@ -294,7 +294,7 @@ private theorem crossCount_clearRow (ops : Accumulator α n m)
     omega
   have hs := clearRow_spec ops s pivotRow pivotCol col hne hb
   dsimp only at hs
-  rw [if_pos hdiv] at hs
+  rw [ite_eq_left hdiv] at hs
   let oldCol : Fin n → Nat := fun r =>
     if pivotRow.val < r.val ∧ s.matrix[(r, pivotCol)] ≠ 0 then 1 else 0
   let newCol : Fin n → Nat := fun r =>
@@ -308,7 +308,7 @@ private theorem crossCount_clearRow (ops : Accumulator α n m)
   have hold := foldl_remove_one (List.finRange m) col oldRow
     (List.mem_finRange col) (List.nodup_finRange m) (by
       unfold oldRow
-      rw [if_pos ⟨hc, hb⟩])
+      rw [ite_eq_left ⟨hc, hb⟩])
   have hcol : (List.finRange n).foldl (fun total r => total + newCol r) 0 =
       (List.finRange n).foldl (fun total r => total + oldCol r) 0 := by
     apply List.foldl_add_congr
@@ -316,10 +316,10 @@ private theorem crossCount_clearRow (ops : Accumulator α n m)
     have hentry :
         (clearRow ops s pivotRow pivotCol col).matrix[(r, pivotCol)] =
           s.matrix[(r, pivotCol)] := by
-      rw [clearRow, if_pos hdiv]
+      rw [clearRow, ite_eq_left hdiv]
       dsimp only
       simp only [Matrix.getElem_pair_eq_nested]
-      rw [Matrix.getElem_colAdd, if_neg hne]
+      rw [Matrix.getElem_colAdd, ite_eq_right hne]
     unfold newCol oldCol
     rw [hentry]
   have hrow : (List.finRange m).foldl (fun total c => total + newRow c) 0 =
@@ -330,15 +330,15 @@ private theorem crossCount_clearRow (ops : Accumulator α n m)
     by_cases hcc : c = col
     · subst c
       unfold newRow
-      rw [if_neg (by intro hbad; exact hbad.2 hs.2)]
+      rw [ite_eq_right (by intro hbad; exact hbad.2 hs.2)]
       simp
     · have hentry :
           (clearRow ops s pivotRow pivotCol col).matrix[(pivotRow, c)] =
             s.matrix[(pivotRow, c)] := by
-        rw [clearRow, if_pos hdiv]
+        rw [clearRow, ite_eq_left hdiv]
         dsimp only
         simp only [Matrix.getElem_pair_eq_nested]
-        rw [Matrix.getElem_colAdd, if_neg hcc]
+        rw [Matrix.getElem_colAdd, ite_eq_right hcc]
       unfold newRow oldRow
       rw [hentry]
       simp [hcc]
@@ -392,7 +392,7 @@ private theorem measure_clearColumn_lt (ops : Accumulator α n m)
   by_cases hdiv : s.matrix[(row, pivotCol)] % s.matrix[(pivotRow, pivotCol)] = 0
   · have hs := clearColumn_spec ops s pivotRow row pivotCol hne hb
     dsimp only at hs
-    rw [if_pos hdiv] at hs
+    rw [ite_eq_left hdiv] at hs
     have hcount := crossCount_clearColumn ops s pivotRow row pivotCol hr hb hdiv
     unfold reductionMeasure
     rw [hs.1]
@@ -413,7 +413,7 @@ private theorem measure_clearRow_lt (ops : Accumulator α n m)
   by_cases hdiv : s.matrix[(pivotRow, col)] % s.matrix[(pivotRow, pivotCol)] = 0
   · have hs := clearRow_spec ops s pivotRow pivotCol col hne hb
     dsimp only at hs
-    rw [if_pos hdiv] at hs
+    rw [ite_eq_left hdiv] at hs
     have hcount := crossCount_clearRow ops s pivotRow pivotCol col hc hb hdiv
     unfold reductionMeasure
     rw [hs.1]
@@ -431,7 +431,7 @@ private theorem repair_pivot (ops : Accumulator α n m)
   have hpivot : matrix[(pivotRow, pivotCol)] = s.matrix[(pivotRow, pivotCol)] := by
     dsimp only [matrix]
     simp only [Matrix.getElem_pair_eq_nested]
-    rw [Matrix.getElem_rowAdd, if_pos rfl]
+    rw [Matrix.getElem_rowAdd, ite_eq_left rfl]
     have hrow' : s.matrix[row][pivotCol] = 0 := by
       simpa only [Matrix.getElem_pair_eq_nested] using hrow
     rw [hrow']
@@ -439,7 +439,7 @@ private theorem repair_pivot (ops : Accumulator α n m)
   have hbad : matrix[(pivotRow, col)] = s.matrix[(row, col)] := by
     dsimp only [matrix]
     simp only [Matrix.getElem_pair_eq_nested]
-    rw [Matrix.getElem_rowAdd, if_pos rfl]
+    rw [Matrix.getElem_rowAdd, ite_eq_left rfl]
     have hcol' : s.matrix[pivotRow][col] = 0 := by
       simpa only [Matrix.getElem_pair_eq_nested] using hcol
     rw [hcol']
@@ -456,7 +456,7 @@ private theorem repair_pivot (ops : Accumulator α n m)
   rw [hc]
   dsimp only
   simp only [Matrix.getElem_pair_eq_nested, Hermite.getElem_combineCols,
-    if_pos]
+    ite_eq_left]
   have hpivot' : (Matrix.rowAdd s.matrix row pivotRow 1)[pivotRow][pivotCol] =
       s.matrix[pivotRow][pivotCol] := by
     simpa only [Matrix.getElem_pair_eq_nested, matrix] using hpivot
@@ -499,9 +499,9 @@ private theorem clearColumn_pivot_ne (ops : Accumulator α n m)
   have hs := clearColumn_spec ops s pivotRow row pivotCol hne hb
   dsimp only at hs
   by_cases hdiv : s.matrix[(row, pivotCol)] % s.matrix[(pivotRow, pivotCol)] = 0
-  · rw [if_pos hdiv] at hs
+  · rw [ite_eq_left hdiv] at hs
     simpa only [hs.1] using hp
-  · rw [if_neg hdiv] at hs
+  · rw [ite_eq_right hdiv] at hs
     rw [hs.1]
     exact Int.ofNat_ne_zero.mpr (Nat.ne_of_gt (Int.gcd_pos_of_ne_zero_left _ hp))
 
@@ -513,9 +513,9 @@ private theorem clearRow_pivot_ne (ops : Accumulator α n m)
   have hs := clearRow_spec ops s pivotRow pivotCol col hne hb
   dsimp only at hs
   by_cases hdiv : s.matrix[(pivotRow, col)] % s.matrix[(pivotRow, pivotCol)] = 0
-  · rw [if_pos hdiv] at hs
+  · rw [ite_eq_left hdiv] at hs
     simpa only [hs.1] using hp
-  · rw [if_neg hdiv] at hs
+  · rw [ite_eq_right hdiv] at hs
     rw [hs.1]
     exact Int.ofNat_ne_zero.mpr (Nat.ne_of_gt (Int.gcd_pos_of_ne_zero_left _ hp))
 
@@ -540,11 +540,11 @@ private theorem crossCount_negateRow (M : Matrix Int n m)
     · subst row
       simp
     · simp only [Matrix.getElem_pair_eq_nested]
-      rw [Matrix.getElem_rowScale, if_neg hne]
+      rw [Matrix.getElem_rowScale, ite_eq_right hne]
   · apply List.foldl_add_congr
     intro col _
     simp only [Matrix.getElem_pair_eq_nested]
-    rw [Matrix.getElem_rowScale, if_pos rfl, Int.neg_mul, Int.one_mul]
+    rw [Matrix.getElem_rowScale, ite_eq_left rfl, Int.neg_mul, Int.one_mul]
     by_cases hlt : pivotCol.val < col.val
     · by_cases hz : M[pivotRow][col] = 0 <;> simp [hlt, hz]
     · simp [hlt]
@@ -556,7 +556,7 @@ private theorem measure_negateRow (M : Matrix Int n m)
   unfold reductionMeasure
   rw [crossCount_negateRow]
   simp only [Matrix.getElem_pair_eq_nested]
-  rw [Matrix.getElem_rowScale, if_pos rfl, Int.neg_mul, Int.one_mul, Int.natAbs_neg]
+  rw [Matrix.getElem_rowScale, ite_eq_left rfl, Int.neg_mul, Int.one_mul, Int.natAbs_neg]
 
 private theorem reduceFuel_reduced (ops : Accumulator α n m)
     (pivotRow : Fin n) (pivotCol : Fin m) (fuel : Nat) (s : Result α n m)
@@ -604,7 +604,7 @@ private theorem reduceFuel_reduced (ops : Accumulator α n m)
                   -s.matrix[(pivotRow, pivotCol)] := by
                 dsimp only [normalized]
                 simp only [Matrix.getElem_pair_eq_nested]
-                rw [Matrix.getElem_rowScale, if_pos rfl, Int.neg_mul, Int.one_mul]
+                rw [Matrix.getElem_rowScale, ite_eq_left rfl, Int.neg_mul, Int.one_mul]
               have hp' : normalized.matrix[(pivotRow, pivotCol)] ≠ 0 := by
                 rw [hpivot]
                 omega
@@ -617,7 +617,7 @@ private theorem reduceFuel_reduced (ops : Accumulator α n m)
                 · intro row hr
                   dsimp only [normalized]
                   simp only [Matrix.getElem_pair_eq_nested]
-                  rw [Matrix.getElem_rowScale, if_neg (by
+                  rw [Matrix.getElem_rowScale, ite_eq_right (by
                     intro heq
                     subst row
                     omega)]
@@ -626,7 +626,7 @@ private theorem reduceFuel_reduced (ops : Accumulator α n m)
                 · intro col hc
                   dsimp only [normalized]
                   simp only [Matrix.getElem_pair_eq_nested]
-                  rw [Matrix.getElem_rowScale, if_pos rfl]
+                  rw [Matrix.getElem_rowScale, ite_eq_left rfl]
                   have hz := findRow?_none hrow col hc
                   simp only [Matrix.getElem_pair_eq_nested] at hz
                   rw [hz]
@@ -637,7 +637,7 @@ private theorem reduceFuel_reduced (ops : Accumulator α n m)
                 have hcolumnZero : normalized.matrix[(q.1, pivotCol)] = 0 := by
                   dsimp only [normalized]
                   simp only [Matrix.getElem_pair_eq_nested]
-                  rw [Matrix.getElem_rowScale, if_neg (by
+                  rw [Matrix.getElem_rowScale, ite_eq_right (by
                     intro heq
                     have := congrArg Fin.val heq
                     omega)]
@@ -646,7 +646,7 @@ private theorem reduceFuel_reduced (ops : Accumulator α n m)
                 have hrowZero : normalized.matrix[(pivotRow, q.2)] = 0 := by
                   dsimp only [normalized]
                   simp only [Matrix.getElem_pair_eq_nested]
-                  rw [Matrix.getElem_rowScale, if_pos rfl]
+                  rw [Matrix.getElem_rowScale, ite_eq_left rfl]
                   have hz := findRow?_none hrow q.2 hs.2.1
                   simp only [Matrix.getElem_pair_eq_nested] at hz
                   rw [hz]
@@ -822,17 +822,17 @@ private theorem swapRows_prefix (ops : Accumulator α n m) {s : Result α n m}
     (h : Prefix s) (i j : Fin n) (hi : s.diag.length ≤ i.val)
     (hj : s.diag.length ≤ j.val) : Prefix (swapRows ops s i j) := by
   by_cases hij : i = j
-  · rw [swapRows, if_pos hij]
+  · rw [swapRows, ite_eq_left hij]
     exact h
-  · apply h.transport (by rw [swapRows, if_neg hij])
+  · apply h.transport (by rw [swapRows, ite_eq_right hij])
     · intro row col hsmall
-      rw [swapRows, if_neg hij]
+      rw [swapRows, ite_eq_right hij]
       dsimp only
       simp only [Matrix.getElem_pair_eq_nested, Matrix.getElem_rowSwap]
       by_cases hrj : row = j
       · subst row
         have hc : col.val < s.diag.length := by omega
-        rw [if_pos rfl]
+        rw [ite_eq_left rfl]
         have hji : j.val ≠ col.val := by omega
         have hii : i.val ≠ col.val := by omega
         have hzj : s.matrix[j][col] = 0 := by
@@ -842,11 +842,11 @@ private theorem swapRows_prefix (ops : Accumulator α n m) {s : Result α n m}
           simpa only [Matrix.getElem_pair_eq_nested] using
             h.offDiagonal i col (Or.inr hc) hii
         rw [hzi, hzj]
-      · rw [if_neg hrj]
+      · rw [ite_eq_right hrj]
         by_cases hri : row = i
         · subst row
           have hc : col.val < s.diag.length := by omega
-          rw [if_pos rfl]
+          rw [ite_eq_left rfl]
           have hijc : i.val ≠ col.val := by omega
           have hjc : j.val ≠ col.val := by omega
           have hzi : s.matrix[i][col] = 0 := by
@@ -856,36 +856,36 @@ private theorem swapRows_prefix (ops : Accumulator α n m) {s : Result α n m}
             simpa only [Matrix.getElem_pair_eq_nested] using
               h.offDiagonal j col (Or.inr hc) hjc
           rw [hzj, hzi]
-        · rw [if_neg hri]
+        · rw [ite_eq_right hri]
     · intro d hd row col hr hc
-      rw [swapRows, if_neg hij]
+      rw [swapRows, ite_eq_right hij]
       dsimp only
       simp only [Matrix.getElem_pair_eq_nested, Matrix.getElem_rowSwap]
       by_cases hrj : row = j
-      · rw [if_pos hrj]
+      · rw [ite_eq_left hrj]
         simpa only [Matrix.getElem_pair_eq_nested] using h.dividesTail d hd i col hi hc
-      · rw [if_neg hrj]
+      · rw [ite_eq_right hrj]
         by_cases hri : row = i
-        · rw [if_pos hri]
+        · rw [ite_eq_left hri]
           simpa only [Matrix.getElem_pair_eq_nested] using h.dividesTail d hd j col hj hc
-        · rw [if_neg hri]
+        · rw [ite_eq_right hri]
           simpa only [Matrix.getElem_pair_eq_nested] using h.dividesTail d hd row col hr hc
 
 private theorem swapCols_prefix (ops : Accumulator α n m) {s : Result α n m}
     (h : Prefix s) (i j : Fin m) (hi : s.diag.length ≤ i.val)
     (hj : s.diag.length ≤ j.val) : Prefix (swapCols ops s i j) := by
   by_cases hij : i = j
-  · rw [swapCols, if_pos hij]
+  · rw [swapCols, ite_eq_left hij]
     exact h
-  · apply h.transport (by rw [swapCols, if_neg hij])
+  · apply h.transport (by rw [swapCols, ite_eq_right hij])
     · intro row col hsmall
-      rw [swapCols, if_neg hij]
+      rw [swapCols, ite_eq_right hij]
       dsimp only
       simp only [Matrix.getElem_pair_eq_nested, Matrix.getElem_colSwap]
       by_cases hcj : col = j
       · subst col
         have hr : row.val < s.diag.length := by omega
-        rw [if_pos rfl]
+        rw [ite_eq_left rfl]
         have hji : row.val ≠ j.val := by omega
         have hii : row.val ≠ i.val := by omega
         have hzj : s.matrix[row][j] = 0 := by
@@ -895,11 +895,11 @@ private theorem swapCols_prefix (ops : Accumulator α n m) {s : Result α n m}
           simpa only [Matrix.getElem_pair_eq_nested] using
             h.offDiagonal row i (Or.inl hr) hii
         rw [hzi, hzj]
-      · rw [if_neg hcj]
+      · rw [ite_eq_right hcj]
         by_cases hci : col = i
         · subst col
           have hr : row.val < s.diag.length := by omega
-          rw [if_pos rfl]
+          rw [ite_eq_left rfl]
           have hijr : row.val ≠ i.val := by omega
           have hjr : row.val ≠ j.val := by omega
           have hzi : s.matrix[row][i] = 0 := by
@@ -909,19 +909,19 @@ private theorem swapCols_prefix (ops : Accumulator α n m) {s : Result α n m}
             simpa only [Matrix.getElem_pair_eq_nested] using
               h.offDiagonal row j (Or.inl hr) hjr
           rw [hzj, hzi]
-        · rw [if_neg hci]
+        · rw [ite_eq_right hci]
     · intro d hd row col hr hc
-      rw [swapCols, if_neg hij]
+      rw [swapCols, ite_eq_right hij]
       dsimp only
       simp only [Matrix.getElem_pair_eq_nested, Matrix.getElem_colSwap]
       by_cases hcj : col = j
-      · rw [if_pos hcj]
+      · rw [ite_eq_left hcj]
         simpa only [Matrix.getElem_pair_eq_nested] using h.dividesTail d hd row i hr hi
-      · rw [if_neg hcj]
+      · rw [ite_eq_right hcj]
         by_cases hci : col = i
-        · rw [if_pos hci]
+        · rw [ite_eq_left hci]
           simpa only [Matrix.getElem_pair_eq_nested] using h.dividesTail d hd row j hr hj
-        · rw [if_neg hci]
+        · rw [ite_eq_right hci]
           simpa only [Matrix.getElem_pair_eq_nested] using h.dividesTail d hd row col hr hc
 
 private theorem dvd_linear {d x y a b : Int} (hx : d ∣ x) (hy : d ∣ y) :
@@ -942,23 +942,23 @@ private theorem rowAdd_prefix {s : Result α n m} (h : Prefix s)
     simp only [Matrix.getElem_pair_eq_nested, Matrix.getElem_rowAdd]
     by_cases hrd : row = dst
     · subst row
-      rw [if_pos rfl]
+      rw [ite_eq_left rfl]
       have hc : col.val < s.diag.length := by omega
       have hz : s.matrix[src][col] = 0 := by
         simpa only [Matrix.getElem_pair_eq_nested] using
           h.offDiagonal src col (Or.inr hc) (by omega)
       rw [hz, Int.mul_zero, Int.add_zero]
-    · rw [if_neg hrd]
+    · rw [ite_eq_right hrd]
   · intro d hd row col hr hc
     simp only [Matrix.getElem_pair_eq_nested, Matrix.getElem_rowAdd]
     by_cases hrd : row = dst
-    · rw [if_pos hrd]
+    · rw [ite_eq_left hrd]
       simpa only [Int.one_mul] using dvd_linear (a := 1) (b := c)
         (by simpa only [Matrix.getElem_pair_eq_nested] using
           h.dividesTail d hd dst col hdst hc)
         (by simpa only [Matrix.getElem_pair_eq_nested] using
           h.dividesTail d hd src col hsrc hc)
-    · rw [if_neg hrd]
+    · rw [ite_eq_right hrd]
       simpa only [Matrix.getElem_pair_eq_nested] using h.dividesTail d hd row col hr hc
 
 private theorem colAdd_prefix {s : Result α n m} (h : Prefix s)
@@ -974,24 +974,24 @@ private theorem colAdd_prefix {s : Result α n m} (h : Prefix s)
     simp only [Matrix.getElem_pair_eq_nested, Matrix.getElem_colAdd]
     by_cases hcd : col = dst
     · subst col
-      rw [if_pos rfl]
+      rw [ite_eq_left rfl]
       have hr : row.val < s.diag.length := by omega
       have hz : s.matrix[row][src] = 0 := by
         simpa only [Matrix.getElem_pair_eq_nested] using
           h.offDiagonal row src (Or.inl hr) (by omega)
       rw [hz, Int.mul_zero, Int.add_zero]
-    · rw [if_neg hcd]
+    · rw [ite_eq_right hcd]
   · intro d hd row col hr hc
     simp only [Matrix.getElem_pair_eq_nested, Matrix.getElem_colAdd]
     by_cases hcd : col = dst
     · subst col
-      rw [if_pos rfl]
+      rw [ite_eq_left rfl]
       simpa only [Int.one_mul] using dvd_linear (a := 1) (b := c)
         (by simpa only [Matrix.getElem_pair_eq_nested] using
           h.dividesTail d hd row dst hr hdst)
         (by simpa only [Matrix.getElem_pair_eq_nested] using
           h.dividesTail d hd row src hr hsrc)
-    · rw [if_neg hcd]
+    · rw [ite_eq_right hcd]
       simpa only [Matrix.getElem_pair_eq_nested] using h.dividesTail d hd row col hr hc
 
 private theorem combineRows_prefix {s : Result α n m} (h : Prefix s)
@@ -1007,7 +1007,7 @@ private theorem combineRows_prefix {s : Result α n m} (h : Prefix s)
     simp only [Matrix.getElem_pair_eq_nested, Hermite.getElem_combineRows]
     by_cases hri : row = i
     · subst row
-      rw [if_pos rfl]
+      rw [ite_eq_left rfl]
       have hc : col.val < s.diag.length := by omega
       have hzi : s.matrix[i][col] = 0 := by
         simpa only [Matrix.getElem_pair_eq_nested] using
@@ -1016,10 +1016,10 @@ private theorem combineRows_prefix {s : Result α n m} (h : Prefix s)
         simpa only [Matrix.getElem_pair_eq_nested] using
           h.offDiagonal j col (Or.inr hc) (by omega)
       simp only [hzi, hzj, Int.mul_zero, Int.zero_add]
-    · rw [if_neg hri]
+    · rw [ite_eq_right hri]
       by_cases hrj : row = j
       · subst row
-        rw [if_pos rfl]
+        rw [ite_eq_left rfl]
         have hc : col.val < s.diag.length := by omega
         have hzi : s.matrix[i][col] = 0 := by
           simpa only [Matrix.getElem_pair_eq_nested] using
@@ -1028,25 +1028,25 @@ private theorem combineRows_prefix {s : Result α n m} (h : Prefix s)
           simpa only [Matrix.getElem_pair_eq_nested] using
             h.offDiagonal j col (Or.inr hc) (by omega)
         simp only [hzi, hzj, Int.mul_zero, Int.zero_add]
-      · rw [if_neg hrj]
+      · rw [ite_eq_right hrj]
   · intro q hq row col hr hc
     simp only [Matrix.getElem_pair_eq_nested, Hermite.getElem_combineRows]
     by_cases hri : row = i
-    · rw [if_pos hri]
+    · rw [ite_eq_left hri]
       exact dvd_linear
         (by simpa only [Matrix.getElem_pair_eq_nested] using
           h.dividesTail q hq i col hi hc)
         (by simpa only [Matrix.getElem_pair_eq_nested] using
           h.dividesTail q hq j col hj hc)
-    · rw [if_neg hri]
+    · rw [ite_eq_right hri]
       by_cases hrj : row = j
-      · rw [if_pos hrj]
+      · rw [ite_eq_left hrj]
         exact dvd_linear
           (by simpa only [Matrix.getElem_pair_eq_nested] using
             h.dividesTail q hq i col hi hc)
           (by simpa only [Matrix.getElem_pair_eq_nested] using
             h.dividesTail q hq j col hj hc)
-      · rw [if_neg hrj]
+      · rw [ite_eq_right hrj]
         simpa only [Matrix.getElem_pair_eq_nested] using
           h.dividesTail q hq row col hr hc
 
@@ -1063,7 +1063,7 @@ private theorem combineCols_prefix {s : Result α n m} (h : Prefix s)
     simp only [Matrix.getElem_pair_eq_nested, Hermite.getElem_combineCols]
     by_cases hci : col = i
     · subst col
-      rw [if_pos rfl]
+      rw [ite_eq_left rfl]
       have hr : row.val < s.diag.length := by omega
       have hzi : s.matrix[row][i] = 0 := by
         simpa only [Matrix.getElem_pair_eq_nested] using
@@ -1072,10 +1072,10 @@ private theorem combineCols_prefix {s : Result α n m} (h : Prefix s)
         simpa only [Matrix.getElem_pair_eq_nested] using
           h.offDiagonal row j (Or.inl hr) (by omega)
       simp only [hzi, hzj, Int.mul_zero, Int.zero_add]
-    · rw [if_neg hci]
+    · rw [ite_eq_right hci]
       by_cases hcj : col = j
       · subst col
-        rw [if_pos rfl]
+        rw [ite_eq_left rfl]
         have hr : row.val < s.diag.length := by omega
         have hzi : s.matrix[row][i] = 0 := by
           simpa only [Matrix.getElem_pair_eq_nested] using
@@ -1084,25 +1084,25 @@ private theorem combineCols_prefix {s : Result α n m} (h : Prefix s)
           simpa only [Matrix.getElem_pair_eq_nested] using
             h.offDiagonal row j (Or.inl hr) (by omega)
         simp only [hzi, hzj, Int.mul_zero, Int.zero_add]
-      · rw [if_neg hcj]
+      · rw [ite_eq_right hcj]
   · intro q hq row col hr hc
     simp only [Matrix.getElem_pair_eq_nested, Hermite.getElem_combineCols]
     by_cases hci : col = i
-    · rw [if_pos hci]
+    · rw [ite_eq_left hci]
       exact dvd_linear
         (by simpa only [Matrix.getElem_pair_eq_nested] using
           h.dividesTail q hq row i hr hi)
         (by simpa only [Matrix.getElem_pair_eq_nested] using
           h.dividesTail q hq row j hr hj)
-    · rw [if_neg hci]
+    · rw [ite_eq_right hci]
       by_cases hcj : col = j
-      · rw [if_pos hcj]
+      · rw [ite_eq_left hcj]
         exact dvd_linear
           (by simpa only [Matrix.getElem_pair_eq_nested] using
             h.dividesTail q hq row i hr hi)
           (by simpa only [Matrix.getElem_pair_eq_nested] using
             h.dividesTail q hq row j hr hj)
-      · rw [if_neg hcj]
+      · rw [ite_eq_right hcj]
         simpa only [Matrix.getElem_pair_eq_nested] using
           h.dividesTail q hq row col hr hc
 
@@ -1118,21 +1118,21 @@ private theorem rowScale_prefix {s : Result α n m} (h : Prefix s)
     simp only [Matrix.getElem_pair_eq_nested, Matrix.getElem_rowScale]
     by_cases hri : row = i
     · subst row
-      rw [if_pos rfl]
+      rw [ite_eq_left rfl]
       have hc : col.val < s.diag.length := by omega
       have hz : s.matrix[i][col] = 0 := by
         simpa only [Matrix.getElem_pair_eq_nested] using
           h.offDiagonal i col (Or.inr hc) (by omega)
       rw [hz, Int.mul_zero]
-    · rw [if_neg hri]
+    · rw [ite_eq_right hri]
   · intro q hq row col hr hc
     simp only [Matrix.getElem_pair_eq_nested, Matrix.getElem_rowScale]
     by_cases hri : row = i
-    · rw [if_pos hri]
+    · rw [ite_eq_left hri]
       exact Int.dvd_mul_of_dvd_right (b := c) (by
         simpa only [Matrix.getElem_pair_eq_nested] using
           h.dividesTail q hq i col hi hc)
-    · rw [if_neg hri]
+    · rw [ite_eq_right hri]
       simpa only [Matrix.getElem_pair_eq_nested] using
         h.dividesTail q hq row col hr hc
 
@@ -1267,7 +1267,7 @@ private theorem Prefix.appendPivot {s : Result α n m} (h : Prefix s)
     simp only [List.length_append, List.length_singleton] at hi
     by_cases hold : i < s.diag.length
     · have hd := h.diagonal i hold
-      rw [List.getElem_append, dif_pos hold]
+      rw [List.getElem_append, dite_eq_left hold]
       exact hd
     · have hieq : i = s.diag.length := by omega
       subst i
@@ -1293,7 +1293,7 @@ private theorem Prefix.appendPivot {s : Result α n m} (h : Prefix s)
   · intro i hi
     simp only [List.length_append, List.length_singleton] at hi
     by_cases hold : i < s.diag.length
-    · rw [List.getElem_append, dif_pos hold]
+    · rw [List.getElem_append, dite_eq_left hold]
       exact h.positive i hold
     · have hieq : i = s.diag.length := by omega
       subst i
@@ -1301,19 +1301,19 @@ private theorem Prefix.appendPivot {s : Result α n m} (h : Prefix s)
   · intro i hi
     simp only [List.length_append, List.length_singleton] at hi
     by_cases hold : i + 1 < s.diag.length
-    · rw [List.getElem_append, dif_pos (by omega), List.getElem_append, dif_pos hold]
+    · rw [List.getElem_append, dite_eq_left (by omega), List.getElem_append, dite_eq_left hold]
       exact h.chain i hold
     · have heq : i + 1 = s.diag.length := by omega
       have hiold : i < s.diag.length := by omega
       have hd := h.dividesTail i hiold pivotRow pivotCol (by simp [pivotRow])
         (by simp [pivotCol])
-      rw [List.getElem_append, dif_pos hiold, List.getElem_append, dif_neg hold]
+      rw [List.getElem_append, dite_eq_left hiold, List.getElem_append, dite_eq_right hold]
       simpa [heq, pivotRow, pivotCol, p] using hd
   · intro i hi row col hr hc
     simp only [List.length_append, List.length_singleton] at hi hr hc
     by_cases hold : i < s.diag.length
     · have hd := h.dividesTail i hold row col (by omega) (by omega)
-      rw [List.getElem_append, dif_pos hold]
+      rw [List.getElem_append, dite_eq_left hold]
       exact hd
     · have hieq : i = s.diag.length := by omega
       subst i
@@ -1331,7 +1331,7 @@ private theorem Prefix.matrix_eq_diag {s : Result α n m} (h : Prefix s)
   · by_cases hr : row.val < s.diag.length
     · have hm := h.diagonal row.val hr
       simp only [Matrix.getElem_pair_eq_nested] at hm
-      rw [Matrix.getElem_diagMatrix, dif_pos ⟨hij, hr⟩]
+      rw [Matrix.getElem_diagMatrix, dite_eq_left ⟨hij, hr⟩]
       have hm' : s.matrix[row][col] = s.diag[row.val] := by
         have hrow : (⟨row.val, Nat.lt_of_lt_of_le hr h.length_le_n⟩ : Fin n) = row :=
           Fin.ext rfl
@@ -1372,10 +1372,10 @@ private theorem swapRows_pivot (ops : Accumulator α n m) (s : Result α n m)
     (swapRows ops s target source).matrix[(target, col)] = s.matrix[(source, col)] := by
   by_cases h : target = source
   · subst source
-    rw [swapRows, if_pos rfl]
-  · rw [swapRows, if_neg h]
+    rw [swapRows, ite_eq_left rfl]
+  · rw [swapRows, ite_eq_right h]
     dsimp only
-    simp only [Matrix.getElem_pair_eq_nested, Matrix.getElem_rowSwap, if_neg h]
+    simp only [Matrix.getElem_pair_eq_nested, Matrix.getElem_rowSwap, ite_eq_right h]
     simp
 
 private theorem swapCols_pivot (ops : Accumulator α n m) (s : Result α n m)
@@ -1383,10 +1383,10 @@ private theorem swapCols_pivot (ops : Accumulator α n m) (s : Result α n m)
     (swapCols ops s target source).matrix[(row, target)] = s.matrix[(row, source)] := by
   by_cases h : target = source
   · subst source
-    rw [swapCols, if_pos rfl]
-  · rw [swapCols, if_neg h]
+    rw [swapCols, ite_eq_left rfl]
+  · rw [swapCols, ite_eq_right h]
     dsimp only
-    simp only [Matrix.getElem_pair_eq_nested, Matrix.getElem_colSwap, if_neg h]
+    simp only [Matrix.getElem_pair_eq_nested, Matrix.getElem_colSwap, ite_eq_right h]
     simp
 
 private theorem moved_pivot (ops : Accumulator α n m) (s : Result α n m)
@@ -1467,7 +1467,7 @@ theorem runFuel_complete (ops : Accumulator α n m) (fuel : Nat)
                 omega
               have hcomplete := ih happend hnext
               rw [hrow, hcol] at hcomplete
-              rw [if_neg hpnonzero]
+              rw [ite_eq_right hpnonzero]
               simpa [reduced, hpnonzero] using hcomplete
         · exact ⟨h, h.matrix_eq_diag_of_col_full (by omega)⟩
       · exact ⟨h, h.matrix_eq_diag_of_row_full (by omega)⟩
@@ -1560,9 +1560,9 @@ private theorem reduceFuel_same (ops : Accumulator α n m)
       rcases h with ⟨rfl, rfl⟩
       rw [reduceFuel, reduceFuel]
       by_cases hp : matrix[(pivotRow, pivotCol)] = 0
-      · rw [if_pos hp, if_pos hp]
+      · rw [ite_eq_left hp, ite_eq_left hp]
         exact ⟨rfl, rfl⟩
-      · rw [if_neg hp, if_neg hp]
+      · rw [ite_eq_right hp, ite_eq_right hp]
         cases hc : findColumn? matrix pivotRow pivotCol with
         | some row =>
             simp only [hc]
@@ -1576,7 +1576,7 @@ private theorem reduceFuel_same (ops : Accumulator α n m)
             | none =>
                 simp only [hr]
                 by_cases hn : matrix[(pivotRow, pivotCol)] < 0
-                · rw [if_pos hn, if_pos hn]
+                · rw [ite_eq_left hn, ite_eq_left hn]
                   cases hb : findBad? (Matrix.rowScale matrix pivotRow (-1))
                       pivotRow pivotCol
                       (Matrix.rowScale matrix pivotRow (-1))[(pivotRow, pivotCol)] with
@@ -1585,7 +1585,7 @@ private theorem reduceFuel_same (ops : Accumulator α n m)
                       simp only [hb]
                       exact ih (repair_same ops ops' ⟨rfl, rfl⟩
                         pivotRow q.1 pivotCol q.2)
-                · rw [if_neg hn, if_neg hn]
+                · rw [ite_eq_right hn, ite_eq_right hn]
                   cases hb : findBad? matrix pivotRow pivotCol
                       matrix[(pivotRow, pivotCol)] with
                   | none => simp only [hb]; exact ⟨rfl, rfl⟩
@@ -1614,9 +1614,9 @@ private theorem runFuel_same (ops : Accumulator α n m)
       rcases h with ⟨rfl, rfl⟩
       rw [runFuel, runFuel]
       by_cases hn : diag.length < n
-      · rw [dif_pos hn, dif_pos hn]
+      · rw [dite_eq_left hn, dite_eq_left hn]
         by_cases hm : diag.length < m
-        · rw [dif_pos hm, dif_pos hm]
+        · rw [dite_eq_left hm, dite_eq_left hm]
           cases hp : findPivot? matrix diag.length with
           | none => simp only [hp]; exact ⟨rfl, rfl⟩
           | some q =>
@@ -1633,18 +1633,18 @@ private theorem runFuel_same (ops : Accumulator α n m)
                   (swapCols ops (swapRows ops
                     ({ matrix := matrix, diag := diag, accumulator := acc } : Result α n m)
                     pivotRow q.1) pivotCol q.2) pivotRow pivotCol).matrix[(pivotRow, pivotCol)] = 0
-              · rw [if_pos hz]
+              · rw [ite_eq_left hz]
                 rw [hreduced.matrix] at hz
-                rw [if_pos hz]
+                rw [ite_eq_left hz]
                 exact hreduced
-              · rw [if_neg hz]
+              · rw [ite_eq_right hz]
                 have hz' : (reduce ops'
                     (swapCols ops' (swapRows ops'
                       ({ matrix := matrix, diag := diag, accumulator := acc' } : Result β n m)
                       pivotRow q.1) pivotCol q.2) pivotRow pivotCol).matrix[(pivotRow, pivotCol)] ≠ 0 := by
                   rw [← hreduced.matrix]
                   exact hz
-                rw [if_neg hz']
+                rw [ite_eq_right hz']
                 have hpivot := congrArg (fun M : Matrix Int n m => M[(pivotRow, pivotCol)])
                   hreduced.matrix
                 have hdiag :
@@ -1666,9 +1666,9 @@ private theorem runFuel_same (ops : Accumulator α n m)
                             pivotRow q.1) pivotCol q.2) pivotRow pivotCol).matrix[(pivotRow, pivotCol)]] := by
                   rw [hreduced.diag, hpivot]
                 exact ih ⟨hreduced.matrix, hdiag⟩
-        · rw [dif_neg hm, dif_neg hm]
+        · rw [dite_eq_right hm, dite_eq_right hm]
           exact ⟨rfl, rfl⟩
-      · rw [dif_neg hn, dif_neg hn]
+      · rw [dite_eq_right hn, dite_eq_right hn]
         exact ⟨rfl, rfl⟩
 
 /-- Every companion accumulator follows the same working-matrix and diagonal

--- a/HexSmith/Diagonal.lean
+++ b/HexSmith/Diagonal.lean
@@ -168,9 +168,9 @@ private theorem swap_same (ops : Smith.Accumulator α r r)
   rcases t with ⟨matrix', diag', acc'⟩
   rcases h with ⟨rfl, rfl⟩
   by_cases hij : i = j
-  · simp only [swap, Smith.swapRows, Smith.swapCols, if_pos hij]
+  · simp only [swap, Smith.swapRows, Smith.swapCols, ite_eq_left hij]
     exact ⟨rfl, rfl⟩
-  · simp only [swap, Smith.swapRows, Smith.swapCols, if_neg hij]
+  · simp only [swap, Smith.swapRows, Smith.swapCols, ite_eq_right hij]
     exact ⟨rfl, rfl⟩
 
 private theorem normalizeFuel_same (ops : Smith.Accumulator α r r)
@@ -186,7 +186,7 @@ private theorem normalizeFuel_same (ops : Smith.Accumulator α r r)
       rcases h with ⟨rfl, rfl⟩
       rw [normalizeFuel, normalizeFuel]
       by_cases ht : target < r
-      · rw [dif_pos ht, dif_pos ht]
+      · rw [dite_eq_left ht, dite_eq_left ht]
         cases hf : findNonzero? matrix target with
         | none => simp only [hf]; exact ⟨rfl, rfl⟩
         | some found =>
@@ -202,28 +202,28 @@ private theorem normalizeFuel_same (ops : Smith.Accumulator α r r)
                 ({ matrix := matrix, diag := diag, accumulator := acc } : Smith.Result α r r)
                 pivot found).matrix[(pivot, pivot)] < 0
             · simp only [pivot] at hp hmatrix hdiag ⊢
-              rw [if_pos hp]
+              rw [ite_eq_left hp]
               have hp' : (swap ops'
                   ({ matrix := matrix, diag := diag, accumulator := acc' } : Smith.Result β r r)
                   ⟨target, ht⟩ found).matrix[
                     ((⟨target, ht⟩ : Fin r), (⟨target, ht⟩ : Fin r))] < 0 := by
                 rw [← hmatrix]
                 exact hp
-              rw [if_pos hp']
+              rw [ite_eq_left hp']
               apply ih
               exact ⟨congrArg (fun M => Matrix.rowScale M ⟨target, ht⟩ (-1)) hmatrix,
                 hdiag⟩
             · simp only [pivot] at hp hmatrix hdiag ⊢
-              rw [if_neg hp]
+              rw [ite_eq_right hp]
               have hp' : ¬ (swap ops'
                   ({ matrix := matrix, diag := diag, accumulator := acc' } : Smith.Result β r r)
                   ⟨target, ht⟩ found).matrix[
                     ((⟨target, ht⟩ : Fin r), (⟨target, ht⟩ : Fin r))] < 0 := by
                 rw [← hmatrix]
                 exact hp
-              rw [if_neg hp']
+              rw [ite_eq_right hp']
               exact ih (target + 1) ⟨hmatrix, hdiag⟩
-      · rw [dif_neg ht, dif_neg ht]
+      · rw [dite_eq_right ht, dite_eq_right ht]
         exact ⟨rfl, rfl⟩
 
 private theorem pairStep_same (ops : Smith.Accumulator α r r)
@@ -235,21 +235,21 @@ private theorem pairStep_same (ops : Smith.Accumulator α r r)
   rcases h with ⟨rfl, rfl⟩
   simp only [pairStep, Matrix.getElem_pair_eq_nested]
   by_cases ha : matrix[i][i] = 0
-  · rw [if_pos ha, if_pos ha]
+  · rw [ite_eq_left ha, ite_eq_left ha]
     by_cases hb : matrix[j][j] = 0
-    · rw [if_pos hb, if_pos hb]
+    · rw [ite_eq_left hb, ite_eq_left hb]
       exact ⟨rfl, rfl⟩
-    · rw [if_neg hb, if_neg hb]
+    · rw [ite_eq_right hb, ite_eq_right hb]
       exact swap_same ops ops' ⟨rfl, rfl⟩ i j
-  · rw [if_neg ha, if_neg ha]
+  · rw [ite_eq_right ha, ite_eq_right ha]
     by_cases hb : matrix[j][j] = 0
-    · rw [if_pos hb, if_pos hb]
+    · rw [ite_eq_left hb, ite_eq_left hb]
       exact ⟨rfl, rfl⟩
-    · rw [if_neg hb, if_neg hb]
+    · rw [ite_eq_right hb, ite_eq_right hb]
       by_cases hab : matrix[i][i] = matrix[j][j]
-      · rw [if_pos hab, if_pos hab]
+      · rw [ite_eq_left hab, ite_eq_left hab]
         exact ⟨rfl, rfl⟩
-      · rw [if_neg hab, if_neg hab]
+      · rw [ite_eq_right hab, ite_eq_right hab]
         exact ⟨rfl, rfl⟩
 
 private theorem passFuel_same (ops : Smith.Accumulator α r r)
@@ -261,10 +261,10 @@ private theorem passFuel_same (ops : Smith.Accumulator α r r)
   | succ fuel ih =>
       rw [passFuel, passFuel]
       by_cases hi : index + 1 < r
-      · rw [dif_pos hi, dif_pos hi]
+      · rw [dite_eq_left hi, dite_eq_left hi]
         exact ih (index + 1) (pairStep_same ops ops' h
           ⟨index, by omega⟩ ⟨index + 1, hi⟩)
-      · rw [dif_neg hi, dif_neg hi]
+      · rw [dite_eq_right hi, dite_eq_right hi]
         exact h
 
 private theorem pass_same (ops : Smith.Accumulator α r r)
@@ -529,7 +529,7 @@ private theorem vectorPassFuel_toList (fuel index : Nat) (v : Vector Nat r)
   | succ fuel ih =>
       rw [vectorPassFuel]
       have hi : index + 1 < r := by omega
-      rw [dif_pos hi]
+      rw [dite_eq_left hi]
       let i : Fin r := ⟨index, by omega⟩
       let j : Fin r := ⟨index + 1, hi⟩
       let w := vectorStep v i j
@@ -624,7 +624,7 @@ def nonzeros : List Nat → List Nat
     nonzeros (List.replicate n 0) = [] := by
   cases n with
   | zero => rfl
-  | succ n => rw [List.replicate_succ, nonzeros, if_pos rfl]
+  | succ n => rw [List.replicate_succ, nonzeros, ite_eq_left rfl]
 
 private theorem chain_zero_all {xs : List Nat} (h : Chain (0 :: xs)) :
     ∀ x ∈ xs, x = 0 := by
@@ -695,15 +695,15 @@ theorem chain_split (xs : List Nat) (h : Chain xs) :
               simp at hx
           · obtain ⟨k, hsplit, hchain, hpos⟩ := ih h.2
             refine ⟨k, ?_, ?_, ?_⟩
-            · rw [nonzeros, if_neg ha]
+            · rw [nonzeros, ite_eq_right ha]
               simpa only [List.cons_append] using congrArg (List.cons a) hsplit
             · by_cases hb : b = 0
               · subst b
                 simp [nonzeros, ha, Chain]
-              · simp only [nonzeros, if_neg ha, if_neg hb, Chain] at hchain ⊢
+              · simp only [nonzeros, ite_eq_right ha, ite_eq_right hb, Chain] at hchain ⊢
                 exact ⟨h.1, hchain⟩
             · intro x hx
-              rw [nonzeros, if_neg ha] at hx
+              rw [nonzeros, ite_eq_right ha] at hx
               simp only [List.mem_cons] at hx
               rcases hx with rfl | hx
               · omega
@@ -849,14 +849,14 @@ theorem pairArray_size (values : Array Int) (hsize : values.size = r)
     (i j : Fin r) : (pairArray values hsize i j).size = r := by
   simp only [pairArray]
   by_cases ha : values[i.val]'(by omega) = 0
-  · rw [if_pos ha]
+  · rw [ite_eq_left ha]
     by_cases hb : values[j.val]'(by omega) = 0
-    · rw [if_pos hb]; exact hsize
-    · rw [if_neg hb]; simpa using hsize
-  · rw [if_neg ha]
+    · rw [ite_eq_left hb]; exact hsize
+    · rw [ite_eq_right hb]; simpa using hsize
+  · rw [ite_eq_right ha]
     by_cases hb : values[j.val]'(by omega) = 0
-    · rw [if_pos hb]; exact hsize
-    · rw [if_neg hb]
+    · rw [ite_eq_left hb]; exact hsize
+    · rw [ite_eq_right hb]
       split <;> simp [hsize]
 
 private theorem pairArray_eq (values : Array Int) (hsize : values.size = r)
@@ -864,14 +864,14 @@ private theorem pairArray_eq (values : Array Int) (hsize : values.size = r)
     pairArray values hsize i j = (pairValues ⟨values, hsize⟩ i j).toArray := by
   simp only [pairArray, pairValues, Fin.getElem_fin, Vector.getElem_mk]
   by_cases ha : values[i.val]'(by omega) = 0
-  · simp only [ha, if_pos]
+  · simp only [ha, ite_eq_left]
     by_cases hb : values[j.val]'(by omega) = 0
-    · simp only [hb, if_pos]
+    · simp only [hb, ite_eq_left]
     · simp [hb]
-  · simp only [ha, if_neg]
+  · simp only [ha, ite_eq_right]
     by_cases hb : values[j.val]'(by omega) = 0
     · simp [hb]
-    · simp only [hb, if_neg]
+    · simp only [hb, ite_eq_right]
       by_cases hab : values[i.val]'(by omega) = values[j.val]'(by omega)
       · simp [hab]
       · simp [hab]
@@ -922,22 +922,22 @@ private theorem pairValues_eq (ops : Smith.Accumulator α r r) (s : Result α r)
     (i j : Fin r) : pairValues s.values i j = (pairStep ops s i j).values := by
   simp only [pairValues, pairStep]
   by_cases ha : s.values[i] = 0
-  · rw [if_pos ha, if_pos ha]
+  · rw [ite_eq_left ha, ite_eq_left ha]
     by_cases hb : s.values[j] = 0
-    · rw [if_pos hb, if_pos hb]
-    · rw [if_neg hb, if_neg hb, swap]
+    · rw [ite_eq_left hb, ite_eq_left hb]
+    · rw [ite_eq_right hb, ite_eq_right hb, swap]
       split
       · rename_i hij
         subst j
         exact (hb ha).elim
       · rfl
-  · rw [if_neg ha, if_neg ha]
+  · rw [ite_eq_right ha, ite_eq_right ha]
     by_cases hb : s.values[j] = 0
-    · rw [if_pos hb, if_pos hb]
-    · rw [if_neg hb, if_neg hb]
+    · rw [ite_eq_left hb, ite_eq_left hb]
+    · rw [ite_eq_right hb, ite_eq_right hb]
       by_cases hab : s.values[i] = s.values[j]
-      · rw [if_pos hab, if_pos hab]
-      · rw [if_neg hab, if_neg hab]
+      · rw [ite_eq_left hab, ite_eq_left hab]
+      · rw [ite_eq_right hab, ite_eq_right hab]
 
 /-- Consecutive form-only adjacent updates. -/
 @[expose]
@@ -1137,7 +1137,7 @@ private theorem normalizeFuel_same (ops : Smith.Accumulator α r r)
       rcases h with ⟨rfl⟩
       rw [normalizeFuel, normalizeFuel]
       by_cases ht : target < r
-      · rw [dif_pos ht, dif_pos ht]
+      · rw [dite_eq_left ht, dite_eq_left ht]
         cases hf : findNonzero? values target with
         | none => simp only [hf]; exact ⟨rfl⟩
         | some found =>
@@ -1157,7 +1157,7 @@ private theorem normalizeFuel_same (ops : Smith.Accumulator α r r)
                   pivot found).values[pivot] < 0 := by
                 rw [← hvalues]
                 exact hp
-              rw [if_pos hp, if_pos hp']
+              rw [ite_eq_left hp, ite_eq_left hp']
               apply ih
               exact ⟨by rw [hvalues]⟩
             · have hp' : ¬ (swap ops'
@@ -1165,9 +1165,9 @@ private theorem normalizeFuel_same (ops : Smith.Accumulator α r r)
                   pivot found).values[pivot] < 0 := by
                 rw [← hvalues]
                 exact hp
-              rw [if_neg hp, if_neg hp']
+              rw [ite_eq_right hp, ite_eq_right hp']
               exact ih (target + 1) ⟨hvalues⟩
-      · rw [dif_neg ht, dif_neg ht]
+      · rw [dite_eq_right ht, dite_eq_right ht]
         exact ⟨rfl⟩
 
 private theorem pairStep_same (ops : Smith.Accumulator α r r)
@@ -1178,21 +1178,21 @@ private theorem pairStep_same (ops : Smith.Accumulator α r r)
   rcases h with ⟨rfl⟩
   simp only [pairStep]
   by_cases ha : values[i] = 0
-  · rw [if_pos ha, if_pos ha]
+  · rw [ite_eq_left ha, ite_eq_left ha]
     by_cases hb : values[j] = 0
-    · rw [if_pos hb, if_pos hb]
+    · rw [ite_eq_left hb, ite_eq_left hb]
       exact ⟨rfl⟩
-    · rw [if_neg hb, if_neg hb]
+    · rw [ite_eq_right hb, ite_eq_right hb]
       exact swap_same ops ops' ⟨rfl⟩ i j
-  · rw [if_neg ha, if_neg ha]
+  · rw [ite_eq_right ha, ite_eq_right ha]
     by_cases hb : values[j] = 0
-    · rw [if_pos hb, if_pos hb]
+    · rw [ite_eq_left hb, ite_eq_left hb]
       exact ⟨rfl⟩
-    · rw [if_neg hb, if_neg hb]
+    · rw [ite_eq_right hb, ite_eq_right hb]
       by_cases hab : values[i] = values[j]
-      · rw [if_pos hab, if_pos hab]
+      · rw [ite_eq_left hab, ite_eq_left hab]
         exact ⟨rfl⟩
-      · rw [if_neg hab, if_neg hab]
+      · rw [ite_eq_right hab, ite_eq_right hab]
         exact ⟨rfl⟩
 
 private theorem passFuel_same (ops : Smith.Accumulator α r r)
@@ -1204,10 +1204,10 @@ private theorem passFuel_same (ops : Smith.Accumulator α r r)
   | succ fuel ih =>
       rw [passFuel, passFuel]
       by_cases hi : index + 1 < r
-      · rw [dif_pos hi, dif_pos hi]
+      · rw [dite_eq_left hi, dite_eq_left hi]
         exact ih (index + 1) (pairStep_same ops ops' h
           ⟨index, by omega⟩ ⟨index + 1, hi⟩)
-      · rw [dif_neg hi, dif_neg hi]
+      · rw [dite_eq_right hi, dite_eq_right hi]
         exact h
 
 private theorem pass_same (ops : Smith.Accumulator α r r)

--- a/HexSmith/Structure.lean
+++ b/HexSmith/Structure.lean
@@ -130,7 +130,7 @@ private theorem form_mul_smithBasis (A : Matrix Int n m) :
       have hq : (Matrix.row Q i)[kk] = 0 := by
         rw [Matrix.getElem_row]
         simp only [Q, Matrix.getElem_ofFn]
-        rw [if_neg]
+        rw [ite_eq_right]
         omega
       have hz : (0 : Vector Int (snfRank A))[kk.val] = 0 :=
         Vector.getElem_zero kk.val kk.isLt
@@ -219,7 +219,7 @@ private theorem vecMul_diagMatrix (d : Vector Int r) (z : Vector Int n)
   rw [getElem_vecMul]
   unfold Vector.dotProduct
   by_cases hj : j.val < r
-  · rw [dif_pos hj]
+  · rw [dite_eq_left hj]
     let target : Fin n := ⟨j.val, Nat.lt_of_lt_of_le hj hrn⟩
     calc
       (List.finRange n).foldl
@@ -231,8 +231,8 @@ private theorem vecMul_diagMatrix (d : Vector Int r) (z : Vector Int n)
         rw [Matrix.getElem_col, Matrix.getElem_diagMatrix]
         by_cases hit : i = target
         · subst i
-          rw [dif_pos ⟨rfl, hj⟩, if_pos rfl]
-        · rw [if_neg hit]
+          rw [dite_eq_left ⟨rfl, hj⟩, ite_eq_left rfl]
+        · rw [ite_eq_right hit]
           split
           next hentry =>
             exfalso
@@ -245,7 +245,7 @@ private theorem vecMul_diagMatrix (d : Vector Int r) (z : Vector Int n)
           (fun _ => d[(⟨j.val, hj⟩ : Fin r)] * z[target])
           (List.mem_finRange target) (List.nodup_finRange n)]
         omega
-  · rw [dif_neg hj]
+  · rw [dite_eq_right hj]
     calc
       (List.finRange n).foldl
           (fun acc i => acc + (Matrix.col (diagMatrix d n m) j)[i] * z[i]) 0 =
@@ -277,12 +277,12 @@ theorem solvable_iff_dvd {A : Matrix Int n m} {S : SmithData n m}
       let col : Fin m := ⟨i.val, Nat.lt_of_lt_of_le i.isLt hS.rank_le_m⟩
       have heq := congrArg (fun v : Vector Int m => v.get col) hz
       change (vecMul z (diagMatrix S.diag n m))[col] = transformed[col] at heq
-      rw [vecMul_diagMatrix S.diag z hS.rank_le_n col, dif_pos i.isLt] at heq
+      rw [vecMul_diagMatrix S.diag z hS.rank_le_n col, dite_eq_left i.isLt] at heq
       exact ⟨z[row], by simpa [row, col, transformed, Int.mul_comm] using heq.symm⟩
     · intro j hj
       have heq := congrArg (fun v : Vector Int m => v.get j) hz
       change (vecMul z (diagMatrix S.diag n m))[j] = transformed[j] at heq
-      rw [vecMul_diagMatrix S.diag z hS.rank_le_n j, dif_neg (by omega)] at heq
+      rw [vecMul_diagMatrix S.diag z hS.rank_le_n j, dite_eq_right (by omega)] at heq
       exact heq.symm
   · rintro ⟨hdvd, hzero⟩
     let z : Vector Int n := Vector.ofFn fun row =>
@@ -309,7 +309,7 @@ theorem solvable_iff_dvd {A : Matrix Int n m} {S : SmithData n m}
       have hzget : z.get row = HexArith.Int.exactDiv transformed[col] S.diag[i] := by
         change z[row.val] = HexArith.Int.exactDiv transformed[col] S.diag[i]
         simp only [z, Vector.getElem_ofFn]
-        rw [dif_pos hcol]
+        rw [dite_eq_left hcol]
       rw [hzget]
       rw [Int.mul_comm]
       exact hquot
@@ -532,7 +532,7 @@ theorem IsSNF.rank_eq_hnfRank {A : Matrix Int n m} {S : SmithData n m}
     intro hgt
     let k := D.rank + 1
     have hsmith := hS.detDivisor_eq k
-    rw [if_pos (by simp [k]; omega)] at hsmith
+    rw [ite_eq_left (by simp [k]; omega)] at hsmith
     have hzero := hH.detDivisor_succ_eq_zero
     rw [hnf_detDivisor_eq A k, hsmith] at hzero
     have hpos : 0 < (S.diag.take k).foldl (· * ·) 1 := by
@@ -545,7 +545,7 @@ theorem IsSNF.rank_eq_hnfRank {A : Matrix Int n m} {S : SmithData n m}
     intro hgt
     let k := S.rank + 1
     have hsmith := hS.detDivisor_eq k
-    rw [if_neg (by simp [k])] at hsmith
+    rw [ite_eq_right (by simp [k])] at hsmith
     have hnonzero := hH.detDivisor_ne_zero k (by simp [k]; omega)
     rw [hnf_detDivisor_eq A k, hsmith] at hnonzero
     exact hnonzero rfl
@@ -774,7 +774,7 @@ private theorem latticeIndex_eq_detDivisor (A : Matrix Int n m) :
       intro hm
       apply hrank
       exact Nat.le_antisymm (snfRank_le_m A) hm
-    rw [if_neg hnotle] at hS
+    rw [ite_eq_right hnotle] at hS
     rw [latticeIndex_eq_zero A hfull, hS]
 
 /-- The lattice index is the product of the Smith invariant factors in full
@@ -787,11 +787,11 @@ theorem latticeIndex_eq_invariantFactors (A : Matrix Int n m) :
   rw [latticeIndex_eq_detDivisor]
   have hS := (snfData_isSNF A).detDivisor_eq m
   by_cases hfull : snfRank A = m
-  · rw [if_pos hfull]
+  · rw [ite_eq_left hfull]
     have hrank : (snfData A).rank = m := by
       rw [← snfRank_eq_data]
       exact hfull
-    rw [if_pos (by omega)] at hS
+    rw [ite_eq_left (by omega)] at hS
     have htake : ((snfData A).diag.take m).toList =
         (snfData A).diag.toList := by
       simp only [Vector.toList_take]
@@ -810,13 +810,13 @@ theorem latticeIndex_eq_invariantFactors (A : Matrix Int n m) :
     rw [vector_foldl_toList (v := invariantFactors A)
       (f := fun acc d => acc * d.natAbs)]
     simpa only [List.foldl_map, Int.natAbs_one] using habs
-  · rw [if_neg hfull]
+  · rw [ite_eq_right hfull]
     have hnotle : ¬ m ≤ (snfData A).rank := by
       rw [← snfRank_eq_data]
       intro hm
       apply hfull
       exact Nat.le_antisymm (snfRank_le_m A) hm
-    rw [if_neg hnotle] at hS
+    rw [ite_eq_right hnotle] at hS
     exact hS
 
 end Hex.Matrix

--- a/HexSmith/Unique.lean
+++ b/HexSmith/Unique.lean
@@ -42,9 +42,9 @@ theorem IsSNF.rank_eq {A : Matrix Int n m} {S S' : SmithData n m}
     intro hlt
     let k := S'.rank + 1
     have heq := h.detDivisor_eq k
-    rw [if_pos (by simp [k]; omega)] at heq
+    rw [ite_eq_left (by simp [k]; omega)] at heq
     have heq' := h'.detDivisor_eq k
-    rw [if_neg (by simp [k])] at heq'
+    rw [ite_eq_right (by simp [k])] at heq'
     rw [heq] at heq'
     have hpos := h.prefix_pos k (by simp [k]; omega)
     exact (Int.natAbs_ne_zero.mpr (Int.ne_of_gt hpos)) heq'
@@ -52,9 +52,9 @@ theorem IsSNF.rank_eq {A : Matrix Int n m} {S S' : SmithData n m}
     intro hlt
     let k := S.rank + 1
     have heq := h.detDivisor_eq k
-    rw [if_neg (by simp [k])] at heq
+    rw [ite_eq_right (by simp [k])] at heq
     have heq' := h'.detDivisor_eq k
-    rw [if_pos (by simp [k]; omega)] at heq'
+    rw [ite_eq_left (by simp [k]; omega)] at heq'
     rw [heq'] at heq
     have hpos := h'.prefix_pos k (by simp [k]; omega)
     exact (Int.natAbs_ne_zero.mpr (Int.ne_of_gt hpos)) heq
@@ -65,9 +65,9 @@ private theorem IsSNF.prefix_eq {A : Matrix Int n m} {S S' : SmithData n m}
     (S.diag.take k).foldl (· * ·) 1 =
       (S'.diag.take k).foldl (· * ·) 1 := by
   have heq := h.detDivisor_eq k
-  rw [if_pos hk] at heq
+  rw [ite_eq_left hk] at heq
   have heq' := h'.detDivisor_eq k
-  rw [if_pos (by omega)] at heq'
+  rw [ite_eq_left (by omega)] at heq'
   have habs : ((S.diag.take k).foldl (· * ·) 1).natAbs =
       ((S'.diag.take k).foldl (· * ·) 1).natAbs := heq.symm.trans heq'
   have hnonneg : 0 ≤ (S.diag.take k).foldl (· * ·) 1 :=

--- a/HexSparsePoly/Arith.lean
+++ b/HexSparsePoly/Arith.lean
@@ -77,36 +77,36 @@ theorem exp_mem_mergeWith {fl fr : R → R} {fb : R → R → R}
       · cases hut
         rfl
   | case3 a as b bs hab hz ih =>
-      rw [mergeWith, if_pos hab, if_pos hz] at ht
+      rw [mergeWith, ite_eq_left hab, ite_eq_left hz] at ht
       rcases ih ht with ⟨u, hu, hut⟩ | ⟨u, hu, hut⟩
       · exact Or.inl ⟨u, List.mem_cons_of_mem _ hu, hut⟩
       · exact Or.inr ⟨u, hu, hut⟩
   | case4 a as b bs hab hz ih =>
-      rw [mergeWith, if_pos hab, if_neg hz] at ht
+      rw [mergeWith, ite_eq_left hab, ite_eq_right hz] at ht
       rcases List.mem_cons.mp ht with rfl | ht'
       · exact Or.inl ⟨a, List.mem_cons_self .., rfl⟩
       · rcases ih ht' with ⟨u, hu, hut⟩ | ⟨u, hu, hut⟩
         · exact Or.inl ⟨u, List.mem_cons_of_mem _ hu, hut⟩
         · exact Or.inr ⟨u, hu, hut⟩
   | case5 a as b bs hab hba hz ih =>
-      rw [mergeWith, if_neg hab, if_pos hba, if_pos hz] at ht
+      rw [mergeWith, ite_eq_right hab, ite_eq_left hba, ite_eq_left hz] at ht
       rcases ih ht with ⟨u, hu, hut⟩ | ⟨u, hu, hut⟩
       · exact Or.inl ⟨u, hu, hut⟩
       · exact Or.inr ⟨u, List.mem_cons_of_mem _ hu, hut⟩
   | case6 a as b bs hab hba hz ih =>
-      rw [mergeWith, if_neg hab, if_pos hba, if_neg hz] at ht
+      rw [mergeWith, ite_eq_right hab, ite_eq_left hba, ite_eq_right hz] at ht
       rcases List.mem_cons.mp ht with rfl | ht'
       · exact Or.inr ⟨b, List.mem_cons_self .., rfl⟩
       · rcases ih ht' with ⟨u, hu, hut⟩ | ⟨u, hu, hut⟩
         · exact Or.inl ⟨u, hu, hut⟩
         · exact Or.inr ⟨u, List.mem_cons_of_mem _ hu, hut⟩
   | case7 a as b bs hab hba hz ih =>
-      rw [mergeWith, if_neg hab, if_neg hba, if_pos hz] at ht
+      rw [mergeWith, ite_eq_right hab, ite_eq_right hba, ite_eq_left hz] at ht
       rcases ih ht with ⟨u, hu, hut⟩ | ⟨u, hu, hut⟩
       · exact Or.inl ⟨u, List.mem_cons_of_mem _ hu, hut⟩
       · exact Or.inr ⟨u, List.mem_cons_of_mem _ hu, hut⟩
   | case8 a as b bs hab hba hz ih =>
-      rw [mergeWith, if_neg hab, if_neg hba, if_neg hz] at ht
+      rw [mergeWith, ite_eq_right hab, ite_eq_right hba, ite_eq_right hz] at ht
       rcases List.mem_cons.mp ht with rfl | ht'
       · exact Or.inl ⟨a, List.mem_cons_self .., rfl⟩
       · rcases ih ht' with ⟨u, hu, hut⟩ | ⟨u, hu, hut⟩
@@ -160,10 +160,10 @@ theorem mergeWith_canonical {fl fr : R → R} {fb : R → R → R}
           rename_i hz
           exact hz
   | case3 a as b bs hab hz ih =>
-      rw [mergeWith, if_pos hab, if_pos hz]
+      rw [mergeWith, ite_eq_left hab, ite_eq_left hz]
       exact ih (List.pairwise_cons.mp hs₁).2 hs₂
   | case4 a as b bs hab hz ih =>
-      rw [mergeWith, if_pos hab, if_neg hz]
+      rw [mergeWith, ite_eq_left hab, ite_eq_right hz]
       rw [List.pairwise_cons] at hs₁
       obtain ⟨hpw, hnz⟩ := ih hs₁.2 hs₂
       refine ⟨List.pairwise_cons.mpr ⟨?_, hpw⟩, ?_⟩
@@ -180,10 +180,10 @@ theorem mergeWith_canonical {fl fr : R → R} {fb : R → R → R}
         · exact hz
         · exact hnz t ht'
   | case5 a as b bs hab hba hz ih =>
-      rw [mergeWith, if_neg hab, if_pos hba, if_pos hz]
+      rw [mergeWith, ite_eq_right hab, ite_eq_left hba, ite_eq_left hz]
       exact ih hs₁ (List.pairwise_cons.mp hs₂).2
   | case6 a as b bs hab hba hz ih =>
-      rw [mergeWith, if_neg hab, if_pos hba, if_neg hz]
+      rw [mergeWith, ite_eq_right hab, ite_eq_left hba, ite_eq_right hz]
       rw [List.pairwise_cons] at hs₂
       obtain ⟨hpw, hnz⟩ := ih hs₁ hs₂.2
       refine ⟨List.pairwise_cons.mpr ⟨?_, hpw⟩, ?_⟩
@@ -200,10 +200,10 @@ theorem mergeWith_canonical {fl fr : R → R} {fb : R → R → R}
         · exact hz
         · exact hnz t ht'
   | case7 a as b bs hab hba hz ih =>
-      rw [mergeWith, if_neg hab, if_neg hba, if_pos hz]
+      rw [mergeWith, ite_eq_right hab, ite_eq_right hba, ite_eq_left hz]
       exact ih (List.pairwise_cons.mp hs₁).2 (List.pairwise_cons.mp hs₂).2
   | case8 a as b bs hab hba hz ih =>
-      rw [mergeWith, if_neg hab, if_neg hba, if_neg hz]
+      rw [mergeWith, ite_eq_right hab, ite_eq_right hba, ite_eq_right hz]
       rw [List.pairwise_cons] at hs₁ hs₂
       obtain ⟨hpw, hnz⟩ := ih hs₁.2 hs₂.2
       refine ⟨List.pairwise_cons.mpr ⟨?_, hpw⟩, ?_⟩
@@ -230,7 +230,7 @@ theorem coeffList_filterMap_map {f : R → R} {l : List (Nat × R)}
   | cons a as ih =>
       rw [List.pairwise_cons] at hs
       by_cases hz : f a.2 = 0
-      · simp only [List.filterMap_cons, if_pos hz]
+      · simp only [List.filterMap_cons, ite_eq_left hz]
         by_cases hae : a.1 = e
         · have hrest0 : coeffList
               (as.filterMap fun t =>
@@ -244,14 +244,14 @@ theorem coeffList_filterMap_map {f : R → R} {l : List (Nat × R)}
               have := hs.1 u hu
               omega
           rw [hrest0]
-          simp only [coeffList, if_pos hae]
+          simp only [coeffList, ite_eq_left hae]
           exact hz.symm
         · rw [ih hs.2]
-          simp only [coeffList, if_neg hae]
-      · simp only [List.filterMap_cons, if_neg hz]
+          simp only [coeffList, ite_eq_right hae]
+      · simp only [List.filterMap_cons, ite_eq_right hz]
         by_cases hae : a.1 = e
-        · simp only [coeffList, if_pos hae]
-        · simp only [coeffList, if_neg hae]
+        · simp only [coeffList, ite_eq_left hae]
+        · simp only [coeffList, ite_eq_right hae]
           exact ih hs.2
 
 /-- Coefficient description of the merge. The three compatibility
@@ -277,7 +277,7 @@ theorem coeffList_mergeWith {fl fr : R → R} {fb : R → R → R}
       rw [show coeffList ([] : List (Nat × R)) e = 0 from rfl, hbl]
   | case3 a as b bs hab hz ih =>
       rw [List.pairwise_cons] at hs₁
-      rw [mergeWith, if_pos hab, if_pos hz, ih hs₁.2 hs₂]
+      rw [mergeWith, ite_eq_left hab, ite_eq_left hz, ih hs₁.2 hs₂]
       by_cases hae : a.1 = e
       · have htail : coeffList as e = 0 := by
           refine coeffList_eq_zero ?_
@@ -287,23 +287,23 @@ theorem coeffList_mergeWith {fl fr : R → R} {fb : R → R → R}
         have hright : coeffList (b :: bs) e = 0 :=
           coeffList_eq_zero_of_lt_head hs₂ (by omega)
         rw [htail, hright, hb00]
-        simp only [coeffList, if_pos hae]
+        simp only [coeffList, ite_eq_left hae]
         rw [hbl, hz]
-      · simp only [coeffList, if_neg hae]
+      · simp only [coeffList, ite_eq_right hae]
   | case4 a as b bs hab hz ih =>
       rw [List.pairwise_cons] at hs₁
-      rw [mergeWith, if_pos hab, if_neg hz]
+      rw [mergeWith, ite_eq_left hab, ite_eq_right hz]
       by_cases hae : a.1 = e
       · have hright : coeffList (b :: bs) e = 0 :=
           coeffList_eq_zero_of_lt_head hs₂ (by omega)
         rw [hright]
-        simp only [coeffList, if_pos hae]
+        simp only [coeffList, ite_eq_left hae]
         rw [hbl]
-      · simp only [coeffList, if_neg hae]
+      · simp only [coeffList, ite_eq_right hae]
         exact ih hs₁.2 hs₂
   | case5 a as b bs hab hba hz ih =>
       rw [List.pairwise_cons] at hs₂
-      rw [mergeWith, if_neg hab, if_pos hba, if_pos hz, ih hs₁ hs₂.2]
+      rw [mergeWith, ite_eq_right hab, ite_eq_left hba, ite_eq_left hz, ih hs₁ hs₂.2]
       by_cases hbe : b.1 = e
       · have htail : coeffList bs e = 0 := by
           refine coeffList_eq_zero ?_
@@ -313,24 +313,24 @@ theorem coeffList_mergeWith {fl fr : R → R} {fb : R → R → R}
         have hleft : coeffList (a :: as) e = 0 :=
           coeffList_eq_zero_of_lt_head hs₁ (by omega)
         rw [htail, hleft, hb00]
-        simp only [coeffList, if_pos hbe]
+        simp only [coeffList, ite_eq_left hbe]
         rw [hbr, hz]
-      · simp only [coeffList, if_neg hbe]
+      · simp only [coeffList, ite_eq_right hbe]
   | case6 a as b bs hab hba hz ih =>
       rw [List.pairwise_cons] at hs₂
-      rw [mergeWith, if_neg hab, if_pos hba, if_neg hz]
+      rw [mergeWith, ite_eq_right hab, ite_eq_left hba, ite_eq_right hz]
       by_cases hbe : b.1 = e
       · have hleft : coeffList (a :: as) e = 0 :=
           coeffList_eq_zero_of_lt_head hs₁ (by omega)
         rw [hleft]
-        simp only [coeffList, if_pos hbe]
+        simp only [coeffList, ite_eq_left hbe]
         rw [hbr]
-      · simp only [coeffList, if_neg hbe]
+      · simp only [coeffList, ite_eq_right hbe]
         exact ih hs₁ hs₂.2
   | case7 a as b bs hab hba hz ih =>
       have habeq : a.1 = b.1 := by omega
       rw [List.pairwise_cons] at hs₁ hs₂
-      rw [mergeWith, if_neg hab, if_neg hba, if_pos hz, ih hs₁.2 hs₂.2]
+      rw [mergeWith, ite_eq_right hab, ite_eq_right hba, ite_eq_left hz, ih hs₁.2 hs₂.2]
       by_cases hae : a.1 = e
       · have htail₁ : coeffList as e = 0 := by
           refine coeffList_eq_zero ?_
@@ -343,16 +343,16 @@ theorem coeffList_mergeWith {fl fr : R → R} {fb : R → R → R}
           have := hs₂.1 t ht
           omega
         rw [htail₁, htail₂, hb00]
-        simp only [coeffList, if_pos hae, if_pos (habeq ▸ hae)]
+        simp only [coeffList, ite_eq_left hae, ite_eq_left (habeq ▸ hae)]
         exact hz.symm
-      · simp only [coeffList, if_neg hae, if_neg (habeq ▸ hae)]
+      · simp only [coeffList, ite_eq_right hae, ite_eq_right (habeq ▸ hae)]
   | case8 a as b bs hab hba hz ih =>
       have habeq : a.1 = b.1 := by omega
       rw [List.pairwise_cons] at hs₁ hs₂
-      rw [mergeWith, if_neg hab, if_neg hba, if_neg hz]
+      rw [mergeWith, ite_eq_right hab, ite_eq_right hba, ite_eq_right hz]
       by_cases hae : a.1 = e
-      · simp only [coeffList, if_pos hae, if_pos (habeq ▸ hae)]
-      · simp only [coeffList, if_neg hae, if_neg (habeq ▸ hae)]
+      · simp only [coeffList, ite_eq_left hae, ite_eq_left (habeq ▸ hae)]
+      · simp only [coeffList, ite_eq_right hae, ite_eq_right (habeq ▸ hae)]
         exact ih hs₁.2 hs₂.2
 
 /-- The canonical-form invariant, list-level: exponents strictly
@@ -436,11 +436,11 @@ theorem mapTerms_canonical {g : Nat → Nat} {f : Nat → R → R}
         hmono x (List.mem_cons_of_mem _ hx) y (List.mem_cons_of_mem _ hy)
       by_cases hz : f a.1 a.2 = 0
       · rw [show mapTerms g f (a :: as) = mapTerms g f as from by
-          simp only [mapTerms, List.filterMap_cons, if_pos hz]]
+          simp only [mapTerms, List.filterMap_cons, ite_eq_left hz]]
         exact ⟨hpw, hnz⟩
       · rw [show mapTerms g f (a :: as) =
             (g a.1, f a.1 a.2) :: mapTerms g f as from by
-          simp only [mapTerms, List.filterMap_cons, if_neg hz]]
+          simp only [mapTerms, List.filterMap_cons, ite_eq_right hz]]
         refine ⟨List.pairwise_cons.mpr ⟨?_, hpw⟩, ?_⟩
         · intro t ht
           obtain ⟨u, hu, hut⟩ := exp_mem_mapTerms ht
@@ -466,7 +466,7 @@ theorem coeffList_mapTerms_apply {g : Nat → Nat} {f : Nat → R → R}
       have ih' := ih hs.2 fun u hu => hinj u (List.mem_cons_of_mem _ hu)
       by_cases hz : f a.1 a.2 = 0
       · rw [show mapTerms g f (a :: as) = mapTerms g f as from by
-          simp only [mapTerms, List.filterMap_cons, if_pos hz]]
+          simp only [mapTerms, List.filterMap_cons, ite_eq_left hz]]
         by_cases hae : a.1 = e
         · have htail : coeffList (mapTerms g f as) (g e) = 0 := by
             refine coeffList_eq_zero ?_
@@ -478,21 +478,21 @@ theorem coeffList_mapTerms_apply {g : Nat → Nat} {f : Nat → R → R}
             have := hs.1 u hu
             omega
           rw [htail]
-          simp only [coeffList, if_pos hae]
+          simp only [coeffList, ite_eq_left hae]
           rw [← hae, hz]
         · rw [ih']
-          simp only [coeffList, if_neg hae]
+          simp only [coeffList, ite_eq_right hae]
       · rw [show mapTerms g f (a :: as) =
             (g a.1, f a.1 a.2) :: mapTerms g f as from by
-          simp only [mapTerms, List.filterMap_cons, if_neg hz]]
+          simp only [mapTerms, List.filterMap_cons, ite_eq_right hz]]
         by_cases hae : a.1 = e
-        · simp only [coeffList, if_pos (show g a.1 = g e from by rw [hae]),
-            if_pos hae]
+        · simp only [coeffList, ite_eq_left (show g a.1 = g e from by rw [hae]),
+            ite_eq_left hae]
           rw [hae]
         · simp only [coeffList,
-            if_neg (fun h : g a.1 = g e =>
+            ite_eq_right (fun h : g a.1 = g e =>
               hae (hinj a (List.mem_cons_self ..) h)),
-            if_neg hae]
+            ite_eq_right hae]
           exact ih'
 
 /-- The mapped list stores nothing outside the image of the exponent
@@ -639,14 +639,14 @@ theorem coeff_mulMonomial' [Mul R] (hc0 : ∀ c : R, c * 0 = 0)
   unfold mulMonomial
   rw [coeff_ofCanonicalList]
   by_cases hef : e ≤ f
-  · rw [if_pos hef]
+  · rw [ite_eq_left hef]
     have happly := coeffList_mapTerms_apply (g := fun e' => e + e')
       (f := fun _ x => c * x) (l := s.terms.toList) (e := f - e)
       s.pairwise_toList (fun u _ h => by omega) (hc0 c)
     rw [show e + (f - e) = f from by omega] at happly
     rw [happly]
     rfl
-  · rw [if_neg hef]
+  · rw [ite_eq_right hef]
     exact coeffList_mapTerms_of_ne fun u _ h => by omega
 
 /-- Grind-classes form of `coeff_mulMonomial'`: a monomial multiple shifts and scales the coefficients. -/
@@ -701,10 +701,10 @@ private theorem getD_foldl_insert [Add R] (ps : List (Nat × R))
       by_cases hpf : p.1 = f
       · rw [List.filter_cons_of_pos (by simpa using hpf), List.foldl_cons,
           Std.ExtTreeMap.getD_insert,
-          if_pos (Std.LawfulEqCmp.compare_eq_iff_eq.mpr hpf), hpf]
+          ite_eq_left (Std.LawfulEqCmp.compare_eq_iff_eq.mpr hpf), hpf]
       · rw [List.filter_cons_of_neg (by simpa using hpf),
           Std.ExtTreeMap.getD_insert,
-          if_neg (fun h => hpf (Std.LawfulEqCmp.compare_eq_iff_eq.mp h))]
+          ite_eq_right (fun h => hpf (Std.LawfulEqCmp.compare_eq_iff_eq.mp h))]
 
 /-- The tree reads back the whole pairwise-product fold. -/
 private theorem getD_mulTree [Add R] [Mul R] (s t : SparsePoly R)

--- a/HexSparsePoly/Basic.lean
+++ b/HexSparsePoly/Basic.lean
@@ -156,7 +156,7 @@ theorem coeffList_eq_zero {l : List (Nat × R)} {e : Nat}
   | nil => rfl
   | cons a as ih =>
       have ha : a.1 ≠ e := h a (List.mem_cons_self ..)
-      simp only [coeffList, if_neg ha]
+      simp only [coeffList, ite_eq_right ha]
       exact ih fun t ht => h t (List.mem_cons_of_mem _ ht)
 
 omit [DecidableEq R] in
@@ -170,11 +170,11 @@ theorem coeffList_eq_of_mem {l : List (Nat × R)} {t : Nat × R} {e : Nat}
   | cons a as ih =>
       rw [List.pairwise_cons] at hs
       cases ht with
-      | head => simp only [coeffList, if_pos he]
+      | head => simp only [coeffList, ite_eq_left he]
       | tail _ hmem =>
           have hlt : a.1 < t.1 := hs.1 t hmem
           have hne : a.1 ≠ e := by omega
-          simp only [coeffList, if_neg hne]
+          simp only [coeffList, ite_eq_right hne]
           exact ih hs.2 hmem
 
 omit [DecidableEq R] in
@@ -194,11 +194,11 @@ theorem coeffSearch_eq_coeffList (ts : Array (Nat × R)) (e : Nat)
       obtain ⟨_, hval⟩ := Array.getElem?_eq_some_iff.mp heq
       subst hval
       by_cases h1 : (ts[(lo + hi) / 2]).1 = e
-      · rw [if_pos h1]
+      · rw [ite_eq_left h1]
         refine (coeffList_eq_of_mem hs ?_ h1).symm
         exact List.mem_iff_getElem.mpr
           ⟨(lo + hi) / 2, by simpa using hmid, by simp⟩
-      · rw [if_neg h1]
+      · rw [ite_eq_right h1]
         have hidx : ∀ i j, (hij : i < j) → (hj : j < ts.size) →
             (ts[i]'(by omega)).1 < ts[j].1 := by
           intro i j hij hj
@@ -206,7 +206,7 @@ theorem coeffSearch_eq_coeffList (ts : Array (Nat × R)) (e : Nat)
             (by simpa using by omega) (by simpa using hj) hij
           simpa using this
         by_cases h2 : (ts[(lo + hi) / 2]).1 < e
-        · rw [if_pos h2]
+        · rw [ite_eq_left h2]
           refine coeffSearch_eq_coeffList ts e hs _ _ hhi ?_
           intro i hisz hie
           obtain ⟨-, hupper⟩ := hrange i hisz hie
@@ -217,7 +217,7 @@ theorem coeffSearch_eq_coeffList (ts : Array (Nat × R)) (e : Nat)
           · subst heq'
             exact absurd hie h1
           · omega
-        · rw [if_neg h2]
+        · rw [ite_eq_right h2]
           refine coeffSearch_eq_coeffList ts e hs _ _ (by omega) ?_
           intro i hisz hie
           obtain ⟨hlower, -⟩ := hrange i hisz hie
@@ -383,7 +383,7 @@ theorem coeffList_ext {l₁ l₂ : List (Nat × R)}
               exact hnz₂ b (List.mem_cons_self ..) hb.symm
           have hcoeff : a.2 = b.2 := by
             have ha := h a.1
-            simp only [coeffList, if_pos hexp.symm] at ha
+            simp only [coeffList, ite_eq_left hexp.symm] at ha
             exact ha
           have htail : as = bs := by
             refine ih (List.pairwise_cons.mp hs₁).2
@@ -399,7 +399,7 @@ theorem coeffList_ext {l₁ l₂ : List (Nat × R)}
                 intro hc
                 exact heq (by omega)
               have he := h e
-              simp only [coeffList, if_neg hna, if_neg hnb] at he
+              simp only [coeffList, ite_eq_right hna, ite_eq_right hnb] at he
               exact he
           rw [Prod.ext hexp hcoeff, htail]
 
@@ -590,24 +590,24 @@ theorem coeffList_addTermList [Add R] {l : List (Nat × R)}
         have hcoeff_e : coeffList (a :: as) e = 0 :=
           coeffList_eq_zero_of_lt_head (List.pairwise_cons.mpr hs) hlt
         by_cases hc : c = 0
-        · simp only [addTermList, if_pos hlt, if_pos hc]
+        · simp only [addTermList, ite_eq_left hlt, ite_eq_left hc]
           by_cases hf : f = e
           · subst hf
-            rw [if_pos rfl, hcoeff_e, addCoeff]
+            rw [ite_eq_left rfl, hcoeff_e, addCoeff]
             simp [hc]
-          · rw [if_neg hf]
-        · simp only [addTermList, if_pos hlt, if_neg hc]
+          · rw [ite_eq_right hf]
+        · simp only [addTermList, ite_eq_left hlt, ite_eq_right hc]
           by_cases hf : f = e
           · subst hf
-            rw [if_pos rfl, hcoeff_e, addCoeff]
+            rw [ite_eq_left rfl, hcoeff_e, addCoeff]
             simp only [coeffList]
             simp [hc]
-          · rw [if_neg hf]
+          · rw [ite_eq_right hf]
             simp only [coeffList]
-            rw [if_neg (fun h : e = f => hf h.symm)]
+            rw [ite_eq_right (fun h : e = f => hf h.symm)]
       · -- the head is the target: combine or delete.
         have hcoeff_e : coeffList (a :: as) e = a.2 := by
-          simp only [coeffList, if_pos heq.symm]
+          simp only [coeffList, ite_eq_left heq.symm]
         have htail_e : coeffList as e = 0 := by
           have := coeffList_tail_eq_zero
             (a := a) (as := as) (List.pairwise_cons.mpr hs)
@@ -615,37 +615,37 @@ theorem coeffList_addTermList [Add R] {l : List (Nat × R)}
           exact this
         have hnotlt : ¬ e < a.1 := by omega
         by_cases hsum : a.2 + c = 0
-        · simp only [addTermList, if_neg hnotlt, if_pos heq.symm, if_pos hsum]
+        · simp only [addTermList, ite_eq_right hnotlt, ite_eq_left heq.symm, ite_eq_left hsum]
           by_cases hf : f = e
           · subst hf
-            rw [if_pos rfl, hcoeff_e, addCoeff, if_neg hnza, if_pos hsum,
+            rw [ite_eq_left rfl, hcoeff_e, addCoeff, ite_eq_right hnza, ite_eq_left hsum,
               htail_e]
-          · rw [if_neg hf]
+          · rw [ite_eq_right hf]
             simp only [coeffList]
-            rw [if_neg (fun h : a.1 = f => hf (by omega))]
-        · simp only [addTermList, if_neg hnotlt, if_pos heq.symm, if_neg hsum]
+            rw [ite_eq_right (fun h : a.1 = f => hf (by omega))]
+        · simp only [addTermList, ite_eq_right hnotlt, ite_eq_left heq.symm, ite_eq_right hsum]
           by_cases hf : f = e
           · subst hf
-            rw [if_pos rfl, hcoeff_e, addCoeff, if_neg hnza, if_neg hsum]
-            simp only [coeffList, if_pos heq.symm]
-          · rw [if_neg hf]
+            rw [ite_eq_left rfl, hcoeff_e, addCoeff, ite_eq_right hnza, ite_eq_right hsum]
+            simp only [coeffList, ite_eq_left heq.symm]
+          · rw [ite_eq_right hf]
             simp only [coeffList]
-            rw [if_neg (fun h : a.1 = f => hf (by omega)),
-              if_neg (fun h : a.1 = f => hf (by omega))]
+            rw [ite_eq_right (fun h : a.1 = f => hf (by omega)),
+              ite_eq_right (fun h : a.1 = f => hf (by omega))]
       · -- the head sits below the target: recurse into the tail.
         have hnotlt : ¬ e < a.1 := by omega
         have hne : ¬ a.1 = e := by omega
-        simp only [addTermList, if_neg hnotlt, if_neg hne]
+        simp only [addTermList, ite_eq_right hnotlt, ite_eq_right hne]
         by_cases hf : f = e
         · subst hf
-          rw [if_pos rfl]
-          simp only [coeffList, if_neg hne]
-          rw [ih hs.2 hnztail, if_pos rfl]
-        · rw [if_neg hf]
+          rw [ite_eq_left rfl]
+          simp only [coeffList, ite_eq_right hne]
+          rw [ih hs.2 hnztail, ite_eq_left rfl]
+        · rw [ite_eq_right hf]
           simp only [coeffList]
           by_cases haf : a.1 = f
-          · rw [if_pos haf, if_pos haf]
-          · rw [if_neg haf, if_neg haf, ih hs.2 hnztail, if_neg hf]
+          · rw [ite_eq_left haf, ite_eq_left haf]
+          · rw [ite_eq_right haf, ite_eq_right haf, ih hs.2 hnztail, ite_eq_right hf]
 
 /-- Coefficient description of {name}`addTerm`: {name}`addCoeff` at the
 target exponent, unchanged elsewhere. -/
@@ -699,7 +699,7 @@ theorem lowerBound_spec (ts : Array (Nat × R)) (e : Nat)
       obtain ⟨_, hval⟩ := Array.getElem?_eq_some_iff.mp heq
       subst hval
       by_cases h1 : (ts[(lo + hi) / 2]).1 < e
-      · rw [if_pos h1]
+      · rw [ite_eq_left h1]
         have := lowerBound_spec ts e hs ((lo + hi) / 2 + 1) hi
           (by omega) hhi ?_ habove
         · exact ⟨by omega, this.2.1, this.2.2.1, this.2.2.2⟩
@@ -710,7 +710,7 @@ theorem lowerBound_spec (ts : Array (Nat × R)) (e : Nat)
           · subst h'
             exact h1
           · omega
-      · rw [if_neg h1]
+      · rw [ite_eq_right h1]
         have := lowerBound_spec ts e hs lo ((lo + hi) / 2)
           (by omega) (by omega) hbelow ?_
         · exact ⟨this.1, by omega, this.2.2.1, this.2.2.2⟩
@@ -778,39 +778,39 @@ theorem addTermList_splice [Add R] {l : List (Nat × R)} {e : Nat}
           simp only [List.getElem?_cons_zero]
           by_cases heq : a.1 = e
           · have hnotlt : ¬ e < a.1 := by omega
-            simp only [addTermList, if_neg hnotlt, if_pos heq]
+            simp only [addTermList, ite_eq_right hnotlt, ite_eq_left heq]
             rw [heq]
             simp
           · have hlt : e < a.1 := by omega
-            simp only [addTermList, if_pos hlt, if_neg heq]
+            simp only [addTermList, ite_eq_left hlt, ite_eq_right heq]
             by_cases hc : c = 0
-            · rw [if_pos hc, if_pos hc]
-            · rw [if_neg hc, if_neg hc]
+            · rw [ite_eq_left hc, ite_eq_left hc]
+            · rw [ite_eq_right hc, ite_eq_right hc]
               rfl
       | succ q =>
           have ha : a.1 < e := hbelow 0 (by simp) (Nat.succ_pos _)
           have hnotlt : ¬ e < a.1 := by omega
           have hne : ¬ a.1 = e := by omega
-          simp only [addTermList, if_neg hnotlt, if_neg hne,
+          simp only [addTermList, ite_eq_right hnotlt, ite_eq_right hne,
             List.getElem?_cons_succ]
           rw [ih (p := q) ?_ ?_]
           · cases has : as[q]? with
             | some t =>
                 simp only
                 by_cases hte : t.1 = e
-                · rw [if_pos hte, if_pos hte]
+                · rw [ite_eq_left hte, ite_eq_left hte]
                   by_cases hsum : t.2 + c = 0
-                  · rw [if_pos hsum, if_pos hsum, List.eraseIdx_cons_succ]
-                  · rw [if_neg hsum, if_neg hsum, List.set_cons_succ]
-                · rw [if_neg hte, if_neg hte]
+                  · rw [ite_eq_left hsum, ite_eq_left hsum, List.eraseIdx_cons_succ]
+                  · rw [ite_eq_right hsum, ite_eq_right hsum, List.set_cons_succ]
+                · rw [ite_eq_right hte, ite_eq_right hte]
                   by_cases hc : c = 0
-                  · rw [if_pos hc, if_pos hc]
-                  · rw [if_neg hc, if_neg hc, List.insertIdx_succ_cons]
+                  · rw [ite_eq_left hc, ite_eq_left hc]
+                  · rw [ite_eq_right hc, ite_eq_right hc, List.insertIdx_succ_cons]
             | none =>
                 simp only
                 by_cases hc : c = 0
-                · rw [if_pos hc, if_pos hc]
-                · rw [if_neg hc, if_neg hc, List.cons_append]
+                · rw [ite_eq_left hc, ite_eq_left hc]
+                · rw [ite_eq_right hc, ite_eq_right hc, List.cons_append]
           · intro i h hip
             have := hbelow (i + 1) (by simpa using by omega) (by omega)
             simpa using this
@@ -859,21 +859,21 @@ theorem addTermArray_eq [Add R] {ts : Array (Nat × R)}
       rw [Array.getElem?_toList, hp]
     simp only [hp']
     by_cases hte : t.1 = e
-    · rw [if_pos hte, if_pos hte]
+    · rw [ite_eq_left hte, ite_eq_left hte]
       by_cases hsum : t.2 + c = 0
-      · rw [if_pos hsum, if_pos hsum, Array.toList_eraseIdx]
-      · rw [if_neg hsum, if_neg hsum, Array.toList_set]
-    · rw [if_neg hte, if_neg hte]
+      · rw [ite_eq_left hsum, ite_eq_left hsum, Array.toList_eraseIdx]
+      · rw [ite_eq_right hsum, ite_eq_right hsum, Array.toList_set]
+    · rw [ite_eq_right hte, ite_eq_right hte]
       by_cases hc : c = 0
-      · rw [if_pos hc, if_pos hc]
-      · rw [if_neg hc, if_neg hc, Array.toList_insertIdx]
+      · rw [ite_eq_left hc, ite_eq_left hc]
+      · rw [ite_eq_right hc, ite_eq_right hc, Array.toList_insertIdx]
   · rename_i hp
     have hp' : ts.toList[lowerBound ts e 0 ts.size]? = none := by
       rw [Array.getElem?_toList, hp]
     simp only [hp']
     by_cases hc : c = 0
-    · rw [if_pos hc, if_pos hc]
-    · rw [if_neg hc, if_neg hc, Array.toList_push]
+    · rw [ite_eq_left hc, ite_eq_left hc]
+    · rw [ite_eq_right hc, ite_eq_right hc, Array.toList_push]
 
 /-- Runtime implementation of {name}`addTerm`: binary search and one
 in-place array splice (value-equal to {name}`addTerm` by
@@ -928,9 +928,9 @@ theorem coeff_foldl_addTerm [Add R] (l : List (Nat × R))
       rw [ih]
       by_cases hte : t.1 = e
       · rw [List.filter_cons_of_pos (by simpa using hte),
-          List.foldl_cons, coeff_addTerm, if_pos hte.symm, hte]
+          List.foldl_cons, coeff_addTerm, ite_eq_left hte.symm, hte]
       · rw [List.filter_cons_of_neg (by simpa using hte),
-          coeff_addTerm, if_neg (fun h : e = t.1 => hte h.symm)]
+          coeff_addTerm, ite_eq_right (fun h : e = t.1 => hte h.symm)]
 
 /-- Coefficient description of {name}`ofTerms`, with no algebra assumed. -/
 theorem coeff_ofTerms_addCoeff [Add R] (ts : Array (Nat × R)) (e : Nat) :
@@ -950,11 +950,11 @@ theorem addCoeff_eq_add [Add R] (hzero : ∀ c : R, 0 + c = c) (d c : R) :
   · subst hd
     by_cases hc : c = 0
     · subst hc
-      rw [if_pos rfl, if_pos rfl, hzero]
-    · rw [if_pos rfl, if_neg hc, hzero]
+      rw [ite_eq_left rfl, ite_eq_left rfl, hzero]
+    · rw [ite_eq_left rfl, ite_eq_right hc, hzero]
   · by_cases hs : d + c = 0
-    · rw [if_neg hd, if_pos hs, hs]
-    · rw [if_neg hd, if_neg hs]
+    · rw [ite_eq_right hd, ite_eq_left hs, hs]
+    · rw [ite_eq_right hd, ite_eq_right hs]
 
 /-- The coefficient of `ofTerms ts` at `e` is the sum, in input order, of
 the coefficients of the terms of `ts` at `e`. The `hzero` hypothesis is
@@ -1002,7 +1002,7 @@ theorem combineRun_canonical [Add R] {l : List (Nat × R)} {e : Nat}
       rw [List.pairwise_cons] at hs
       have hts : ∀ u ∈ ts, t.1 ≤ u.1 := hs.1
       by_cases hte : t.1 = e
-      · simp only [combineRun, if_pos hte]
+      · simp only [combineRun, ite_eq_left hte]
         exact ih hs.2 fun u hu => Nat.le_trans (hte ▸ hts u hu) (Nat.le_refl _)
       · have hlt : e < t.1 := by
           have := hge t (List.mem_cons_self ..)
@@ -1010,9 +1010,9 @@ theorem combineRun_canonical [Add R] {l : List (Nat × R)} {e : Nat}
         obtain ⟨hpw, hnz, hge'⟩ := ih (e := t.1) (acc := addCoeff 0 t.2)
           hs.2 hts
         by_cases hacc : acc = 0
-        · simp only [combineRun, if_neg hte, if_pos hacc]
+        · simp only [combineRun, ite_eq_right hte, ite_eq_left hacc]
           exact ⟨hpw, hnz, fun u hu => by have := hge' u hu; omega⟩
-        · simp only [combineRun, if_neg hte, if_neg hacc]
+        · simp only [combineRun, ite_eq_right hte, ite_eq_right hacc]
           refine ⟨List.pairwise_cons.mpr ⟨?_, hpw⟩, ?_, ?_⟩
           · intro u hu
             have := hge' u hu
@@ -1054,13 +1054,13 @@ theorem coeffList_combineRun [Add R] {l : List (Nat × R)} {e : Nat}
       have hts : ∀ u ∈ ts, t.1 ≤ u.1 := hs.1
       by_cases hte : t.1 = e
       · rw [show combineRun e acc (t :: ts) = combineRun e (addCoeff acc t.2) ts
-          from by rw [combineRun, if_pos hte]]
+          from by rw [combineRun, ite_eq_left hte]]
         rw [ih hs.2 (fun u hu => hte ▸ hts u hu)]
         by_cases hf : f = e
         · subst hf
-          rw [if_pos rfl, if_pos rfl,
+          rw [ite_eq_left rfl, ite_eq_left rfl,
             List.filter_cons_of_pos (by simpa using hte), List.foldl_cons]
-        · rw [if_neg hf, if_neg hf,
+        · rw [ite_eq_right hf, ite_eq_right hf,
             List.filter_cons_of_neg (by simpa using fun h : t.1 = f => hf (by omega))]
       · have hlt : e < t.1 := by
           have := hge t (List.mem_cons_self ..)
@@ -1075,36 +1075,36 @@ theorem coeffList_combineRun [Add R] {l : List (Nat × R)} {e : Nat}
         by_cases hacc : acc = 0
         · rw [show combineRun e acc (t :: ts) =
               combineRun t.1 (addCoeff 0 t.2) ts
-            from by rw [combineRun, if_neg hte, if_pos hacc]]
+            from by rw [combineRun, ite_eq_right hte, ite_eq_left hacc]]
           rw [ihspec]
           by_cases hf1 : f = t.1
           · subst hf1
-            rw [if_pos rfl, if_neg (by omega),
+            rw [ite_eq_left rfl, ite_eq_right (by omega),
               List.filter_cons_of_pos (by simp), List.foldl_cons]
-          · rw [if_neg hf1]
+          · rw [ite_eq_right hf1]
             by_cases hfe : f = e
             · subst hfe
-              rw [if_pos rfl,
+              rw [ite_eq_left rfl,
                 List.filter_cons_of_neg (by simpa using fun h : t.1 = f => hf1 h.symm),
                 hfilter_e, hacc]
-            · rw [if_neg hfe,
+            · rw [ite_eq_right hfe,
                 List.filter_cons_of_neg (by simpa using fun h : t.1 = f => hf1 h.symm)]
         · rw [show combineRun e acc (t :: ts) =
               (e, acc) :: combineRun t.1 (addCoeff 0 t.2) ts
-            from by rw [combineRun, if_neg hte, if_neg hacc]]
+            from by rw [combineRun, ite_eq_right hte, ite_eq_right hacc]]
           simp only [coeffList]
           by_cases hfe : f = e
           · subst hfe
-            rw [if_pos rfl, if_pos rfl,
+            rw [ite_eq_left rfl, ite_eq_left rfl,
               List.filter_cons_of_neg (by simpa using fun h : t.1 = f => by omega),
               hfilter_e]
             rfl
-          · rw [if_neg (fun h : e = f => hfe h.symm), if_neg hfe, ihspec]
+          · rw [ite_eq_right (fun h : e = f => hfe h.symm), ite_eq_right hfe, ihspec]
             by_cases hf1 : f = t.1
             · subst hf1
-              rw [if_pos rfl, List.filter_cons_of_pos (by simp),
+              rw [ite_eq_left rfl, List.filter_cons_of_pos (by simp),
                 List.foldl_cons]
-            · rw [if_neg hf1,
+            · rw [ite_eq_right hf1,
                 List.filter_cons_of_neg (by simpa using fun h : t.1 = f => hf1 h.symm)]
 
 /-- Coefficient description of {name}`combineSorted` on a `≤`-sorted
@@ -1122,8 +1122,8 @@ theorem coeffList_combineSorted [Add R] {l : List (Nat × R)}
         coeffList_combineRun hs.2 hs.1]
       by_cases hf : f = t.1
       · subst hf
-        rw [if_pos rfl, List.filter_cons_of_pos (by simp), List.foldl_cons]
-      · rw [if_neg hf,
+        rw [ite_eq_left rfl, List.filter_cons_of_pos (by simp), List.foldl_cons]
+      · rw [ite_eq_right hf,
           List.filter_cons_of_neg (by simpa using fun h : t.1 = f => hf h.symm)]
 
 omit [Zero R] [DecidableEq R] in
@@ -1274,16 +1274,16 @@ elsewhere, even when `c = 0`. -/
     (monomial e c).coeff f = if f = e then c else 0 := by
   unfold monomial
   by_cases hc : c = 0
-  · rw [dif_pos hc]
+  · rw [dite_eq_left hc]
     by_cases hf : f = e
-    · rw [if_pos hf, coeff_zero, hc]
-    · rw [if_neg hf, coeff_zero]
-  · rw [dif_neg hc]
+    · rw [ite_eq_left hf, coeff_zero, hc]
+    · rw [ite_eq_right hf, coeff_zero]
+  · rw [dite_eq_right hc]
     show coeffList [(e, c)] f = _
     simp only [coeffList]
     by_cases hf : f = e
-    · rw [if_pos (hf ▸ rfl), if_pos hf]
-    · rw [if_neg (fun h : e = f => hf h.symm), if_neg hf]
+    · rw [ite_eq_left (hf ▸ rfl), ite_eq_left hf]
+    · rw [ite_eq_right (fun h : e = f => hf h.symm), ite_eq_right hf]
 
 /-- A constant stores its value at exponent `0`. -/
 @[simp, grind =] theorem coeff_C (c : R) (f : Nat) :

--- a/HexSparsePoly/Dense.lean
+++ b/HexSparsePoly/Dense.lean
@@ -98,24 +98,24 @@ theorem getD_foldl_set {l : List (Nat × R)}
           rw [Array.size_setIfInBounds]
           exact hbound t (List.mem_cons_of_mem _ ht))]
       by_cases hmem : ∃ t ∈ as, t.1 = i
-      · rw [if_pos hmem]
+      · rw [ite_eq_left hmem]
         obtain ⟨t, ht, hti⟩ := hmem
-        rw [if_pos ⟨t, List.mem_cons_of_mem _ ht, hti⟩]
+        rw [ite_eq_left ⟨t, List.mem_cons_of_mem _ ht, hti⟩]
         have hai : ¬ a.1 = i := by
           have := hs.1 t ht
           omega
-        simp only [coeffList, if_neg hai]
-      · rw [if_neg hmem]
+        simp only [coeffList, ite_eq_right hai]
+      · rw [ite_eq_right hmem]
         by_cases hai : a.1 = i
-        · rw [if_pos ⟨a, List.mem_cons_self .., hai⟩]
+        · rw [ite_eq_left ⟨a, List.mem_cons_self .., hai⟩]
           subst hai
           rw [show coeffList (a :: as) a.1 = a.2 from by simp [coeffList]]
           have hlt : a.1 < (base.setIfInBounds a.1 a.2).size := by
             rw [Array.size_setIfInBounds]
             exact hbound a (List.mem_cons_self ..)
-          rw [Array.getD, dif_pos hlt]
+          rw [Array.getD, dite_eq_left hlt]
           exact Array.getElem_setIfInBounds_self hlt
-        · rw [if_neg (by
+        · rw [ite_eq_right (by
             intro hcon
             obtain ⟨t, ht, hti⟩ := hcon
             rcases List.mem_cons.mp ht with rfl | ht'
@@ -125,10 +125,10 @@ theorem getD_foldl_set {l : List (Nat × R)}
           · have hi' : i < (base.setIfInBounds a.1 a.2).size := by
               rw [Array.size_setIfInBounds]
               exact hi
-            rw [Array.getD, dif_pos hi', Array.getD, dif_pos hi]
+            rw [Array.getD, dite_eq_left hi', Array.getD, dite_eq_left hi]
             exact Array.getElem_setIfInBounds_ne hi hai
-          · rw [Array.getD, dif_neg (by rwa [Array.size_setIfInBounds]),
-              Array.getD, dif_neg hi]
+          · rw [Array.getD, dite_eq_right (by rwa [Array.size_setIfInBounds]),
+              Array.getD, dite_eq_right hi]
 
 /-- Write each term of an arbitrary term array into a coefficient array
 sized by the largest exponent. A conversion, not a canonicaliser: with
@@ -212,13 +212,13 @@ theorem coeffList_termsOfCoeffsList (l : List R) (i e : Nat) :
             have := exp_mem_termsOfCoeffsList ht
             omega
           · simp only [coeffList]
-            rw [if_pos (show i = i + 0 by omega)]
+            rw [ite_eq_left (show i = i + 0 by omega)]
       | succ e =>
           rw [List.getD_cons_succ]
           split
           · rw [show i + (e + 1) = (i + 1) + e from by omega, ih]
           · simp only [coeffList,
-              if_neg (show ¬ i = i + (e + 1) from by omega)]
+              ite_eq_right (show ¬ i = i + (e + 1) from by omega)]
             rw [show i + (e + 1) = (i + 1) + e from by omega, ih]
 
 /-- The walk stores nothing below its starting index. -/
@@ -252,18 +252,18 @@ def toDense (s : SparsePoly R) : DensePoly R :=
       exact exp_lt_foldl_max ht 0)
     e]
   by_cases hmem : ∃ t ∈ s.terms.toList, t.1 = e
-  · rw [if_pos hmem]
+  · rw [ite_eq_left hmem]
     rfl
-  · rw [if_neg hmem]
+  · rw [ite_eq_right hmem]
     have : s.coeff e = 0 := by
       refine coeffList_eq_zero ?_
       intro t ht hte
       exact hmem ⟨t, ht, hte⟩
     rw [this]
     by_cases he : e < (Array.replicate (termsBound s.terms) (0 : R)).size
-    · rw [Array.getD, dif_pos he]
+    · rw [Array.getD, dite_eq_left he]
       exact Array.getElem_replicate he
-    · rw [Array.getD, dif_neg he]
+    · rw [Array.getD, dite_eq_right he]
 
 /-- Convert from the dense representation, keeping the nonzero
 coefficients with their indices.
@@ -296,14 +296,14 @@ private theorem foldl_push_eq_termsOfCoeffsList (l : List R) :
       intro i acc
       simp only [List.foldl_cons]
       by_cases hc : c = 0
-      · rw [if_pos hc]
+      · rw [ite_eq_left hc]
         show (cs.foldl _ (acc, i + 1)).1 = _
         rw [ih (i + 1) acc]
-        simp only [termsOfCoeffsList, if_pos hc]
-      · rw [if_neg hc]
+        simp only [termsOfCoeffsList, ite_eq_left hc]
+      · rw [ite_eq_right hc]
         show (cs.foldl _ (acc.push (i, c), i + 1)).1 = _
         rw [ih (i + 1) (acc.push (i, c))]
-        simp only [termsOfCoeffsList, if_neg hc]
+        simp only [termsOfCoeffsList, ite_eq_right hc]
         apply Array.toList_inj.mp
         simp
 
@@ -370,13 +370,13 @@ theorem getD_coeffsOfTerms {ts : Array (Nat × R)}
       exact exp_lt_foldl_max ht 0)
     e]
   by_cases hmem : ∃ t ∈ ts.toList, t.1 = e
-  · rw [if_pos hmem]
-  · rw [if_neg hmem,
+  · rw [ite_eq_left hmem]
+  · rw [ite_eq_right hmem,
       coeffList_eq_zero fun t ht hte => hmem ⟨t, ht, hte⟩]
     by_cases he : e < (Array.replicate (termsBound ts) (0 : R)).size
-    · rw [Array.getD, dif_pos he]
+    · rw [Array.getD, dite_eq_left he]
       exact Array.getElem_replicate he
-    · rw [Array.getD, dif_neg he]
+    · rw [Array.getD, dite_eq_right he]
 
 /-- The sparse image of a coefficient array stores exactly its
 coefficients. -/
@@ -438,7 +438,7 @@ theorem coeffs_terms {cs : Array R} (h : DensePolyNormalized cs) :
           · omega
           · rw [Array.back?_eq_getElem?,
               Array.getElem?_eq_getElem (by omega)] at hback
-            rw [Array.getD, dif_pos (by omega)]
+            rw [Array.getD, dite_eq_left (by omega)]
             intro hval
             exact hback (congrArg some hval)
         have hcoeff : coeffList (termsOfCoeffs cs).toList
@@ -460,7 +460,7 @@ theorem coeffs_terms {cs : Array R} (h : DensePolyNormalized cs) :
   intro i hi₁ hi₂
   have hgetD := getD_coeffsOfTerms hsorted i
   rw [coeffList_termsOfCoeffs] at hgetD
-  rw [Array.getD, dif_pos hi₁, Array.getD, dif_pos hi₂] at hgetD
+  rw [Array.getD, dite_eq_left hi₁, Array.getD, dite_eq_left hi₂] at hgetD
   exact hgetD
 
 /-- Round trip on the bundled types, dense side out: unconditional,
@@ -593,10 +593,10 @@ theorem foldl_congr' {α β : Type _} {l : List α} {f g : β → α → β}
 assumed. -/
 theorem addCoeff_zero_left (c : S) : addCoeff 0 c = c := by
   unfold addCoeff
-  rw [if_pos rfl]
+  rw [ite_eq_left rfl]
   by_cases hc : c = 0
-  · rw [if_pos hc, hc]
-  · rw [if_neg hc]
+  · rw [ite_eq_left hc, hc]
+  · rw [ite_eq_right hc]
 
 /-- Coefficients of a fold of sums, sparse side. -/
 theorem coeff_foldl_add {α : Type _} (l : List α)
@@ -647,19 +647,19 @@ private theorem foldl_add_block (a : Nat × S) {l : List (Nat × S)}
           simp only [decide_eq_true_eq]
           omega
         rw [hempty, List.foldl_nil,
-          if_pos (show a.1 ≤ f from by omega)]
+          ite_eq_left (show a.1 ≤ f from by omega)]
         have : coeffList (b :: bs) (f - a.1) = b.2 := by
           simp only [coeffList]
-          rw [if_pos (show b.1 = f - a.1 from by omega)]
+          rw [ite_eq_left (show b.1 = f - a.1 from by omega)]
         rw [this]
       · rw [List.filter_cons_of_neg (by simpa using hbf), ih hs.2]
         by_cases haf : a.1 ≤ f
-        · rw [if_pos haf, if_pos haf]
+        · rw [ite_eq_left haf, ite_eq_left haf]
           have : coeffList (b :: bs) (f - a.1) = coeffList bs (f - a.1) := by
             simp only [coeffList]
-            rw [if_neg (show ¬ b.1 = f - a.1 from by omega)]
+            rw [ite_eq_right (show ¬ b.1 = f - a.1 from by omega)]
           rw [this]
-        · rw [if_neg haf, if_neg haf]
+        · rw [ite_eq_right haf, ite_eq_right haf]
 
 /-- The pairwise-product coefficient, reorganised as a fold of
 {name}`mulMonomial` coefficients over the left operand's terms. -/
@@ -728,12 +728,12 @@ theorem toDense_foldl_monomial (s : SparsePoly S) :
         rw [ih hl.2, DensePoly.coeff_monomial]
         simp only [coeffList, show (Zero.zero : S) = 0 from rfl]
         by_cases hf : f = a.1
-        · rw [if_pos hf, if_pos hf.symm,
+        · rw [ite_eq_left hf, ite_eq_left hf.symm,
             coeffList_eq_zero (fun t ht hte => by
               have := hl.1 t ht
               omega)]
           grind
-        · rw [if_neg hf, if_neg (fun h : a.1 = f => hf h.symm)]
+        · rw [ite_eq_right hf, ite_eq_right (fun h : a.1 = f => hf h.symm)]
           grind
   rw [hfold s.terms.toList s.pairwise_toList,
     show (0 : DensePoly S).coeff f = 0 from
@@ -863,12 +863,12 @@ theorem right_distrib (s t u : SparsePoly S) :
 /-- The zeroth power is one. -/
 @[simp, grind =] theorem pow_zero (s : SparsePoly S) : s ^ 0 = 1 := by
   show pow s 0 = 1
-  rw [pow, dif_pos rfl]
+  rw [pow, dite_eq_left rfl]
 
 private theorem pow_unfold (s : SparsePoly S) (n : Nat) (hn : ¬ n = 0) :
     s ^ n = if n % 2 = 1 then s * (s * s) ^ (n / 2) else (s * s) ^ (n / 2) := by
   show pow s n = _
-  rw [pow, dif_neg hn]
+  rw [pow, dite_eq_right hn]
   rfl
 
 /-- The conversion respects scalar multiplication. -/
@@ -925,16 +925,16 @@ theorem pow_succ (s : SparsePoly S) (n : Nat) : s ^ (n + 1) = s * s ^ n := by
   | _ n ih =>
       match n with
       | 0 =>
-          rw [pow_unfold s 1 (by omega), if_pos rfl, pow_zero, pow_zero]
+          rw [pow_unfold s 1 (by omega), ite_eq_left rfl, pow_zero, pow_zero]
       | m + 1 =>
           by_cases hodd : (m + 2) % 2 = 1
-          · rw [pow_unfold s (m + 2) (by omega), if_pos hodd,
+          · rw [pow_unfold s (m + 2) (by omega), ite_eq_left hodd,
               pow_unfold s (m + 1) (by omega),
-              if_neg (show ¬ (m + 1) % 2 = 1 from by omega),
+              ite_eq_right (show ¬ (m + 1) % 2 = 1 from by omega),
               show (m + 2) / 2 = (m + 1) / 2 from by omega]
-          · rw [pow_unfold s (m + 2) (by omega), if_neg hodd,
+          · rw [pow_unfold s (m + 2) (by omega), ite_eq_right hodd,
               pow_unfold s (m + 1) (by omega),
-              if_pos (show (m + 1) % 2 = 1 from by omega),
+              ite_eq_left (show (m + 1) % 2 = 1 from by omega),
               show (m + 2) / 2 = (m + 1) / 2 + 1 from by omega,
               ih ((m + 1) / 2) (by omega) (s * s), mul_assoc]
 
@@ -1044,7 +1044,7 @@ where the degree is. -/
       simp
   | some t =>
       have hsize := size_toDense_eq hback
-      rw [dif_neg (by omega)]
+      rw [dite_eq_right (by omega)]
       simp only [Option.map_some]
       congr 1
       omega

--- a/HexSparsePoly/Euclid.lean
+++ b/HexSparsePoly/Euclid.lean
@@ -97,7 +97,7 @@ theorem mulMonomial_divMonomial {C : Type u} [Lean.Grind.CommRing C]
     intro f
     rw [coeff_mulMonomial, coeff_ofCanonicalList]
     by_cases hef : e ≤ f
-    · rw [if_pos hef]
+    · rw [ite_eq_left hef]
       have happly := coeffList_mapTerms_apply (g := fun x => x - e)
         (f := fun _ c => c) (l := s.terms.toList) (e := f)
         s.pairwise_toList
@@ -111,7 +111,7 @@ theorem mulMonomial_divMonomial {C : Type u} [Lean.Grind.CommRing C]
         grind
       rw [hone]
       rfl
-    · rw [if_neg hef]
+    · rw [ite_eq_right hef]
       have hzero : s.coeff f = 0 :=
         coeffList_eq_zero fun u hu huf => by
           have := hall u hu
@@ -252,16 +252,16 @@ theorem divExactMonic?_eq_some {s t q : SparsePoly S} (ht : t.Monic) :
   constructor
   · intro h
     by_cases hr : (divModMonic s t ht).2 = 0
-    · rw [if_pos hr, Option.some.injEq] at h
+    · rw [ite_eq_left hr, Option.some.injEq] at h
       have hspec := divModMonic_spec s t ht
       rw [hr, add_zero, h] at hspec
       exact hspec.symm
-    · rw [if_neg hr] at h
+    · rw [ite_eq_right hr] at h
       cases h
   · intro hs
     have hdvd : t ∣ s := ⟨q, by rw [hs, mul_comm]⟩
     have hr := divModMonic_snd_eq_zero_of_dvd ht hdvd
-    rw [if_pos hr, Option.some.injEq]
+    rw [ite_eq_left hr, Option.some.injEq]
     have hspec := divModMonic_spec s t ht
     rw [hr, add_zero] at hspec
     have hqt : (divModMonic s t ht).1 * t = q * t := by rw [hspec, hs]
@@ -294,10 +294,10 @@ theorem divExactMonic?_isSome {s t : SparsePoly S} (ht : t.Monic) :
       refine ⟨(divModMonic s t ht).1, ?_⟩
       rw [mul_comm]
       exact hspec.symm
-    · rw [if_neg hr] at h
+    · rw [ite_eq_right hr] at h
       cases h
   · intro hdvd
-    rw [if_pos (divModMonic_snd_eq_zero_of_dvd ht hdvd)]
+    rw [ite_eq_left (divModMonic_snd_eq_zero_of_dvd ht hdvd)]
     rfl
 
 end Laws

--- a/HexSparsePoly/Eval.lean
+++ b/HexSparsePoly/Eval.lean
@@ -86,12 +86,12 @@ theorem pow1_eq (x : S) (g : Nat) (hg : 1 ≤ g) : pow1 x g = x ^ g := by
       rw [pow1]
       grind
   | case3 x g hodd ih =>
-      rw [pow1, if_pos hodd, ih (by omega), sq_pow]
+      rw [pow1, ite_eq_left hodd, ih (by omega), sq_pow]
       have hexp : g + 2 = 2 * ((g + 2) / 2) + 1 := by omega
       rw [hexp]
       grind
   | case4 x g hodd ih =>
-      rw [pow1, if_neg hodd, ih (by omega), sq_pow]
+      rw [pow1, ite_eq_right hodd, ih (by omega), sq_pow]
       have hexp : 2 * ((g + 2) / 2) = g + 2 := by omega
       rw [hexp]
 
@@ -232,12 +232,12 @@ theorem coeffList_filter_ne_zero {l : List (Nat × R)} {e : Nat}
       · rw [List.filter_cons_of_neg (by simpa using ha)]
         rw [ih]
         simp only [coeffList]
-        rw [if_neg (fun h : a.1 = e => he (by omega))]
+        rw [ite_eq_right (fun h : a.1 = e => he (by omega))]
       · rw [List.filter_cons_of_pos (by simpa using ha)]
         simp only [coeffList]
         by_cases hae : a.1 = e
-        · rw [if_pos hae, if_pos hae]
-        · rw [if_neg hae, if_neg hae, ih]
+        · rw [ite_eq_left hae, ite_eq_left hae]
+        · rw [ite_eq_right hae, ite_eq_right hae, ih]
 
 attribute [local instance 1100] Lean.Grind.Semiring.natCast
 
@@ -283,7 +283,7 @@ coefficient moves from `e` to `k · e` untouched. -/
 theorem coeff_substPow_mul [Add R] (s : SparsePoly R) {k : Nat}
     (hk : k ≠ 0) (e : Nat) : (s.substPow k).coeff (k * e) = s.coeff e := by
   unfold substPow
-  rw [dif_neg hk, coeff_ofCanonicalList]
+  rw [dite_eq_right hk, coeff_ofCanonicalList]
   exact coeffList_mapTerms_apply (g := fun e => k * e)
     s.pairwise_toList
     (fun u _ h => by
@@ -296,7 +296,7 @@ theorem coeff_substPow_of_ne [Add R] (s : SparsePoly R) {k : Nat}
     (hk : k ≠ 0) {f : Nat} (hf : ∀ e, f ≠ k * e) :
     (s.substPow k).coeff f = 0 := by
   unfold substPow
-  rw [dif_neg hk, coeff_ofCanonicalList]
+  rw [dite_eq_right hk, coeff_ofCanonicalList]
   exact coeffList_mapTerms_of_ne fun u _ h => hf u.1 h.symm
 
 /-- One step of the `substScale` walk: the power of `a` for the next
@@ -492,12 +492,12 @@ theorem polyPow1_eq (p : SparsePoly K) (g : Nat) (hg : 1 ≤ g) :
   | case2 p =>
       rw [polyPow1, pow_succ, pow_zero, mul_one]
   | case3 p g hodd ih =>
-      rw [polyPow1, if_pos hodd, ih (by omega), poly_sq_pow]
+      rw [polyPow1, ite_eq_left hodd, ih (by omega), poly_sq_pow]
       show p ^ (2 * ((g + 2) / 2)) * p = p ^ (g + 2)
       rw [mul_comm, ← pow_succ,
         show 2 * ((g + 2) / 2) + 1 = g + 2 from by omega]
   | case4 p g hodd ih =>
-      rw [polyPow1, if_neg hodd, ih (by omega), poly_sq_pow,
+      rw [polyPow1, ite_eq_right hodd, ih (by omega), poly_sq_pow,
         show 2 * ((g + 2) / 2) = g + 2 from by omega]
 
 /-- Evaluation is additive, by transport. -/
@@ -705,11 +705,11 @@ private theorem psf_eq_terms_sum (q : DensePoly K) (cs : List K) :
       by_cases hc : c = 0
       · rw [show termsOfCoeffsList base (c :: cs) =
             termsOfCoeffsList (base + 1) cs from by
-          rw [termsOfCoeffsList, if_pos hc]]
+          rw [termsOfCoeffsList, ite_eq_left hc]]
         rw [hc, dense_C_zero, DensePoly.zero_mul, DensePoly.zero_add]
       · rw [show termsOfCoeffsList base (c :: cs) =
             (base, c) :: termsOfCoeffsList (base + 1) cs from by
-          rw [termsOfCoeffsList, if_neg hc]]
+          rw [termsOfCoeffsList, ite_eq_right hc]]
         rw [List.foldl_cons]
         conv => rhs; rw [dense_foldl_add_init, DensePoly.zero_add]
 
@@ -812,19 +812,19 @@ private theorem foldl_single_match {l : List (Nat × K)}
       rw [List.pairwise_cons] at hs
       rw [List.foldl_cons]
       by_cases hue : u.1 = e
-      · rw [if_pos (by rw [hue]),
+      · rw [ite_eq_left (by rw [hue]),
           show (0 : K) + u.2 = u.2 from by grind,
           foldl_add_ifs_zero (fun v hv => by
-            rw [if_neg (fun h => by
+            rw [ite_eq_right (fun h => by
               have hev : e = v.1 := Nat.eq_of_mul_eq_mul_left
                 (by omega) h
               have := hs.1 v hv
               omega)])]
-        simp only [coeffList, if_pos hue]
-      · rw [if_neg (fun h => hue (Nat.eq_of_mul_eq_mul_left
+        simp only [coeffList, ite_eq_left hue]
+      · rw [ite_eq_right (fun h => hue (Nat.eq_of_mul_eq_mul_left
             (by omega) h).symm),
           show (0 : K) + 0 = 0 from by grind, ih hs.2]
-        simp only [coeffList, if_neg (fun h : u.1 = e => hue h)]
+        simp only [coeffList, ite_eq_right (fun h : u.1 = e => hue h)]
 
 /-- The fast path and the general path agree: what lets the cyclotomic
 adapter use {name}`substPow` and reason with {name}`compose`. -/
@@ -846,7 +846,7 @@ theorem substPow_eq_compose (s : SparsePoly K) (k : Nat) :
   · subst hk
     show (s.substPow 0).coeff f = _
     unfold substPow
-    rw [dif_pos rfl, coeff_ofTerms_addCoeff]
+    rw [dite_eq_left rfl, coeff_ofTerms_addCoeff]
     have hz : ∀ c : K, (0 : K) + c = c := by grind
     simp only [addCoeff_eq_add hz, Array.toList_map]
     by_cases hf : f = 0
@@ -858,21 +858,21 @@ theorem substPow_eq_compose (s : SparsePoly K) (k : Nat) :
           simp)]
       rw [List.foldl_map]
       refine foldl_congr' rfl fun b u _ => ?_
-      rw [if_pos (by omega)]
+      rw [ite_eq_left (by omega)]
     · rw [show ((s.terms.toList.map fun t => ((0 : Nat), t.2)).filter
           (fun t => t.1 = f)) = [] from List.filter_eq_nil_iff.mpr (fun a ha => by
           obtain ⟨u, hu, rfl⟩ := List.mem_map.mp ha
           simpa using fun h : (0 : Nat) = f => hf h.symm)]
       rw [List.foldl_nil]
       exact ((foldl_add_ifs_zero (fun u _ => by
-        rw [if_neg (by omega)])) 0).symm
+        rw [ite_eq_right (by omega)])) 0).symm
   · by_cases hmul : ∃ e, f = k * e
     · obtain ⟨e, rfl⟩ := hmul
       rw [coeff_substPow_mul s hk]
       exact (foldl_single_match s.pairwise_toList hk e).symm
     · rw [coeff_substPow_of_ne s hk (fun e h => hmul ⟨e, h⟩)]
       exact ((foldl_add_ifs_zero (fun u _ => by
-        rw [if_neg (fun h => hmul ⟨u.1, h⟩)])) 0).symm
+        rw [ite_eq_right (fun h => hmul ⟨u.1, h⟩)])) 0).symm
 
 private theorem eval_foldl_add {α : Type _} (l : List α)
     (g : α → SparsePoly K) (x : K) :
@@ -949,7 +949,7 @@ private theorem coeffList_substScaleGo (a : K) (l : List (Nat × K)) :
         rw [substScaleGo]
         unfold substScaleStep
         by_cases hgap : u.1 - prev = 0
-        · rw [if_pos hgap]
+        · rw [ite_eq_left hgap]
           have hpe : prev = u.1 := by omega
           refine ⟨pw, ?_, ?_, ?_⟩
           · cases pw with
@@ -957,8 +957,8 @@ private theorem coeffList_substScaleGo (a : K) (l : List (Nat × K)) :
                 show (if u.2 = 0 then _ else u :: _) = _
                 rw [show pwVal (none : Option K) = 1 from rfl]
                 by_cases hu2 : u.2 = 0
-                · rw [if_pos hu2, if_pos (by rw [hu2]; grind)]
-                · rw [if_neg hu2, if_neg (by
+                · rw [ite_eq_left hu2, ite_eq_left (by rw [hu2]; grind)]
+                · rw [ite_eq_right hu2, ite_eq_right (by
                     intro h
                     exact hu2 (by grind))]
                   rw [show (u.1, u.2 * (1 : K)) =
@@ -970,7 +970,7 @@ private theorem coeffList_substScaleGo (a : K) (l : List (Nat × K)) :
             have := hnone rfl
             omega
           · rw [hval, hpe]
-        · rw [if_neg hgap]
+        · rw [ite_eq_right hgap]
           cases pw with
           | none =>
               have h0 : prev = 0 := hnone rfl
@@ -997,18 +997,18 @@ private theorem coeffList_substScaleGo (a : K) (l : List (Nat × K)) :
           omega)]
         grind
       by_cases hzero : u.2 * pwVal pw' = 0
-      · rw [if_pos hzero]
+      · rw [ite_eq_left hzero]
         by_cases hf : u.1 = f
         · rw [← hf, htail_zero]
-          simp only [coeffList, if_true]
+          simp only [coeffList, ite_true]
           rw [← hv', ← hzero]
         · rw [hrest f]
-          simp only [coeffList, if_neg hf]
-      · rw [if_neg hzero]
+          simp only [coeffList, ite_eq_right hf]
+      · rw [ite_eq_right hzero]
         by_cases hf : u.1 = f
-        · simp only [coeffList, if_pos hf]
+        · simp only [coeffList, ite_eq_left hf]
           rw [← hf, hv']
-        · simp only [coeffList, if_neg hf]
+        · simp only [coeffList, ite_eq_right hf]
           exact hrest f
 
 /-- Coefficient law for {name}`substScale`: each coefficient is scaled
@@ -1034,16 +1034,16 @@ private theorem foldl_scale_match {l : List (Nat × K)}
       rw [List.pairwise_cons] at hs
       rw [List.foldl_cons]
       by_cases huf : f = u.1
-      · rw [if_pos huf,
+      · rw [ite_eq_left huf,
           show (0 : K) + u.2 * a ^ u.1 = u.2 * a ^ u.1 from by grind,
           foldl_add_ifs_zero (fun v hv => by
-            rw [if_neg (fun h => by
+            rw [ite_eq_right (fun h => by
               have := hs.1 v hv
               omega)])]
-        simp only [coeffList, if_pos huf.symm]
+        simp only [coeffList, ite_eq_left huf.symm]
         rw [huf]
-      · rw [if_neg huf, show (0 : K) + 0 = 0 from by grind, ih hs.2]
-        simp only [coeffList, if_neg (fun h : u.1 = f => huf h.symm)]
+      · rw [ite_eq_right huf, show (0 : K) + 0 = 0 from by grind, ih hs.2]
+        simp only [coeffList, ite_eq_right (fun h : u.1 = f => huf h.symm)]
 
 /-- Argument scaling is composition with the degree-one monomial
 `a · x`: the sparse fast path and the general path agree. -/

--- a/HexTruncatedSeries/Classes.lean
+++ b/HexTruncatedSeries/Classes.lean
@@ -177,7 +177,7 @@ instance (priority := 900) (m : Nat) : NatInverses Rat m where
   invNat k := if k = 0 then 0 else (k : Rat)⁻¹
   invNat_eq := by
     intro k hk _
-    rw [if_neg (by omega)]
+    rw [ite_eq_right (by omega)]
     exact Rat.mul_inv_cancel _ (by simp; omega)
 
 end Hex.TSeries

--- a/HexTruncatedSeries/Comp.lean
+++ b/HexTruncatedSeries/Comp.lean
@@ -167,7 +167,7 @@ private theorem compHorner_eq_raw [Lean.Grind.CommRing R]
   simp only [Nat.min_self, Agree.mulUpTo_full]
   apply ext
   intro i hi
-  rw [coeff_ofFn _ i hi, if_pos hi]
+  rw [coeff_ofFn _ i hi, ite_eq_left hi]
 
 private theorem hornerFold [Lean.Grind.CommRing R]
     (a b : TSeries R n) (k : Nat) (z : TSeries R n) :
@@ -203,7 +203,7 @@ private theorem evalBlock_agree [Lean.Grind.CommRing R]
       (blockSum p s a b q) := by
   intro i hi him
   unfold evalBlock blockSum
-  rw [coeff_ofFn _ i hi, if_pos him,
+  rw [coeff_ofFn _ i hi, ite_eq_left him,
     coeff_foldl_add (List.range s)
       (fun j => if q * s + j < p then C (a.coeff (q * s + j)) * b ^ j else 0)
       0 i hi, coeff_zero]
@@ -331,11 +331,11 @@ private theorem foldIndicatorRange [Lean.Grind.CommRing R]
         (List.range p).foldl (fun acc k => acc + f k) 0 := by
     apply List.foldl_add_congr
     intro k hk
-    rw [if_pos (List.mem_range.mp hk)]
+    rw [ite_eq_left (List.mem_range.mp hk)]
   rw [hfirst, List.foldl_map]
   apply List.foldl_add_eq_self
   intro k hk
-  rw [if_neg]
+  rw [ite_eq_right]
   have hk' := List.mem_range.mp hk
   omega
 
@@ -553,7 +553,7 @@ theorem comp_eq_horner [Lean.Grind.CommRing R] (a b : TSeries R n)
   apply ext
   intro i hi
   unfold comp
-  rw [coeff_compUpTo_horner n a b h i hi, if_pos hi]
+  rw [coeff_compUpTo_horner n a b h i hi, ite_eq_left hi]
 
 /-- Bounded composition agrees with full composition below its bound. -/
 theorem coeff_compUpTo [Lean.Grind.CommRing R] (m : Nat)
@@ -619,8 +619,8 @@ theorem comp_X_left [Lean.Grind.CommRing R] (b : TSeries R n)
             rw [coeff_X k (List.mem_range.mp hk)]
             by_cases hk1 : k = 1
             · subst k
-              rw [if_pos rfl, C_one, hpow, one_mul, if_pos rfl]
-            · rw [if_neg hk1, C_zero, zero_mul, if_neg hk1]
+              rw [ite_eq_left rfl, C_one, hpow, one_mul, ite_eq_left rfl]
+            · rw [ite_eq_right hk1, C_zero, zero_mul, ite_eq_right hk1]
       _ = 0 + b :=
         List.foldl_add_single _ _ _ _ (List.mem_range.mpr hn) List.nodup_range
       _ = b := by grind
@@ -807,11 +807,11 @@ theorem comp_zero_right [Lean.Grind.CommRing R] (a : TSeries R n) :
             intro k hk
             by_cases hk0 : k = 0
             · subst k
-              rw [if_pos rfl, pow_zero, mul_one]
+              rw [ite_eq_left rfl, pow_zero, mul_one]
             · cases k with
               | zero => contradiction
               | succ k =>
-                  rw [if_neg (by omega), pow_succ, mul_zero, mul_zero]
+                  rw [ite_eq_right (by omega), pow_succ, mul_zero, mul_zero]
       _ = 0 + C (a.coeff 0) :=
         List.foldl_add_single _ _ _ _ (List.mem_range.mpr hn) List.nodup_range
       _ = C (a.coeff 0) := by grind
@@ -852,16 +852,16 @@ theorem coeff_comp_zero [Lean.Grind.CommRing R] (a b : TSeries R n)
             rw [coeff_C_mul _ _ 0 hn]
             by_cases hk0 : k = 0
             · subst k
-              rw [pow_zero, coeff_one 0 hn, if_pos rfl]
+              rw [pow_zero, coeff_one 0 hn, ite_eq_left rfl]
               grind
             · have hbzero := pow_vanish b h k 0 hn (by omega)
-              rw [hbzero, if_neg hk0]
+              rw [hbzero, ite_eq_right hk0]
               grind
       _ = 0 + a.coeff 0 :=
         List.foldl_add_single _ _ _ _ (List.mem_range.mpr hn) List.nodup_range
       _ = a.coeff 0 := by grind
   · unfold coeff
-    rw [dif_neg hn, dif_neg hn]
+    rw [dite_eq_right hn, dite_eq_right hn]
 
 /-- Substitution is associative when both inner series have zero constant
 coefficient. -/
@@ -911,7 +911,7 @@ theorem compUpTo [Lean.Grind.CommRing R] (p : Nat)
     (a b : TSeries R n) (h : b.coeff 0 = 0) :
     Agree p (Hex.TSeries.compUpTo p a b) (comp a b) := by
   intro i hi hip
-  rw [coeff_compUpTo p a b h i hi, if_pos hip]
+  rw [coeff_compUpTo p a b h i hi, ite_eq_left hip]
 
 end Agree
 

--- a/HexTruncatedSeries/ExpLog.lean
+++ b/HexTruncatedSeries/ExpLog.lean
@@ -74,11 +74,11 @@ theorem deriv_log [Lean.Grind.CommRing R] [NatInverses R (n - 1)]
   intro i hi
   rw [coeff_deriv (log a) i hi]
   unfold log logUpTo
-  rw [coeff_ofFn _ (i + 1) (by omega), if_pos (by omega),
+  rw [coeff_ofFn _ (i + 1) (by omega), ite_eq_left (by omega),
     coeff_truncate _ _ (i + 1) (by omega),
     coeff_integrate _ (i + 1) (by omega)]
-  simp only [show i + 1 ≠ 0 by omega, if_false, Nat.add_sub_cancel]
-  rw [coeff_mulUpTo (n - 1) _ _ i (by omega), if_pos hi,
+  simp only [show i + 1 ≠ 0 by omega, ite_false, Nat.add_sub_cancel]
+  rw [coeff_mulUpTo (n - 1) _ _ i (by omega), ite_eq_left hi,
     coeff_mul _ _ i hi]
   simp only [invOfUnit]
   have hinv := NatInverses.invNat_eq (R := R) (m := n - 1) (i + 1)
@@ -92,7 +92,7 @@ private theorem logUpTo_coeff_zero [Lean.Grind.CommRing R]
     (hn : 0 < n) (hm : 0 < m) :
     (logUpTo m a).coeff 0 = 0 := by
   unfold logUpTo
-  rw [coeff_ofFn _ 0 hn, if_pos hm,
+  rw [coeff_ofFn _ 0 hn, ite_eq_left hm,
     coeff_truncate _ _ 0 (by omega), coeff_integrate _ 0 (by omega)]
   simp
 
@@ -110,7 +110,7 @@ private theorem expStep_coeff_zero [Lean.Grind.CommRing R]
     (hn : 0 < n) (hm : 0 < m) :
     (expStep a y m).coeff 0 = 1 := by
   unfold expStep
-  rw [coeff_mulUpTo m y (C 1 + a - logUpTo m y) 0 hn, if_pos hm,
+  rw [coeff_mulUpTo m y (C 1 + a - logUpTo m y) 0 hn, ite_eq_left hm,
     coeff_mul_zero y (C 1 + a - logUpTo m y) hn,
     coeff_sub (C 1 + a) (logUpTo m y) 0 hn,
     coeff_add (C 1) a 0 hn, coeff_C 1 0 hn,
@@ -134,7 +134,7 @@ theorem exp_coeff_zero [Lean.Grind.CommRing R] [NatInverses R (n - 1)]
     (a : TSeries R n) (h : a.coeff 0 = 0) (h0 : 0 < n) :
     (exp a).coeff 0 = 1 := by
   unfold exp expUpTo
-  rw [coeff_ofFn _ 0 h0, if_pos h0]
+  rw [coeff_ofFn _ 0 h0, ite_eq_left h0]
   simpa only [Nat.min_self] using expNewton_coeff_zero a h h0 (steps n)
 
 private theorem deriv_add [Lean.Grind.CommRing R] (a b : TSeries R n) :
@@ -150,7 +150,7 @@ private theorem deriv_one [Lean.Grind.CommRing R] :
   apply ext
   intro i hi
   rw [coeff_deriv 1 i hi, coeff_one (i + 1) (by omega),
-    if_neg (by omega), coeff_zero]
+    ite_eq_right (by omega), coeff_zero]
   grind
 
 private theorem deriv_zero [Lean.Grind.CommRing R] :
@@ -195,7 +195,7 @@ private theorem unitCoeff_mul [Lean.Grind.CommRing R]
   · rw [coeff_mul_zero a b hn, ha, hb]
     grind
   · unfold coeff at ha ⊢
-    rw [dif_neg hn] at ha ⊢
+    rw [dite_eq_right hn] at ha ⊢
     exact ha
 
 private theorem logArg [Lean.Grind.CommRing R]
@@ -205,7 +205,7 @@ private theorem logArg [Lean.Grind.CommRing R]
   · rw [coeff_sub a 1 0 hn, coeff_one 0 hn, ha]
     grind
   · unfold coeff
-    rw [dif_neg hn]
+    rw [dite_eq_right hn]
 
 private theorem log_mul [Lean.Grind.CommRing R]
     [NatInverses R (n - 1)] (a b : TSeries R n)
@@ -352,7 +352,7 @@ theorem logUpTo_agree [Lean.Grind.CommRing R]
     intro i hi him
     have hau : a.coeff 0 * 1 = 1 := by rw [ha0]; grind
     unfold log logUpTo
-    rw [coeff_ofFn _ i hi, if_pos him, coeff_ofFn _ i hi, if_pos hi,
+    rw [coeff_ofFn _ i hi, ite_eq_left him, coeff_ofFn _ i hi, ite_eq_left hi,
       coeff_truncate _ _ i hi, coeff_truncate _ _ i hi]
     cases i with
     | zero =>
@@ -361,9 +361,9 @@ theorem logUpTo_agree [Lean.Grind.CommRing R]
     | succ i =>
         rw [coeff_integrate _ (i + 1) (by omega),
           coeff_integrate _ (i + 1) (by omega)]
-        simp only [show i + 1 ≠ 0 by omega, if_false, Nat.add_sub_cancel]
-        rw [coeff_mulUpTo (m - 1) _ _ i (by omega), if_pos (by omega),
-          coeff_mulUpTo (n - 1) _ _ i (by omega), if_pos (by omega),
+        simp only [show i + 1 ≠ 0 by omega, ite_false, Nat.add_sub_cancel]
+        rw [coeff_mulUpTo (m - 1) _ _ i (by omega), ite_eq_left (by omega),
+          coeff_mulUpTo (n - 1) _ _ i (by omega), ite_eq_left (by omega),
           coeff_mul _ _ i (by omega), coeff_mul _ _ i (by omega)]
         congr 1
         unfold convCoeff
@@ -372,8 +372,8 @@ theorem logUpTo_agree [Lean.Grind.CommRing R]
         have hj' : j < i + 1 := List.mem_range.mp hj
         rw [coeff_truncate _ _ (i - j) (by omega),
           coeff_truncate _ _ (i - j) (by omega),
-          coeff_invUpTo m a 1 hau (i - j) (by omega), if_pos (by omega),
-          coeff_invUpTo n a 1 hau (i - j) (by omega), if_pos (by omega)]
+          coeff_invUpTo m a 1 hau (i - j) (by omega), ite_eq_left (by omega),
+          coeff_invUpTo n a 1 hau (i - j) (by omega), ite_eq_left (by omega)]
   · intro i hi _
     omega
 
@@ -563,7 +563,7 @@ private theorem exp_eq [Lean.Grind.CommRing R]
   apply ext
   intro i hi
   unfold exp expUpTo
-  rw [coeff_ofFn _ i hi, if_pos hi, Nat.min_self]
+  rw [coeff_ofFn _ i hi, ite_eq_left hi, Nat.min_self]
 
 /-- Bounded exponential agrees with the full exponential throughout the
 requested prefix. -/
@@ -580,7 +580,7 @@ theorem expUpTo_agree [Lean.Grind.CommRing R]
       exact (h.mono (two_pow_steps_ge (min m n))).symm
     intro i hi him
     unfold expUpTo
-    rw [coeff_ofFn _ i hi, if_pos him, exp_eq a]
+    rw [coeff_ofFn _ i hi, ite_eq_left him, exp_eq a]
     exact hiter i hi (by omega)
   · intro i hi _
     omega

--- a/HexTruncatedSeries/Inverse.lean
+++ b/HexTruncatedSeries/Inverse.lean
@@ -133,7 +133,7 @@ private theorem invUpTo_correct [Lean.Grind.CommRing R]
   have hwrap : Agree p (invUpTo m a u) b := by
     intro i hi hip
     unfold invUpTo
-    rw [coeff_ofFn _ i hi, if_pos (by
+    rw [coeff_ofFn _ i hi, ite_eq_left (by
       change i < min m n at hip
       omega)]
   have herr : Agree p (invError a (invUpTo m a u)) (invError a b) :=
@@ -183,7 +183,7 @@ theorem coeff_invUpTo [Lean.Grind.CommRing R] (m : Nat)
     exact agreeInv_unique hbounded hfull i hi (by omega)
   · rename_i him
     unfold invUpTo
-    rw [coeff_ofFn _ i hi, if_neg him]
+    rw [coeff_ofFn _ i hi, ite_eq_right him]
 
 /-- Newton inversion satisfies the defining multiplicative equation. -/
 theorem invOfUnit_mul [Lean.Grind.CommRing R] (a : TSeries R n) (u : R)

--- a/HexTruncatedSeries/Newton.lean
+++ b/HexTruncatedSeries/Newton.lean
@@ -49,10 +49,10 @@ theorem steps_mono {m n : Nat} (h : m ≤ n) : steps m ≤ steps n := by
       exact Nat.le_trans (Nat.log2_self_le ha) hab
   unfold steps
   by_cases hm : m ≤ 1
-  · rw [if_pos hm]
+  · rw [ite_eq_left hm]
     omega
   · have hn : ¬n ≤ 1 := by omega
-    rw [if_neg hm, if_neg hn]
+    rw [ite_eq_right hm, ite_eq_right hn]
     exact Nat.add_le_add_right (log2_mono (Nat.sub_le_sub_right h 1)) 1
 
 /-- If every Newton stage preserves the prefix established by the preceding

--- a/HexTruncatedSeries/Precision.lean
+++ b/HexTruncatedSeries/Precision.lean
@@ -226,7 +226,7 @@ theorem divXPow?_eq_some_iff [Lean.Grind.CommRing R] [DecidableEq R]
       coeff_divXPow?_eq_some a k h⟩
   · rintro ⟨hz, hc⟩
     unfold divXPow?
-    rw [if_pos ((allZeroBelow_eq_true a (min k n)).mpr hz)]
+    rw [ite_eq_left ((allZeroBelow_eq_true a (min k n)).mpr hz)]
     congr 1
     apply ext
     intro i hi
@@ -244,12 +244,12 @@ theorem divXPow?_mulXPow [Lean.Grind.CommRing R] [DecidableEq R]
   constructor
   · intro i hi
     by_cases hin : i < n
-    · rw [coeff_mulXPow a k i hin, if_neg (by omega)]
+    · rw [coeff_mulXPow a k i hin, ite_eq_right (by omega)]
     · rw [coeff]
       split <;> simp_all
   · intro i hi
     rw [coeff_truncate a (Nat.sub_le n k) i hi,
-      coeff_mulXPow a k (i + k) (by omega), if_pos (by omega)]
+      coeff_mulXPow a k (i + k) (by omega), ite_eq_left (by omega)]
     congr 1
     omega
 
@@ -263,11 +263,11 @@ theorem mulXPow_extend_divXPow?_eq [Lean.Grind.CommRing R] [DecidableEq R]
   intro i hi
   rw [coeff_mulXPow _ k i hi]
   by_cases hki : k ≤ i
-  · rw [if_pos hki, coeff_extend b (Nat.sub_le n k) (i - k) (by omega),
+  · rw [ite_eq_left hki, coeff_extend b (Nat.sub_le n k) (i - k) (by omega),
       coeff_divXPow?_eq_some a k h (i - k) (by omega)]
     congr 1
     omega
-  · rw [if_neg hki]
+  · rw [ite_eq_right hki]
     have hz := (divXPow?_eq_some_iff a k b).mp h |>.1 i (by omega)
     exact hz.symm
 
@@ -347,7 +347,7 @@ theorem integrate_congr [Lean.Grind.CommRing R] (a : TSeries R n)
     @coeff_integrate R n _ h₂ a i hi]
   by_cases hi0 : i = 0
   · simp [hi0]
-  · rw [if_neg hi0, if_neg hi0,
+  · rw [ite_eq_right hi0, ite_eq_right hi0,
       NatInverses.invNat_unique h₁ h₂ i (by omega) (by omega)]
 
 /-- Differentiation cancels zero-constant integration at every represented
@@ -359,7 +359,7 @@ theorem deriv_integrate [Lean.Grind.CommRing R] [NatInverses R n]
   intro i hi
   rw [coeff_deriv (integrate a) i (by omega),
     coeff_integrate a (i + 1) (by omega)]
-  simp only [show i + 1 ≠ 0 by omega, if_false, Nat.add_sub_cancel]
+  simp only [show i + 1 ≠ 0 by omega, ite_false, Nat.add_sub_cancel]
   have hinv := NatInverses.invNat_eq (R := R) (m := n) (i + 1)
     (by omega) (by omega)
   rw [Lean.Grind.Semiring.natCast_succ] at hinv
@@ -484,10 +484,10 @@ theorem derivPad_add [Lean.Grind.CommRing R] (a b : TSeries R n) :
   rw [coeff_derivPad (a + b) i hi, coeff_add _ _ i hi,
     coeff_derivPad a i hi, coeff_derivPad b i hi]
   by_cases hnext : i + 1 < n
-  · rw [if_pos hnext, if_pos hnext, if_pos hnext,
+  · rw [ite_eq_left hnext, ite_eq_left hnext, ite_eq_left hnext,
       coeff_add a b (i + 1) hnext]
     grind
-  · rw [if_neg hnext, if_neg hnext, if_neg hnext]
+  · rw [ite_eq_right hnext, ite_eq_right hnext, ite_eq_right hnext]
     grind
 
 /-- The precision-preserving derivative kills constant series. -/
@@ -498,9 +498,9 @@ theorem derivPad_C [Lean.Grind.CommRing R] (c : R) :
   intro i hi
   rw [coeff_derivPad (C c) i hi, coeff_zero]
   by_cases hnext : i + 1 < n
-  · rw [if_pos hnext, coeff_C c (i + 1) hnext, if_neg (by omega)]
+  · rw [ite_eq_left hnext, coeff_C c (i + 1) hnext, ite_eq_right (by omega)]
     grind
-  · rw [if_neg hnext]
+  · rw [ite_eq_right hnext]
 
 /-- The precision-preserving derivative kills zero. -/
 @[simp]
@@ -527,9 +527,9 @@ theorem derivPad_C_mul [Lean.Grind.CommRing R] (c : R) (a : TSeries R n) :
   rw [coeff_derivPad (C c * a) i hi, coeff_C_mul c a.derivPad i hi,
     coeff_derivPad a i hi]
   by_cases hnext : i + 1 < n
-  · rw [if_pos hnext, if_pos hnext, coeff_C_mul c a (i + 1) hnext]
+  · rw [ite_eq_left hnext, ite_eq_left hnext, coeff_C_mul c a (i + 1) hnext]
     grind
-  · rw [if_neg hnext, if_neg hnext]
+  · rw [ite_eq_right hnext, ite_eq_right hnext]
     grind
 
 /-- The precision-preserving derivative commutes with an additive fold. -/
@@ -601,7 +601,7 @@ theorem derivPad_mul_agree [Lean.Grind.CommRing R] (a b : TSeries R n) :
     Agree (n - 1) (a * b).derivPad
       (a.derivPad * b + a * b.derivPad) := by
   intro i hi hip
-  rw [coeff_derivPad (a * b) i hi, if_pos (by omega),
+  rw [coeff_derivPad (a * b) i hi, ite_eq_left (by omega),
     coeff_mul a b (i + 1) (by omega), coeff_add _ _ i hi,
     coeff_mul _ _ i hi, coeff_mul _ _ i hi]
   unfold convCoeff
@@ -610,14 +610,14 @@ theorem derivPad_mul_agree [Lean.Grind.CommRing R] (a b : TSeries R n) :
   · apply List.foldl_add_congr
     intro j hj
     have hj' : j < i + 1 := List.mem_range.mp hj
-    rw [coeff_derivPad a j (by omega), if_pos (by omega)]
+    rw [coeff_derivPad a j (by omega), ite_eq_left (by omega)]
     have hidx : i + 1 - (j + 1) = i - j := by omega
     rw [hidx]
     grind
   · apply List.foldl_add_congr
     intro j hj
     have hj' : j < i + 1 := List.mem_range.mp hj
-    rw [coeff_derivPad b (i - j) (by omega), if_pos (by omega)]
+    rw [coeff_derivPad b (i - j) (by omega), ite_eq_left (by omega)]
     have hidx : i - j + 1 = i + 1 - j := by omega
     rw [hidx]
     grind
@@ -627,7 +627,7 @@ prefix. -/
 theorem derivPad_X_agree [Lean.Grind.CommRing R] :
     Agree (n - 1) (derivPad (X : TSeries R n)) 1 := by
   intro i hi hip
-  rw [coeff_derivPad X i hi, if_pos (by omega), coeff_X (i + 1) (by omega),
+  rw [coeff_derivPad X i hi, ite_eq_left (by omega), coeff_X (i + 1) (by omega),
     coeff_one i hi]
   by_cases hi0 : i = 0
   · subst i
@@ -749,7 +749,7 @@ prefix. -/
 theorem mulUpTo [Lean.Grind.CommRing R] (p : Nat) (a b : TSeries R n) :
     Agree p (Hex.TSeries.mulUpTo p a b) (a * b) := by
   intro i hi hip
-  rw [coeff_mulUpTo p a b i hi, if_pos hip]
+  rw [coeff_mulUpTo p a b i hi, ite_eq_left hip]
 
 /-- Multiplication bounded at the represented precision is ordinary
 multiplication. -/

--- a/HexTruncatedSeries/Revert.lean
+++ b/HexTruncatedSeries/Revert.lean
@@ -81,8 +81,8 @@ private theorem X_mul_shiftQuotient [Lean.Grind.CommRing R]
   rw [mul_comm X (shiftQuotient b), coeff_mul_X (shiftQuotient b) i hi]
   by_cases hi0 : i = 0
   · subst i
-    rw [if_pos rfl, h0]
-  · rw [if_neg hi0, coeff_shiftQuotient b (i - 1) (by omega)]
+    rw [ite_eq_left rfl, h0]
+  · rw [ite_eq_right hi0, coeff_shiftQuotient b (i - 1) (by omega)]
     congr 1
     omega
 
@@ -128,7 +128,7 @@ private theorem lagrangeState_power [Lean.Grind.CommRing R]
       by_cases hm : m = 0
       · subst m
         simpa [pow_zero] using ih
-      · rw [if_neg hm]
+      · rw [ite_eq_right hm]
         rw [show m + 1 - 1 = m by omega]
         change mulUpTo n (lagrangeState p m).1 p = p ^ m
         have hpow : p ^ (m - 1) * p = p ^ m := by
@@ -158,8 +158,8 @@ private theorem lagrangeState_coeff [Lean.Grind.CommRing R]
         change (lagrangeState p 0).2.coeff i = _
         rw [lagrangeState]
         change (0 : TSeries R n).coeff i = _
-        rw [coeff_zero, if_neg (by omega)]
-      · rw [if_neg hm0]
+        rw [coeff_zero, ite_eq_right (by omega)]
+      · rw [ite_eq_right hm0]
         change
           (⟨(lagrangeState p m).2.coeffs.modify m fun _ =>
             NatInverses.invNat (R := R) (m := n - 1) m *
@@ -168,18 +168,18 @@ private theorem lagrangeState_coeff [Lean.Grind.CommRing R]
         rw [coeff_modify (lagrangeState p m).2 m i _ hi]
         by_cases hmi : m = i
         · subst i
-          rw [if_pos rfl, if_pos (by omega), Agree.mulUpTo_full,
+          rw [ite_eq_left rfl, ite_eq_left (by omega), Agree.mulUpTo_full,
             lagrangeState_power]
           rw [← pow_succ, show m - 1 + 1 = m by omega]
-        · rw [if_neg hmi, ih hmn]
+        · rw [ite_eq_right hmi, ih hmn]
           by_cases hii : 0 < i ∧ i < m
-          · rw [if_pos hii, if_pos (by omega)]
-          · rw [if_neg hii]
+          · rw [ite_eq_left hii, ite_eq_left (by omega)]
+          · rw [ite_eq_right hii]
             have hnot : ¬(0 < i ∧ i < m + 1) := by
               intro h
               apply hmi
               omega
-            rw [if_neg hnot]
+            rw [ite_eq_right hnot]
 
 /-- Coefficients produced by direct Lagrange inversion have the advertised
 closed form. -/
@@ -195,7 +195,7 @@ private theorem coeff_revLagrange [Lean.Grind.CommRing R]
   by_cases hi0 : i = 0
   · subst i
     simp
-  · rw [if_neg hi0, if_pos (by omega)]
+  · rw [ite_eq_right hi0, ite_eq_left (by omega)]
 
 private theorem shiftQuotient_mul_inv [Lean.Grind.CommRing R]
     (b : TSeries R n) (v : R) (hv : b.coeff 1 * v = 1)
@@ -249,7 +249,7 @@ private theorem coeff_pow_mul_derivPad [Lean.Grind.CommRing R]
   change (p ^ r * b.derivPad).coeff (r - 1) = _
   by_cases hr1 : r = 1
   · subst r
-    rw [if_pos rfl]
+    rw [ite_eq_left rfl]
     have halg : p ^ 1 * (q + X * q.derivPad) =
         1 + X * (p * q.derivPad) := by
       rw [pow_one, Lean.Grind.Semiring.left_distrib, hpq]
@@ -258,7 +258,7 @@ private theorem coeff_pow_mul_derivPad [Lean.Grind.CommRing R]
       coeff_one 0 (by omega), coeff_mul_zero _ _ (by omega)]
     rw [X_coeff_zero]
     grind
-  · rw [if_neg hr1]
+  · rw [ite_eq_right hr1]
     have hr2 : 1 < r := by omega
     have hcancel : p ^ r * q = p ^ (r - 1) := by
       simpa only [pow_one] using pow_mul_pow_cancel p q hpq r 1 (by omega)
@@ -269,7 +269,7 @@ private theorem coeff_pow_mul_derivPad [Lean.Grind.CommRing R]
     rw [hmainCoeff, halg, coeff_add _ _ (r - 1) (by omega),
       mul_comm X (p ^ r * q.derivPad),
       coeff_mul_X (p ^ r * q.derivPad) (r - 1) (by omega),
-      if_neg (by omega)]
+      ite_eq_right (by omega)]
     have hinvDeriv : Agree (n - 1)
         (p ^ r * q.derivPad + p ^ (r - 2) * p.derivPad) 0 := by
       have hprod := derivPad_mul_agree q p
@@ -302,7 +302,7 @@ private theorem coeff_pow_mul_derivPad [Lean.Grind.CommRing R]
     have hpow := derivPad_pow_agree p (r - 1)
     have hpowCoeff := hpow (r - 2) (by omega) (by omega)
     rw [coeff_derivPad (p ^ (r - 1)) (r - 2) (by omega),
-      if_pos (by omega), show r - 2 + 1 = r - 1 by omega] at hpowCoeff
+      ite_eq_left (by omega), show r - 2 + 1 = r - 1 by omega] at hpowCoeff
     have hright :
         (C (((r - 1 : Nat) : R)) * p ^ (r - 1 - 1) * p.derivPad).coeff
             (r - 2) =
@@ -370,19 +370,19 @@ private theorem coeff_lagrange_term [Lean.Grind.CommRing R]
         _ = X ^ j * ((p ^ k * q ^ j) * b.derivPad) := by grind
         _ = X ^ j * (p ^ (k - j) * b.derivPad) := by rw [hcancel]
     rw [halg, coeff_X_pow_mul (p ^ (k - j) * b.derivPad) j (k - 1)
-      (by omega), if_pos (by omega)]
+      (by omega), ite_eq_left (by omega)]
     rw [show k - 1 - j = k - j - 1 by omega,
       coeff_pow_mul_derivPad b v h0 hv (k - j) (by omega) (by omega)]
     by_cases hj : j + 1 = k
-    · rw [if_pos hj, if_pos (by omega)]
-    · rw [if_neg hj, if_neg (by omega)]
+    · rw [ite_eq_left hj, ite_eq_left (by omega)]
+    · rw [ite_eq_right hj, ite_eq_right (by omega)]
   · have hz := pow_vanish b h0 j
     have hmul := Agree.mul
       (Agree.mul (Agree.refl j (p ^ k)) hz)
       (Agree.refl j b.derivPad)
     have hzero : Agree j (p ^ k * b ^ j * b.derivPad) 0 := by
       simpa only [mul_zero, zero_mul] using hmul
-    rw [if_neg (by omega)]
+    rw [ite_eq_right (by omega)]
     have hc := hzero (k - 1) (by omega) (by omega)
     rw [coeff_zero] at hc
     exact hc
@@ -409,7 +409,7 @@ private theorem pow_taylor [Lean.Grind.CommRing R]
   | zero =>
       rw [pow_zero, pow_zero]
       unfold tangent
-      rw [if_pos rfl, add_zero]
+      rw [ite_eq_left rfl, add_zero]
       exact Agree.refl (p + p) (1 : TSeries R n)
   | succ k ih =>
       rw [pow_succ]
@@ -469,9 +469,9 @@ private theorem tangent_sum [Lean.Grind.CommRing R]
           apply List.foldl_add_congr
           intro j hj
           have hjq : j < q := List.mem_range.mp hj
-          rw [coeff_derivPad b j (by omega), if_pos (by omega)]
+          rw [coeff_derivPad b j (by omega), ite_eq_left (by omega)]
         rw [hpref, coeff_derivPad b q (Nat.lt_succ_self q),
-          if_neg (Nat.lt_irrefl (q + 1)),
+          ite_eq_right (Nat.lt_irrefl (q + 1)),
           C_zero, zero_mul, add_zero]
       change
         (List.range (q + 1)).foldl
@@ -486,7 +486,7 @@ private theorem tangent_sum [Lean.Grind.CommRing R]
       apply List.foldl_add_congr
       intro j hj
       unfold tangent
-      rw [if_neg (by omega), Nat.succ_sub_one]
+      rw [ite_eq_right (by omega), Nat.succ_sub_one]
       have hc :
           C (b.coeff (j + 1)) *
               (C (((j + 1 : Nat) : R)) : TSeries R (q + 1)) =
@@ -514,9 +514,9 @@ private theorem derivPad_comp_agree [Lean.Grind.CommRing R]
     unfold tangent
     by_cases hk0 : k = 0
     · subst k
-      rw [if_pos rfl, pow_zero, derivPad_one, mul_zero]
+      rw [ite_eq_left rfl, pow_zero, derivPad_one, mul_zero]
       exact Agree.refl (n - 1) 0
-    · rw [if_neg hk0]
+    · rw [ite_eq_right hk0]
       exact hmul
   apply Agree.trans hfold
   rw [tangent_sum a b b.derivPad h0]
@@ -532,7 +532,7 @@ private theorem comp_taylor [Lean.Grind.CommRing R]
     · rw [coeff_add y d 0 hn, hy, hd0]
       grind
     · unfold coeff
-      rw [dif_neg hn]
+      rw [dite_eq_right hn]
   rw [comp_spec b (y + d) hyd, comp_spec b y hy]
   have hfold :
       Agree (p + p)
@@ -582,22 +582,22 @@ private theorem derivPad_coeff_zero_mul [Lean.Grind.CommRing R]
   · rw [coeff_derivPad b 0 hn]
     simp only [Nat.zero_add]
     by_cases h1 : 1 < n
-    · rw [if_pos h1, Lean.Grind.Semiring.natCast_one]
+    · rw [ite_eq_left h1, Lean.Grind.Semiring.natCast_one]
       calc
         1 * b.coeff 1 * v = b.coeff 1 * v := by grind
         _ = 1 := hv
-    · rw [if_neg h1]
+    · rw [ite_eq_right h1]
       have hb : b.coeff 1 = 0 := by
         unfold coeff
-        rw [dif_neg h1]
+        rw [dite_eq_right h1]
       rw [hb] at hv
       simpa only [zero_mul] using hv
   · have hd : b.derivPad.coeff 0 = 0 := by
       unfold coeff
-      rw [dif_neg hn]
+      rw [dite_eq_right hn]
     have hb : b.coeff 1 = 0 := by
       unfold coeff
-      rw [dif_neg (by omega)]
+      rw [dite_eq_right (by omega)]
     rw [hd]
     calc
       0 * v = b.coeff 1 * v := by rw [hb]
@@ -631,10 +631,10 @@ private theorem revStep_correct [Lean.Grind.CommRing R]
         _ = 1 := derivPad_coeff_zero_mul b v hv
     · have hd : denominator.coeff 0 = 0 := by
         unfold coeff
-        rw [dif_neg hn]
+        rw [dite_eq_right hn]
       have hb : b.coeff 1 = 0 := by
         unfold coeff
-        rw [dif_neg (by omega)]
+        rw [dite_eq_right (by omega)]
       rw [hd]
       calc
         0 * v = b.coeff 1 * v := by rw [hb]
@@ -642,7 +642,7 @@ private theorem revStep_correct [Lean.Grind.CommRing R]
   have hinv : Agree m inverse (invOfUnit denominator v) := by
     intro i hi him
     dsimp only [inverse]
-    rw [coeff_invUpTo m denominator v hden0 i hi, if_pos him]
+    rw [coeff_invUpTo m denominator v hden0 i hi, ite_eq_left him]
   have hdeninv : Agree m (denominator * inverse) 1 := by
     have hmul := Agree.mul (Agree.refl m denominator) hinv
     rw [invOfUnit_mul denominator v hden0] at hmul
@@ -676,14 +676,14 @@ private theorem revStep_correct [Lean.Grind.CommRing R]
         hcorrectionSmall 0 hn hp, coeff_zero]
       grind
     · unfold coeff
-      rw [dif_neg hn]
+      rw [dite_eq_right hn]
   have hyc0 : (y - correction).coeff 0 = 0 := by
     by_cases hn : 0 < n
     · rw [coeff_sub y correction 0 hn, hy,
         hcorrectionSmall 0 hn hp, coeff_zero]
       grind
     · unfold coeff
-      rw [dif_neg hn]
+      rw [dite_eq_right hn]
   have htaylor : Agree m (comp b (y - correction))
       (comp b y - derivative * correction) := by
     have ht := comp_taylor b y (-correction) p hy hneg0 hnegSmall
@@ -705,12 +705,12 @@ private theorem revStep_correct [Lean.Grind.CommRing R]
   have hstep : Agree m (revStep b v y m) (y - correction) := by
     intro i hi him
     unfold revStep
-    rw [coeff_ofFn _ i hi, if_pos him]
+    rw [coeff_ofFn _ i hi, ite_eq_left him]
   have hstep0 : (revStep b v y m).coeff 0 = 0 := by
     by_cases hn : 0 < n
     · exact (hstep 0 hn (by dsimp only [m]; omega)).trans hyc0
     · unfold coeff
-      rw [dif_neg hn]
+      rw [dite_eq_right hn]
   have hcomp := Agree.comp_inner b (revStep b v y m) (y - correction)
     hstep hstep0 hyc0
   have hresult := (Agree.sub hcomp (Agree.refl m X)).trans hideal
@@ -732,8 +732,8 @@ private theorem coeff_mul_right_lead [Lean.Grind.CommRing R]
           have hjp : j < p + 1 := List.mem_range.mp hj
           by_cases hj0 : j = 0
           · subst j
-            rw [if_pos rfl, Nat.sub_zero]
-          · rw [if_neg hj0, hd (p - j) (by omega) (by omega), coeff_zero]
+            rw [ite_eq_left rfl, Nat.sub_zero]
+          · rw [ite_eq_right hj0, hd (p - j) (by omega) (by omega), coeff_zero]
             grind
     _ = 0 + a.coeff 0 * d.coeff p :=
       List.foldl_add_single _ _ _ _ (List.mem_range.mpr (by omega)) List.nodup_range
@@ -805,12 +805,12 @@ private theorem revInit_zero [Lean.Grind.CommRing R] (m : Nat) (v : R) :
   by_cases hn : 0 < n
   · rw [coeff_mulUpTo m (C v) X 0 hn]
     by_cases hm : 0 < m
-    · rw [if_pos hm, coeff_mul_zero (C v) X hn,
+    · rw [ite_eq_left hm, coeff_mul_zero (C v) X hn,
         coeff_C v 0 hn, X_coeff_zero]
       grind
-    · rw [if_neg hm]
+    · rw [ite_eq_right hm]
   · unfold coeff
-    rw [dif_neg hn]
+    rw [dite_eq_right hn]
 
 private theorem revNewton_correctAt [Lean.Grind.CommRing R]
     (m : Nat) (b : TSeries R n) (v : R) (h0 : b.coeff 0 = 0)
@@ -853,7 +853,7 @@ private theorem revOfUnit_eq [Lean.Grind.CommRing R]
   apply ext
   intro i hi
   unfold revOfUnit revUpTo
-  rw [coeff_ofFn _ i hi, if_pos hi, Nat.min_self]
+  rw [coeff_ofFn _ i hi, ite_eq_left hi, Nat.min_self]
 
 /-- Bounded Newton reversion agrees with the full compositional inverse
 throughout the requested prefix. -/
@@ -877,7 +877,7 @@ theorem revUpTo_agree [Lean.Grind.CommRing R]
   intro i hi him
   have hiq : i < q := by dsimp only [q]; omega
   unfold revOfUnit revUpTo
-  rw [coeff_ofFn _ i hi, if_pos him, coeff_ofFn _ i hi, if_pos hi,
+  rw [coeff_ofFn _ i hi, ite_eq_left him, coeff_ofFn _ i hi, ite_eq_left hi,
     Nat.min_self]
   exact hiter i hi hiq
 
@@ -894,10 +894,10 @@ private theorem coeff_comp_one [Lean.Grind.CommRing R]
   rw [hzy] at ht
   have hc := ht 1 h (by omega)
   rw [coeff_add _ _ 1 h, comp_zero_right,
-    coeff_C (b.coeff 0) 1 h, if_neg (by omega),
+    coeff_C (b.coeff 0) 1 h, ite_eq_right (by omega),
     coeff_mul_right_lead (comp b.derivPad 0) y 1 h hyAgree,
     coeff_comp_zero b.derivPad 0 (coeff_zero 0),
-    coeff_derivPad b 0 (by omega), if_pos h,
+    coeff_derivPad b 0 (by omega), ite_eq_left h,
     Lean.Grind.Semiring.natCast_one] at hc
   grind
 
@@ -1015,11 +1015,11 @@ private theorem lagrange_coeff [Lean.Grind.CommRing R]
                 coeff_lagrange_term b v h0 hv k j hk hkn]
               by_cases hjk : j = k - 1
               · subst j
-                rw [if_pos rfl, if_pos (by omega),
+                rw [ite_eq_left rfl, ite_eq_left (by omega),
                   coeff_derivPad g (k - 1) (by omega),
-                  show k - 1 + 1 = k by omega, if_pos hkn]
+                  show k - 1 + 1 = k by omega, ite_eq_left hkn]
                 grind
-              · rw [if_neg hjk, if_neg (by omega)]
+              · rw [ite_eq_right hjk, ite_eq_right (by omega)]
                 grind
       _ = 0 + (((k : Nat) : R) * g.coeff k) :=
         List.foldl_add_single _ _ _ _ (List.mem_range.mpr (by omega))
@@ -1046,8 +1046,8 @@ theorem revLagrange_eq [Lean.Grind.CommRing R]
   rw [coeff_revLagrange b v i hi]
   by_cases hi0 : i = 0
   · subst i
-    rw [if_pos rfl, revOfUnit_coeff_zero b v h0 hv]
-  · rw [if_neg hi0]
+    rw [ite_eq_left rfl, revOfUnit_coeff_zero b v h0 hv]
+  · rw [ite_eq_right hi0]
     have hlag := lagrange_coeff b v h0 hv i (by omega) hi
     have hinv := NatInverses.invNat_eq (R := R) (m := n - 1)
       i (by omega) (by omega)
@@ -1072,7 +1072,7 @@ theorem revOfUnit_coeff_one [Lean.Grind.CommRing R]
     rw [revOfUnit_eq b v]
     exact (revNewton_correct b v h0 hv (steps n)).1
   have hc := coeff_comp_one b (revOfUnit b v) hrev0 h
-  rw [hleft, coeff_X 1 h, if_pos rfl] at hc
+  rw [hleft, coeff_X 1 h, ite_eq_left rfl] at hc
   calc
     (revOfUnit b v).coeff 1 = 1 * (revOfUnit b v).coeff 1 := by grind
     _ = (b.coeff 1 * v) * (revOfUnit b v).coeff 1 := by rw [hv]
@@ -1110,7 +1110,7 @@ theorem revOfUnit_le_one [Lean.Grind.CommRing R] (b : TSeries R n) (v : R)
   have hi0 : i = 0 := by omega
   subst i
   unfold revOfUnit revUpTo steps
-  simp only [Nat.min_self, if_pos (by omega : 1 ≤ 1), newton]
+  simp only [Nat.min_self, ite_eq_left (by omega : 1 ≤ 1), newton]
   grind
 
 /-- The Newton numerator vanishes throughout the precision already established

--- a/HexTruncatedSeries/Ring.lean
+++ b/HexTruncatedSeries/Ring.lean
@@ -113,7 +113,7 @@ theorem coeff_modify [Zero R] (a : TSeries R n) (k i : Nat)
     (⟨a.coeffs.modify k fun _ => c⟩ : TSeries R n).coeff i =
       if k = i then c else a.coeff i := by
   unfold coeff
-  rw [dif_pos hi, Vector.getElem_modify hi, dif_pos hi]
+  rw [dite_eq_left hi, Vector.getElem_modify hi, dite_eq_left hi]
 
 private theorem getFoldNotMem {α : Type u} {N : Nat}
     (g : Nat → α → α) {r : Nat} (hr : r < N) :
@@ -154,19 +154,19 @@ theorem mulUpTo_eq_impl : @mulUpTo = @mulUpToImpl := by
   rw [coeff_ofFn _ i hi]
   unfold mulUpToImpl
   unfold coeff
-  rw [dif_pos hi]
+  rw [dite_eq_left hi]
   change (if i < m then convCoeff a.coeff b.coeff i else 0) =
     ((List.range (min m n)).foldl
       (fun out j => out.modify j fun _ => convCoeff a.coeff b.coeff j)
       (zero (R := R) (n := n)).coeffs)[i]'hi
   by_cases him : i < m
   · have hmin : i < min m n := by omega
-    rw [if_pos him]
+    rw [ite_eq_left him]
     exact (getFoldMem
       (g := fun j (_ : R) => convCoeff a.coeff b.coeff j)
       (List.range (min m n)) List.nodup_range _ i hi
       (List.mem_range.mpr hmin)).symm
-  · rw [if_neg him]
+  · rw [ite_eq_right him]
     have hnot : i ∉ List.range (min m n) := by
       intro hmem
       have := List.mem_range.mp hmem
@@ -177,7 +177,7 @@ theorem mulUpTo_eq_impl : @mulUpTo = @mulUpToImpl := by
           change (ofFn (n := n) (fun _ => (0 : R))).coeff i = 0
           rw [coeff_ofFn _ i hi]
         unfold coeff at hz
-        rw [dif_pos hi] at hz
+        rw [dite_eq_left hi] at hz
         exact hz.symm
       _ = _ := (getFoldNotMem
         (g := fun j (_ : R) => convCoeff a.coeff b.coeff j)
@@ -266,7 +266,7 @@ theorem X_coeff_zero [Lean.Grind.CommRing R] :
   · rw [coeff_X 0 hn]
     simp
   · unfold coeff
-    rw [dif_neg hn]
+    rw [dite_eq_right hn]
 
 /-- Embedding one as a constant series agrees with the series one. -/
 @[simp] theorem C_one [Lean.Grind.CommRing R] :
@@ -300,12 +300,12 @@ theorem X_coeff_zero [Lean.Grind.CommRing R] :
   rw [coeff_C (a * b) i hi, coeff_mul (C a) (C b) i hi]
   by_cases hi0 : i = 0
   · subst i
-    rw [if_pos rfl]
+    rw [ite_eq_left rfl]
     unfold convCoeff
     change a * b = 0 + (C a : TSeries R n).coeff 0 * (C b).coeff 0
     rw [coeff_C a 0 hi, coeff_C b 0 hi]
     grind
-  · rw [if_neg hi0]
+  · rw [ite_eq_right hi0]
     unfold convCoeff
     apply (List.foldl_add_eq_self _ _ 0 ?_).symm
     intro j hj
@@ -810,7 +810,7 @@ private theorem powGo_eq [Lean.Grind.CommRing R]
       rw [powLoop.eq_def]
       by_cases hk : k = 0
       · simp [hk, linearPow, mul_one]
-      · rw [dif_neg hk]
+      · rw [dite_eq_right hk]
         have hlt : k / 2 < k :=
           Nat.div_lt_self (Nat.pos_of_ne_zero hk) (by decide)
         cases Nat.mod_two_eq_zero_or_one k with
@@ -821,7 +821,7 @@ private theorem powGo_eq [Lean.Grind.CommRing R]
             have hnot : ¬ k % 2 = 1 := by omega
             have hdiv : 2 * (k / 2) / 2 = k / 2 :=
               Nat.mul_div_right (k / 2) (by decide)
-            rw [if_neg hnot]
+            rw [ite_eq_right hnot]
             calc
               powLoop acc (base * base) (k / 2) =
                   acc * linearPow (base * base) (k / 2) := ih _ hlt _ _
@@ -830,7 +830,7 @@ private theorem powGo_eq [Lean.Grind.CommRing R]
             have hk_eq : k = 2 * (k / 2) + 1 := by
               have h := Nat.mod_add_div k 2
               omega
-            rw [if_pos hmod1]
+            rw [ite_eq_left hmod1]
             calc
               powLoop (acc * base) (base * base) (k / 2) =
                   (acc * base) * linearPow (base * base) (k / 2) := ih _ hlt _ _
@@ -1003,9 +1003,9 @@ theorem mul_comm [Lean.Grind.CommRing R] (a b : TSeries R n) : a * b = b * a := 
   · subst i
     change 0 + (X : TSeries R n).coeff 0 * a.coeff 0 = _
     rw [coeff_X 0 hi]
-    rw [if_neg (by decide), if_pos rfl]
+    rw [ite_eq_right (by decide), ite_eq_left rfl]
     grind
-  · rw [if_neg hi0]
+  · rw [ite_eq_right hi0]
     calc
       (List.range (i + 1)).foldl
           (fun acc j => acc + (X : TSeries R n).coeff j * a.coeff (i - j)) 0 =
@@ -1033,7 +1033,7 @@ theorem mul_comm [Lean.Grind.CommRing R] (a b : TSeries R n) : a * b = b * a := 
       by_cases hi0 : i = 0
       · subst i
         simp
-      · rw [if_neg hi0, ih (i - 1) (by omega)]
+      · rw [ite_eq_right hi0, ih (i - 1) (by omega)]
         by_cases hik : i = k + 1
         · simp [hik]
         · have : i - 1 ≠ k := by omega
@@ -1059,11 +1059,11 @@ coefficients below that degree equal to zero. -/
       by_cases hi0 : i = 0
       · subst i
         simp
-      · rw [if_neg hi0, ih (i - 1) (by omega)]
+      · rw [ite_eq_right hi0, ih (i - 1) (by omega)]
         by_cases hki : k + 1 ≤ i
-        · rw [if_pos hki, if_pos (by omega)]
+        · rw [ite_eq_left hki, ite_eq_left (by omega)]
           rw [show (i - 1) - k = i - (k + 1) by omega]
-        · rw [if_neg hki, if_neg (by omega)]
+        · rw [ite_eq_right hki, ite_eq_right (by omega)]
 
 /-- A scalar monomial has its scalar coefficient in exactly one degree. -/
 theorem coeff_C_mul_X_pow [Lean.Grind.CommRing R]

--- a/HexTruncatedSeries/Sqrt.lean
+++ b/HexTruncatedSeries/Sqrt.lean
@@ -234,7 +234,7 @@ private theorem sqrtOfRoot_eq [Lean.Grind.CommRing R]
   intro i hi
   unfold sqrtOfRoot sqrtUpTo
   simp only [Nat.min_self]
-  rw [coeff_ofFn _ i hi, if_pos hi, coeff_mulUpTo n _ _ i hi, if_pos hi]
+  rw [coeff_ofFn _ i hi, ite_eq_left hi, coeff_mulUpTo n _ _ i hi, ite_eq_left hi]
 
 /-- Bounded square-root lifting agrees with the full lift throughout the
 requested prefix. -/
@@ -257,7 +257,7 @@ theorem sqrtUpTo_agree [Lean.Grind.CommRing R]
   intro i hi him
   have hiq : i < q := by dsimp only [q]; omega
   unfold sqrtUpTo
-  rw [coeff_ofFn _ i hi, if_pos him]
+  rw [coeff_ofFn _ i hi, ite_eq_left him]
   rw [sqrtOfRoot_eq]
   exact hmul i hi hiq
 

--- a/HexTruncatedSeriesMathlib/Basic.lean
+++ b/HexTruncatedSeriesMathlib/Basic.lean
@@ -227,7 +227,7 @@ instance (priority := 800) natInversesOfAlgebra [CommRing R] [Algebra ℚ R]
   invNat k := if k = 0 then 0 else algebraMap ℚ R ((k : ℚ)⁻¹)
   invNat_eq := by
     intro k hk _
-    rw [if_neg (by omega)]
+    rw [_root_.ite_eq_right (by omega)]
     rw [show (k : R) = algebraMap ℚ R (k : ℚ) by simp, ← map_mul,
       Rat.mul_inv_cancel _ (by simp; omega), map_one]
 

--- a/HexTruncatedSeriesMathlib/Newton.lean
+++ b/HexTruncatedSeriesMathlib/Newton.lean
@@ -47,7 +47,7 @@ private theorem one_add_X_mul_geom [CommRing R] [Algebra ℚ R] :
               PowerSeries.mk (fun j => algebraMap ℚ R ((-1 : ℚ) ^ j))) =
             algebraMap ℚ R ((-1 : ℚ) ^ k) by
           simp,
-        PowerSeries.coeff_one, if_neg (by omega), ← map_add]
+        PowerSeries.coeff_one, _root_.ite_eq_right (by omega), ← map_add]
       rw [_root_.pow_succ]
       simp
 
@@ -84,7 +84,7 @@ theorem ofPowerSeries_subst [CommRing R] (f g : PowerSeries R)
     · rw [coeff_ofPowerSeries g 0 hn,
         PowerSeries.coeff_zero_eq_constantCoeff_apply, hg]
     · unfold Hex.TSeries.coeff
-      rw [dif_neg hn]
+      rw [_root_.dite_eq_right hn]
   rw [coeff_ofPowerSeries (f.subst g) i hi, comp_spec _ _ hg0,
     coeff_foldl_add (List.range n)
       (fun k => C ((ofPowerSeries (n := n) f).coeff k) *

--- a/HexTruncatedSeriesMathlib/Ops.lean
+++ b/HexTruncatedSeriesMathlib/Ops.lean
@@ -107,8 +107,8 @@ theorem mulXPow_ofPowerSeries [CommRing R] (f : PowerSeries R) (k : Nat) :
   rw [Hex.TSeries.coeff_mulXPow _ k i hi,
     coeff_ofPowerSeries _ i hi, PowerSeries.coeff_X_pow_mul']
   by_cases hki : k ≤ i
-  · rw [if_pos hki, if_pos hki, coeff_ofPowerSeries f (i - k) (by omega)]
-  · rw [if_neg hki, if_neg hki]
+  · rw [_root_.ite_eq_left hki, _root_.ite_eq_left hki, coeff_ofPowerSeries f (i - k) (by omega)]
+  · rw [_root_.ite_eq_right hki, _root_.ite_eq_right hki]
 
 /-- Coefficients of a truncated derivative agree with Mathlib's formal
 derivative wherever both are represented. -/

--- a/bench/HexPolyFp/Bench.lean
+++ b/bench/HexPolyFp/Bench.lean
@@ -212,7 +212,7 @@ theorem monicModulusFive_monic (degree : Nat) : DensePoly.Monic (monicModulusFiv
   by_cases h : (1 : ZMod64 5) = 0
   · exact False.elim (one_ne_zero_five h)
   · have h' : ¬ ((1 : ZMod64 5) = Zero.zero) := h
-    simp only [dif_neg h']
+    simp only [dite_eq_right h']
     simp [Array.getElem_push] <;> rfl
 
 /-- Deterministic monic modulus of degree `degree` over the large benchmark prime. -/

--- a/scripts/bench/proof_only_runtime_exemptions/hexarith-barrett-accumulator-lean-5463fd89-37049f16.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexarith-barrett-accumulator-lean-5463fd89-37049f16.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexArith/Barrett/Accumulator.lean",
+ "baseline_blob": "5463fd8910ec9aeba98c8c583854f0493dc7c37a",
+ "current_blob": "37049f16fd4de8d71e4fea95acf0da85bdf420ce",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexarith-montgomery-context-lean-6712bd70-96432dfb.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexarith-montgomery-context-lean-6712bd70-96432dfb.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexArith/Montgomery/Context.lean",
+ "baseline_blob": "6712bd70c3b7774cadef600f93cbe8bc83516972",
+ "current_blob": "96432dfbfd48de30418e99c170115b5d57c21edc",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexarith-montgomery-redc-lean-39866195-3e51b8b9.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexarith-montgomery-redc-lean-39866195-3e51b8b9.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexArith/Montgomery/Redc.lean",
+ "baseline_blob": "39866195d7cef0447ad34db13d8d53acb4239f69",
+ "current_blob": "3e51b8b921374e508004114e4d5839267603dc97",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexarith-nat-prime-lean-1bdbc090-79835bd4.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexarith-nat-prime-lean-1bdbc090-79835bd4.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexArith/Nat/Prime.lean",
+ "baseline_blob": "1bdbc0907db62e7a03c7c3b4a2e078d0541b6bb0",
+ "current_blob": "79835bd403b7f80148457fdaaa135ced6340ae5c",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexbareiss-bareiss-lean-1ff1f240-67fc1e5c.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexbareiss-bareiss-lean-1ff1f240-67fc1e5c.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexBareiss/Bareiss.lean",
+ "baseline_blob": "1ff1f240b0e5ea320e2ea200f1d272b60758becb",
+ "current_blob": "67fc1e5c12ce1ea2388f209b52c20b5842001ffc",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexbasic-rand-lean-aa8588a6-ae4a0ab7.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexbasic-rand-lean-aa8588a6-ae4a0ab7.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexBasic/Rand.lean",
+ "baseline_blob": "aa8588a6a6a6db3e4393346d885e1f81ccd2aaff",
+ "current_blob": "ae4a0ab74c3f7e4bdb6f05d56502803f5e037610",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-bhkscandidates-lean-05135a2a-a0231f1a.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-bhkscandidates-lean-05135a2a-a0231f1a.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexBerlekampZassenhaus/BhksCandidates.lean",
+ "baseline_blob": "05135a2a35ac6d6b8245115a4fb615997ce008a8",
+ "current_blob": "a0231f1a4f22137b2252b2641f9f32bcd18e3cb1",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-bhksrecover-lean-bd33611f-78585034.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-bhksrecover-lean-bd33611f-78585034.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexBerlekampZassenhaus/BhksRecover.lean",
+ "baseline_blob": "bd33611f871936792b705f418c317fea049fd644",
+ "current_blob": "78585034031f7343c72bf3c4c566f7a11bf6f2ee",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-certificate-lean-83887ccd-6750f621.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-certificate-lean-83887ccd-6750f621.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexBerlekampZassenhaus/Certificate.lean",
+ "baseline_blob": "83887ccd940bb0686d891b0b3ddf2a8000097234",
+ "current_blob": "6750f621a457e713f2265f6c20c7b5a99729aa1f",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-chooseprimedata-lean-2e79f0d0-71de107e.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-chooseprimedata-lean-2e79f0d0-71de107e.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexBerlekampZassenhaus/ChoosePrimeData.lean",
+ "baseline_blob": "2e79f0d0178c8165d812fb085a9aa6b929f2e60b",
+ "current_blob": "71de107e5e8857e27e715703ffcb7452dfbe7215",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-eisensteincriterion-lean-b9c6419e-425a59c2.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-eisensteincriterion-lean-b9c6419e-425a59c2.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexBerlekampZassenhaus/EisensteinCriterion.lean",
+ "baseline_blob": "b9c6419e089f2523ea212a9c59e3856ccdfeeb15",
+ "current_blob": "425a59c285a4f8f11667ff5a294e513f7c8323f0",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-factorirreducibility-lean-97656591-52061647.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-factorirreducibility-lean-97656591-52061647.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexBerlekampZassenhaus/FactorIrreducibility.lean",
+ "baseline_blob": "9765659116ef856d268ab95543ba867d4cb742da",
+ "current_blob": "520616474e51ca2ae7ddfc9db25ec1ac7a95710d",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-factorization-lean-bb06dd6b-c4c33cae.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-factorization-lean-bb06dd6b-c4c33cae.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexBerlekampZassenhaus/Factorization.lean",
+ "baseline_blob": "bb06dd6b8bade049d2ffc6e1844297e56bd23bff",
+ "current_blob": "c4c33cae7f28d527676b6790ef58e3efe6396e7d",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-factorizationresult-lean-3d1316b3-b610fe0f.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-factorizationresult-lean-3d1316b3-b610fe0f.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexBerlekampZassenhaus/FactorizationResult.lean",
+ "baseline_blob": "3d1316b3479b2b9a2d2bf73d5ee1a08154586147",
+ "current_blob": "b610fe0f477649f4f1ff9403f5a054046a0f0af2",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-factorproduct-lean-434110d3-7c13e67e.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-factorproduct-lean-434110d3-7c13e67e.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexBerlekampZassenhaus/FactorProduct.lean",
+ "baseline_blob": "434110d3de51c9ab3a747768bbe364f3ca47ffd3",
+ "current_blob": "7c13e67ef1db88b083d0b6cc066f147fb3c67a5f",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-irreducibledecide-lean-568d95df-467d6372.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-irreducibledecide-lean-568d95df-467d6372.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexBerlekampZassenhaus/IrreducibleDecide.lean",
+ "baseline_blob": "568d95dfceb706fd2f50b337ec8c12552b103e78",
+ "current_blob": "467d63722080f9322cfdcd8f13a7fa01a5dd7ef1",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-lattice-lean-1e7d3ff0-64d4dc39.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-lattice-lean-1e7d3ff0-64d4dc39.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexBerlekampZassenhaus/Lattice.lean",
+ "baseline_blob": "1e7d3ff08062a2e97617de2758353e24a2473116",
+ "current_blob": "64d4dc398199097dd73b045fc2ac7cd4f3df0238",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-modular-primeplan-lean-bc4d2026-86aae554.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-modular-primeplan-lean-bc4d2026-86aae554.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexBerlekampZassenhaus/Modular/PrimePlan.lean",
+ "baseline_blob": "bc4d2026af3dda89e2928c572570e4fb3866f8e8",
+ "current_blob": "86aae554c3798a8d2d425ddc4e319c64eb0bda17",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-primeselection-lean-a6fee73d-53f062d0.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-primeselection-lean-a6fee73d-53f062d0.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexBerlekampZassenhaus/PrimeSelection.lean",
+ "baseline_blob": "a6fee73d273564dc868986dd0bf70a2728ad66ef",
+ "current_blob": "53f062d0adf2cd9d53b427ed37fa3a155bffe4ad",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-primitivefactors-lean-6844218b-c10c19af.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-primitivefactors-lean-6844218b-c10c19af.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexBerlekampZassenhaus/PrimitiveFactors.lean",
+ "baseline_blob": "6844218b246fa70e85d247c7e1d8a5bf03266384",
+ "current_blob": "c10c19afb9d528dc406832428d083caeb8c7a5d3",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-quadraticfactors-lean-5a4e8f56-48cdf8d0.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-quadraticfactors-lean-5a4e8f56-48cdf8d0.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexBerlekampZassenhaus/QuadraticFactors.lean",
+ "baseline_blob": "5a4e8f56e14ef4a9fcddf090e7cd885a19c3bb69",
+ "current_blob": "48cdf8d0e34b420fc4e8c4c45b0a1b97b037f6de",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-quadraticnormrecover-lean-c6e07acf-29150d05.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-quadraticnormrecover-lean-c6e07acf-29150d05.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexBerlekampZassenhaus/QuadraticNormRecover.lean",
+ "baseline_blob": "c6e07acf6188001533bc070565e64d7afec73295",
+ "current_blob": "29150d05f8640ea66baca37cdf5e35d834825540",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-recombination-lean-6521c13f-d574f800.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-recombination-lean-6521c13f-d574f800.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexBerlekampZassenhaus/Recombination.lean",
+ "baseline_blob": "6521c13fc4eef16a5c5f0659ea2937d5a0c00aa3",
+ "current_blob": "d574f80061be6117b0296f3b9604f1c741e5722e",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-recombinationfactors-lean-d3abf1cc-0fbf7110.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-recombinationfactors-lean-d3abf1cc-0fbf7110.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexBerlekampZassenhaus/RecombinationFactors.lean",
+ "baseline_blob": "d3abf1cce3402232f8c5effe9d20b031a4f98ca4",
+ "current_blob": "0fbf71105de7f44e70175dc86ed79480a7e57dba",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-trialfactorization-lean-10f286f5-c82d9ef6.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-trialfactorization-lean-10f286f5-c82d9ef6.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexBerlekampZassenhaus/TrialFactorization.lean",
+ "baseline_blob": "10f286f545616103d874b5a92b71e87360ef174b",
+ "current_blob": "c82d9ef68fbe1e2df7165d9f3c3a0605c56599b4",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexhensel-linear-lean-0007811d-f4f9fc7a.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexhensel-linear-lean-0007811d-f4f9fc7a.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexHensel/Linear.lean",
+ "baseline_blob": "0007811df443d1459f11b55d0426ff254bdb3931",
+ "current_blob": "f4f9fc7a4f3902ed354a67309dde7e50a3a3a120",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexhensel-modulardivision-lean-116b4fb3-5c38fe22.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexhensel-modulardivision-lean-116b4fb3-5c38fe22.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexHensel/ModularDivision.lean",
+ "baseline_blob": "116b4fb3095f9bfc06bff7f34a886dddb4fbf035",
+ "current_blob": "5c38fe22f8eef067916567f53d3c6306c4c3b360",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexhensel-modularpolynomial-lean-365863b3-33f14c3f.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexhensel-modularpolynomial-lean-365863b3-33f14c3f.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexHensel/ModularPolynomial.lean",
+ "baseline_blob": "365863b33c3db420f5e2115fb4064f962278ab65",
+ "current_blob": "33f14c3f18316921e4d6bc80feb2a78cea906d58",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexhensel-quadratic-lean-538ba40c-9f6f4fa2.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexhensel-quadratic-lean-538ba40c-9f6f4fa2.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexHensel/Quadratic.lean",
+ "baseline_blob": "538ba40c06fed7d90f726c415eaccb032544284c",
+ "current_blob": "9f6f4fa2bf9a55ff17447c4ad3b7d48691e273bd",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexhensel-quadraticmultifactor-lean-2eff8277-e2d09488.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexhensel-quadraticmultifactor-lean-2eff8277-e2d09488.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexHensel/QuadraticMultifactor.lean",
+ "baseline_blob": "2eff8277884c01294d4e6c8afb1d4274d32fd885",
+ "current_blob": "e2d09488e36f9edec2a45ac7abbe097797b03a9e",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexhensel-wordtransport-lean-aac8269b-597867b2.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexhensel-wordtransport-lean-aac8269b-597867b2.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexHensel/WordTransport.lean",
+ "baseline_blob": "aac8269baf1471275c2eaf52e979f7a0b1ec92ff",
+ "current_blob": "597867b2a55d4b92e152383adf67b30913915f42",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexlll-native-lean-2b4bc50e-406e80a9.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexlll-native-lean-2b4bc50e-406e80a9.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexLLL/Native.lean",
+ "baseline_blob": "2b4bc50e79d04397228550c7dacb426b35e9cc37",
+ "current_blob": "406e80a9f91a85f89aa84502fb8b09161b95d180",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexmatrix-basic-lean-76cf5715-d9e73a19.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexmatrix-basic-lean-76cf5715-d9e73a19.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexMatrix/Basic.lean",
+ "baseline_blob": "76cf5715027bfc7994f51e734b5bcb74a94ca047",
+ "current_blob": "d9e73a1912f20e777575abf25c03e6bfe00cc412",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexmatrix-diagonal-lean-1e4257b3-3d982cb7.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexmatrix-diagonal-lean-1e4257b3-3d982cb7.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexMatrix/Diagonal.lean",
+ "baseline_blob": "1e4257b3bcd214f71082004f05763b9d9cc64af7",
+ "current_blob": "3d982cb7d9298f32c17e12b53a38f79910e3c298",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexmatrix-dotproduct-lean-268063dc-4b823b3f.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexmatrix-dotproduct-lean-268063dc-4b823b3f.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexMatrix/DotProduct.lean",
+ "baseline_blob": "268063dc164c6137f6306824ae71580da4cbe5a7",
+ "current_blob": "4b823b3f77e37b7f6fff87bbb974d2aee75284af",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexmatrix-elementary-lean-349c04a4-ee51555d.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexmatrix-elementary-lean-349c04a4-ee51555d.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexMatrix/Elementary.lean",
+ "baseline_blob": "349c04a42e99fbe0b390fd11b2366e7e0a623ef4",
+ "current_blob": "ee51555dfefd6c58faa2def9afa8c98e40d9dc9d",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexmatrix-elementaryalgebra-lean-e4feb098-7319cb57.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexmatrix-elementaryalgebra-lean-e4feb098-7319cb57.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexMatrix/ElementaryAlgebra.lean",
+ "baseline_blob": "e4feb098af140d14ddfad696d546aa9cc2de0ada",
+ "current_blob": "7319cb57eb638be8bc4fd82a269c0b5fb4a89482",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexmatrix-gram-lean-e102edd9-4094f87e.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexmatrix-gram-lean-e102edd9-4094f87e.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexMatrix/Gram.lean",
+ "baseline_blob": "e102edd94787b0ade9a3b48ee594609fc6eabda6",
+ "current_blob": "4094f87ea847c3848e3108b68b039f76c0d09609",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexmatrix-lattice-lean-14f093c3-123b6cce.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexmatrix-lattice-lean-14f093c3-123b6cce.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexMatrix/Lattice.lean",
+ "baseline_blob": "14f093c3941384cbf0bb826a9936ff354f41e3ee",
+ "current_blob": "123b6cced8cba585f3d77f08aa65bd1795dc1846",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexmatrix-matrixalgebra-lean-6c5546ac-7be2254e.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexmatrix-matrixalgebra-lean-6c5546ac-7be2254e.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexMatrix/MatrixAlgebra.lean",
+ "baseline_blob": "6c5546acf86fdf33cbae4ef422ad17af82eb88f9",
+ "current_blob": "7be2254ea732a2e52a3945ca0c31f870ed3c8a9b",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexmatrix-pad-lean-91429f59-6a0cf098.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexmatrix-pad-lean-91429f59-6a0cf098.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexMatrix/Pad.lean",
+ "baseline_blob": "91429f59185793028ce9f8aedf2324f982817cde",
+ "current_blob": "6a0cf098f7b84ab1731d4beb170713a48e7f0fae",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexmatrix-strassen-lean-3983ff60-9d594e04.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexmatrix-strassen-lean-3983ff60-9d594e04.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexMatrix/Strassen.lean",
+ "baseline_blob": "3983ff6052b10c7e406d1c066252ab37063db688",
+ "current_blob": "9d594e041dd6dd932ad867a4351e589534b900f4",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexmatrix-submatrix-lean-b001d667-6b407d73.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexmatrix-submatrix-lean-b001d667-6b407d73.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexMatrix/Submatrix.lean",
+ "baseline_blob": "b001d6674a02adb64a78cba57c7596a1d021bc20",
+ "current_blob": "6b407d7310c15dd6419ccf6e448e47dc40649bca",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexmodarith-ntt-convolution-lean-4bb8fe5b-4d68a5cd.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexmodarith-ntt-convolution-lean-4bb8fe5b-4d68a5cd.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexModArith/Ntt/Convolution.lean",
+ "baseline_blob": "4bb8fe5b16d02db7852cf29dfb6606d17617bdcd",
+ "current_blob": "4d68a5cddf67990cbc7e0bb7ac7ffcec3b70d1a8",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexmodarith-residue-lean-26e8b637-2e8dc7a9.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexmodarith-residue-lean-26e8b637-2e8dc7a9.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexModArith/Residue.lean",
+ "baseline_blob": "26e8b637086e9493ad19930d9b9aa5ce1dda4c24",
+ "current_blob": "2e8dc7a9a8cd5682bb51842b51275eead3ec0055",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexmodarith-ring-lean-d6268df4-572bd487.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexmodarith-ring-lean-d6268df4-572bd487.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexModArith/Ring.lean",
+ "baseline_blob": "d6268df4b91cceffe40a3f4e5be556862510234d",
+ "current_blob": "572bd48723e1bb1b5eac544bdf950f9ac3759e31",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexmodarith-wordmod-lean-f811408c-791c19ee.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexmodarith-wordmod-lean-f811408c-791c19ee.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexModArith/WordMod.lean",
+ "baseline_blob": "f811408ca15045c071f7f671587a7dd556e0b8b9",
+ "current_blob": "791c19eed7a203e0ebc8c8fce0265aebf88f30e6",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexpolyfp-compose-lean-79fe5d28-d681bc47.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexpolyfp-compose-lean-79fe5d28-d681bc47.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexPolyFp/Compose.lean",
+ "baseline_blob": "79fe5d281f3009f42744ff252d82ec2d47ee2ccf",
+ "current_blob": "d681bc47f06b65c45651f73e30af5593b5b5ccae",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexpolyfp-enumeration-lean-2c9b3462-52dcb086.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexpolyfp-enumeration-lean-2c9b3462-52dcb086.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexPolyFp/Enumeration.lean",
+ "baseline_blob": "2c9b34622bce2e5510692187d7f2370d96a16791",
+ "current_blob": "52dcb086e516d615bc516b266f76dada9a9f9be2",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexpolyfp-frobenius-lean-1a213334-d6c64e08.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexpolyfp-frobenius-lean-1a213334-d6c64e08.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexPolyFp/Frobenius.lean",
+ "baseline_blob": "1a213334362800de936d821c3f625d9958054fe2",
+ "current_blob": "d6c64e0880c0cda795c172feb17012734a0fec99",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexpolyfp-packed-lean-58fe8d71-b07fc4c5.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexpolyfp-packed-lean-58fe8d71-b07fc4c5.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexPolyFp/Packed.lean",
+ "baseline_blob": "58fe8d715d30ad4f0647653c18302e35757eac8b",
+ "current_blob": "b07fc4c59be0f81b7a0b7cf4995731797e3c4c65",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexpolyfp-packedmul-lean-67a156ff-eae7391f.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexpolyfp-packedmul-lean-67a156ff-eae7391f.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexPolyFp/PackedMul.lean",
+ "baseline_blob": "67a156fffbe741e1b6e9de4686facd5329ca4065",
+ "current_blob": "eae7391f6c9904856d816c50a2d30fedc1964e2a",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexpolyfp-quotient-lean-efb7321b-6f59a51b.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexpolyfp-quotient-lean-efb7321b-6f59a51b.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexPolyFp/Quotient.lean",
+ "baseline_blob": "efb7321b2d8299e727a0e60c3a0cfca1f9cc7bd1",
+ "current_blob": "6f59a51b3aa55e96aa3b556a1676090561d6c254",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexpolyfp-quotient-ring-lean-08910520-417d8e86.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexpolyfp-quotient-ring-lean-08910520-417d8e86.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexPolyFp/Quotient/Ring.lean",
+ "baseline_blob": "08910520465148cad18733c811e789baf3a8ab8f",
+ "current_blob": "417d8e8692b99db1da247f94a024ecafcb80018b",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexpolyfp-quotientfrobenius-lean-cbef5cd3-4a747bc8.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexpolyfp-quotientfrobenius-lean-cbef5cd3-4a747bc8.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexPolyFp/QuotientFrobenius.lean",
+ "baseline_blob": "cbef5cd34b581e312d21c2f76da11d6989b2aa6a",
+ "current_blob": "4a747bc8865cad1f4bdd444d37b8e596c003f477",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexpolyfp-ring-lean-76f6b1eb-ecae2c81.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexpolyfp-ring-lean-76f6b1eb-ecae2c81.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexPolyFp/Ring.lean",
+ "baseline_blob": "76f6b1eb60eb0f2e95a94dd4be9671a04a75c2a5",
+ "current_blob": "ecae2c81fcddd76d79a7dd5ee60aeb9f433be3d4",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexpolyfp-squarefree-algebra-lean-f73ccb41-6d6ec6ff.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexpolyfp-squarefree-algebra-lean-f73ccb41-6d6ec6ff.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexPolyFp/SquareFree/Algebra.lean",
+ "baseline_blob": "f73ccb41e43a74fe21a82821848a24a962780a39",
+ "current_blob": "6d6ec6ffc6a30edaff0e5fe0ebb56f34b275f0d5",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexpolyfp-squarefree-yuncorrect-lean-801aa017-8b84551b.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexpolyfp-squarefree-yuncorrect-lean-801aa017-8b84551b.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexPolyFp/SquareFree/YunCorrect.lean",
+ "baseline_blob": "801aa0178d3a30031cf3510524a802351325c825",
+ "current_blob": "8b84551b4835a0d6754476a525a4f75431b59fe6",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexpolyfp-squarefree-yunmeasure-lean-d94c73ce-348dbce4.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexpolyfp-squarefree-yunmeasure-lean-d94c73ce-348dbce4.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexPolyFp/SquareFree/YunMeasure.lean",
+ "baseline_blob": "d94c73cebf620b91c2901c4dadb8c6a7ef75f5be",
+ "current_blob": "348dbce4c17bfed941fe0de818d48c46d430637c",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexpolyz-decomposition-lean-275022cc-e301d669.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexpolyz-decomposition-lean-275022cc-e301d669.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexPolyZ/Decomposition.lean",
+ "baseline_blob": "275022ccb5ce74a3bac17daa81a2ede16fe7e963",
+ "current_blob": "e301d6696fd3898969ee97fed31a04a02eff2f17",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexpolyz-integerpolynomial-lean-2a98177e-cbb73fbe.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexpolyz-integerpolynomial-lean-2a98177e-cbb73fbe.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexPolyZ/IntegerPolynomial.lean",
+ "baseline_blob": "2a98177eb8b631f974050c535d88e96cd0ccdcd6",
+ "current_blob": "cbb73fbeea543a0c31b529b31fb9454a250ead07",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexpolyz-kronecker-lean-1e4bcbf4-732857bd.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexpolyz-kronecker-lean-1e4bcbf4-732857bd.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexPolyZ/Kronecker.lean",
+ "baseline_blob": "1e4bcbf4f376e1885e97f3cd1710a211ba6e24ea",
+ "current_blob": "732857bdcc110866c697deb70d6afdd382f429c2",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexpolyz-mignotte-lean-dad60376-5a526eb5.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexpolyz-mignotte-lean-dad60376-5a526eb5.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexPolyZ/Mignotte.lean",
+ "baseline_blob": "dad60376ea46b628e1fb96a578455851200e4c7a",
+ "current_blob": "5a526eb542b053b229f2f1536b3a875988eb1d44",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexpolyz-rational-lean-5495375e-a32953c6.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexpolyz-rational-lean-5495375e-a32953c6.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexPolyZ/Rational.lean",
+ "baseline_blob": "5495375e8339591996f2607e4a858f48e09a80b2",
+ "current_blob": "a32953c66adbff4207d98a982e5420d5505fa91b",
+ "reason": "Renames the conditional-reduction lemmas Lean 4.34 deprecates (if_pos, if_neg, dif_pos, dif_neg, if_true, if_false) to their successors ite_eq_left, ite_eq_right, dite_eq_left, dite_eq_right, ite_true, ite_false. The successors have identical statements and argument structure, and every edit is inside a proof; no definition and no factorization-service runtime path changes."
+}


### PR DESCRIPTION
This PR replaces every use of the conditional-reduction lemmas Lean 4.34 deprecates. `if_pos`, `if_neg`, `dif_pos`, `dif_neg`, `if_true` and `if_false` become `ite_eq_left`, `ite_eq_right`, `dite_eq_left`, `dite_eq_right`, `ite_true` and `ite_false`; the successors have identical statements and argument structure, so the rewrite is mechanical. A handful of Mathlib renames ride along: `Set.mem_setOf_eq`, `Set.compl_setOf`, `Prime.not_unit`, `Matrix.det_of_upperTriangular` and `continuousOn_iff_continuous_restrict`.

`HexBasic/Conditional.lean` and `HexPoly/Conditional.lean` declare shims under the successors' names, so the `*Mathlib` files that `open Hex` from outside the `Hex` namespace now qualify with `_root_.` to pick core's lemma. Those shims were introduced for the 4.33/4.34 transition and are now redundant; removing them is left for a follow-up.

That accounts for 3051 of the build's warnings.

🤖 Prepared with Claude Code