### PR TITLE
style: prefer `have`/`let` over `haveI`/`letI` in proposition-valued goals

### DIFF
--- a/HexBerlekampMathlib/Irreducibility.lean
+++ b/HexBerlekampMathlib/Irreducibility.lean
@@ -210,7 +210,7 @@ theorem irreducible_dvd_frobeniusPolynomial_of_natDegree_dvd
   have : Module.Finite (ZMod p) (AdjoinRoot g) :=
     (AdjoinRoot.powerBasis hg_ne_zero).finite
   have : Finite (AdjoinRoot g) := Module.finite_of_finite (ZMod p)
-  letI : Fintype (AdjoinRoot g) := Fintype.ofFinite _
+  let : Fintype (AdjoinRoot g) := Fintype.ofFinite _
   have hcard : Fintype.card (AdjoinRoot g) = p ^ g.natDegree := by
     rw [← Nat.card_eq_fintype_card,
         ← FiniteField.pow_finrank_eq_natCard p (AdjoinRoot g),

--- a/HexBerlekampZassenhausMathlib/BadVector.lean
+++ b/HexBerlekampZassenhausMathlib/BadVector.lean
@@ -741,8 +741,8 @@ theorem coord_cast_eq_zero_of_liftedFactor_dvd_cldCombination
           (Int.castRingHom (ZMod (p ^ a)))) :
     ((v[Fin.castAdd (f.degree?.getD 0) i₀] : ℤ) : ZMod (p ^ a)) = 0 := by
   classical
-  letI : Fact (1 < p ^ a) := ⟨hk⟩
-  haveI : Nontrivial (ZMod (p ^ a)) := inferInstance
+  let : Fact (1 < p ^ a) := ⟨hk⟩
+  have : Nontrivial (ZMod (p ^ a)) := inferInstance
   let φ := Int.castRingHom (ZMod (p ^ a))
   let q₀ := (HexPolyZMathlib.toPolynomial
     (liftedFactors.getD i₀.val 1)).map φ
@@ -893,7 +893,7 @@ theorem isCoprime_cldQuotientMod
         (Hex.cldQuotientMod f q p a)).map
           (Int.castRingHom (ZMod (p ^ a)))) := by
   classical
-  letI : Fact (1 < p ^ a) := ⟨hk⟩
+  let : Fact (1 < p ^ a) := ⟨hk⟩
   let φ := Int.castRingHom (ZMod (p ^ a))
   let Q := (HexPolyZMathlib.toPolynomial q).map φ
   let H := (HexPolyZMathlib.toPolynomial h).map φ

--- a/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
+++ b/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
@@ -544,7 +544,7 @@ theorem cldQuotientMod_congr_mul_derivative
       (g * Hex.cldQuotientMod input g p k)
       (input * Hex.DensePoly.derivative g) (p ^ k) := by
   have hpk_pos : 0 < p ^ k := by omega
-  haveI : Fact (1 < p ^ k) := ⟨hk⟩
+  have : Fact (1 < p ^ k) := ⟨hk⟩
   -- Executable quotient / remainder of the monic division underlying `cldQuotientMod`.
   set num : Hex.ZPoly :=
     Hex.ZPoly.reduceModPow (input * Hex.DensePoly.derivative g) p k with hnum

--- a/HexBerlekampZassenhausMathlib/Classical/Factorization.lean
+++ b/HexBerlekampZassenhausMathlib/Classical/Factorization.lean
@@ -660,7 +660,7 @@ theorem factorDirectCoreOfPlan_factored
       omega
     rw [hk, pow_zero] at hrecover
     omega
-  letI := modular.data.bounds
+  let := modular.data.bounds
   have hadm :
       Hex.leadingCoeffAdmissible core.poly modular.data.p :=
     Hex.isGoodPrime_leadingCoeffAdmissible core.poly modular.data.p

--- a/HexBerlekampZassenhausMathlib/Classical/Recovery.lean
+++ b/HexBerlekampZassenhausMathlib/Classical/Recovery.lean
@@ -128,7 +128,7 @@ theorem directScaledProduct_congr_of_modP_support
       (Hex.DensePoly.scale
         (Hex.DensePoly.leadingCoeff cofactor) factor)
       (d.p ^ d.k) := by
-  letI := data.bounds
+  let := data.bounds
   let k := Hex.precisionForCoeffBound B data.p
   let d := Hex.ZPoly.directLiftData core B data
   let T : LiftedFactorSubset d :=
@@ -205,7 +205,7 @@ theorem directCandidate_eq_of_modP_support
           (Hex.ZPoly.monicTarget core data.p
             (Hex.precisionForCoeffBound B data.p))
           (Hex.precisionForCoeffBound B data.p) data) S) = factor := by
-  letI := data.bounds
+  let := data.bounds
   let k := Hex.precisionForCoeffBound B data.p
   let d := Hex.ZPoly.directLiftData core B data
   let T : LiftedFactorSubset d :=

--- a/HexBerlekampZassenhausMathlib/Classical/SupportPartition.lean
+++ b/HexBerlekampZassenhausMathlib/Classical/SupportPartition.lean
@@ -58,7 +58,7 @@ theorem modPFactorSubset_disjoint_of_modPFactorization
       ¬ Associated (HexPolyZMathlib.toPolynomial f)
         (HexPolyZMathlib.toPolynomial g)) :
     Disjoint S T := by
-  letI := data.bounds
+  let := data.bounds
   have hcore_modP_nz :
       (@Hex.ZPoly.modP data.p data.bounds core).isZero = false :=
     Hex.isGoodPrime_modP_isZero_false core data.p hval.good
@@ -137,8 +137,8 @@ theorem directSupportCandidate_map_associated
       ((HexPolyZMathlib.toPolynomial
         (liftedFactorProduct d T)).map
           (Int.castRingHom (ZMod data.p))) := by
-  letI := data.bounds
-  letI : Fact (_root_.Nat.Prime data.p) :=
+  let := data.bounds
+  let : Fact (_root_.Nat.Prime data.p) :=
     ⟨natPrime_of_hexNatPrime hprime⟩
   let d := Hex.ZPoly.directLiftData core B data
   let T := liftedSubsetOfModPSubset data d
@@ -245,8 +245,8 @@ theorem modPSubset_subset_of_product_dvd
           (modPFactorProduct data T)) :
     S ⊆ T := by
   classical
-  letI := data.bounds
-  letI : Fact (_root_.Nat.Prime data.p) :=
+  let := data.bounds
+  let : Fact (_root_.Nat.Prime data.p) :=
     ⟨natPrime_of_hexNatPrime hval.prime⟩
   have hinj :=
     toMathlibPolynomial_modPFactor_injective_of_modPFactorization
@@ -288,7 +288,7 @@ theorem directSupport_subset_of_dvd
     (hrecover : directSupportCandidate core B data S = factor)
     (hdvd : factor ∣ directSupportCandidate core B data T) :
     S ⊆ T := by
-  letI := data.bounds
+  let := data.bounds
   have hcand_dvd :
       (HexPolyZMathlib.toPolynomial
         (directSupportCandidate core B data S)).map
@@ -496,7 +496,7 @@ theorem directSupportPartition_initial
     (hgcd : Int.gcd (Hex.DensePoly.leadingCoeff core)
       (Int.ofNat (data.p ^ Hex.precisionForCoeffBound B data.p)) = 1) :
     DirectSupportPartition core B data Finset.univ core := by
-  letI := data.bounds
+  let := data.bounds
   have hpart :=
     modPSubsetPartitionHypotheses_of_modPFactorization
       core data hcore_degree_pos hval
@@ -601,8 +601,8 @@ theorem DirectSupportPartition.factorDvdCandidate
       directSupportCandidate core B data T ∣ target) :
     factor ∣ directSupportCandidate core B data T := by
   classical
-  letI := data.bounds
-  letI : Fact (_root_.Nat.Prime data.p) :=
+  let := data.bounds
+  let : Fact (_root_.Nat.Prime data.p) :=
     ⟨natPrime_of_hexNatPrime hval.prime⟩
   let cast := Int.castRingHom (ZMod data.p)
   let candidate := directSupportCandidate core B data T

--- a/HexBerlekampZassenhausMathlib/ForwardHenselTransport.lean
+++ b/HexBerlekampZassenhausMathlib/ForwardHenselTransport.lean
@@ -124,8 +124,8 @@ theorem representsMonicTarget_of_represents
     (hrep : RepresentsIntegerFactorModP primeData factor S) :
     RepresentsIntegerFactorModP primeData
       (Hex.ZPoly.monicTarget factor primeData.p k) S := by
-  letI := primeData.bounds
-  letI : Hex.ZMod64.PrimeModulus primeData.p :=
+  let := primeData.bounds
+  let : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
   have hp : 1 < primeData.p := hprime.one_lt
   have htarget_monic :
@@ -193,9 +193,9 @@ theorem henselLiftData_represents_lifted_of_modP
     RepresentsIntegerFactorAtLift core (Hex.henselLiftData core B primeData) factor
       (liftedSubsetOfModPSubset primeData (Hex.henselLiftData core B primeData)
         (henselLiftData_liftedFactors_size_eq core B primeData) S) := by
-  letI := primeData.bounds
-  haveI hprime_fact : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
-  letI : Hex.ZMod64.PrimeModulus primeData.p :=
+  let := primeData.bounds
+  have hprime_fact : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
+  let : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime
       (by
         constructor
@@ -279,7 +279,7 @@ theorem henselLiftData_represents_lifted_of_modP
     rw [show liftedS = liftedSubsetOfModPSubset primeData d hsize S from rfl,
       h1, h2, h3, h4]
   -- Derive `hdeg` from `hg1` and monicness via `Monic.natDegree_map`.
-  haveI : Nontrivial (ZMod primeData.p) := inferInstance
+  have : Nontrivial (ZMod primeData.p) := inferInstance
   have hdeg : g.natDegree = g'.natDegree := by
     have hg_map_natDeg :
         (g.map (Int.castRingHom (ZMod primeData.p))).natDegree = g.natDegree :=
@@ -422,9 +422,9 @@ theorem henselLiftData_liftedSubset_congr_of_modP
         (liftedSubsetOfModPSubset primeData (Hex.henselLiftData target B primeData)
           (henselLiftData_liftedFactors_size_eq target B primeData) S))
       factor (primeData.p ^ B) := by
-  letI := primeData.bounds
-  haveI hprime_fact : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
-  letI : Hex.ZMod64.PrimeModulus primeData.p :=
+  let := primeData.bounds
+  have hprime_fact : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
+  let : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime
       (by
         constructor
@@ -506,7 +506,7 @@ theorem henselLiftData_liftedSubset_congr_of_modP
         (HexPolyZMathlib.toPolynomial factor).map (Int.castRingHom (ZMod primeData.p))
     rw [show liftedS = liftedSubsetOfModPSubset primeData d hsize S from rfl,
       h1, h2, h3, h4]
-  haveI : Nontrivial (ZMod primeData.p) := inferInstance
+  have : Nontrivial (ZMod primeData.p) := inferInstance
   have hdeg : g.natDegree = g'.natDegree := by
     have hg_map_natDeg :
         (g.map (Int.castRingHom (ZMod primeData.p))).natDegree = g.natDegree :=
@@ -626,7 +626,7 @@ theorem directLiftData_subset_congr_monicTarget
         (Hex.precisionForCoeffBound B primeData.p))
       ((Hex.ZPoly.directLiftData core B primeData).p ^
         (Hex.ZPoly.directLiftData core B primeData).k) := by
-  letI := primeData.bounds
+  let := primeData.bounds
   set precision := Hex.precisionForCoeffBound B primeData.p with hprecision_def
   set target := Hex.ZPoly.monicTarget core primeData.p precision with htarget_def
   set monicFactor := Hex.ZPoly.monicTarget factor primeData.p precision with hfactor_def

--- a/HexBerlekampZassenhausMathlib/Hensel/DirectLift.lean
+++ b/HexBerlekampZassenhausMathlib/Hensel/DirectLift.lean
@@ -154,7 +154,7 @@ theorem directLiftFacts
     (hgcd : Int.gcd (Hex.DensePoly.leadingCoeff core)
       (Int.ofNat (data.p ^ Hex.precisionForCoeffBound B data.p)) = 1) :
     DirectLiftFacts core B data := by
-  letI := data.bounds
+  let := data.bounds
   set k := Hex.precisionForCoeffBound B data.p with hk
   set target := Hex.ZPoly.monicTarget core data.p k with htarget
   have hp : 1 < data.p := hval.prime.one_lt

--- a/HexBerlekampZassenhausMathlib/Hensel/LiftedFactors.lean
+++ b/HexBerlekampZassenhausMathlib/Hensel/LiftedFactors.lean
@@ -118,7 +118,7 @@ theorem henselLiftData_liftedFactors_size_eq
     (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData) :
     (Hex.henselLiftData core B primeData).liftedFactors.size =
       primeData.factorsModP.size := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   show (Hex.ZPoly.multifactorLiftQuadratic primeData.p B core
         (primeData.factorsModP.map Hex.FpPoly.liftToZ)).size
       = primeData.factorsModP.size
@@ -162,7 +162,7 @@ theorem henselLiftData_liftedFactor_monic
     ∀ i : Fin (Hex.henselLiftData core B primeData).liftedFactors.size,
       Hex.DensePoly.Monic
         (Hex.henselLiftData core B primeData).liftedFactors[i] := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   intro i
   exact Hex.ZPoly.multifactorLiftQuadratic_each_monic
     primeData.p B core
@@ -207,7 +207,7 @@ theorem henselLiftData_liftedFactor_monic_of_choosePrimeData
     ∀ i : Fin (Hex.henselLiftData core B primeData).liftedFactors.size,
       Hex.DensePoly.Monic
         (Hex.henselLiftData core B primeData).liftedFactors[i] := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   have hinv :
       Hex.ZPoly.QuadraticMultifactorLiftInvariant
         primeData.p B core
@@ -254,7 +254,7 @@ theorem henselLiftData_liftedFactor_injective
     (hfactorsModP_nodup : primeData.factorsModP.toList.Nodup) :
     Function.Injective
       (liftedFactor (Hex.henselLiftData core B primeData)) := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   -- The lifted-factor array equals the multifactor output by definition of
   -- `Hex.henselLiftData`. We name a local abbreviation for the multifactor output
   -- to thread index reasoning through both views.

--- a/HexBerlekampZassenhausMathlib/IntReductionMod/Descent.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod/Descent.lean
@@ -118,7 +118,7 @@ theorem irreducible_of_isPrimitive_of_irreducible_map_intCast_zmod
       (Int.castRingHom (ZMod p)) f.leadingCoeff ≠ 0)
     (hirr : Irreducible (f.map (Int.castRingHom (ZMod p)))) :
     Irreducible f := by
-  haveI : IsDomain (ZMod p) := inferInstance
+  have : IsDomain (ZMod p) := inferInstance
   set φ : ℤ →+* ZMod p := Int.castRingHom (ZMod p) with hφ_def
   refine ⟨?_, ?_⟩
   · intro hunit
@@ -268,7 +268,7 @@ theorem Hex_ZPoly_Irreducible_of_primeChoice_fModP
         (@HexBerlekampMathlib.toMathlibPolynomial primeData.p
           primeData.bounds primeData.fModP)) :
     Hex.ZPoly.Irreducible core := by
-  letI := primeData.bounds
+  let := primeData.bounds
   refine Hex_ZPoly_Irreducible_of_irreducible_modP
     (p := primeData.p) (core := core) hprim hlc_map_ne ?_
   simpa [hfModP_eq] using hirr_fModP
@@ -301,7 +301,7 @@ theorem squareFreeCore_irreducible_of_small_mod_singleton
         (@HexBerlekampMathlib.toMathlibPolynomial primeData.p
           primeData.bounds primeData.fModP)) :
     Hex.ZPoly.Irreducible core := by
-  haveI : Fact (Nat.Prime primeData.p) := ⟨hprime⟩
+  have : Fact (Nat.Prime primeData.p) := ⟨hprime⟩
   exact Hex_ZPoly_Irreducible_of_primeChoice_fModP
     (primeData := primeData)
     (core := core)
@@ -529,20 +529,20 @@ theorem irreducible_of_smallMod_form
           (@Hex.monicModularImage primeData.p primeData.bounds
             (@Hex.ZPoly.modP primeData.p primeData.bounds core)))) = true) :
     Hex.ZPoly.Irreducible core := by
-  letI := primeData.bounds
+  let := primeData.bounds
   have hprime : _root_.Nat.Prime primeData.p := by
     refine _root_.Nat.prime_def_lt.mpr ⟨hprime_hex.two_le, ?_⟩
     intro m hmlt hmdvd
     rcases hprime_hex.right m hmdvd with h | h
     · exact h
     · exact absurd h (Nat.ne_of_lt hmlt)
-  haveI : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
-  letI : Hex.ZMod64.PrimeModulus primeData.p := Hex.ZMod64.primeModulusOfPrime hprime_hex
+  have : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
+  let : Hex.ZMod64.PrimeModulus primeData.p := Hex.ZMod64.primeModulusOfPrime hprime_hex
   have hformCopy := hform
   obtain ⟨_, hzero, hfactors_eq⟩ := hformCopy
   let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime_hex
-  letI := hfield
+  let := hfield
   -- Translate factorsModP.size ≤ 1 into bfact.factors.length ≤ 1.
   have hfactors_len_le :
       (@Hex.Berlekamp.berlekampFactor primeData.p primeData.bounds
@@ -664,7 +664,7 @@ theorem irreducible_of_smallMod
       (Int.castRingHom (ZMod primeData.p))
         (HexPolyZMathlib.toPolynomial core).leadingCoeff ≠ 0) :
     Hex.ZPoly.Irreducible core := by
-  letI := primeData.bounds
+  let := primeData.bounds
   have hsquareFree : Hex.squareFreeModP core primeData.p :=
     Hex.isGoodPrime_squareFreeModP core primeData.p hgood
   have hsquareFree_modP :
@@ -681,7 +681,7 @@ theorem irreducible_of_smallMod
     rcases hprime_hex.right m hmdvd with h | h
     · exact h
     · exact absurd h (Nat.ne_of_lt hmlt)
-  haveI : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
+  have : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
   have hsquareFree_monic :
       Hex.gcdIsUnit
         (Hex.DensePoly.gcd
@@ -715,7 +715,7 @@ theorem squarefree_toMathlibPolynomial_monicModPImage_of_goodPrime
       (@HexBerlekampMathlib.toMathlibPolynomial primeData.p primeData.bounds
         (@monicModPImage primeData.p primeData.bounds
           (@Hex.ZPoly.modP primeData.p primeData.bounds core))) := by
-  letI := primeData.bounds
+  let := primeData.bounds
   have hsquareFree : Hex.squareFreeModP core primeData.p :=
     Hex.isGoodPrime_squareFreeModP core primeData.p hgood
   have hsquareFree_modP :
@@ -732,7 +732,7 @@ theorem squarefree_toMathlibPolynomial_monicModPImage_of_goodPrime
     rcases hprime_hex.right m hmdvd with h | h
     · exact h
     · exact absurd h (Nat.ne_of_lt hmlt)
-  haveI : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
+  have : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
   have hsquareFree_monic :
       Hex.gcdIsUnit
         (Hex.DensePoly.gcd
@@ -1160,7 +1160,7 @@ theorem choosePrimeData?_leadingCoeff_castRingHom_ne_zero
     (hselected : Hex.choosePrimeData? f = some primeData) :
     (Int.castRingHom (ZMod primeData.p))
         (HexPolyZMathlib.toPolynomial f).leadingCoeff ≠ 0 := by
-  letI := primeData.bounds
+  let := primeData.bounds
   exact
     leadingCoeff_castRingHom_ne_zero_of_isGoodPrime f
       (Hex.choosePrimeData?_isGoodPrime f primeData hselected)
@@ -1220,7 +1220,7 @@ the result without needing coprimality of `x` and `y`.
 private lemma dvd_gcd_mul_gcd_of_dvd_mul {α : Type*} [EuclideanDomain α]
     [DecidableEq α] {g x y : α} (h : g ∣ x * y) :
     g ∣ EuclideanDomain.gcd g x * EuclideanDomain.gcd g y := by
-  letI : GCDMonoid α := EuclideanDomain.gcdMonoid α
+  let : GCDMonoid α := EuclideanDomain.gcdMonoid α
   show g ∣ gcd g x * gcd g y
   have h1 : g ∣ gcd g x * y := dvd_gcd_mul_of_dvd_mul h
   rw [mul_comm] at h1

--- a/HexBerlekampZassenhausMathlib/IrreducibilityCertificate.lean
+++ b/HexBerlekampZassenhausMathlib/IrreducibilityCertificate.lean
@@ -104,7 +104,7 @@ private theorem natDegree_toMathlibPolynomial_factorPolys_eq
     letI := primeData.bounds
     (HexBerlekampMathlib.toMathlibPolynomial primeData.factorPolys[i]).natDegree =
       primeData.factorDegrees[i] := by
-  letI := primeData.bounds
+  let := primeData.bounds
   have hpair :=
     checkCertAtFactor_of_checkFactorCerts primeData hcheck i hi_deg hi_polys hi_certs
   have hdegree :
@@ -219,8 +219,8 @@ theorem checkIrreducibleCert_sound
           exact List.mem_of_mem_drop hmem_drop
       -- Extract `Nat.Prime primeData.p` from hypothesis
       have hp_prime : Nat.Prime primeData.p := hprime primeData hpd_mem
-      haveI : Fact (Nat.Prime primeData.p) := ⟨hp_prime⟩
-      letI := primeData.bounds
+      have : Fact (Nat.Prime primeData.p) := ⟨hp_prime⟩
+      let := primeData.bounds
       -- Extract checkForPolynomial fact
       have hcheckPoly := Hex.checkIrreducibleCert_prime_data f cert hcert primeData hpd_mem
       have hgood := Hex.checkIrreducibleCert_isGoodPrime f cert hcert primeData hpd_mem
@@ -254,7 +254,7 @@ theorem checkIrreducibleCert_sound
       -- Then c.leadingCoeff mod p ≠ 0 (using p prime → ZMod p domain)
       have hc_lc_map_ne :
           (Int.castRingHom (ZMod primeData.p)) c.leadingCoeff ≠ 0 := by
-        haveI : IsDomain (ZMod primeData.p) := inferInstance
+        have : IsDomain (ZMod primeData.p) := inferInstance
         intro heq
         apply hF_lc_map_ne
         have : F.leadingCoeff = c.leadingCoeff * d.leadingCoeff := by
@@ -275,7 +275,7 @@ theorem checkIrreducibleCert_sound
         map_intCast_zmod_toPolynomial_eq_factorPolys_product f primeData hcheckPoly
       rw [hF_modP_eq] at hc_modP_dvd_F_modP
       -- Construct Hex.ZMod64.PrimeModulus from Mathlib primality
-      haveI hpm : Hex.ZMod64.PrimeModulus primeData.p :=
+      have hpm : Hex.ZMod64.PrimeModulus primeData.p :=
         Hex.ZMod64.primeModulusOfPrime
           ⟨hp_prime.two_le, fun m hdvd => hp_prime.eq_one_or_self_of_dvd m hdvd⟩
       -- Each factor in factorPolys is irreducible (via Rabin)

--- a/HexBerlekampZassenhausMathlib/Lattice/DirectAdequacy.lean
+++ b/HexBerlekampZassenhausMathlib/Lattice/DirectAdequacy.lean
@@ -201,7 +201,7 @@ theorem directLiftedFactor_core_congr
               (Hex.ZPoly.directLiftData core B data)) \ {i})))
       ((Hex.ZPoly.directLiftData core B data).p ^
         (Hex.ZPoly.directLiftData core B data).k) := by
-  letI := data.bounds
+  let := data.bounds
   let d := Hex.ZPoly.directLiftData core B data
   have hp_eq : d.p = data.p := by
     simp [d, Hex.ZPoly.directLiftData]
@@ -276,7 +276,7 @@ theorem directLiftedFactors_isCoprime
             ((Hex.ZPoly.directLiftData core B data).p ^
               (Hex.ZPoly.directLiftData core B data).k)))) := by
   classical
-  letI := data.bounds
+  let := data.bounds
   let k := Hex.precisionForCoeffBound B data.p
   let target := Hex.ZPoly.monicTarget core data.p k
   let d := Hex.ZPoly.directLiftData core B data
@@ -330,7 +330,7 @@ theorem directLiftedFactors_isCoprime
         ((HexPolyZMathlib.toPolynomial (liftedFactor d j)).map
           (Int.castRingHom (ZMod data.p))) :=
     hcomp.of_isCoprime_of_dvd_right hjdvd
-  haveI : Fact (_root_.Nat.Prime data.p) :=
+  have : Fact (_root_.Nat.Prime data.p) :=
     ⟨natPrime_of_hexNatPrime hval.prime⟩
   have hpow := HexHenselMathlib.coprime_mod_p_lifts
     (HexPolyZMathlib.toPolynomial (liftedFactor d i))
@@ -359,7 +359,7 @@ theorem directLiftedFactor_map_irreducible
       ((HexPolyZMathlib.toPolynomial
         (liftedFactor (Hex.ZPoly.directLiftData core B data) i)).map
           (Int.castRingHom (ZMod data.p))) := by
-  letI := data.bounds
+  let := data.bounds
   let d := Hex.ZPoly.directLiftData core B data
   let hsize : d.liftedFactors.size = data.factorsModP.size :=
     henselLiftData_liftedFactors_size_eq
@@ -418,7 +418,7 @@ theorem directLiftedFactor_natDegree_le_core
       ((Hex.ZPoly.directLiftData core B data).liftedFactors.getD i.val 1)).natDegree ≤
         (HexPolyZMathlib.toPolynomial core).natDegree := by
   classical
-  letI := data.bounds
+  let := data.bounds
   let d := Hex.ZPoly.directLiftData core B data
   let q := HexPolyZMathlib.toPolynomial (liftedFactor d i)
   let h := liftedFactorProduct d
@@ -470,7 +470,7 @@ theorem directLiftedFactor_natDegree_le_core
       rwa [HexPolyMathlib.natDegree_toPolynomial]
     rw [hzero, Polynomial.natDegree_zero] at hcore_degree_map
     omega
-  haveI : Fact (_root_.Nat.Prime data.p) :=
+  have : Fact (_root_.Nat.Prime data.p) :=
     ⟨natPrime_of_hexNatPrime hval.prime⟩
   have hq_monic : q.Monic :=
     HexHenselMathlib.toPolynomial_monic_of_dense_monic _
@@ -524,7 +524,7 @@ theorem directLiftedFactor_isCoprime_cldQuotient
               ((Hex.ZPoly.directLiftData core B data).p ^
                 (Hex.ZPoly.directLiftData core B data).k)))) := by
   classical
-  letI := data.bounds
+  let := data.bounds
   let d := Hex.ZPoly.directLiftData core B data
   let q := HexPolyZMathlib.toPolynomial (liftedFactor d i)
   let complement :=
@@ -574,7 +574,7 @@ theorem directLiftedFactor_isCoprime_cldQuotient
   have hp : _root_.Nat.Prime d.p := by
     rw [hp_eq]
     exact natPrime_of_hexNatPrime hval.prime
-  letI : Fact (_root_.Nat.Prime d.p) := ⟨hp⟩
+  let : Fact (_root_.Nat.Prime d.p) := ⟨hp⟩
   have hirr :=
     directLiftedFactor_map_irreducible_at_liftPrime
       core B data hval facts i
@@ -781,7 +781,7 @@ theorem directAdequacy
     (hB_floor : Hex.bhksRecoveryFloor core ≤ B)
     (_hB_ne : B ≠ 0) :
     DirectAdequacy core B data := by
-  letI := data.bounds
+  let := data.bounds
   have hcore_ne : core ≠ 0 :=
     zpoly_ne_zero_of_pos_lc hcore_lc_pos
   have hcore_size : 0 < core.size :=
@@ -1011,7 +1011,7 @@ theorem directCutProjection
           (Hex.ZPoly.directLiftData core B data).liftedFactors) hrows)
       (directTrueSupports core B data) := by
   classical
-  letI := data.bounds
+  let := data.bounds
   let d := Hex.ZPoly.directLiftData core B data
   let A := directAdequacy core B data hcore_lc_pos hcore_pos
     hcore_prim hcore_sqfree hval hB_floor hB_ne
@@ -1116,7 +1116,7 @@ theorem directProjectedSpan_eq
             (Hex.ZPoly.directLiftData core B data).liftedFactors) hrows) =
       BHKS.trueSupportSpanInt (directTrueSupports core B data) := by
   classical
-  letI := data.bounds
+  let := data.bounds
   let d := Hex.ZPoly.directLiftData core B data
   have hcore_ne : core ≠ 0 :=
     zpoly_ne_zero_of_pos_lc hcore_lc_pos

--- a/HexBerlekampZassenhausMathlib/Lattice/DirectSupport.lean
+++ b/HexBerlekampZassenhausMathlib/Lattice/DirectSupport.lean
@@ -329,8 +329,8 @@ theorem directSupport_nonempty_of_represents
     (hnorm : Hex.normalizeFactorSign factor = factor)
     (hrep : RepresentsIntegerFactorModP data factor S) :
     S.Nonempty := by
-  letI := data.bounds
-  letI : Hex.ZMod64.PrimeModulus data.p :=
+  let := data.bounds
+  let : Hex.ZMod64.PrimeModulus data.p :=
     Hex.ZMod64.primeModulusOfPrime hval.prime
   by_contra hempty
   rw [Finset.not_nonempty_iff_eq_empty] at hempty

--- a/HexBerlekampZassenhausMathlib/Lattice/SupportEquivalence.lean
+++ b/HexBerlekampZassenhausMathlib/Lattice/SupportEquivalence.lean
@@ -70,7 +70,7 @@ theorem mem_trueSupportSpanInt_of_constant_on_partition
       ∀ S ∈ trueSupports, ∀ i ∈ S, ∀ j ∈ S, v i = v j) :
     v ∈ trueSupportSpanInt trueSupports := by
   classical
-  letI : Fintype trueSupports := (Set.toFinite trueSupports).fintype
+  let : Fintype trueSupports := (Set.toFinite trueSupports).fintype
   let rep : trueSupports → Fin r :=
     fun S => (hne S.1 S.2).choose
   have hrep (S : trueSupports) : rep S ∈ S.1 :=
@@ -159,7 +159,7 @@ theorem exists_adjustedVector
       ∀ x : Fin (L.factorCount + L.coeffWidth),
         w[x].natAbs ≤ V + V * U + trueSupports.ncard * U := by
   classical
-  letI : Fintype trueSupports := (Set.toFinite trueSupports).fintype
+  let : Fintype trueSupports := (Set.toFinite trueSupports).fintype
   let e : Fin L.factorCount → ℤ :=
     fun i => v[Fin.castAdd L.coeffWidth i]
   obtain ⟨S₀, hS₀, i₀, hi₀, k₀, hk₀, hik⟩ :=

--- a/HexBerlekampZassenhausMathlib/LatticeFactorization.lean
+++ b/HexBerlekampZassenhausMathlib/LatticeFactorization.lean
@@ -42,7 +42,7 @@ theorem irreducible_of_directSingleton
     (hcore_prim : Hex.ZPoly.Primitive core)
     (hsmall : data.factorsModP.size ≤ 1) :
     Hex.ZPoly.Irreducible core := by
-  letI := data.bounds
+  let := data.bounds
   have hadm :
       Hex.leadingCoeffAdmissible core data.p :=
     Hex.isGoodPrime_leadingCoeffAdmissible core data.p

--- a/HexBerlekampZassenhausMathlib/M1Recovery.lean
+++ b/HexBerlekampZassenhausMathlib/M1Recovery.lean
@@ -408,7 +408,7 @@ theorem leadingCoeffAdmissible_of_gcd_pow
     (hgcd : Int.gcd (Hex.DensePoly.leadingCoeff core)
       (Int.ofNat (p ^ k)) = 1) :
     Hex.leadingCoeffAdmissible core p := by
-  letI : Fact (_root_.Nat.Prime p) := ⟨natPrime_of_hexNatPrime hprime⟩
+  let : Fact (_root_.Nat.Prime p) := ⟨natPrime_of_hexNatPrime hprime⟩
   have hs_inv :
       (Hex.ZPoly.leadingCoeffInverse core p k *
           Hex.DensePoly.leadingCoeff core) %
@@ -475,7 +475,7 @@ theorem monicModularImage_modP_eq_modP_monicTarget
     (hgcd : Int.gcd (Hex.DensePoly.leadingCoeff core) (Int.ofNat (p ^ k)) = 1) :
     Hex.monicModularImage (Hex.ZPoly.modP p core) =
       Hex.ZPoly.modP p (Hex.ZPoly.monicTarget core p k) := by
-  haveI : Fact (_root_.Nat.Prime p) := ⟨natPrime_of_hexNatPrime hprime⟩
+  have : Fact (_root_.Nat.Prime p) := ⟨natPrime_of_hexNatPrime hprime⟩
   have hadm : Hex.leadingCoeffAdmissible core p :=
     leadingCoeffAdmissible_of_gcd_pow core p k hprime hpk hk hgcd
   have hsize : 0 < (Hex.ZPoly.modP p core).size := by

--- a/HexBerlekampZassenhausMathlib/ModPFactor.lean
+++ b/HexBerlekampZassenhausMathlib/ModPFactor.lean
@@ -65,7 +65,7 @@ theorem toMathlibPolynomial_modPFactorProduct
     HexBerlekampMathlib.toMathlibPolynomial (modPFactorProduct primeData S) =
       ∏ i ∈ S,
         HexBerlekampMathlib.toMathlibPolynomial (modPFactor primeData i) := by
-  letI := primeData.bounds
+  let := primeData.bounds
   unfold modPFactorProduct
   rw [show
       (S.toList.foldl (fun acc i => acc * modPFactor primeData i)
@@ -152,7 +152,7 @@ private theorem monicModularImage_dvd_self_of_isZero_false
     {p : Nat} [Hex.ZMod64.Bounds p] (hprime : Hex.Nat.Prime p)
     {f : Hex.FpPoly p} (hf : f.isZero = false) :
     Hex.monicModularImage f ∣ f := by
-  letI : Hex.ZMod64.PrimeModulus p := Hex.ZMod64.primeModulusOfPrime hprime
+  let : Hex.ZMod64.PrimeModulus p := Hex.ZMod64.primeModulusOfPrime hprime
   have hsize_pos : 0 < f.size :=
     (Hex.DensePoly.isZero_eq_false_iff _).mp hf
   have hlead_ne :
@@ -170,7 +170,7 @@ theorem monicModPImage_dvd_self_of_ne_zero
     {p : Nat} [Hex.ZMod64.Bounds p]
     (hprime : Hex.Nat.Prime p) {f : Hex.FpPoly p} (hf : f.isZero = false) :
     monicModPImage f ∣ f := by
-  letI : Hex.ZMod64.PrimeModulus p := Hex.ZMod64.primeModulusOfPrime hprime
+  let : Hex.ZMod64.PrimeModulus p := Hex.ZMod64.primeModulusOfPrime hprime
   unfold monicModPImage
   simp only [hf, Bool.false_eq_true, ↓reduceIte]
   have hf_ne : f ≠ 0 := by
@@ -303,8 +303,8 @@ theorem monicModPImage_dvd_monicModularImage_of_dvd_of_goodPrime
         (@Hex.ZPoly.modP primeData.p primeData.bounds factor) ∣
       Hex.monicModularImage
         (@Hex.ZPoly.modP primeData.p primeData.bounds core) := by
-  letI := primeData.bounds
-  letI : Hex.ZMod64.PrimeModulus primeData.p :=
+  let := primeData.bounds
+  let : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
   have hcore_iszero :
       (@Hex.ZPoly.modP primeData.p primeData.bounds core).isZero = false :=
@@ -494,8 +494,8 @@ theorem mem_modPSubset_of_dvd
           (@Hex.ZPoly.modP primeData.p primeData.bounds factor))) :
     i ∈ S := by
   classical
-  letI := primeData.bounds
-  haveI : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
+  let := primeData.bounds
+  have : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
   let F : ModPFactorIndex primeData → Polynomial (ZMod primeData.p) :=
     fun j => @HexBerlekampMathlib.toMathlibPolynomial primeData.p primeData.bounds
       (modPFactor primeData j)
@@ -561,7 +561,7 @@ leading-coefficient normalisation divides the unit scalar back out. -/
 theorem monicModPImage_scale {p : Nat} [Hex.ZMod64.Bounds p]
     (hprime : Hex.Nat.Prime p) {c : Hex.ZMod64 p} (hc : c ≠ 0) (f : Hex.FpPoly p) :
     monicModPImage (Hex.DensePoly.scale c f) = monicModPImage f := by
-  letI : Hex.ZMod64.PrimeModulus p := Hex.ZMod64.primeModulusOfPrime hprime
+  let : Hex.ZMod64.PrimeModulus p := Hex.ZMod64.primeModulusOfPrime hprime
   cases hf : f.isZero with
   | true =>
     have hf_size : f.size = 0 := by
@@ -633,7 +633,7 @@ private theorem modP_scale_neg_one {p : Nat} [Hex.ZMod64.Bounds p] (f : Hex.ZPol
 /-- `-1` is a nonzero residue modulo a prime. -/
 private theorem neg_one_ne_zero_zmod {p : Nat} [Hex.ZMod64.Bounds p]
     (hprime : Hex.Nat.Prime p) : (-1 : Hex.ZMod64 p) ≠ 0 := by
-  haveI : Fact (_root_.Nat.Prime p) := ⟨natPrime_of_hexNatPrime hprime⟩
+  have : Fact (_root_.Nat.Prime p) := ⟨natPrime_of_hexNatPrime hprime⟩
   intro h
   have hz : HexModArithMathlib.ZMod64.toZMod (-1 : Hex.ZMod64 p) =
       HexModArithMathlib.ZMod64.toZMod (0 : Hex.ZMod64 p) := by rw [h]
@@ -684,7 +684,7 @@ theorem representsIntegerFactorModP_of_associated
       Associated (HexPolyZMathlib.toPolynomial f) (HexPolyZMathlib.toPolynomial g))
     (hf : RepresentsIntegerFactorModP primeData f S) :
     RepresentsIntegerFactorModP primeData g S := by
-  letI := primeData.bounds
+  let := primeData.bounds
   unfold RepresentsIntegerFactorModP at hf ⊢
   rw [hf]
   exact monicModPImage_modP_eq_of_associated hprime hassoc
@@ -759,7 +759,7 @@ theorem modPFactorSubset_disjoint_of_not_associated
       ¬ Associated (HexPolyZMathlib.toPolynomial f) (HexPolyZMathlib.toPolynomial g)) :
     Disjoint S T := by
   classical
-  letI := primeData.bounds
+  let := primeData.bounds
   set p := primeData.p with hp_def
   -- `modP f`, `modP g` are nonzero because they divide the nonzero `modP core`.
   have hf_modP_nz : (Hex.ZPoly.modP p f).isZero = false :=

--- a/HexBerlekampZassenhausMathlib/ModPFactorization.lean
+++ b/HexBerlekampZassenhausMathlib/ModPFactorization.lean
@@ -182,11 +182,11 @@ theorem ModPFactorization.factorCount_le_degree_of_product
         (Array.polyProduct (data.factorsModP.map Hex.FpPoly.liftToZ))
         target data.p) :
     data.factorsModP.size ≤ target.degree?.getD 0 := by
-  letI := data.bounds
+  let := data.bounds
   have hp : 1 < data.p := h.prime.one_lt
-  haveI : Fact (_root_.Nat.Prime data.p) :=
+  have : Fact (_root_.Nat.Prime data.p) :=
     ⟨natPrime_of_hexNatPrime h.prime⟩
-  haveI : Nontrivial (ZMod data.p) := inferInstance
+  have : Nontrivial (ZMod data.p) := inferInstance
   let t : Multiset (Polynomial ℤ) :=
     (data.factorsModP.toList : Multiset (Hex.FpPoly data.p)).map
       (fun g => HexPolyZMathlib.toPolynomial (Hex.FpPoly.liftToZ g))

--- a/HexBerlekampZassenhausMathlib/ModPPartition.lean
+++ b/HexBerlekampZassenhausMathlib/ModPPartition.lean
@@ -47,9 +47,9 @@ private lemma toMathlibPolynomial_factorsModP_product_eq_monicModularImage
       HexBerlekampMathlib.toMathlibPolynomial
         (Hex.monicModularImage
           (@Hex.ZPoly.modP primeData.p primeData.bounds core)) := by
-  letI := primeData.bounds
+  let := primeData.bounds
   have hprime : Hex.Nat.Prime primeData.p := hval.prime
-  letI : Hex.ZMod64.PrimeModulus primeData.p :=
+  let : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
   have hp : 1 < primeData.p := by have := hprime.two_le; omega
   -- Descend the bundle's `ℤ` congruence to an `FpPoly` product equality;
@@ -81,7 +81,7 @@ private lemma univ_val_map_modPFactor_eq_factorsModP_map
         HexBerlekampMathlib.toMathlibPolynomial (modPFactor primeData i)) =
       ((primeData.factorsModP.toList : Multiset _).map
         HexBerlekampMathlib.toMathlibPolynomial) := by
-  letI := primeData.bounds
+  let := primeData.bounds
   unfold modPFactor
   rw [Finset.val_univ_fin]
   rw [show (primeData.factorsModP.toList : List _) =
@@ -144,9 +144,9 @@ theorem exists_factor_of_modPIndex
         HexBerlekampMathlib.toMathlibPolynomial
           (monicModPImage (Hex.ZPoly.modP primeData.p g)) := by
   classical
-  letI := primeData.bounds
+  let := primeData.bounds
   have hprime : Hex.Nat.Prime primeData.p := hval.prime
-  letI : Hex.ZMod64.PrimeModulus primeData.p :=
+  let : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
   have hprime_root : _root_.Nat.Prime primeData.p := by
     refine _root_.Nat.prime_def_lt.mpr ⟨hprime.two_le, ?_⟩
@@ -154,7 +154,7 @@ theorem exists_factor_of_modPIndex
     rcases hprime.right m hmdvd with h | h
     · exact h
     · exact absurd h (Nat.ne_of_lt hmlt)
-  haveI : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime_root⟩
+  have : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime_root⟩
   have hgood : @Hex.isGoodPrime core primeData.p primeData.bounds = true :=
     hval.good
   have hcore_modP_iszero :
@@ -162,7 +162,7 @@ theorem exists_factor_of_modPIndex
     Hex.isGoodPrime_modP_isZero_false core primeData.p hgood
   let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
-  letI := hfield
+  let := hfield
   set f : ModPFactorIndex primeData → Polynomial (ZMod primeData.p) :=
       fun i => HexBerlekampMathlib.toMathlibPolynomial (modPFactor primeData i)
       with hf_def
@@ -318,9 +318,9 @@ theorem existsUnique_modPFactorSubset_of_choosePrimeData_of_some
     ∃! S : ModPFactorSubset primeData,
       RepresentsIntegerFactorModP primeData factor S := by
   classical
-  letI := primeData.bounds
+  let := primeData.bounds
   have hprime : Hex.Nat.Prime primeData.p := hval.prime
-  letI : Hex.ZMod64.PrimeModulus primeData.p :=
+  let : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
   have hprime_root : _root_.Nat.Prime primeData.p := by
     refine _root_.Nat.prime_def_lt.mpr ⟨hprime.two_le, ?_⟩
@@ -328,7 +328,7 @@ theorem existsUnique_modPFactorSubset_of_choosePrimeData_of_some
     rcases hprime.right m hmdvd with h | h
     · exact h
     · exact absurd h (Nat.ne_of_lt hmlt)
-  haveI : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime_root⟩
+  have : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime_root⟩
   have hgood : @Hex.isGoodPrime core primeData.p primeData.bounds = true :=
     hval.good
   have hzero : (@Hex.ZPoly.modP primeData.p primeData.bounds core).isZero = false :=
@@ -336,7 +336,7 @@ theorem existsUnique_modPFactorSubset_of_choosePrimeData_of_some
   have hnodup : primeData.factorsModP.toList.Nodup := hval.nodup
   let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
-  letI := hfield
+  let := hfield
   -- Set up abbreviations.
   set f : ModPFactorIndex primeData → Polynomial (ZMod primeData.p) :=
       fun i => HexBerlekampMathlib.toMathlibPolynomial (modPFactor primeData i)
@@ -497,7 +497,7 @@ theorem existsUnique_modPFactorSubset_of_modPFactorization
     (hval : ModPFactorization core primeData) :
     ∃! S : ModPFactorSubset primeData,
       RepresentsIntegerFactorModP primeData factor S := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   -- `core ≠ 0` from `isGoodPrime` (which forces `(modP p core).isZero = false`).
   have hcore_ne : core ≠ 0 := by
     intro hcore_zero
@@ -561,7 +561,7 @@ theorem core_ne_zero_of_modPFactorization
     (core : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
     (hval : ModPFactorization core primeData) :
     core ≠ 0 := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   intro hcore_zero
   have hgood : @Hex.isGoodPrime core primeData.p primeData.bounds = true :=
     hval.good
@@ -584,7 +584,7 @@ theorem toMathlibPolynomial_modPFactor_injective_of_modPFactorization
     letI := primeData.bounds
     Function.Injective (fun i : ModPFactorIndex primeData =>
       HexBerlekampMathlib.toMathlibPolynomial (modPFactor primeData i)) := by
-  letI := primeData.bounds
+  let := primeData.bounds
   have hnodup : primeData.factorsModP.toList.Nodup := hval.nodup
   have hinjPoly : Function.Injective
       (HexBerlekampMathlib.toMathlibPolynomial : Hex.FpPoly primeData.p → _) :=
@@ -601,7 +601,7 @@ theorem toMathlibPolynomial_modPFactor_monic_of_modPFactorization
     letI := primeData.bounds
     ∀ i : ModPFactorIndex primeData,
       (HexBerlekampMathlib.toMathlibPolynomial (modPFactor primeData i)).Monic := by
-  letI := primeData.bounds
+  let := primeData.bounds
   have hmonic := hval.monic
   intro i
   exact HexBerlekampMathlib.toMathlibPolynomial_monic _ (hmonic _ (Array.getElem_mem _))
@@ -623,7 +623,7 @@ theorem modPFactor_index_cover
       g ∣ core ∧
       i ∈ S ∧
       RepresentsIntegerFactorModP primeData g S := by
-  letI := primeData.bounds
+  let := primeData.bounds
   have hcore_ne : core ≠ 0 := core_ne_zero_of_modPFactorization core primeData hval
   obtain ⟨g, hirr, hdvd, hfi_dvd⟩ :=
     exists_factor_of_modPIndex core hcore_ne hcore_pos primeData hval i

--- a/HexBerlekampZassenhausMathlib/Modular/FactorCoprimality.lean
+++ b/HexBerlekampZassenhausMathlib/Modular/FactorCoprimality.lean
@@ -236,11 +236,11 @@ theorem factorsModP_coprime_of_factorsModPBerlekampForm
     letI := primeData.bounds
     Hex.ZPoly.QuadraticMultifactorCoprimeSplits primeData.p
       primeData.factorsModP.toList := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   obtain ⟨hprime, hzero, heq⟩ := hform
   let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
-  letI : Hex.ZMod64.PrimeModulus primeData.p :=
+  let : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
   -- The modular image is square-free under `isGoodPrime`.
   have hsf_common :
@@ -361,11 +361,11 @@ theorem factorsModP_monic_of_factorsModPBerlekampForm
     (hform : Hex.factorsModPBerlekampForm core primeData) :
     letI := primeData.bounds
     ∀ g ∈ primeData.factorsModP, Hex.DensePoly.Monic g := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   obtain ⟨hprime, hzero, heq⟩ := hform
   let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
-  letI : Hex.ZMod64.PrimeModulus primeData.p :=
+  let : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
   have hmonicImage_monic :
       Hex.DensePoly.Monic (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core)) :=
@@ -589,7 +589,7 @@ theorem factors_irreducible_of_factorsModPBerlekampForm
       Irreducible
         (@HexBerlekampMathlib.toMathlibPolynomial primeData.p primeData.bounds
           (modPFactor primeData i)) := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   have hmonicImage_pos :
       0 < (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core)).degree?.getD 0 :=
     monicModularImage_modP_degree?_pos_of_factorsModPBerlekampForm
@@ -597,7 +597,7 @@ theorem factors_irreducible_of_factorsModPBerlekampForm
   obtain ⟨hprime, hzero, heq⟩ := hform
   let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
-  letI : Hex.ZMod64.PrimeModulus primeData.p :=
+  let : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
   have hprime_root : _root_.Nat.Prime primeData.p := by
     refine _root_.Nat.prime_def_lt.mpr ⟨hprime.two_le, ?_⟩
@@ -605,7 +605,7 @@ theorem factors_irreducible_of_factorsModPBerlekampForm
     rcases hprime.right m hmdvd with h | h
     · exact h
     · exact absurd h (Nat.ne_of_lt hmlt)
-  haveI : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime_root⟩
+  have : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime_root⟩
   have hsf_common :
       ∀ d : Hex.FpPoly primeData.p,
         d ∣ Hex.ZPoly.modP primeData.p core →
@@ -652,7 +652,7 @@ theorem factors_irreducible_of_factorsModPBerlekampForm
       Hex.DensePoly.Monic
         (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core)) :=
     Hex.monicModularImage_monic hprime (Hex.ZPoly.modP primeData.p core) hzero
-  letI := hfield
+  let := hfield
   have hraw_irr :
       ∀ g ∈ (@Hex.Berlekamp.berlekampFactor primeData.p primeData.bounds
           (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core))
@@ -752,7 +752,7 @@ theorem factors_irreducible_of_choosePrimeData_of_some
       Irreducible
         (@HexBerlekampMathlib.toMathlibPolynomial primeData.p primeData.bounds
           (modPFactor primeData i)) := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   have hform : Hex.factorsModPBerlekampForm core primeData := by
     obtain ⟨hzero, hfactors_eq⟩ :=
       Hex.choosePrimeData?_factorsModP_berlekamp_form core primeData hselected

--- a/HexBerlekampZassenhausMathlib/Modular/FactorProduct.lean
+++ b/HexBerlekampZassenhausMathlib/Modular/FactorProduct.lean
@@ -60,7 +60,7 @@ theorem henselLiftData_liftedFactor_modP_eq_modPFactor
         (liftedIndexOfModPIndex primeData (Hex.henselLiftData core B primeData)
           (henselLiftData_liftedFactors_size_eq core B primeData) i)) =
       modPFactor primeData i := by
-  letI := primeData.bounds
+  let := primeData.bounds
   set arr :=
     Hex.ZPoly.multifactorLiftQuadratic primeData.p B core
       (primeData.factorsModP.map Hex.FpPoly.liftToZ) with harr_def
@@ -170,11 +170,11 @@ theorem factorsModP_nodup_of_factorsModPBerlekampForm
       letI := data.bounds
       Hex.isGoodPrime f data.p = true) :
     data.factorsModP.toList.Nodup := by
-  letI : Hex.ZMod64.Bounds data.p := data.bounds
+  let : Hex.ZMod64.Bounds data.p := data.bounds
   obtain ⟨hprime, hzero, heq⟩ := hform
   let hfield : Hex.ZMod64.PrimeModulus data.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
-  letI : Hex.ZMod64.PrimeModulus data.p := Hex.ZMod64.primeModulusOfPrime hprime
+  let : Hex.ZMod64.PrimeModulus data.p := Hex.ZMod64.primeModulusOfPrime hprime
   -- Square-free precondition on the modular image, extracted from `isGoodPrime`.
   have hsf_common :
       ∀ d : Hex.FpPoly data.p,
@@ -395,9 +395,9 @@ theorem monicModularImage_modP_degree?_pos_of_factorsModPBerlekampForm
     (hf_pos : 0 < f.degree?.getD 0) :
     letI := data.bounds
     0 < (Hex.monicModularImage (Hex.ZPoly.modP data.p f)).degree?.getD 0 := by
-  letI : Hex.ZMod64.Bounds data.p := data.bounds
+  let : Hex.ZMod64.Bounds data.p := data.bounds
   obtain ⟨hprime, hzero, heq⟩ := hform
-  letI : Hex.ZMod64.PrimeModulus data.p := Hex.ZMod64.primeModulusOfPrime hprime
+  let : Hex.ZMod64.PrimeModulus data.p := Hex.ZMod64.primeModulusOfPrime hprime
   have hfsize_ge_two : 2 ≤ f.size := by
     unfold Hex.DensePoly.degree? at hf_pos
     by_cases hfs0 : f.size = 0
@@ -481,7 +481,7 @@ theorem factorsModP_natDegree_pos_of_factorsModPBerlekampForm
     letI := data.bounds
     ∀ g ∈ data.factorsModP,
       0 < (HexPolyZMathlib.toPolynomial (Hex.FpPoly.liftToZ g)).natDegree := by
-  letI : Hex.ZMod64.Bounds data.p := data.bounds
+  let : Hex.ZMod64.Bounds data.p := data.bounds
   -- Step A: 0 < (monicModularImage (modP data.p f)).degree?.getD 0
   have hmonicImage_pos :
       0 < (Hex.monicModularImage (Hex.ZPoly.modP data.p f)).degree?.getD 0 :=
@@ -489,7 +489,7 @@ theorem factorsModP_natDegree_pos_of_factorsModPBerlekampForm
   obtain ⟨hprime, hzero, heq⟩ := hform
   let hfield : Hex.ZMod64.PrimeModulus data.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
-  letI : Hex.ZMod64.PrimeModulus data.p := Hex.ZMod64.primeModulusOfPrime hprime
+  let : Hex.ZMod64.PrimeModulus data.p := Hex.ZMod64.primeModulusOfPrime hprime
   -- Step B: positivity for every entry in the Berlekamp factor list.
   have hFactorsPos :
       ∀ h ∈ (@Hex.Berlekamp.berlekampFactor data.p data.bounds
@@ -742,11 +742,11 @@ theorem factorsModP_polyProduct_congr_of_factorsModPBerlekampForm_of_primitive_p
       (Hex.FpPoly.liftToZ
         (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core)))
       primeData.p := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   obtain ⟨hprime, hzero, heq⟩ := hform
   let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
-  letI : Hex.ZMod64.PrimeModulus primeData.p :=
+  let : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
   -- `monicModularImage (modP p core)` is monic.
   have hmonicImage_monic :
@@ -821,11 +821,11 @@ theorem factorsModP_polyProduct_congr_of_factorsModPBerlekampForm
     Hex.ZPoly.congr
       (Array.polyProduct (primeData.factorsModP.map Hex.FpPoly.liftToZ))
       core primeData.p := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   obtain ⟨hprime, hzero, heq⟩ := hform
   let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
-  letI : Hex.ZMod64.PrimeModulus primeData.p :=
+  let : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
   have hp : 1 < primeData.p := by have := hprime.two_le; omega
   -- `monicModularImage (modP p core) = modP p core` (because `core` is monic).
@@ -864,7 +864,7 @@ theorem factorsModP_ne_nil_of_factorsModPBerlekampForm
     (core : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
     (hform : Hex.factorsModPBerlekampForm core primeData) :
     primeData.factorsModP.toList ≠ [] := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   obtain ⟨hprime, hzero, heq⟩ := hform
   let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime

--- a/HexBerlekampZassenhausMathlib/Modular/PrimePlan.lean
+++ b/HexBerlekampZassenhausMathlib/Modular/PrimePlan.lean
@@ -178,7 +178,7 @@ private theorem map_natDegree_factorsModP
     data.factorsModP.toList.map
         (fun g => (HexBerlekampMathlib.toMathlibPolynomial g).natDegree) =
       (Hex.directFactorDegrees data).toList := by
-  letI := data.bounds
+  let := data.bounds
   simp only [Hex.directFactorDegrees, Array.toList_map]
   refine List.map_congr_left ?_
   intro g _
@@ -199,9 +199,9 @@ theorem exists_subMultiset_directFactorDegrees_of_dvd
     {c : Hex.ZPoly} (hdvd : c ∣ core) :
     ∃ S ≤ ((Hex.directFactorDegrees data).toList : Multiset Nat),
       S.sum = c.degree?.getD 0 := by
-  letI := data.bounds
-  haveI : Fact (_root_.Nat.Prime data.p) := ⟨natPrime_of_hexNatPrime hval.prime⟩
-  letI : Hex.ZMod64.PrimeModulus data.p :=
+  let := data.bounds
+  have : Fact (_root_.Nat.Prime data.p) := ⟨natPrime_of_hexNatPrime hval.prime⟩
+  let : Hex.ZMod64.PrimeModulus data.p :=
     Hex.ZMod64.primeModulusOfPrime hval.prime
   have hcore_modP_nz :
       (@Hex.ZPoly.modP data.p data.bounds core).isZero = false :=

--- a/HexBerlekampZassenhausMathlib/ModularPolynomial.lean
+++ b/HexBerlekampZassenhausMathlib/ModularPolynomial.lean
@@ -122,7 +122,7 @@ theorem toMathlibPolynomial_factorProduct (primeData : Hex.PrimeFactorData) :
     HexBerlekampMathlib.toMathlibPolynomial primeData.factorProduct =
       (primeData.factorPolys.toList.map
         HexBerlekampMathlib.toMathlibPolynomial).prod := by
-  letI := primeData.bounds
+  let := primeData.bounds
   show HexBerlekampMathlib.toMathlibPolynomial
       (primeData.factorPolys.foldl (· * ·) 1) = _
   rw [← Array.foldl_toList]
@@ -153,7 +153,7 @@ theorem toMathlibPolynomial_factorProduct_eq_map_intCast_zmod
     HexBerlekampMathlib.toMathlibPolynomial primeData.factorProduct =
       (HexPolyZMathlib.toPolynomial f).map
         (Int.castRingHom (ZMod primeData.p)) := by
-  letI := primeData.bounds
+  let := primeData.bounds
   have hprod : primeData.factorProduct = Hex.ZPoly.modP primeData.p f := by
     simp [Hex.PrimeFactorData.checkForPolynomial] at hcheck
     exact hcheck.1.2
@@ -179,7 +179,7 @@ theorem map_intCast_zmod_toPolynomial_eq_factorPolys_product
         (Int.castRingHom (ZMod primeData.p)) =
       (primeData.factorPolys.toList.map
         HexBerlekampMathlib.toMathlibPolynomial).prod := by
-  letI := primeData.bounds
+  let := primeData.bounds
   rw [← toMathlibPolynomial_factorProduct_eq_map_intCast_zmod f primeData hcheck]
   exact toMathlibPolynomial_factorProduct primeData
 

--- a/HexBerlekampZassenhausMathlib/RecombinationCandidate.lean
+++ b/HexBerlekampZassenhausMathlib/RecombinationCandidate.lean
@@ -161,7 +161,7 @@ theorem subsetsOfSizeWithComplement_liftedFactors_exists_subset
   classical
   have hpos : 0 < d.liftedFactors.size := by
     rw [← Array.length_toList, hloc]; simp
-  haveI : Nonempty (LiftedFactorIndex d) := ⟨⟨0, hpos⟩⟩
+  have : Nonempty (LiftedFactorIndex d) := ⟨⟨0, hpos⟩⟩
   have hne : (Finset.univ : LiftedFactorSubset d).Nonempty := Finset.univ_nonempty
   -- A Boolean mask over the tail, from the `subsetSplits` enumeration.
   have hsplit : (sc_sel, sc_rest) ∈ Hex.subsetSplits tail :=

--- a/HexBerlekampZassenhausMathlib/Resultant.lean
+++ b/HexBerlekampZassenhausMathlib/Resultant.lean
@@ -42,7 +42,7 @@ theorem abs_det_le_row_l2norm_prod
   let o := b.toBasis.orientation
   let rows : Fin N → EuclideanSpace ℝ (Fin N) :=
     fun i => WithLp.toLp 2 (fun j => (A i j : ℝ))
-  haveI : Fact (Module.finrank ℝ (EuclideanSpace ℝ (Fin N)) = N) := ⟨by simp⟩
+  have : Fact (Module.finrank ℝ (EuclideanSpace ℝ (Fin N)) = N) := ⟨by simp⟩
   have hvol : |o.volumeForm rows| ≤ ∏ i : Fin N, ‖rows i‖ :=
     o.abs_volumeForm_apply_le rows
   have hrob : |o.volumeForm rows| = |b.toBasis.det rows| :=
@@ -1382,7 +1382,7 @@ theorem pow_dvd_resultant_of_map_dvd_left_coprime
   by_cases hdg : d ≤ g.natDegree
   · exact pow_dvd_resultant_of_map_dvd hq_monic hq_deg hf_ne hf_lc_coprime hdf hdg
       hf_dvd hg_dvd
-  · letI : Fact (1 < p ^ k) := ⟨hmod⟩
+  · let : Fact (1 < p ^ k) := ⟨hmod⟩
     let φ := Int.castRingHom (ZMod (p ^ k))
     have hgmap : g.map φ = 0 := by
       by_contra hgmap_ne

--- a/HexBerlekampZassenhausMathlib/SubsetCoprimality.lean
+++ b/HexBerlekampZassenhausMathlib/SubsetCoprimality.lean
@@ -80,7 +80,7 @@ theorem henselLiftData_liftedFactor_injective_of_choosePrimeData
     (hfactorsModP_nodup : primeData.factorsModP.toList.Nodup) :
     Function.Injective
       (liftedFactor (Hex.henselLiftData core B primeData)) := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   have hinv :
       Hex.ZPoly.QuadraticMultifactorLiftInvariant
         primeData.p B core
@@ -140,8 +140,8 @@ theorem henselLiftData_liftedFactor_natDegree_pos
     ∀ i : Fin (Hex.henselLiftData core B primeData).liftedFactors.size,
       0 < (HexPolyZMathlib.toPolynomial
             (liftedFactor (Hex.henselLiftData core B primeData) i)).natDegree := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
-  haveI : Fact (1 < primeData.p) := ⟨hp⟩
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  have : Fact (1 < primeData.p) := ⟨hp⟩
   intro i
   change 0 < (HexPolyZMathlib.toPolynomial
     (Hex.henselLiftData core B primeData).liftedFactors[i]).natDegree
@@ -310,7 +310,7 @@ theorem henselLiftData_liftedFactor_natDegree_pos_of_choosePrimeData
     ∀ i : Fin (Hex.henselLiftData core B primeData).liftedFactors.size,
       0 < (HexPolyZMathlib.toPolynomial
             (liftedFactor (Hex.henselLiftData core B primeData) i)).natDegree := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   have hinv :
       Hex.ZPoly.QuadraticMultifactorLiftInvariant
         primeData.p B core
@@ -404,7 +404,7 @@ theorem henselLiftData_liftedSubset_product_congr_mod_base
             (henselLiftData_liftedFactors_size_eq core B primeData) S))
         (Hex.FpPoly.liftToZ (modPFactorProduct primeData S))
         primeData.p := by
-  letI := primeData.bounds
+  let := primeData.bounds
   intro S
   let d := Hex.henselLiftData core B primeData
   let hsize := henselLiftData_liftedFactors_size_eq core B primeData
@@ -537,7 +537,7 @@ private theorem toPolynomial_liftedSubset_map_intCast_zmod_eq_toMathlibPolynomia
         (liftedFactorProduct d (liftedSubsetOfModPSubset primeData d hsize S))).map
           (Int.castRingHom (ZMod primeData.p)) =
       HexBerlekampMathlib.toMathlibPolynomial (modPFactorProduct primeData S) := by
-  letI := primeData.bounds
+  let := primeData.bounds
   intro d hsize
   have hcongr :=
     henselLiftData_liftedSubset_product_congr_mod_base core B primeData
@@ -560,7 +560,7 @@ private theorem modPFactor_ne_of_ne
     {i j : ModPFactorIndex primeData} (hij : i ≠ j) :
     letI := primeData.bounds
     modPFactor primeData i ≠ modPFactor primeData j := by
-  letI := primeData.bounds
+  let := primeData.bounds
   intro h
   apply hij
   have hi_list : i.val < primeData.factorsModP.toList.length := by
@@ -606,8 +606,8 @@ private theorem isCoprime_toMathlibPolynomial_modPFactor_of_ne
     IsCoprime
       (HexBerlekampMathlib.toMathlibPolynomial (modPFactor primeData i))
       (HexBerlekampMathlib.toMathlibPolynomial (modPFactor primeData j)) := by
-  letI := primeData.bounds
-  haveI : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
+  let := primeData.bounds
+  have : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
   have hi_monic_fp : Hex.DensePoly.Monic (modPFactor primeData i) :=
     hfactors_monic _ (Array.getElem_mem _)
   have hj_monic_fp : Hex.DensePoly.Monic (modPFactor primeData j) :=
@@ -688,9 +688,9 @@ theorem henselLiftData_liftedSubset_complement_isCoprime_mod_p
           (liftedFactorProduct d ((Finset.univ : LiftedFactorSubset d) \
             liftedSubsetOfModPSubset primeData d hsize S))).map
         (Int.castRingHom (ZMod primeData.p))) := by
-  letI := primeData.bounds
+  let := primeData.bounds
   intro d hsize
-  haveI : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
+  have : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
   -- Rewrite both lifted products via the modP identification with `toMathlibPolynomial`
   -- of `modPFactorProduct`. The complement requires the
   -- `liftedSubsetOfModPSubset_compl_eq` rewrite first.
@@ -820,7 +820,7 @@ theorem henselLiftData_liftedFactorProduct_univ_congr_core
         (Finset.univ : Finset
           (LiftedFactorIndex (Hex.henselLiftData core B primeData))))
       core (primeData.p ^ B) := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   rw [liftedFactorProduct_univ_eq_polyProduct_liftedFactors]
   change Hex.ZPoly.congr
     (Array.polyProduct
@@ -858,7 +858,7 @@ theorem henselLiftData_liftedFactorProduct_subset_complement_congr_core
         liftedFactorProduct (Hex.henselLiftData core B primeData)
           (Finset.univ \ S))
       core (primeData.p ^ B) := by
-  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  let : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   have hfull :=
     henselLiftData_liftedFactorProduct_univ_congr_core core B primeData
       hprime_invariant hp hB

--- a/HexBerlekampZassenhausMathlib/UFDPartition.lean
+++ b/HexBerlekampZassenhausMathlib/UFDPartition.lean
@@ -498,7 +498,7 @@ theorem normalizedFactors_le_map_normalize_of_dvd_prod_irreducibles
     have hunit : IsUnit g := isUnit_of_dvd_one hdvd
     rw [normalizedFactors_of_isUnit hunit]
     exact Multiset.zero_le _
-  · haveI : Nontrivial α := nontrivial_of_ne b 0 (hirr b hb).ne_zero
+  · have : Nontrivial α := nontrivial_of_ne b 0 (hirr b hb).ne_zero
     have hprod_ne : qs.prod ≠ 0 :=
       Multiset.prod_ne_zero fun hmem => (hirr 0 hmem).ne_zero rfl
     have hnorm_prod : normalizedFactors qs.prod = qs.map normalize :=
@@ -543,7 +543,7 @@ theorem existsUnique_subset_product_eq_of_dvd_of_squarefree_prod
     · rintro S ⟨hSle, _⟩
       exact Multiset.le_zero.mp hSle
   · -- factors ≠ ∅: pick `b ∈ factors` to derive `Nontrivial α`.
-    haveI : Nontrivial α := nontrivial_of_ne b 0 (hirr b hb).ne_zero
+    have : Nontrivial α := nontrivial_of_ne b 0 (hirr b hb).ne_zero
     have hprod_ne : factors.prod ≠ 0 :=
       Multiset.prod_ne_zero fun hmem => (hirr 0 hmem).ne_zero rfl
     have hd_ne : d ≠ 0 := by

--- a/HexBerlekampZassenhausMathlib/WordCld.lean
+++ b/HexBerlekampZassenhausMathlib/WordCld.lean
@@ -313,7 +313,7 @@ theorem cldQuotientModWord?_eq (f g : Hex.ZPoly) (p a : Nat)
     rw [ZPoly.coeff_reduceModPow, hmtoNat, hmeq, Int.ofNat_eq_natCast]
     exact ⟨Int.natCast_nonneg _, by exact_mod_cast intModNat_lt _ (p ^ a) (by omega)⟩
   · -- the cast equality: both quotients are `numerator /ₘ divisor` in `ZMod (p^a)[X]`
-    haveI : Fact (1 < (UInt64.ofNat mval).toNat) := ⟨by rw [hmtoNat]; exact hm1⟩
+    have : Fact (1 < (UInt64.ofNat mval).toNat) := ⟨by rw [hmtoNat]; exact hm1⟩
     have hmpa : (UInt64.ofNat mval).toNat = p ^ a := by rw [hmtoNat]; exact hmeq
     have hpapos : 0 < (UInt64.ofNat mval).toNat := by rw [hmtoNat]; omega
     -- `g` is monic in the various images

--- a/HexCharPolyMathlib/Basic.lean
+++ b/HexCharPolyMathlib/Basic.lean
@@ -790,12 +790,12 @@ theorem equiv_charPoly {n : Nat} (A : Hex.Matrix R n n) :
       simpa using (show n + 1 ≤ k by omega)
     rw [hhex]
     by_cases hR : Nontrivial R
-    · letI : Nontrivial R := hR
+    · let : Nontrivial R := hR
       symm
       apply Polynomial.coeff_eq_zero_of_natDegree_lt
       rw [Matrix.charpoly_natDegree_eq_dim]
       simpa only [Fintype.card_fin] using Nat.lt_of_not_ge hk
-    · haveI : Subsingleton R := not_nontrivial_iff_subsingleton.mp hR
+    · have : Subsingleton R := not_nontrivial_iff_subsingleton.mp hR
       exact Subsingleton.elim _ _
 
 end HexCharPolyMathlib

--- a/HexGFqMathlib/Subfield.lean
+++ b/HexGFqMathlib/Subfield.lean
@@ -207,7 +207,7 @@ theorem substHom_reduceMod (b : Hex.FpPoly p) (fm : Hex.FpPoly p)
     (hzero : substHom f hf hp hirr b fm = 0) (g : Hex.FpPoly p) :
     substHom f hf hp hirr b (Hex.GFqRing.reduceMod fm g) =
       substHom f hf hp hirr b g := by
-  letI : Hex.DensePoly.DivModLaws (Hex.ZMod64 p) :=
+  let : Hex.DensePoly.DivModLaws (Hex.ZMod64 p) :=
     Hex.ZMod64.instDivModLawsZMod64Fp p
   have hspec := Hex.DensePoly.DivModLaws.divMod_spec (R := Hex.ZMod64 p) g fm
   have hg : (Hex.DensePoly.divMod g fm).1 * fm + Hex.GFqRing.reduceMod fm g = g := hspec

--- a/HexHenselMathlib/HenselLemmas.lean
+++ b/HexHenselMathlib/HenselLemmas.lean
@@ -250,7 +250,7 @@ theorem quadraticHenselStep_bezout_correct
       Polynomial.map_mul, Polynomial.map_add, Polynomial.map_one, hone] using hmap
   · have hm_eq : m = 1 := by omega
     subst m
-    haveI : Subsingleton (ZMod (1 * 1)) := ZMod.subsingleton_iff.mpr (by norm_num)
+    have : Subsingleton (ZMod (1 * 1)) := ZMod.subsingleton_iff.mpr (by norm_num)
     apply Polynomial.ext
     intro n
     exact Subsingleton.elim _ _
@@ -333,7 +333,7 @@ theorem hensel_unique (f g h g' h' : Polynomial ℤ) (p : ℕ) (k : ℕ)
   simp only at hprod hprod' hg1 hcop ⊢
   induction k with
   | zero =>
-    haveI : Subsingleton (ZMod (p ^ 0)) := ZMod.subsingleton_iff.mpr (by simp)
+    have : Subsingleton (ZMod (p ^ 0)) := ZMod.subsingleton_iff.mpr (by simp)
     refine ⟨?_, ?_⟩ <;>
     · apply Polynomial.ext; intro n
       exact Subsingleton.elim _ _

--- a/HexIntervalMathlib/Experiment/PntTable10Exact.lean
+++ b/HexIntervalMathlib/Experiment/PntTable10Exact.lean
@@ -68,7 +68,7 @@ theorem exactBound_le_of_majorant (k : Nat) (a1 a2 epsilon A1 A2 E b b' T : Real
         A2 * y ^ k * Real.exp (-(2 * y / 3)) + E * y ^ k ≤ T) :
     exactBound k a1 a2 epsilon b b' ≤ T := by
   let interval : Set Real := Set.Icc (Real.exp b) (Real.exp b')
-  haveI : Nonempty interval :=
+  have : Nonempty interval :=
     ⟨Real.exp b, by
       change Real.exp b ∈ Set.Icc (Real.exp b) (Real.exp b')
       exact ⟨le_rfl, Real.exp_le_exp.mpr hbb'⟩⟩

--- a/HexModArithMathlib/WordMod.lean
+++ b/HexModArithMathlib/WordMod.lean
@@ -38,7 +38,7 @@ def toZMod (a : Hex.WordMod ctx) : ZMod m.toNat := (a.toNat : ZMod m.toNat)
 
 /-- The canonical representative of a transferred class is the residue's value. -/
 @[simp] theorem val_toZMod (a : Hex.WordMod ctx) : (toZMod a).val = a.toNat := by
-  haveI : NeZero m.toNat := ⟨Nat.ne_of_gt ctx.p_pos⟩
+  have : NeZero m.toNat := ⟨Nat.ne_of_gt ctx.p_pos⟩
   rw [toZMod, ZMod.val_natCast, Nat.mod_eq_of_lt a.toNat_lt]
 
 /-- `toZMod` is injective: its `ZMod` value is the residue, which pins the word. -/
@@ -55,24 +55,24 @@ theorem toZMod_injective : Function.Injective (toZMod (ctx := ctx)) := by
     _ = b.val.toNat := Hex.WordMod.toNat_mul_word b
 
 @[simp] theorem toZMod_zero : toZMod (0 : Hex.WordMod ctx) = 0 := by
-  haveI : NeZero m.toNat := ⟨Nat.ne_of_gt ctx.p_pos⟩
+  have : NeZero m.toNat := ⟨Nat.ne_of_gt ctx.p_pos⟩
   apply ZMod.val_injective
   rw [val_toZMod, ZMod.val_zero, Hex.WordMod.toNat_zero]
 
 @[simp] theorem toZMod_add (a b : Hex.WordMod ctx) :
     toZMod (a + b) = toZMod a + toZMod b := by
-  haveI : NeZero m.toNat := ⟨Nat.ne_of_gt ctx.p_pos⟩
+  have : NeZero m.toNat := ⟨Nat.ne_of_gt ctx.p_pos⟩
   apply ZMod.val_injective
   rw [ZMod.val_add, val_toZMod, val_toZMod, val_toZMod, Hex.WordMod.toNat_add]
 
 @[simp] theorem toZMod_mul (a b : Hex.WordMod ctx) :
     toZMod (a * b) = toZMod a * toZMod b := by
-  haveI : NeZero m.toNat := ⟨Nat.ne_of_gt ctx.p_pos⟩
+  have : NeZero m.toNat := ⟨Nat.ne_of_gt ctx.p_pos⟩
   apply ZMod.val_injective
   rw [ZMod.val_mul, val_toZMod, val_toZMod, val_toZMod, Hex.WordMod.toNat_mul]
 
 @[simp] theorem toZMod_one : toZMod (1 : Hex.WordMod ctx) = 1 := by
-  haveI : NeZero m.toNat := ⟨Nat.ne_of_gt ctx.p_pos⟩
+  have : NeZero m.toNat := ⟨Nat.ne_of_gt ctx.p_pos⟩
   apply ZMod.val_injective
   rw [val_toZMod, Hex.WordMod.toNat_one, ZMod.val_one_eq_one_mod]
 
@@ -106,7 +106,7 @@ ring structure back through the injective `toZMod`. -/
 
 @[simp] theorem toZMod_natCast (n : Nat) :
     toZMod ((n : Hex.WordMod ctx)) = (n : ZMod m.toNat) := by
-  haveI : NeZero m.toNat := ⟨Nat.ne_of_gt ctx.p_pos⟩
+  have : NeZero m.toNat := ⟨Nat.ne_of_gt ctx.p_pos⟩
   show toZMod (Hex.WordMod.ofNat n) = _
   rw [toZMod, Hex.WordMod.toNat_ofNat, ZMod.natCast_mod]
 

--- a/HexMvPolyMathlib/Aeval.lean
+++ b/HexMvPolyMathlib/Aeval.lean
@@ -153,7 +153,7 @@ direct Mathlib-free evaluator. -/
     MvPoly n R cmp →ₐ[R] S where
   toRingHom := eval₂Hom (algebraMap R S) x
   commutes' r := by
-    letI : DecidableEq R := instDecidableEqOfLawfulBEq
+    let : DecidableEq R := instDecidableEqOfLawfulBEq
     rw [algebraMap_apply]
     change
       eval₂ (algebraMap R S) x
@@ -231,14 +231,14 @@ map. -/
 @[simp] theorem aeval_C [CommSemiring R]
     [CommSemiring S] [Algebra R S] (x : Fin n → S) (r : R) :
     aeval x (C r : MvPoly n R cmp) = algebraMap R S r := by
-  letI : DecidableEq R := instDecidableEqOfLawfulBEq
+  let : DecidableEq R := instDecidableEqOfLawfulBEq
   rw [aeval_apply, toMvPolynomial_C, MvPolynomial.aeval_C]
 
 /-- Algebra evaluation sends a variable polynomial to its assigned value. -/
 @[simp] theorem aeval_X [CommSemiring R]
     [CommSemiring S] [Algebra R S] (x : Fin n → S) (i : Fin n) :
     aeval x (X i : MvPoly n R cmp) = x i := by
-  letI : DecidableEq R := instDecidableEqOfLawfulBEq
+  let : DecidableEq R := instDecidableEqOfLawfulBEq
   rw [aeval_apply, toMvPolynomial_X, MvPolynomial.aeval_X]
 
 /-- Algebra evaluation preserves negation. -/

--- a/HexNumberFieldMathlib/AdjoinRoot.lean
+++ b/HexNumberFieldMathlib/AdjoinRoot.lean
@@ -178,7 +178,7 @@ presentation. -/
 theorem toComplex_injective [ZPoly.CheckedIrreducible p]
     (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x) :
     Function.Injective (fun a : QAdjoin p x => toComplex a rep h) := by
-  letI : Fact (_root_.Irreducible (definingPolynomial p)) :=
+  let : Fact (_root_.Irreducible (definingPolynomial p)) :=
     ⟨definingPolynomial_irreducible p⟩
   intro a b hab
   apply toAdjoinRoot_bijective.1
@@ -543,7 +543,7 @@ noncomputable scoped instance (p : ZPoly) (x : SimpleRoot p)
 /-- A checked rational presentation has characteristic zero. -/
 noncomputable scoped instance (p : ZPoly) (x : SimpleRoot p)
     [ZPoly.CheckedIrreducible p] : CharZero (QAdjoin p x) := by
-  letI : Field (QAdjoin p x) := field p x
+  let : Field (QAdjoin p x) := field p x
   let rep : RefinedIsolation p := Quot.out x
   have hrep : SimpleRoot.mk rep = x := Quot.out_eq x
   constructor
@@ -585,7 +585,7 @@ theorem toAdjoinRoot_zero [ZPoly.CheckedIrreducible p] :
     toAdjoinRoot (0 : QAdjoin p x) = 0 := by
   let rep : RefinedIsolation p := Quot.out x
   have hrep : SimpleRoot.mk rep = x := Quot.out_eq x
-  letI : Fact (_root_.Irreducible (definingPolynomial p)) :=
+  let : Fact (_root_.Irreducible (definingPolynomial p)) :=
     ⟨definingPolynomial_irreducible p⟩
   apply (rootHom rep).injective
   rw [rootHom_toAdjoinRoot, (rootHom rep).map_zero]
@@ -596,7 +596,7 @@ theorem toAdjoinRoot_one [ZPoly.CheckedIrreducible p] :
     toAdjoinRoot (1 : QAdjoin p x) = 1 := by
   let rep : RefinedIsolation p := Quot.out x
   have hrep : SimpleRoot.mk rep = x := Quot.out_eq x
-  letI : Fact (_root_.Irreducible (definingPolynomial p)) :=
+  let : Fact (_root_.Irreducible (definingPolynomial p)) :=
     ⟨definingPolynomial_irreducible p⟩
   apply (rootHom rep).injective
   rw [rootHom_toAdjoinRoot, (rootHom rep).map_one]
@@ -608,7 +608,7 @@ theorem toAdjoinRoot_add [ZPoly.CheckedIrreducible p]
     toAdjoinRoot (a + b) = toAdjoinRoot a + toAdjoinRoot b := by
   let rep : RefinedIsolation p := Quot.out x
   have hrep : SimpleRoot.mk rep = x := Quot.out_eq x
-  letI : Fact (_root_.Irreducible (definingPolynomial p)) :=
+  let : Fact (_root_.Irreducible (definingPolynomial p)) :=
     ⟨definingPolynomial_irreducible p⟩
   apply (rootHom rep).injective
   rw [rootHom_toAdjoinRoot, (rootHom rep).map_add,
@@ -621,7 +621,7 @@ theorem toAdjoinRoot_mul [ZPoly.CheckedIrreducible p]
     toAdjoinRoot (a * b) = toAdjoinRoot a * toAdjoinRoot b := by
   let rep : RefinedIsolation p := Quot.out x
   have hrep : SimpleRoot.mk rep = x := Quot.out_eq x
-  letI : Fact (_root_.Irreducible (definingPolynomial p)) :=
+  let : Fact (_root_.Irreducible (definingPolynomial p)) :=
     ⟨definingPolynomial_irreducible p⟩
   apply (rootHom rep).injective
   rw [rootHom_toAdjoinRoot, (rootHom rep).map_mul,
@@ -635,7 +635,7 @@ theorem toAdjoinRoot_smul [ZPoly.CheckedIrreducible p]
     toAdjoinRoot (q • a) = q • toAdjoinRoot a := by
   let rep : RefinedIsolation p := Quot.out x
   have hrep : SimpleRoot.mk rep = x := Quot.out_eq x
-  letI : Fact (_root_.Irreducible (definingPolynomial p)) :=
+  let : Fact (_root_.Irreducible (definingPolynomial p)) :=
     ⟨definingPolynomial_irreducible p⟩
   apply (rootHom rep).injective
   rw [rootHom_toAdjoinRoot]

--- a/HexNumberFieldMathlib/AlgebraicRoots.lean
+++ b/HexNumberFieldMathlib/AlgebraicRoots.lean
@@ -61,7 +61,7 @@ theorem roots?_isSome (f : AlgebraicPoly) :
       cases h : f.isZero <;> simp_all
     obtain ⟨common, hcommon⟩ := exists_presentation f hf
     rw [hcommon]
-    letI : ZPoly.CheckedIrreducible common.generator.p :=
+    let : ZPoly.CheckedIrreducible common.generator.p :=
       common.generator.checked
     exact QAdjoin.roots?_isSome
       (DensePoly.ofCoeffs common.coefficients)
@@ -85,7 +85,7 @@ private theorem presentation_polynomial (f : AlgebraicPoly)
         (DensePoly.ofCoeffs common.coefficients)
         common.generator.rep common.generator.rep_mk =
       f.toPolynomial := by
-  letI : ZPoly.CheckedIrreducible common.generator.p :=
+  let : ZPoly.CheckedIrreducible common.generator.p :=
     common.generator.checked
   obtain ⟨hsize, hvalues⟩ :=
     Common.presentation?_sound f.coeffs hcommon
@@ -121,7 +121,7 @@ private theorem roots_eq_fixed (f : AlgebraicPoly)
     f.roots = @QAdjoin.roots _ _ common.generator.checked
       (DensePoly.ofCoeffs common.coefficients)
       common.generator.rep common.generator.rep_mk := by
-  letI : ZPoly.CheckedIrreducible common.generator.p :=
+  let : ZPoly.CheckedIrreducible common.generator.p :=
     common.generator.checked
   have halgebraic := roots?_eq_roots f
   rw [AlgebraicPoly.roots?, ite_eq_right (by simp [hf])] at halgebraic
@@ -152,7 +152,7 @@ theorem roots_all_iff (f : AlgebraicPoly) :
   · have hf : f.isZero = false := by
       cases h : f.isZero <;> simp_all
     obtain ⟨common, hcommon⟩ := exists_presentation f hf
-    letI : ZPoly.CheckedIrreducible common.generator.p :=
+    let : ZPoly.CheckedIrreducible common.generator.p :=
       common.generator.checked
     rw [roots_eq_fixed f common hf hcommon,
       ← presentation_polynomial f common hcommon]
@@ -172,7 +172,7 @@ theorem contains_roots_iff (f : AlgebraicPoly) (z : ℂ) :
   · have hf : f.isZero = false := by
       cases h : f.isZero <;> simp_all
     obtain ⟨common, hcommon⟩ := exists_presentation f hf
-    letI : ZPoly.CheckedIrreducible common.generator.p :=
+    let : ZPoly.CheckedIrreducible common.generator.p :=
       common.generator.checked
     rw [roots_eq_fixed f common hf hcommon,
       ← presentation_polynomial f common hcommon]
@@ -191,7 +191,7 @@ theorem multiplicity_roots (f : AlgebraicPoly) (z : ℂ) :
   · have hf : f.isZero = false := by
       cases h : f.isZero <;> simp_all
     obtain ⟨common, hcommon⟩ := exists_presentation f hf
-    letI : ZPoly.CheckedIrreducible common.generator.p :=
+    let : ZPoly.CheckedIrreducible common.generator.p :=
       common.generator.checked
     rw [roots_eq_fixed f common hf hcommon,
       ← presentation_polynomial f common hcommon]
@@ -217,7 +217,7 @@ theorem roots_noDuplicates (f : AlgebraicPoly) :
   · have hf : f.isZero = false := by
       cases h : f.isZero <;> simp_all
     obtain ⟨common, hcommon⟩ := exists_presentation f hf
-    letI : ZPoly.CheckedIrreducible common.generator.p :=
+    let : ZPoly.CheckedIrreducible common.generator.p :=
       common.generator.checked
     rw [roots_eq_fixed f common hf hcommon]
     exact QAdjoin.roots_noDuplicates
@@ -233,7 +233,7 @@ theorem roots_ordered (f : AlgebraicPoly) :
   · have hf : f.isZero = false := by
       cases h : f.isZero <;> simp_all
     obtain ⟨common, hcommon⟩ := exists_presentation f hf
-    letI : ZPoly.CheckedIrreducible common.generator.p :=
+    let : ZPoly.CheckedIrreducible common.generator.p :=
       common.generator.checked
     rw [roots_eq_fixed f common hf hcommon]
     exact QAdjoin.roots_ordered
@@ -251,7 +251,7 @@ theorem totalMultiplicity_roots (f : AlgebraicPoly)
     | true =>
         exact (hfPolynomial ((isZero_iff f).mp h)).elim
   obtain ⟨common, hcommon⟩ := exists_presentation f hf
-  letI : ZPoly.CheckedIrreducible common.generator.p :=
+  let : ZPoly.CheckedIrreducible common.generator.p :=
     common.generator.checked
   have hpolynomial := presentation_polynomial f common hcommon
   rw [roots_eq_fixed f common hf hcommon, ← hpolynomial]

--- a/HexNumberFieldMathlib/Basic.lean
+++ b/HexNumberFieldMathlib/Basic.lean
@@ -77,7 +77,7 @@ rational minimal polynomial. -/
 theorem p_eq_minpoly (a : AlgebraicNumber) :
     (a.p.leadingCoeff : Rat)⁻¹ • HexPolyZMathlib.toPolyℚ a.p =
       minpoly Rat a.toComplex := by
-  letI : ZPoly.CheckedIrreducible a.p := a.checked
+  let : ZPoly.CheckedIrreducible a.p := a.checked
   have hroot :
       Polynomial.aeval a.toComplex (HexPolyZMathlib.toPolyℚ a.p) = 0 := by
     rw [Polynomial.aeval_def, Polynomial.eval₂_eq_eval_map]
@@ -388,7 +388,7 @@ theorem AlgebraicNumber.beq_iff (a b : AlgebraicNumber) :
   constructor
   · rintro ⟨hp, hmeet⟩
     let brep : RefinedIsolation a.p := b.rep.castPoly hp
-    letI : ZPoly.CheckedIrreducible a.p := a.checked
+    let : ZPoly.CheckedIrreducible a.p := a.checked
     have hinter : Intersects a.rep brep := by
       change a.rep.1.square.discsMeet brep.1.square = true
       rw [show brep.1.square = b.rep.1.square by
@@ -404,7 +404,7 @@ theorem AlgebraicNumber.beq_iff (a b : AlgebraicNumber) :
     have hp := AlgebraicNumber.eq_polynomial hroot
     refine ⟨hp, ?_⟩
     let brep : RefinedIsolation a.p := b.rep.castPoly hp
-    letI : ZPoly.CheckedIrreducible a.p := a.checked
+    let : ZPoly.CheckedIrreducible a.p := a.checked
     have hroot' : a.rep.root = brep.root := by
       rw [show brep.root = b.rep.root by
         exact RefinedIsolation.castPoly_root hp b.rep]

--- a/HexNumberFieldMathlib/Coordinates.lean
+++ b/HexNumberFieldMathlib/Coordinates.lean
@@ -116,7 +116,7 @@ theorem degree_dvd_of_mem (gamma a : AlgebraicNumber)
     degree a ∣ degree gamma := by
   let K : IntermediateField Rat ℂ := Rat⟮gamma.toComplex⟯
   let aK : K := ⟨a.toComplex, ha⟩
-  letI : FiniteDimensional Rat K :=
+  let : FiniteDimensional Rat K :=
     IntermediateField.adjoin.finiteDimensional (isIntegral_toComplex gamma)
   have hmin : minpoly Rat aK = minpoly Rat a.toComplex :=
     (minpoly.algHom_eq K.val K.val.injective aK).symm
@@ -142,7 +142,7 @@ theorem trace?_sound (gamma a : AlgebraicNumber)
   let K : IntermediateField Rat ℂ := Rat⟮gamma.toComplex⟯
   let aK : K := ⟨a.toComplex, ha⟩
   change t = Algebra.trace Rat K aK
-  letI : FiniteDimensional Rat K :=
+  let : FiniteDimensional Rat K :=
     IntermediateField.adjoin.finiteDimensional (isIntegral_toComplex gamma)
   have hmin : minpoly Rat aK = minpoly Rat a.toComplex :=
     (minpoly.algHom_eq K.val K.val.injective aK).symm
@@ -178,7 +178,7 @@ private theorem traceGram_det_ne_zero (gamma : AlgebraicNumber)
       (Matrix.ofFn fun i : Fin (degree gamma) =>
         fun j : Fin (degree gamma) => powerTraces[i.val + j.val]!))) ≠ 0 := by
   let K : IntermediateField Rat ℂ := Rat⟮gamma.toComplex⟯
-  letI : FiniteDimensional Rat K :=
+  let : FiniteDimensional Rat K :=
     IntermediateField.adjoin.finiteDimensional (isIntegral_toComplex gamma)
   let pb := IntermediateField.adjoin.powerBasis (isIntegral_toComplex gamma)
   have hpbdim : pb.dim = degree gamma := by
@@ -317,7 +317,7 @@ private theorem basisCoeffs_solve (gamma a : AlgebraicNumber)
               i.val⟩ : Rat⟮gamma.toComplex⟯) =
         (⟨a.toComplex, ha⟩ : Rat⟮gamma.toComplex⟯) := by
   let K : IntermediateField Rat ℂ := Rat⟮gamma.toComplex⟯
-  letI : FiniteDimensional Rat K :=
+  let : FiniteDimensional Rat K :=
     IntermediateField.adjoin.finiteDimensional (isIntegral_toComplex gamma)
   let pb := IntermediateField.adjoin.powerBasis (isIntegral_toComplex gamma)
   have hpbdim : pb.dim = degree gamma := by
@@ -595,7 +595,7 @@ theorem coordinates?_isSome (gamma a : AlgebraicNumber)
     let coordinate : QAdjoin gamma.p gamma.x :=
       QAdjoin.reduce gamma.p gamma.x
         (DensePoly.ofCoeffs coeffs.toArray)
-    letI : ZPoly.CheckedIrreducible gamma.p := gamma.checked
+    let : ZPoly.CheckedIrreducible gamma.p := gamma.checked
     obtain ⟨recovered, hrecovered⟩ := Option.isSome_iff_exists.mp
       (QAdjoin.toAlgebraicNumber?_isSome coordinate gamma.rep
         gamma.rep_mk)
@@ -620,7 +620,7 @@ theorem coordinates?_sound (gamma a : AlgebraicNumber)
     (powers : Array AlgebraicNumber) {coordinate : QAdjoin gamma.p gamma.x}
     (h : coordinates? gamma a powers = some coordinate) :
     QAdjoin.toComplex coordinate gamma.rep gamma.rep_mk = a.toComplex := by
-  letI : ZPoly.CheckedIrreducible gamma.p := gamma.checked
+  let : ZPoly.CheckedIrreducible gamma.p := gamma.checked
   unfold coordinates? at h
   split at h
   next hzero =>

--- a/HexNumberFieldMathlib/Exact.lean
+++ b/HexNumberFieldMathlib/Exact.lean
@@ -402,7 +402,7 @@ theorem exact?_isSome (a : AlgebraicRoot) :
     (Hex.ZPoly.isIrreducible_iff
       entry.1).mpr hirredProp
   let checked : ZPoly.CheckedIrreducible entry.1 := ⟨hirred, hdegree⟩
-  letI : ZPoly.CheckedIrreducible entry.1 := checked
+  let : ZPoly.CheckedIrreducible entry.1 := checked
   have hentryNe : entry.1 ≠ 0 := by
     intro hq
     rw [hq] at hdegree
@@ -622,9 +622,9 @@ private theorem minpoly_relation [ZPoly.CheckedIrreducible p]
     0 < d ∧ d ≤ p.degree?.getD 0 ∧
       (a.relationAt? a.krylovOrbit d).isSome := by
   let b : AdjoinRoot (definingPolynomial p) := toAdjoinRoot a
-  letI : Module.Free Rat (AdjoinRoot (definingPolynomial p)) :=
+  let : Module.Free Rat (AdjoinRoot (definingPolynomial p)) :=
     (definingPolynomial_monic p).free_adjoinRoot
-  letI : Module.Finite Rat (AdjoinRoot (definingPolynomial p)) :=
+  let : Module.Finite Rat (AdjoinRoot (definingPolynomial p)) :=
     (definingPolynomial_monic p).finite_adjoinRoot
   have hbint : IsIntegral Rat b := IsIntegral.of_finite Rat b
   let m : Polynomial Rat := minpoly Rat b
@@ -845,9 +845,9 @@ private theorem minpoly?_natDegree [ZPoly.CheckedIrreducible p]
     (HexPolyZMathlib.toPolyℚ q).natDegree = (minpoly Rat b).natDegree := by
   let b : AdjoinRoot (definingPolynomial p) := toAdjoinRoot a
   let d := (minpoly Rat b).natDegree
-  letI : Module.Free Rat (AdjoinRoot (definingPolynomial p)) :=
+  let : Module.Free Rat (AdjoinRoot (definingPolynomial p)) :=
     (definingPolynomial_monic p).free_adjoinRoot
-  letI : Module.Finite Rat (AdjoinRoot (definingPolynomial p)) :=
+  let : Module.Finite Rat (AdjoinRoot (definingPolynomial p)) :=
     (definingPolynomial_monic p).finite_adjoinRoot
   have hbint : IsIntegral Rat b := IsIntegral.of_finite Rat b
   unfold minpoly? at hq
@@ -932,9 +932,9 @@ private theorem minpoly?_certificates [ZPoly.CheckedIrreducible p]
     ZPoly.ratPolyPrimitivePart_primitive (relationPoly coeffs) hcontentNe
   let q := ZPoly.ratPolyPrimitivePart (relationPoly coeffs)
   let b : AdjoinRoot (definingPolynomial p) := toAdjoinRoot a
-  letI : Module.Free Rat (AdjoinRoot (definingPolynomial p)) :=
+  let : Module.Free Rat (AdjoinRoot (definingPolynomial p)) :=
     (definingPolynomial_monic p).free_adjoinRoot
-  letI : Module.Finite Rat (AdjoinRoot (definingPolynomial p)) :=
+  let : Module.Finite Rat (AdjoinRoot (definingPolynomial p)) :=
     (definingPolynomial_monic p).finite_adjoinRoot
   have hbint : IsIntegral Rat b := IsIntegral.of_finite Rat b
   let E := adjoinRootAlgEquiv (p := p) (x := x)
@@ -978,7 +978,7 @@ private theorem minpoly?_certificates [ZPoly.CheckedIrreducible p]
       hirredProp
   let checked : ZPoly.CheckedIrreducible q := ⟨hirred, by
     simpa [q] using hdegree⟩
-  letI : ZPoly.CheckedIrreducible q := checked
+  let : ZPoly.CheckedIrreducible q := checked
   have hsimple : HasOnlySimpleRoots q :=
     (HexRootsMathlib.hasOnlySimpleRoots_iff_separable q (by simpa [q] using hqne)).mpr
       (ZPoly.CheckedIrreducible.separable q)

--- a/HexNumberFieldMathlib/Lazy.lean
+++ b/HexNumberFieldMathlib/Lazy.lean
@@ -395,7 +395,7 @@ private theorem ZPoly.reciprocal_isRoot {p : ZPoly} {z : ℂ}
     (hroot : (HexRootsMathlib.toPolyℂ p).IsRoot z) :
     (HexRootsMathlib.toPolyℂ p.reciprocal).IsRoot z⁻¹ := by
   rw [ZPoly.toPolyℂ_reciprocal p hp]
-  letI : Invertible z := invertibleOfNonzero hz
+  let : Invertible z := invertibleOfNonzero hz
   change ((HexRootsMathlib.toPolyℂ p).reverse).eval z⁻¹ = 0
   change (HexRootsMathlib.toPolyℂ p).eval z = 0 at hroot
   have hreverse :=

--- a/HexNumberFieldMathlib/Primitive.lean
+++ b/HexNumberFieldMathlib/Primitive.lean
@@ -134,7 +134,7 @@ private theorem shift_degree_le (theta alpha candidate : AlgebraicNumber)
   let alphaK : K := IntermediateField.AdjoinPair.gen₂
     Rat theta.toComplex alpha.toComplex
   let candidateK : K := thetaK + (c : Rat) • alphaK
-  letI : FiniteDimensional Rat K :=
+  let : FiniteDimensional Rat K :=
     IntermediateField.finiteDimensional_adjoin_pair
       (isIntegral_toComplex theta) (isIntegral_toComplex alpha)
   have hvalue : candidate.toComplex = (candidateK : ℂ) := by
@@ -159,7 +159,7 @@ private theorem exists_shift_degree_eq (theta alpha : AlgebraicNumber) :
     Rat theta.toComplex alpha.toComplex
   let alphaK : K := IntermediateField.AdjoinPair.gen₂
     Rat theta.toComplex alpha.toComplex
-  letI : FiniteDimensional Rat K :=
+  let : FiniteDimensional Rat K :=
     IntermediateField.finiteDimensional_adjoin_pair
       (isIntegral_toComplex theta) (isIntegral_toComplex alpha)
   have hgen : ∀ phi psi : K →ₐ[Rat] ℂ,
@@ -372,7 +372,7 @@ theorem extend?_field (theta alpha gamma : AlgebraicNumber)
           Rat theta.toComplex alpha.toComplex
   have hle : Rat⟮gamma.toComplex⟯ ≤ K :=
     IntermediateField.adjoin_simple_le_iff.mpr hmember
-  letI : FiniteDimensional Rat K :=
+  let : FiniteDimensional Rat K :=
     IntermediateField.finiteDimensional_adjoin_pair
       (isIntegral_toComplex theta) (isIntegral_toComplex alpha)
   apply IntermediateField.eq_of_le_of_finrank_eq hle

--- a/HexNumberFieldMathlib/Roots.lean
+++ b/HexNumberFieldMathlib/Roots.lean
@@ -702,7 +702,7 @@ private theorem conjugateEmbedding_apply [ZPoly.CheckedIrreducible p]
 private theorem conjugateEmbedding_injective [ZPoly.CheckedIrreducible p]
     (y : ℂ) (hy : (HexRootsMathlib.toPolyℂ p).eval y = 0) :
     Function.Injective (conjugateEmbedding (x := x) y hy) := by
-  letI : Fact (_root_.Irreducible (definingPolynomial p)) :=
+  let : Fact (_root_.Irreducible (definingPolynomial p)) :=
     ⟨definingPolynomial_irreducible p⟩
   exact (AdjoinRoot.lift (algebraMap Rat ℂ) y
     (definingPolynomial_isRoot hy)).injective.comp
@@ -904,7 +904,7 @@ theorem normEliminant_ne_zero [ZPoly.CheckedIrreducible p]
     simp at hdegree
   have hPne : P ≠ 0 := by
     exact HexRootsMathlib.toPolyℂ_ne_zero p hpSize
-  letI : Fintype (P.rootSet ℂ) :=
+  let : Fintype (P.rootSet ℂ) :=
     (Polynomial.rootSet_finite P ℂ).fintype
   let H (y : P.rootSet ℂ) : Polynomial ℂ :=
     Q.map (conjugateEmbedding y.1 (by

--- a/HexNumberFieldTowerMathlib/Adjoin.lean
+++ b/HexNumberFieldTowerMathlib/Adjoin.lean
@@ -263,7 +263,7 @@ private theorem vanishing_factor_unique {T : NumberTower} {f : Poly T}
       (T.toPolynomial b.1) = 0) :
     a = b := by
   by_contra hab
-  letI : Std.Symm (fun x y : Poly T × Nat => x.1 ≠ y.1) :=
+  let : Std.Symm (fun x y : Poly T × Nat => x.1 ≠ y.1) :=
     ⟨fun _ _ h => h.symm⟩
   have hfactorNe : a.1 ≠ b.1 :=
     (factor_fsts_pairwise r hsound).forall ha hb hab

--- a/HexNumberFieldTowerMathlib/ArithmeticCore/Basic.lean
+++ b/HexNumberFieldTowerMathlib/ArithmeticCore/Basic.lean
@@ -1389,7 +1389,7 @@ theorem denseMap_eq_denseEval (lower : List Level) (x : ℂ)
       coeffField lower hvalid hinjective hinv
     denseMap lower x hvalid hinjective hinv f =
       denseEval lower x degree f := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffField lower hvalid hinjective hinv
   rw [denseMap,
     Polynomial.eval₂_eq_sum_range'
@@ -1409,7 +1409,7 @@ theorem denseMap_mul (lower : List Level) (x : ℂ)
     denseMap lower x hvalid hinjective hinv (f * g) =
       denseMap lower x hvalid hinjective hinv f *
         denseMap lower x hvalid hinjective hinv g := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffField lower hvalid hinjective hinv
   simp [denseMap, HexPolyMathlib.toPolynomial_mul, Polynomial.eval₂_mul]
 
@@ -1424,7 +1424,7 @@ theorem denseMap_add (lower : List Level) (x : ℂ)
     denseMap lower x hvalid hinjective hinv (f + g) =
       denseMap lower x hvalid hinjective hinv f +
         denseMap lower x hvalid hinjective hinv g := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffField lower hvalid hinjective hinv
   simp [denseMap, HexPolyMathlib.toPolynomial_add, Polynomial.eval₂_add]
 
@@ -1439,7 +1439,7 @@ theorem denseMap_scale (lower : List Level) (x : ℂ)
       coeffField lower hvalid hinjective hinv
     denseMap lower x hvalid hinjective hinv (DensePoly.scale c f) =
       coeffDenote lower c * denseMap lower x hvalid hinjective hinv f := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffField lower hvalid hinjective hinv
   simp [denseMap, HexPolyMathlib.toPolynomial_scale, Polynomial.eval₂_mul,
     coeffHom]
@@ -1454,7 +1454,7 @@ theorem denseMap_C (lower : List Level) (x : ℂ)
       coeffField lower hvalid hinjective hinv
     denseMap lower x hvalid hinjective hinv (DensePoly.C c) =
       coeffDenote lower c := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffField lower hvalid hinjective hinv
   simp [denseMap, coeffHom]
 

--- a/HexNumberFieldTowerMathlib/ArithmeticCore/Field.lean
+++ b/HexNumberFieldTowerMathlib/ArithmeticCore/Field.lean
@@ -22,7 +22,7 @@ theorem denseMap_zero (lower : List Level) (x : ℂ)
     letI : Field (Arithmetic.Coeff lower) :=
       coeffField lower hvalid hinjective hinv
     denseMap lower x hvalid hinjective hinv 0 = 0 := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffField lower hvalid hinjective hinv
   simp [denseMap]
 
@@ -335,12 +335,12 @@ theorem separates_of_irreducible (level : Level) (lower : List Level)
     Irreducible (HexPolyMathlib.toPolynomial
       (Arithmetic.Coeff.relation level lower)) →
       Separates level lower := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffField lower hvalid.2.2 hlowerInjective hlowerInv
   intro hirreducible
   let ι : Arithmetic.Coeff lower →+* ℂ :=
     coeffHom lower hvalid.2.2 hlowerInjective hlowerInv
-  letI : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
+  let : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
   let relation := Arithmetic.Coeff.relation level lower
   let p := HexPolyMathlib.toPolynomial relation
   have hpMonic : p.Monic := by
@@ -412,13 +412,13 @@ theorem relation_irreducible_of_injective (level : Level)
       coeffField lower hvalid.2.2 hlowerInjective hlowerInv
     Irreducible (HexPolyMathlib.toPolynomial
       (Arithmetic.Coeff.relation level lower)) := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffField lower hvalid.2.2 hlowerInjective hlowerInv
   let relation := Arithmetic.Coeff.relation level lower
   let p := HexPolyMathlib.toPolynomial relation
   let ι : Arithmetic.Coeff lower →+* ℂ :=
     coeffHom lower hvalid.2.2 hlowerInjective hlowerInv
-  letI : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
+  let : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
   have hpMonic : p.Monic := by
     rw [Polynomial.Monic.def]
     change (HexPolyMathlib.toPolynomial relation).leadingCoeff = 1
@@ -489,7 +489,7 @@ theorem xgcdLeft_size_one (level : Level) (lower : List Level)
       coeffField lower hvalid.2.2 hlowerInjective hinv
     (DensePoly.xgcdLeft (Arithmetic.Coeff.value level lower a)
       (Arithmetic.Coeff.relation level lower)).gcd.size = 1 := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffField lower hvalid.2.2 hlowerInjective hinv
   let value := Arithmetic.Coeff.value level lower a
   let relation := Arithmetic.Coeff.relation level lower
@@ -630,7 +630,7 @@ theorem denote_xgcd_inverse (level : Level) (lower : List Level)
           (((List.range level.degree).map fun i =>
             (normalized.coeff i).data).toArray)) =
       (denote (level :: lower) a)⁻¹ := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffField lower hvalid.2.2 hlowerInjective hinv
   let value := Arithmetic.Coeff.value level lower a
   let relation := Arithmetic.Coeff.relation level lower
@@ -836,7 +836,7 @@ theorem denote_invCoords (levels : List Level) (hvalid : LevelsValid levels)
           (denote lower b.data)⁻¹
         rw [denote_fixed]
         exact ih hvalid.2.2 hlowerInjective b.data
-      letI : Field (Arithmetic.Coeff lower) :=
+      let : Field (Arithmetic.Coeff lower) :=
         coeffField lower hvalid.2.2 hlowerInjective hlowerInv
       let zeroTest :=
         (Arithmetic.fixedCoeffs
@@ -1003,7 +1003,7 @@ from raw data reads off its first entry. -/
 theorem coeffRatEquiv_ofData (data : Array Rat) :
     letI : Field (Arithmetic.Coeff []) := coeffFieldNil
     coeffRatEquiv (Arithmetic.Coeff.ofData [] data) = data.getD 0 0 := by
-  letI : Field (Arithmetic.Coeff []) := coeffFieldNil
+  let : Field (Arithmetic.Coeff []) := coeffFieldNil
   change (Arithmetic.fixedCoeffs (levelsDim []) data).getD 0 0 =
     data.getD 0 0
   simp [Arithmetic.fixedCoeffs, levelsDim, Array.getD]
@@ -1015,7 +1015,7 @@ theorem map_rawPoly_nil (f : Array (Array Rat)) :
     (HexPolyMathlib.toPolynomial (Factor.rawPoly [] f)).map
         coeffRatEquiv.toRingHom =
       HexPolyMathlib.toPolynomial (Factor.toRatPoly f) := by
-  letI : Field (Arithmetic.Coeff []) := coeffFieldNil
+  let : Field (Arithmetic.Coeff []) := coeffFieldNil
   ext n
   rw [Polynomial.coeff_map, HexPolyMathlib.coeff_toPolynomial,
     HexPolyMathlib.coeff_toPolynomial]
@@ -1032,7 +1032,7 @@ theorem isIrreducible_nil_toMathlib (f : Array (Array Rat))
     (hcheck : Factor.isIrreducible [] f = true) :
     letI : Field (Arithmetic.Coeff []) := coeffFieldNil
     Irreducible (HexPolyMathlib.toPolynomial (Factor.rawPoly [] f)) := by
-  letI : Field (Arithmetic.Coeff []) := coeffFieldNil
+  let : Field (Arithmetic.Coeff []) := coeffFieldNil
   simp only [Factor.isIrreducible, Bool.and_eq_true] at hcheck
   have hdegree := hcheck.1.1.1
   have hirreducible := hcheck.2
@@ -1112,7 +1112,7 @@ theorem map_relation_nil (level : Level) (hstruct : level.Structural 1) :
         coeffRatEquiv.toRingHom =
       HexPolyMathlib.toPolynomial
         (Factor.toRatPoly (level.polynomial [])) := by
-  letI : Field (Arithmetic.Coeff []) := coeffFieldNil
+  let : Field (Arithmetic.Coeff []) := coeffFieldNil
   ext n
   rw [Polynomial.coeff_map, HexPolyMathlib.coeff_toPolynomial,
     HexPolyMathlib.coeff_toPolynomial]
@@ -1189,9 +1189,9 @@ theorem relation_irreducible_rational (level : Level)
     letI : Field (Arithmetic.Coeff []) := coeffFieldNil
     Irreducible (HexPolyMathlib.toPolynomial
       (Arithmetic.Coeff.relation level [])) := by
-  letI : Field (Arithmetic.Coeff []) := coeffFieldNil
+  let : Field (Arithmetic.Coeff []) := coeffFieldNil
   obtain ⟨_, original, checked, hp, hraw⟩ := hrelation
-  letI : ZPoly.CheckedIrreducible original := checked
+  let : ZPoly.CheckedIrreducible original := checked
   have hirrOriginal :
       Irreducible (HexPolyZMathlib.toPolyℚ original) :=
     ZPoly.CheckedIrreducible.irreducibleRat original
@@ -1236,7 +1236,7 @@ associate; relative certificates over the rational base use the recursive
 factor checker base case. -/
 theorem DenoteInjective.singleton (level : Level)
     (hvalid : LevelsValid [level]) : DenoteInjective [level] := by
-  letI : Field (Arithmetic.Coeff []) := coeffFieldNil
+  let : Field (Arithmetic.Coeff []) := coeffFieldNil
   have hrelation : Irreducible (HexPolyMathlib.toPolynomial
       (Arithmetic.Coeff.relation level [])) := by
     cases hvalid.2.1 with

--- a/HexNumberFieldTowerMathlib/Factor.lean
+++ b/HexNumberFieldTowerMathlib/Factor.lean
@@ -142,7 +142,7 @@ private theorem map_rawPoly (T : NumberTower) (f : Poly T) :
         (coeffEquiv T).toRingHom = HexPolyMathlib.toPolynomial f := by
   let hinjective := coeffDenote_injective T
   let hinv := LevelSemantics.coeffDenote_inv T.levels.toList T.valid hinjective
-  letI : Field (Arithmetic.Coeff T.levels.toList) :=
+  let : Field (Arithmetic.Coeff T.levels.toList) :=
     Norm.coeffFieldPoly T.levels.toList T.valid hinjective hinv
   apply Polynomial.ext
   intro n
@@ -187,7 +187,7 @@ theorem rawPolynomial_rawPoly (T : NumberTower) (f : Poly T) :
       T.toPolynomial f := by
   let hinjective := coeffDenote_injective T
   let hinv := LevelSemantics.coeffDenote_inv T.levels.toList T.valid hinjective
-  letI : Field (Arithmetic.Coeff T.levels.toList) :=
+  let : Field (Arithmetic.Coeff T.levels.toList) :=
     Norm.coeffFieldPoly T.levels.toList T.valid hinjective hinv
   rw [Norm.rawPolynomial_eq_map T.levels.toList T.valid hinjective hinv,
     toPolynomial_eq_map, ← map_rawPoly T f, Polynomial.map_map]
@@ -205,7 +205,7 @@ theorem polyCoords_rawPoly (T : NumberTower) (f : Poly T) :
       f.toArray.map coeffs := by
   let hinjective := coeffDenote_injective T
   let hinv := LevelSemantics.coeffDenote_inv T.levels.toList T.valid hinjective
-  letI : Field (Arithmetic.Coeff T.levels.toList) :=
+  let : Field (Arithmetic.Coeff T.levels.toList) :=
     Norm.coeffFieldPoly T.levels.toList T.valid hinjective hinv
   let q := Factor.rawPoly T.levels.toList (f.toArray.map coeffs)
   have hmap : (HexPolyMathlib.toPolynomial q).map
@@ -280,7 +280,7 @@ private theorem toPolynomial_of_polyCoords (T : NumberTower)
       (HexPolyMathlib.toPolynomial p).map (coeffEquiv T).toRingHom := by
   let hinjective := coeffDenote_injective T
   let hinv := LevelSemantics.coeffDenote_inv T.levels.toList T.valid hinjective
-  letI : Field (Arithmetic.Coeff T.levels.toList) :=
+  let : Field (Arithmetic.Coeff T.levels.toList) :=
     Norm.coeffFieldPoly T.levels.toList T.valid hinjective hinv
   dsimp only
   apply Polynomial.ext
@@ -319,7 +319,7 @@ private theorem publicCoords_of_canonical (T : NumberTower)
       factor := by
   let hinjective := coeffDenote_injective T
   let hinv := LevelSemantics.coeffDenote_inv T.levels.toList T.valid hinjective
-  letI : Field (Arithmetic.Coeff T.levels.toList) :=
+  let : Field (Arithmetic.Coeff T.levels.toList) :=
     Norm.coeffFieldPoly T.levels.toList T.valid hinjective hinv
   let p := Factor.rawPoly T.levels.toList factor
   let g : Poly T := DensePoly.ofCoeffs (factor.map (ofCoeffs T))
@@ -459,7 +459,7 @@ private theorem toPolynomial_rawPow (levels : List Level)
       Norm.coeffFieldPoly levels hvalid hinjective hinv
     HexPolyMathlib.toPolynomial (Factor.polyPow f n) =
       HexPolyMathlib.toPolynomial f ^ n := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   induction n using Nat.strong_induction_on with
   | h n ih =>
@@ -558,7 +558,7 @@ private theorem map_factorFold (T : NumberTower)
           product * Factorization.polyPow factor.1 factor.2) publicInit) := by
   let hinjective := coeffDenote_injective T
   let hinv := LevelSemantics.coeffDenote_inv T.levels.toList T.valid hinjective
-  letI : Field (Arithmetic.Coeff T.levels.toList) :=
+  let : Field (Arithmetic.Coeff T.levels.toList) :=
     Norm.coeffFieldPoly T.levels.toList T.valid hinjective hinv
   dsimp only
   induction factors generalizing rawInit publicInit with
@@ -583,7 +583,7 @@ theorem isIrreducible_iff (T : NumberTower) (f : Poly T) :
         f.leadingCoeff = 1 ∧ PolynomialIrreducible T f := by
   let hinjective := coeffDenote_injective T
   let hinv := LevelSemantics.coeffDenote_inv T.levels.toList T.valid hinjective
-  letI : Field (Arithmetic.Coeff T.levels.toList) :=
+  let : Field (Arithmetic.Coeff T.levels.toList) :=
     Norm.coeffFieldPoly T.levels.toList T.valid hinjective hinv
   let raw := Factor.rawPoly T.levels.toList (f.toArray.map coeffs)
   have hmap : (HexPolyMathlib.toPolynomial raw).map
@@ -648,7 +648,7 @@ theorem factor?_sound (T : NumberTower) (f : Poly T)
   simp only [checkFactorization, Factor.check, Bool.and_eq_true] at hcheck
   let hinjective := coeffDenote_injective T
   let hinv := LevelSemantics.coeffDenote_inv T.levels.toList T.valid hinjective
-  letI : Field (Arithmetic.Coeff T.levels.toList) :=
+  let : Field (Arithmetic.Coeff T.levels.toList) :=
     Norm.coeffFieldPoly T.levels.toList T.valid hinjective hinv
   have hscalar : coeffEquiv T
       (Arithmetic.Coeff.ofData T.levels.toList (coeffs r.scalar)) =

--- a/HexNumberFieldTowerMathlib/FactorGeneric/Complete.lean
+++ b/HexNumberFieldTowerMathlib/FactorGeneric/Complete.lean
@@ -42,13 +42,13 @@ theorem factorSquarefree_isSome :
         Subsingleton.elim _ _
       subst hvalid
       subst hinjective
-      letI : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
+      let : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
         LevelSemantics.DenoteInjective.nil
         LevelSemantics.coeffDenote_inv_nil
       let ι := LevelSemantics.coeffHom [] trivial
         LevelSemantics.DenoteInjective.nil
         LevelSemantics.coeffDenote_inv_nil
-      letI : CharZero (Arithmetic.Coeff []) :=
+      let : CharZero (Arithmetic.Coeff []) :=
         { cast_injective := by
             intro m n hmn
             apply Nat.cast_injective (R := ℂ)
@@ -69,9 +69,9 @@ theorem factorSquarefree_isSome :
         hinjectiveLower
       let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
         hinjectiveTop
-      letI : Field (Arithmetic.Coeff lower) :=
+      let : Field (Arithmetic.Coeff lower) :=
         Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-      letI : Field (Arithmetic.Coeff (level :: lower)) :=
+      let : Field (Arithmetic.Coeff (level :: lower)) :=
         Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
       have harrayDegree : 0 < f.size - 1 :=
         array_degree_pos_of_raw_degree_pos (level :: lower) f hdegree
@@ -577,7 +577,7 @@ private theorem factorRat_mem_monic (input : DensePoly Rat)
     ∀ factor ∈ factors,
       (HexPolyMathlib.toPolynomial
         (Factor.rawPoly [] factor)).Monic := by
-  letI : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
+  let : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
     LevelSemantics.DenoteInjective.nil
     LevelSemantics.coeffDenote_inv_nil
   intro factor hfactor
@@ -636,7 +636,7 @@ private theorem factorSquarefree_mem_monic
       (HexPolyMathlib.toPolynomial
         (Factor.rawPoly levels factor)).Monic := by
   let hinv := LevelSemantics.coeffDenote_inv levels hvalid hinjective
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   dsimp only
   intro factor hfactor
@@ -737,7 +737,7 @@ private theorem factorFold_sound
             HexPolyMathlib.toPolynomial
               (Factor.rawPoly levels component.1) ^ component.2).prod := by
   let hinv := LevelSemantics.coeffDenote_inv levels hvalid hinjective
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   dsimp only
   intro hstate
@@ -842,7 +842,7 @@ theorem factorRaw_isSome (levels : List Level)
     (f : Array (Array Rat)) :
     (Factor.factorRaw? levels f).isSome := by
   let hinv := LevelSemantics.coeffDenote_inv levels hvalid hinjective
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let components := Factor.yunRaw levels f
   have hcheck : Factor.checkYun levels f components :=
@@ -899,7 +899,7 @@ theorem isIrreducible_nil_iff (f : Array (Array Rat)) :
     Factor.isIrreducible [] f ↔
       (Factor.rawPoly [] f).leadingCoeff = 1 ∧
         Irreducible (HexPolyMathlib.toPolynomial (Factor.rawPoly [] f)) := by
-  letI : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
+  let : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
     LevelSemantics.DenoteInjective.nil
     LevelSemantics.coeffDenote_inv_nil
   constructor
@@ -924,7 +924,7 @@ theorem isIrreducible_nil_iff (f : Array (Array Rat)) :
       apply (Norm.isSquarefree_iff [] trivial
         LevelSemantics.DenoteInjective.nil
         LevelSemantics.coeffDenote_inv_nil f).mpr
-      letI : CharZero (Arithmetic.Coeff []) :=
+      let : CharZero (Arithmetic.Coeff []) :=
         { cast_injective := by
             intro m n hmn
             apply Nat.cast_injective (R := ℂ)
@@ -1030,7 +1030,7 @@ theorem isIrreducible_iff_of_injective (levels : List Level)
         Irreducible (HexPolyMathlib.toPolynomial
           (Factor.rawPoly levels f)) := by
   let hinv := LevelSemantics.coeffDenote_inv levels hvalid hinjective
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   cases levels with
   | nil =>
@@ -1075,7 +1075,7 @@ theorem isIrreducible_iff_of_injective (levels : List Level)
           exact Nat.pos_of_ne_zero hnatDegree
         let ι := LevelSemantics.coeffHom (level :: lower) hvalid
           hinjective hinv
-        letI : CharZero (Arithmetic.Coeff (level :: lower)) :=
+        let : CharZero (Arithmetic.Coeff (level :: lower)) :=
           { cast_injective := by
               intro m n hmn
               apply Nat.cast_injective (R := ℂ)
@@ -1166,7 +1166,7 @@ private theorem toPolynomial_polyPow (levels : List Level)
     HexPolyMathlib.toPolynomial (Factor.polyPow f n) =
       HexPolyMathlib.toPolynomial f ^ n := by
   let hinv := LevelSemantics.coeffDenote_inv levels hvalid hinjective
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   induction n using Nat.strong_induction_on with
   | h n ih =>
@@ -1206,7 +1206,7 @@ private theorem toPolynomial_factorFold (levels : List Level)
           HexPolyMathlib.toPolynomial
             (Factor.rawPoly levels entry.1) ^ entry.2).prod := by
   let hinv := LevelSemantics.coeffDenote_inv levels hvalid hinjective
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   dsimp only
   induction entries generalizing acc with
@@ -1228,7 +1228,7 @@ private theorem leadingCoeff_mul_monic (levels : List Level)
         HexPolyMathlib.toPolynomial (Norm.monic p) =
       HexPolyMathlib.toPolynomial p := by
   let hinv := LevelSemantics.coeffDenote_inv levels hvalid hinjective
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   dsimp only
   rw [Norm.monic]
@@ -1259,7 +1259,7 @@ private theorem C_leadingCoeff_eq_of_degreeZero (levels : List Level)
       Norm.coeffFieldPoly levels hvalid hinjective hinv
     DensePoly.C p.leadingCoeff = p := by
   let hinv := LevelSemantics.coeffDenote_inv levels hvalid hinjective
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   dsimp only
   apply (HexPolyMathlib.equiv
@@ -1292,7 +1292,7 @@ theorem factorRaw_check (levels : List Level)
     (hresult : Factor.factorRaw? levels f = some raw) :
     Factor.check levels f raw.scalar raw.factors = true := by
   let hinv := LevelSemantics.coeffDenote_inv levels hvalid hinjective
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let p := Factor.rawPoly levels f
   have hresult' := hresult
@@ -1467,7 +1467,7 @@ theorem denoteInjective_of_valid : ∀ (levels : List Level),
       have hinjectiveLower := ih hvalid.2.2
       let hinvLower := LevelSemantics.coeffDenote_inv lower hvalid.2.2
         hinjectiveLower
-      letI : Field (Arithmetic.Coeff lower) :=
+      let : Field (Arithmetic.Coeff lower) :=
         Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
       have hrelation : Irreducible (HexPolyMathlib.toPolynomial
           (Arithmetic.Coeff.relation level lower)) := by

--- a/HexNumberFieldTowerMathlib/FactorGeneric/Product.lean
+++ b/HexNumberFieldTowerMathlib/FactorGeneric/Product.lean
@@ -39,7 +39,7 @@ theorem rawPoly_nil_eq_zero_iff (f : Array (Array Rat)) :
       LevelSemantics.DenoteInjective.nil
       LevelSemantics.coeffDenote_inv_nil
     Factor.rawPoly [] f = 0 ↔ Factor.toRatPoly f = 0 := by
-  letI : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
+  let : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
     LevelSemantics.DenoteInjective.nil
     LevelSemantics.coeffDenote_inv_nil
   constructor
@@ -70,7 +70,7 @@ theorem map_monic_rawPoly_nil (f : Array (Array Rat)) :
       HexPolyMathlib.toPolynomial
         (let p := Factor.toRatPoly f
          if p.isZero then 0 else DensePoly.scale p.leadingCoeff⁻¹ p) := by
-  letI : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
+  let : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
     LevelSemantics.DenoteInjective.nil
     LevelSemantics.coeffDenote_inv_nil
   let raw := Factor.rawPoly [] f
@@ -155,7 +155,7 @@ theorem rawFactorFoldl (levels : List Level)
         (factors.map fun factor => HexPolyMathlib.toPolynomial
           (R := Arithmetic.Coeff levels)
           (Factor.rawPoly levels factor)).prod := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   induction factors generalizing init with
   | nil => simp
@@ -202,7 +202,7 @@ theorem factorSquarefree_product (levels : List Level)
           (Norm.monic (Factor.rawPoly levels f)) := by
   cases levels with
   | nil =>
-      letI : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
+      let : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
         LevelSemantics.DenoteInjective.nil
         LevelSemantics.coeffDenote_inv_nil
       dsimp only
@@ -276,7 +276,7 @@ theorem factorSquarefree_product (levels : List Level)
   | cons level lower =>
       let hinv := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
         hinjective
-      letI : Field (Arithmetic.Coeff (level :: lower)) :=
+      let : Field (Arithmetic.Coeff (level :: lower)) :=
         Norm.coeffFieldPoly (level :: lower) hvalid hinjective hinv
       dsimp only
       simp only [Factor.factorSquarefree?] at hresult
@@ -399,9 +399,9 @@ theorem recover_product_associated (level : Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   let delta := Arithmetic.Coeff.ofData (level :: lower) #[(shift : Rat)] *
     Factor.topGenerator level lower
@@ -576,9 +576,9 @@ theorem recover_product_monic (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   dsimp only
   intro hsound
@@ -666,9 +666,9 @@ theorem recover_product (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   dsimp only
   intro hcomponentNe hnormSquarefree hnormEq hlowerCoords hlowerProduct
@@ -693,13 +693,13 @@ theorem recover_product (level : Level) (lower : List Level)
     hinjectiveLower hinvLower
   let ιTop := LevelSemantics.coeffHom (level :: lower) hvalid
     hinjectiveTop hinvTop
-  letI : CharZero (Arithmetic.Coeff lower) :=
+  let : CharZero (Arithmetic.Coeff lower) :=
     { cast_injective := by
         intro m n hmn
         apply Nat.cast_injective (R := ℂ)
         have hmapped := congrArg ιLower hmn
         simpa only [map_natCast] using hmapped }
-  letI : CharZero (Arithmetic.Coeff (level :: lower)) :=
+  let : CharZero (Arithmetic.Coeff (level :: lower)) :=
     { cast_injective := by
         intro m n hmn
         apply Nat.cast_injective (R := ℂ)

--- a/HexNumberFieldTowerMathlib/FactorGeneric/Trager.lean
+++ b/HexNumberFieldTowerMathlib/FactorGeneric/Trager.lean
@@ -89,9 +89,9 @@ theorem ofData_lower_eq_lowerHom (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   rw [Norm.lowerHom_apply]
   apply hinjectiveTop
@@ -127,9 +127,9 @@ theorem rawPoly_embedLower_polyCoords (level : Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   rw [rawPoly_embedLower]
   apply (HexPolyMathlib.equiv
@@ -203,9 +203,9 @@ theorem toPolynomial_shiftTop (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   let delta := Arithmetic.Coeff.ofData (level :: lower) #[(c : Rat)] *
     Factor.topGenerator level lower
@@ -248,9 +248,9 @@ theorem shiftDelta_neg (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   dsimp only
   apply hinjectiveTop
@@ -291,9 +291,9 @@ theorem irreducible_shiftTop_iff (level : Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   let delta := Arithmetic.Coeff.ofData (level :: lower) #[(c : Rat)] *
     Factor.topGenerator level lower
@@ -341,9 +341,9 @@ theorem rawPoly_shiftTop_zero (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   apply (HexPolyMathlib.equiv
     (R := Arithmetic.Coeff (level :: lower))).injective
@@ -380,9 +380,9 @@ theorem toPolynomial_shiftTop_zero (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   dsimp only
   rw [toPolynomial_shiftTop level lower hvalid hinjectiveTop]
@@ -424,9 +424,9 @@ theorem tragerNorm_shiftTop (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   rw [tragerNorm, polyCoords_rawPoly_shiftTop]
   exact Norm.oneLevel_shift_zero level lower hvalid hinjectiveTop f c
@@ -452,9 +452,9 @@ theorem tragerNorm_mul (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   exact Norm.oneLevel_mul level lower hvalid hinjectiveTop a b 0
 
@@ -504,9 +504,9 @@ theorem tragerNorm_dvd (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   change (HexPolyMathlib.toPolynomial a ∣
       HexPolyMathlib.toPolynomial b) → _
@@ -547,9 +547,9 @@ theorem tragerNorm_not_isUnit (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   change ¬ IsUnit (HexPolyMathlib.toPolynomial
     (tragerNorm level lower f))
@@ -582,7 +582,7 @@ theorem toPolynomial_monic_associated (levels : List Level)
       Norm.coeffFieldPoly levels hvalid hinjective hinv
     Associated (HexPolyMathlib.toPolynomial (Norm.monic f))
       (HexPolyMathlib.toPolynomial f) := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   have hzero : f.isZero = false := by
     rw [DensePoly.isZero_eq_false_iff]
@@ -608,7 +608,7 @@ theorem toPolynomial_monic_monic (levels : List Level)
     letI : Field (Arithmetic.Coeff levels) :=
       Norm.coeffFieldPoly levels hvalid hinjective hinv
     (HexPolyMathlib.toPolynomial (Norm.monic f)).Monic := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   have hzero : f.isZero = false := by
     rw [DensePoly.isZero_eq_false_iff]
@@ -638,7 +638,7 @@ theorem monic_eq_self (levels : List Level)
     letI : Field (Arithmetic.Coeff levels) :=
       Norm.coeffFieldPoly levels hvalid hinjective hinv
     (HexPolyMathlib.toPolynomial f).Monic → Norm.monic f = f := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   intro hf
   apply (HexPolyMathlib.equiv
@@ -705,9 +705,9 @@ theorem recoveredCommon_irreducible (level : Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   let lifted := Factor.rawPoly (level :: lower)
     (Factor.embedLower level lower (Factor.polyCoords q))
@@ -865,9 +865,9 @@ theorem recoveredFactor_irreducible (level : Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   let shifted := Factor.rawPoly (level :: lower)
     (Factor.shiftTop level lower component shift)
@@ -1013,9 +1013,9 @@ theorem oneLevel_degree_pos (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   dsimp only
   intro hsquarefree
@@ -1062,11 +1062,11 @@ theorem squarefree_toPolynomial_of_check (levels : List Level)
       Norm.coeffFieldPoly levels hvalid hinjective hinv
     Squarefree (HexPolyMathlib.toPolynomial
       (Factor.rawPoly levels f)) := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let P := HexPolyMathlib.toPolynomial (Factor.rawPoly levels f)
   let φ := LevelSemantics.coeffHom levels hvalid hinjective hinv
-  letI : CharZero (Arithmetic.Coeff levels) :=
+  let : CharZero (Arithmetic.Coeff levels) :=
     { cast_injective := by
         intro m n hmn
         apply CharZero.cast_injective (R := ℂ)
@@ -1253,9 +1253,9 @@ theorem recover_mem_sound (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   let shifted := Factor.rawPoly (level :: lower)
     (Factor.shiftTop level lower component shift)
@@ -1291,7 +1291,7 @@ theorem polyCoords_rawPoly_ofRatPoly (f : DensePoly Rat)
     (hf : f ≠ 0) :
     Factor.polyCoords (Factor.rawPoly [] (Factor.ofRatPoly f)) =
       Factor.ofRatPoly f := by
-  letI : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
+  let : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
     LevelSemantics.DenoteInjective.nil
     LevelSemantics.coeffDenote_inv_nil
   let q := Factor.rawPoly [] (Factor.ofRatPoly f)
@@ -1548,7 +1548,7 @@ theorem rawRatFactor_irreducible (integer : ZPoly)
       entry.1.toRatPoly
     Irreducible (HexPolyMathlib.toPolynomial
       (Factor.rawPoly [] (Factor.ofRatPoly q))) := by
-  letI : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
+  let : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
     LevelSemantics.DenoteInjective.nil
     LevelSemantics.coeffDenote_inv_nil
   let q := DensePoly.scale entry.1.toRatPoly.leadingCoeff⁻¹
@@ -1581,7 +1581,7 @@ theorem generatedRatFactors_sound (integer : ZPoly)
       Factor.polyCoords (Factor.rawPoly [] factor) = factor ∧
         Irreducible (HexPolyMathlib.toPolynomial
           (Factor.rawPoly [] factor)) := by
-  letI : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
+  let : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
     LevelSemantics.DenoteInjective.nil
     LevelSemantics.coeffDenote_inv_nil
   let rawFactors := (ZPoly.factorize integer).factors.flatMap fun entry =>
@@ -1633,7 +1633,7 @@ theorem factorRat_mem_sound (input : DensePoly Rat)
       Factor.polyCoords (Factor.rawPoly [] factor) = factor ∧
         Irreducible (HexPolyMathlib.toPolynomial
           (Factor.rawPoly [] factor)) := by
-  letI : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
+  let : Field (Arithmetic.Coeff []) := Norm.coeffFieldPoly [] trivial
     LevelSemantics.DenoteInjective.nil
     LevelSemantics.coeffDenote_inv_nil
   intro factor hfactor
@@ -1694,7 +1694,7 @@ theorem factorSquarefree_mem_sound :
   | nil =>
       intro hvalid hinjective f factors hresult
       let hinv := LevelSemantics.coeffDenote_inv [] hvalid hinjective
-      letI : Field (Arithmetic.Coeff []) :=
+      let : Field (Arithmetic.Coeff []) :=
         Norm.coeffFieldPoly [] hvalid hinjective hinv
       have hvalidEq : hvalid = (trivial : LevelsValid []) :=
         Subsingleton.elim _ _
@@ -1710,9 +1710,9 @@ theorem factorSquarefree_mem_sound :
         hinjectiveLower
       let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
         hinjectiveTop
-      letI : Field (Arithmetic.Coeff lower) :=
+      let : Field (Arithmetic.Coeff lower) :=
         Norm.coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-      letI : Field (Arithmetic.Coeff (level :: lower)) :=
+      let : Field (Arithmetic.Coeff (level :: lower)) :=
         Norm.coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
       dsimp only
       simp only [Factor.factorSquarefree?] at hresult

--- a/HexNumberFieldTowerMathlib/FactorGeneric/Yun.lean
+++ b/HexNumberFieldTowerMathlib/FactorGeneric/Yun.lean
@@ -39,7 +39,7 @@ theorem rawPolynomial_monic_associated
     (hf : Norm.rawPolynomial levels f ≠ 0) :
     Associated (Norm.rawPolynomial levels (Norm.monic f))
       (Norm.rawPolynomial levels f) := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let ι := LevelSemantics.coeffHom levels hvalid hinjective hinv
   have hfSource : HexPolyMathlib.toPolynomial f ≠ 0 := by
@@ -101,7 +101,7 @@ theorem monicGcd_dvd
       Norm.coeffFieldPoly levels hvalid hinjective hinv
     Norm.monic (DensePoly.gcd f g) ∣ f ∧
       Norm.monic (DensePoly.gcd f g) ∣ g := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let raw := HexPolyMathlib.toPolynomial (DensePoly.gcd f g)
   let normalized := EuclideanDomain.gcd
@@ -139,7 +139,7 @@ theorem rawPolynomial_monicGcd_ne_zero
     (f g : DensePoly (Arithmetic.Coeff levels))
     (hf : Norm.rawPolynomial levels f ≠ 0) :
     Norm.rawPolynomial levels (Norm.monic (DensePoly.gcd f g)) ≠ 0 := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   have hfSource : HexPolyMathlib.toPolynomial f ≠ 0 := by
     intro hzero
@@ -185,7 +185,7 @@ theorem rootMultiplicity_monicGcd
       (Norm.monic (DensePoly.gcd f g))).rootMultiplicity z =
       min ((Norm.rawPolynomial levels f).rootMultiplicity z)
         ((Norm.rawPolynomial levels g).rootMultiplicity z) := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let sourceGcd := EuclideanDomain.gcd
     (HexPolyMathlib.toPolynomial f) (HexPolyMathlib.toPolynomial g)
@@ -257,7 +257,7 @@ theorem rawPolynomial_div_mul
     Norm.rawPolynomial levels (dividend / divisor) *
         Norm.rawPolynomial levels divisor =
       Norm.rawPolynomial levels dividend := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   have hmod : dividend % divisor = 0 :=
     DensePoly.mod_eq_zero_of_dvd dividend divisor hdivisor
@@ -284,7 +284,7 @@ theorem rawPolynomial_div_ne_zero
     (hdivisor : divisor ∣ dividend)
     (hdividend : Norm.rawPolynomial levels dividend ≠ 0) :
     Norm.rawPolynomial levels (dividend / divisor) ≠ 0 := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   intro hquotient
   have hreconstruct := rawPolynomial_div_mul hvalid hinjective hinv
@@ -303,7 +303,7 @@ theorem rootMultiplicity_monicDiv
       (Norm.monic (dividend / divisor))).rootMultiplicity z =
       (Norm.rawPolynomial levels dividend).rootMultiplicity z -
         (Norm.rawPolynomial levels divisor).rootMultiplicity z := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   have hquotient := rawPolynomial_div_ne_zero hvalid hinjective hinv
     dividend divisor hdivisor hdividend
@@ -325,7 +325,7 @@ theorem rawPolynomial_monicDiv_ne_zero
     (hdivisor : divisor ∣ dividend)
     (hdividend : Norm.rawPolynomial levels dividend ≠ 0) :
     Norm.rawPolynomial levels (Norm.monic (dividend / divisor)) ≠ 0 := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   have hquotient := rawPolynomial_div_ne_zero hvalid hinjective hinv
     dividend divisor hdivisor hdividend
@@ -354,7 +354,7 @@ theorem YunInvariant.step (z : ℂ) (r k : Nat)
     let shared := Norm.monic (DensePoly.gcd w repeated)
     let nextRepeated := Norm.monic (repeated / shared)
     YunInvariant z r (k + 1) shared nextRepeated := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let shared := Norm.monic (DensePoly.gcd w repeated)
   let nextRepeated := Norm.monic (repeated / shared)
@@ -401,7 +401,7 @@ theorem YunInvariant.component (z : ℂ) (r k : Nat)
     let component := Norm.monic (w / shared)
     (Norm.rawPolynomial levels component).rootMultiplicity z =
       if k = r then 1 else 0 := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let shared := Norm.monic (DensePoly.gcd w repeated)
   let component := Norm.monic (w / shared)
@@ -440,7 +440,7 @@ theorem YunInvariant.init
     YunInvariant z
       ((Norm.rawPolynomial levels f).rootMultiplicity z) 1
       distinct repeated := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let normalized := Norm.monic f
   let repeated := Norm.monic
@@ -510,7 +510,7 @@ re-elaborating the coefficient-field construction at every induction step. -/
 theorem natDegree_rawPolynomial
     (f : DensePoly (Arithmetic.Coeff levels)) :
     (Norm.rawPolynomial levels f).natDegree = f.degree?.getD 0 := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   rw [← Norm.rawPolynomialHom_apply levels hvalid hinjective hinv]
   change ((HexPolyMathlib.toPolynomial f).map
@@ -528,7 +528,7 @@ theorem rawPolynomial_eq_map
     Norm.rawPolynomial levels f =
       (HexPolyMathlib.toPolynomial f).map
         (LevelSemantics.coeffHom levels hvalid hinjective hinv) := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   rw [← Norm.rawPolynomialHom_apply levels hvalid hinjective hinv]
   rfl
@@ -540,7 +540,7 @@ theorem degree_pos_of_rawPolynomial_root
     (hf : Norm.rawPolynomial levels f ≠ 0) {z : ℂ}
     (hroot : (Norm.rawPolynomial levels f).IsRoot z) :
     0 < f.degree?.getD 0 := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   have hdegree := Polynomial.degree_pos_of_root hf hroot
   have hnatDegree : 0 < (Norm.rawPolynomial levels f).natDegree :=
@@ -581,7 +581,7 @@ theorem yunAux_sound (z : ℂ) (r : Nat)
     ∀ entry ∈ (Factor.yunAux levels w repeated k fuel out).toList,
       (Norm.rawPolynomial levels
         (Factor.rawPoly levels entry.1)).IsRoot z → entry.2 = r := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   induction fuel generalizing w repeated k out with
   | zero => simpa [Factor.yunAux] using hOut
@@ -643,7 +643,7 @@ theorem yunAux_rootMultiplicity_le_one (z : ℂ) (r : Nat)
     ∀ entry ∈ (Factor.yunAux levels w repeated k fuel out).toList,
       (Norm.rawPolynomial levels
         (Factor.rawPoly levels entry.1)).rootMultiplicity z ≤ 1 := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   induction fuel generalizing w repeated k out with
   | zero => simpa [Factor.yunAux] using hOut
@@ -684,7 +684,7 @@ theorem yunAux_complete (z : ℂ) (r : Nat)
     ∃ entry ∈ (Factor.yunAux levels w repeated k fuel out).toList,
       (Norm.rawPolynomial levels
         (Factor.rawPoly levels entry.1)).IsRoot z ∧ entry.2 = r := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   induction fuel generalizing w repeated k out with
   | zero => omega
@@ -854,7 +854,7 @@ theorem yunAux_monic
     ∀ entry ∈
       (Factor.yunAux levels w repeated multiplicity fuel out).toList,
       (Factor.rawPoly levels entry.1).leadingCoeff = 1 := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   induction fuel generalizing w repeated multiplicity out with
   | zero => simpa [Factor.yunAux] using hOut
@@ -912,7 +912,7 @@ theorem yun_sound
       (Factor.rawPoly levels entry.1)).IsRoot z) :
     entry.2 = (Norm.rawPolynomial levels
       (Factor.rawPoly levels f)).rootMultiplicity z := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let p := Factor.rawPoly levels f
   have hdegreeP : 0 < p.degree?.getD 0 := hdegree
@@ -951,7 +951,7 @@ theorem yun_complete
         (Factor.rawPoly levels entry.1)).IsRoot z ∧
       entry.2 = (Norm.rawPolynomial levels
         (Factor.rawPoly levels f)).rootMultiplicity z := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let p := Factor.rawPoly levels f
   have hdegreeP : 0 < p.degree?.getD 0 := hdegree
@@ -1001,7 +1001,7 @@ theorem yun_rootMultiplicity_le_one
     (hentry : entry ∈ (Factor.yunRaw levels f).toList) (z : ℂ) :
     (Norm.rawPolynomial levels
       (Factor.rawPoly levels entry.1)).rootMultiplicity z ≤ 1 := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let p := Factor.rawPoly levels f
   have hdegreeP : 0 < p.degree?.getD 0 := hdegree
@@ -1069,7 +1069,7 @@ theorem yun_squarefree
     (component : Array (Array Rat) × Nat)
     (hcomponent : component ∈ (Factor.yunRaw levels f).toList) :
     Norm.isSquarefree levels component.1 := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let P := Norm.rawPolynomial levels
     (Factor.rawPoly levels component.1)
@@ -1104,7 +1104,7 @@ theorem yun_coprime
     (hmultiplicity : a.2 < b.2) :
     (DensePoly.gcd (Factor.rawPoly levels a.1)
       (Factor.rawPoly levels b.1)).size ≤ 1 := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let pa := Factor.rawPoly levels a.1
   let pb := Factor.rawPoly levels b.1
@@ -1198,7 +1198,7 @@ theorem rawPolynomial_polyPow
     (f : DensePoly (Arithmetic.Coeff levels)) (n : Nat) :
     Norm.rawPolynomial levels (Factor.polyPow f n) =
       Norm.rawPolynomial levels f ^ n := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   induction n using Nat.strong_induction_on with
   | h n ih =>
@@ -1238,7 +1238,7 @@ theorem rawPolynomial_yunFold
         Norm.rawPolynomial levels
           (Factor.rawPoly levels component.1) ^ component.2).prod *
         Norm.rawPolynomial levels acc := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   induction components generalizing acc with
   | nil => simp
@@ -1271,7 +1271,7 @@ theorem yunMultiplicity_sum
         (Factor.rawPoly levels entry.1)).rootMultiplicity z).sum =
       (Norm.rawPolynomial levels
         (Factor.rawPoly levels f)).rootMultiplicity z := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let input := Norm.rawPolynomial levels (Factor.rawPoly levels f)
   have hinputNe : input ≠ 0 := by
@@ -1379,7 +1379,7 @@ theorem yun_rawPolynomial_monic
     (hentry : entry ∈ (Factor.yunRaw levels f).toList) :
     (Norm.rawPolynomial levels
       (Factor.rawPoly levels entry.1)).Monic := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   have hsource : (HexPolyMathlib.toPolynomial
       (Factor.rawPoly levels entry.1)).Monic := by
@@ -1396,7 +1396,7 @@ theorem yun_product
     (hdegree : 0 < (Factor.rawPoly levels f).degree?.getD 0) :
     Factor.yunProduct levels (Factor.yunRaw levels f) =
       Factor.polyCoords (Norm.monic (Factor.rawPoly levels f)) := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let p := Factor.rawPoly levels f
   let components := (Factor.yunRaw levels f).toList
@@ -1507,7 +1507,7 @@ certificate check. -/
 theorem checkYun_yunRaw
     (f : Array (Array Rat)) :
     Factor.checkYun levels f (Factor.yunRaw levels f) := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     Norm.coeffFieldPoly levels hvalid hinjective hinv
   let p := Factor.rawPoly levels f
   by_cases hdegreeZero : p.degree?.getD 0 = 0

--- a/HexNumberFieldTowerMathlib/Flatten.lean
+++ b/HexNumberFieldTowerMathlib/Flatten.lean
@@ -739,7 +739,7 @@ private theorem checkCoordinate?_sound (target gamma : AlgebraicNumber)
     (coordinate out : QAdjoin gamma.p gamma.x)
     (h : checkCoordinate? target gamma coordinate = some out) :
     QAdjoin.toComplex out gamma.rep gamma.rep_mk = target.toComplex := by
-  letI : ZPoly.CheckedIrreducible gamma.p := gamma.checked
+  let : ZPoly.CheckedIrreducible gamma.p := gamma.checked
   unfold checkCoordinate? at h
   obtain ⟨recovered, hrecovered, h⟩ := Option.bind_eq_some_iff.mp h
   by_cases heq : recovered == target
@@ -780,7 +780,7 @@ private theorem recoverPairFast?_sound (theta alpha gamma : AlgebraicNumber)
   by_cases hshift : shift = 0
   · simp [hshift] at h
   · simp only [hshift, ↓reduceIte] at h
-    letI : ZPoly.CheckedIrreducible gamma.p := gamma.checked
+    let : ZPoly.CheckedIrreducible gamma.p := gamma.checked
     let gammaCoordinate := gamma.toQAdjoin
     let affine : DensePoly (QAdjoin gamma.p gamma.x) :=
       DensePoly.ofList
@@ -1671,7 +1671,7 @@ private theorem fold_unit_range {p : ZPoly} {x : SimpleRoot p}
     (List.range count).foldl (fun value i =>
       if index = i then value + (1 : Rat) • values i else value) 0 =
         if index < count then values index else 0 := by
-  letI : Field (QAdjoin p x) := QAdjoin.field p x
+  let : Field (QAdjoin p x) := QAdjoin.field p x
   induction count with
   | zero => simp
   | succ count ih =>
@@ -1717,7 +1717,7 @@ private theorem basisImages_complex (T : NumberTower)
         (basisImages generators candidate.coordinates |>.getD index 0)
         candidate.root.rep candidate.root.rep_mk =
       T.toComplex (T.ofCoeffs (unitCoords T.dim index)) := by
-  letI : ZPoly.CheckedIrreducible candidate.root.p := candidate.root.checked
+  let : ZPoly.CheckedIrreducible candidate.root.p := candidate.root.checked
   have hgeneratorShape := generators?_shape T hgenerators
   have hcandidateShape := candidate?_shape T generators hcandidate
   have hcoordinates := candidate?_represents T generators hcandidate
@@ -1771,7 +1771,7 @@ private theorem constructed_basis_roundtrip (T : NumberTower)
         (toPrimitiveWith (basisImages generators candidate.coordinates)
           (T.ofCoeffs (unitCoords T.dim index))) =
       T.ofCoeffs (unitCoords T.dim index) := by
-  letI : ZPoly.CheckedIrreducible candidate.root.p := candidate.root.checked
+  let : ZPoly.CheckedIrreducible candidate.root.p := candidate.root.checked
   rw [toPrimitiveWith_unit _ index hindex]
   apply toComplex_injective T
   rw [fromPrimitiveWith_complex candidate.value candidate.root.rep
@@ -1815,12 +1815,12 @@ theorem flatten?_sound (T : NumberTower) {F : Flattening T}
     have hgeneratorsSound := Flatten.generators?_sound T hgenerators
     have hcandidateSound := Flatten.candidate?_matches T generators
       hgeneratorsSound hcandidate
-    letI : ZPoly.CheckedIrreducible candidate.root.p :=
+    let : ZPoly.CheckedIrreducible candidate.root.p :=
       candidate.root.checked
     let rep := candidate.root.rep
     have hrep : SimpleRoot.mk rep = candidate.root.x :=
       candidate.root.rep_mk
-    letI : Field (Elem T) := elemField T
+    let : Field (Elem T) := elemField T
     let towerAdd : Elem T →+ ℂ :=
       { toFun := T.toComplex
         map_zero' := by
@@ -1830,7 +1830,7 @@ theorem flatten?_sound (T : NumberTower) {F : Flattening T}
           intro a b
           change T.toComplex (a + b) = T.toComplex a + T.toComplex b
           exact map_add T a b }
-    letI : Module Rat (Elem T) :=
+    let : Module Rat (Elem T) :=
       Function.Injective.module Rat towerAdd (toComplex_injective T)
         (fun q a => by
           change T.toComplex (q • a) = q • T.toComplex a
@@ -1998,7 +1998,7 @@ theorem flatten_toComplex (T : NumberTower) {F : Flattening T}
     (h : T.flatten? = some F) (a : Elem T) :
     QAdjoin.toComplex (F.toPrimitive a) F.root.rep F.root.rep_mk =
       T.toComplex a := by
-  letI : ZPoly.CheckedIrreducible F.root.p := F.root.checked
+  let : ZPoly.CheckedIrreducible F.root.p := F.root.checked
   exact (flatten?_sound T h).2.2.1 a
 
 /-- The inverse primitive coordinate map preserves the fixed complex value. -/
@@ -2006,7 +2006,7 @@ theorem flatten_fromComplex (T : NumberTower) {F : Flattening T}
     (h : T.flatten? = some F) (a : QAdjoin F.root.p F.root.x) :
     T.toComplex (F.fromPrimitive a) =
       QAdjoin.toComplex a F.root.rep F.root.rep_mk := by
-  letI : ZPoly.CheckedIrreducible F.root.p := F.root.checked
+  let : ZPoly.CheckedIrreducible F.root.p := F.root.checked
   exact (flatten?_sound T h).2.2.2.1 a
 
 end Hex.NumberTower

--- a/HexNumberFieldTowerMathlib/NormCore/Basic.lean
+++ b/HexNumberFieldTowerMathlib/NormCore/Basic.lean
@@ -337,9 +337,9 @@ theorem rawPolynomialHom_apply (levels : List Level)
     letI : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
     rawPolynomialHom levels hvalid hinjective hinv f =
       rawPolynomial levels f := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     coeffFieldPoly levels hvalid hinjective hinv
-  letI : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
   ext n
   rw [coeff_rawPolynomial, rawToComplex_eq_denote]
   simp [rawPolynomialHom, LevelSemantics.coeffHom,
@@ -359,7 +359,7 @@ theorem rawPolynomial_eq_map (levels : List Level)
     rawPolynomial levels f =
       (HexPolyMathlib.toPolynomial f).map
         (LevelSemantics.coeffHom levels hvalid hinjective hinv) := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     coeffFieldPoly levels hvalid hinjective hinv
   rw [← rawPolynomialHom_apply levels hvalid hinjective hinv]
   rfl
@@ -373,9 +373,9 @@ theorem rawPolynomial_injective (levels : List Level)
       LevelSemantics.coeffDenote levels a⁻¹ =
         (LevelSemantics.coeffDenote levels a)⁻¹) :
     Function.Injective (rawPolynomial levels) := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     coeffFieldPoly levels hvalid hinjective hinv
-  letI : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
   intro f g h
   apply (HexPolyMathlib.equiv
     (R := Arithmetic.Coeff levels)).injective
@@ -399,9 +399,9 @@ theorem rawPolynomial_one (levels : List Level)
       LevelSemantics.coeffDenote levels a⁻¹ =
         (LevelSemantics.coeffDenote levels a)⁻¹) :
     rawPolynomial levels 1 = 1 := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     coeffFieldPoly levels hvalid hinjective hinv
-  letI : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
   rw [← rawPolynomialHom_apply levels hvalid hinjective hinv]
   exact (rawPolynomialHom levels hvalid hinjective hinv).map_one
 
@@ -417,9 +417,9 @@ theorem rawPolynomial_mul (levels : List Level)
     (f g : DensePoly (Arithmetic.Coeff levels)) :
     rawPolynomial levels (f * g) =
       rawPolynomial levels f * rawPolynomial levels g := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     coeffFieldPoly levels hvalid hinjective hinv
-  letI : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
   let φ := rawPolynomialHom levels hvalid hinjective hinv
   calc
     rawPolynomial levels (f * g) = φ (f * g) :=
@@ -441,9 +441,9 @@ theorem rawPolynomial_C (levels : List Level)
     (a : Arithmetic.Coeff levels) :
     rawPolynomial levels (DensePoly.C a) =
       Polynomial.C (LevelSemantics.coeffDenote levels a) := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     coeffFieldPoly levels hvalid hinjective hinv
-  letI : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
   rw [← rawPolynomialHom_apply levels hvalid hinjective hinv]
   simp [rawPolynomialHom, HexPolyMathlib.toPolynomial_C,
     LevelSemantics.coeffHom]
@@ -556,7 +556,7 @@ theorem conjugatePolynomial_eq_map (level : Level) (lower : List Level)
       (HexPolyMathlib.toPolynomial
         (Factor.rawPoly (level :: lower) f)).map
           (conjugateMap level lower hvalid hinjective x hrelation) := by
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     coeffFieldPoly (level :: lower) hvalid hinjective
       (LevelSemantics.coeffDenote_inv (level :: lower) hvalid hinjective)
   ext n
@@ -641,9 +641,9 @@ theorem derivative_eq (levels : List Level)
     letI : Field (Arithmetic.Coeff levels) :=
       coeffFieldPoly levels hvalid hinjective hinv
     derivative levels f = DensePoly.derivative f := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     coeffFieldPoly levels hvalid hinjective hinv
-  letI : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
   apply rawPolynomial_injective levels hvalid hinjective hinv
   rw [rawPolynomial_derivative]
   have hmap (g : DensePoly (Arithmetic.Coeff levels)) :
@@ -666,9 +666,9 @@ theorem isSquarefree_iff (levels : List Level)
     (f : Array (Array Rat)) :
     Norm.isSquarefree levels f ↔
       Squarefree (rawPolynomial levels (Factor.rawPoly levels f)) := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     coeffFieldPoly levels hvalid hinjective hinv
-  letI : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
   let p := Factor.rawPoly levels f
   let P := HexPolyMathlib.toPolynomial p
   let d := DensePoly.derivative p
@@ -798,9 +798,9 @@ theorem rawOuter_eq_map (levels : List Level)
     letI : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
     rawOuter levels f = (HexPolyMathlib.toPolynomial f).map
       (rawPolynomialHom levels hvalid hinjective hinv) := by
-  letI : Field (Arithmetic.Coeff levels) :=
+  let : Field (Arithmetic.Coeff levels) :=
     coeffFieldPoly levels hvalid hinjective hinv
-  letI : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff levels)) := denseCommRing
   ext n
   rw [coeff_rawOuter, Polynomial.coeff_map,
     HexPolyMathlib.coeff_toPolynomial,
@@ -926,11 +926,11 @@ theorem outerEval_map (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
   let topHom := LevelSemantics.coeffHom (level :: lower) hvalid
     hinjectiveTop hinvTop
   let lowerPolyHom : DensePoly (Arithmetic.Coeff lower) →+*
@@ -990,9 +990,9 @@ theorem eval_liftCoefficient (level : Level) (lower : List Level)
     (rawOuter lower (liftCoefficient level lower a)).eval
         (Polynomial.C x) =
       Polynomial.C (LevelSemantics.evalAt level lower x a) := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjective hinv
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
   let lifted := liftCoefficient level lower a
   have hsize : lifted.size ≤ level.degree := by
     exact (DensePoly.size_ofCoeffs_le _).trans (by simp [lifted,
@@ -1039,9 +1039,9 @@ theorem eval_shiftBase (lower : List Level)
         DensePoly.C (Arithmetic.Coeff.ofData lower #[(-(c : Rat))])]
     (rawOuter lower base).eval (Polynomial.C x) =
       Polynomial.X - Polynomial.C ((c : ℂ) * x) := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid hinjective hinv
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
   let base : DensePoly (DensePoly (Arithmetic.Coeff lower)) :=
     DensePoly.ofCoeffs #[DensePoly.monomial 1 1,
       DensePoly.C (Arithmetic.Coeff.ofData lower #[(-(c : Rat))])]
@@ -1085,9 +1085,9 @@ theorem eval_shiftedOuter (level : Level) (lower : List Level)
         (Polynomial.C x) =
       (conjugatePolynomial level lower x f).comp
         (Polynomial.X - Polynomial.C ((c : ℂ) * x)) := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjective hinv
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
   let ψ (g : DensePoly (DensePoly (Arithmetic.Coeff lower))) :
       Polynomial ℂ := (rawOuter lower g).eval (Polynomial.C x)
   let q := Polynomial.X - Polynomial.C ((c : ℂ) * x)
@@ -1190,9 +1190,9 @@ theorem rawOuter_defining (level : Level) (lower : List Level)
     change Arithmetic.Coeff.ofData lower #[] =
       Arithmetic.Coeff.ofData lower #[]
     rfl
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjective hinv
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
   apply Polynomial.ext
   intro n
   by_cases hn : n ≤ level.degree
@@ -1231,11 +1231,11 @@ theorem outerEval_defining (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
   let topHom := LevelSemantics.coeffHom (level :: lower) hvalid
     hinjectiveTop hinvTop
   apply Polynomial.map_injective topHom topHom.injective
@@ -1301,7 +1301,7 @@ theorem conjugatePolynomial_shiftTop (level : Level)
         (Polynomial.X - Polynomial.C ((c : ℂ) * x)) := by
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   let conjugate := conjugateMap level lower hvalid hinjectiveTop x hrelation
   have hsource : conjugatePolynomial level lower x f =
@@ -1394,11 +1394,11 @@ theorem outerEval_shifted (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
   let topHom := LevelSemantics.coeffHom (level :: lower) hvalid
     hinjectiveTop hinvTop
   have hrelation :

--- a/HexNumberFieldTowerMathlib/NormCore/Trager.lean
+++ b/HexNumberFieldTowerMathlib/NormCore/Trager.lean
@@ -33,11 +33,11 @@ private theorem relation_sum_of_mem_rootSet (level : Level)
     (∑ j ∈ Finset.range level.degree,
         LevelSemantics.denote lower (level.defining.getD j #[]) * x ^ j) +
       x ^ level.degree = 0 := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjective hinv
   let ι : Arithmetic.Coeff lower →+* ℂ :=
     LevelSemantics.coeffHom lower hvalid.2.2 hinjective hinv
-  letI : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
+  let : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
   change x ∈ (HexPolyMathlib.toPolynomial
     (Arithmetic.Coeff.relation level lower)).rootSet ℂ → _
   intro hx
@@ -113,10 +113,10 @@ theorem oneLevel_resultant (level : Level) (lower : List Level)
         (rawOuter lower (shiftedOuter level lower f c))
         (m := (definingOuter level lower).degree?.getD 0)
         (n := (shiftedOuter level lower f c).degree?.getD 0) := by
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hlower hinjective hinv
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
-  letI : IsDomain (DensePoly (Arithmetic.Coeff lower)) :=
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : IsDomain (DensePoly (Arithmetic.Coeff lower)) :=
     (HexPolyMathlib.equiv
       (R := Arithmetic.Coeff lower)).toMulEquiv.isDomain
         (Polynomial (Arithmetic.Coeff lower))
@@ -170,14 +170,14 @@ theorem oneLevel_shift_zero (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
   let ι : Arithmetic.Coeff lower →+* ℂ :=
     LevelSemantics.coeffHom lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
+  let : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
   let relation := Arithmetic.Coeff.relation level lower
   let p := HexPolyMathlib.toPolynomial relation
   let shifted := Factor.shiftTop level lower f c
@@ -309,12 +309,12 @@ theorem shifted_dvd_norm (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
-  letI : IsDomain (DensePoly (Arithmetic.Coeff lower)) :=
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : IsDomain (DensePoly (Arithmetic.Coeff lower)) :=
     (HexPolyMathlib.equiv
       (R := Arithmetic.Coeff lower)).toMulEquiv.isDomain
         (Polynomial (Arithmetic.Coeff lower))
@@ -385,14 +385,14 @@ theorem oneLevel_ne_zero (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
   let ι : Arithmetic.Coeff lower →+* ℂ :=
     LevelSemantics.coeffHom lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
+  let : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
   let relation := Arithmetic.Coeff.relation level lower
   let p := HexPolyMathlib.toPolynomial relation
   have hpDegree : p.natDegree = level.degree := by
@@ -545,14 +545,14 @@ theorem oneLevel_mul (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
   let ι : Arithmetic.Coeff lower →+* ℂ :=
     LevelSemantics.coeffHom lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
+  let : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
   let relation := Arithmetic.Coeff.relation level lower
   let p := HexPolyMathlib.toPolynomial relation
   let M := rawOuter lower (definingOuter level lower)
@@ -698,17 +698,17 @@ theorem oneLevel_lift (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
   let lifted := HexPolyMathlib.ofPolynomial
     ((HexPolyMathlib.toPolynomial q).map
       (lowerHom level lower hvalid hinjectiveTop))
   let ι : Arithmetic.Coeff lower →+* ℂ :=
     LevelSemantics.coeffHom lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
+  let : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
   let relation := Arithmetic.Coeff.relation level lower
   let p := HexPolyMathlib.toPolynomial relation
   let M := rawOuter lower (definingOuter level lower)
@@ -980,16 +980,16 @@ theorem findSquarefreeShift_isSome_of_injective
     hinjectiveTop.tail level lower hvalid.1.1
   let hinvLower := LevelSemantics.coeffDenote_inv lower hvalid.2.2
     hinjectiveLower
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
   let ι : Arithmetic.Coeff lower →+* ℂ :=
     LevelSemantics.coeffHom lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : CharZero (Arithmetic.Coeff lower) :=
+  let : CharZero (Arithmetic.Coeff lower) :=
     { cast_injective := fun m n h => by
         apply CharZero.cast_injective (R := ℂ)
         simpa only [map_natCast] using congrArg ι h }
-  letI : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
+  let : Algebra (Arithmetic.Coeff lower) ℂ := ι.toAlgebra
   let relation := Arithmetic.Coeff.relation level lower
   let p := HexPolyMathlib.toPolynomial relation
   have hpIrreducible : Irreducible p := by
@@ -1013,7 +1013,7 @@ theorem findSquarefreeShift_isSome_of_injective
       (IsAlgClosed.splits _), hpDegree]
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
   let P := HexPolyMathlib.toPolynomial
     (Factor.rawPoly (level :: lower) f)

--- a/HexNumberFieldTowerMathlib/Split.lean
+++ b/HexNumberFieldTowerMathlib/Split.lean
@@ -35,11 +35,11 @@ private theorem oneLevel_isRoot (level : Level) (lower : List Level)
     hinjectiveLower
   let hinvTop := LevelSemantics.coeffDenote_inv (level :: lower) hvalid
     hinjectiveTop
-  letI : Field (Arithmetic.Coeff lower) :=
+  let : Field (Arithmetic.Coeff lower) :=
     coeffFieldPoly lower hvalid.2.2 hinjectiveLower hinvLower
-  letI : Field (Arithmetic.Coeff (level :: lower)) :=
+  let : Field (Arithmetic.Coeff (level :: lower)) :=
     coeffFieldPoly (level :: lower) hvalid hinjectiveTop hinvTop
-  letI : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
+  let : CommRing (DensePoly (Arithmetic.Coeff lower)) := denseCommRing
   have hdvd := shifted_dvd_norm level lower hvalid hinjectiveTop f 0
   have hdvdComplex := Polynomial.map_dvd
     (LevelSemantics.coeffHom (level :: lower) hvalid hinjectiveTop hinvTop)
@@ -80,7 +80,7 @@ private theorem basePolynomial (f : Array (Array Rat)) :
     rawPolynomial [] (Factor.rawPoly [] f) =
       (HexPolyMathlib.toPolynomial (Factor.toRatPoly f)).map
         (algebraMap Rat ℂ) := by
-  letI : Field (Arithmetic.Coeff []) := LevelSemantics.coeffFieldNil
+  let : Field (Arithmetic.Coeff []) := LevelSemantics.coeffFieldNil
   have hvalidNil : LevelsValid [] := by exact trivial
   have hhom :
       (algebraMap Rat ℂ).comp LevelSemantics.coeffRatEquiv.toRingHom =
@@ -117,7 +117,7 @@ theorem iterated_isRoot_toRat (T : NumberTower) (f : Poly T) (z : ℂ)
 
 private theorem toRatPoly_ne_zero (f : Array (Array Rat))
     (hf : Factor.rawPoly [] f ≠ 0) : Factor.toRatPoly f ≠ 0 := by
-  letI : Field (Arithmetic.Coeff []) := LevelSemantics.coeffFieldNil
+  let : Field (Arithmetic.Coeff []) := LevelSemantics.coeffFieldNil
   intro hzero
   have hmap := LevelSemantics.map_rawPoly_nil f
   rw [hzero, HexPolyMathlib.toPolynomial_zero] at hmap

--- a/HexPolyFpMathlib/SquareFree.lean
+++ b/HexPolyFpMathlib/SquareFree.lean
@@ -119,7 +119,7 @@ theorem isCoprime_toMathlibPolynomial_of_normalizeMonic_gcd_eq_one
     [Fact (Nat.Prime p)] {a b : Hex.FpPoly p}
     (h : (Hex.FpPoly.normalizeMonic (Hex.DensePoly.gcd a b)).2 = 1) :
     IsCoprime (toMathlibPolynomial a) (toMathlibPolynomial b) := by
-  haveI : Hex.ZMod64.PrimeModulus p := primeModulus_of_fact p
+  have : Hex.ZMod64.PrimeModulus p := primeModulus_of_fact p
   obtain ⟨u, hu⟩ := isUnit_toMathlibPolynomial_of_normalizeMonic_eq_one h
   have hbez : (Hex.DensePoly.xgcd a b).left * a + (Hex.DensePoly.xgcd a b).right * b
       = Hex.DensePoly.gcd a b :=


### PR DESCRIPTION
This PR replaces `haveI`/`letI` with `have`/`let` at the 414 sites where Lean 4.34's linter reports that the goal is a proposition, so the instance-binder variants buy nothing.

Stacked on https://github.com/kim-em/hex-dev/pull/9995 (chore: replace deprecated `if_pos`/`if_neg` with their `ite`/`dite` successors); GitHub retargets this at `main` once that merges.

🤖 Prepared with Claude Code