### PR TITLE
feat(number-field): roots of integer polynomials as algebraic numbers

### DIFF
--- a/HexNumberField.lean
+++ b/HexNumberField.lean
@@ -14,6 +14,7 @@ public import HexNumberField.Lazy
 public import HexNumberField.Disambiguate
 public import HexNumberField.AlgebraicPoly
 public import HexNumberField.Roots
+public import HexNumberField.IntegerRoots
 
 public section
 

--- a/HexNumberField/IntegerRoots.lean
+++ b/HexNumberField/IntegerRoots.lean
@@ -74,6 +74,25 @@ def approx (a : AlgebraicNumber) (prec : Int := 64) : DyadicComplexBall :=
 
 end AlgebraicNumber
 
+namespace AlgebraicRoot
+
+/-- The lazy root selected by one refined isolation of a normalized squarefree
+polynomial. -/
+@[expose]
+def ofRefined (q : ZPoly) (prim : ZPoly.content q = 1) (pos_lc : 0 < q.leadingCoeff)
+    (pos_degree : 0 < q.degree?.getD 0) (squarefree : HasOnlySimpleRoots q)
+    (rep : RefinedIsolation q) : AlgebraicRoot :=
+  { p := q
+    prim := prim
+    pos_lc := pos_lc
+    pos_degree := pos_degree
+    squarefree := squarefree
+    x := SimpleRoot.mk rep
+    rep := rep
+    rep_mk := rfl }
+
+end AlgebraicRoot
+
 namespace ZPoly
 
 /-- Every distinct complex root of `p` as a canonical algebraic number, or
@@ -91,14 +110,7 @@ def algebraicRoots? (p : ZPoly) : Option (Array AlgebraicNumber) :=
             let isolations ← isolate q hsimple (separationDepth q : Int)
             let refined ← isolations.mapM DyadicRootIsolation.toRefined?
             let roots ← refined.mapM fun rep =>
-              ({ p := q
-                 prim := hprim
-                 pos_lc := hpos
-                 pos_degree := hdeg
-                 squarefree := hsimple
-                 x := SimpleRoot.mk rep
-                 rep := rep
-                 rep_mk := rfl } : AlgebraicRoot).exact?
+              (AlgebraicRoot.ofRefined q hprim hpos hdeg hsimple rep).exact?
             some (roots.toList.mergeSort AlgebraicNumber.rootLe).toArray
           else
             none

--- a/HexNumberField/IntegerRoots.lean
+++ b/HexNumberField/IntegerRoots.lean
@@ -1,0 +1,175 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexNumberField.Convert
+
+public section
+
+/-!
+Roots of integer polynomials as canonical algebraic numbers, the reality
+test on stored isolations, and display.
+
+`ZPoly.algebraicRoots` is the entry point a user reaches for first: it turns
+an integer polynomial into its distinct complex roots, each a canonical
+`AlgebraicNumber`, real roots first in increasing order. The reality test
+compares the centre of a stored isolation with the dyadic upper bound of its
+disc radius; at separation precision that decides reality exactly, as the
+companion proves.
+-/
+
+namespace Hex
+
+namespace DyadicSquare
+
+/-- The closed circumscribed disc, with its radius rounded up to `radiusHi`,
+meets the real axis. -/
+@[expose]
+def meetsRealAxis (s : DyadicSquare) : Bool :=
+  -s.radiusHi ≤ s.im && s.im ≤ s.radiusHi
+
+end DyadicSquare
+
+namespace AlgebraicRoot
+
+/-- The selected root is real. Exact at the stored separation precision. -/
+@[expose]
+def isReal (a : AlgebraicRoot) : Bool :=
+  a.rep.1.square.meetsRealAxis
+
+end AlgebraicRoot
+
+namespace AlgebraicNumber
+
+/-- The represented number is real. Exact at the stored separation precision. -/
+@[expose]
+def isReal (a : AlgebraicNumber) : Bool :=
+  a.rep.1.square.meetsRealAxis
+
+/-- The output order of `ZPoly.algebraicRoots`: real roots first, in
+increasing order of their isolation centres (which is their order as real
+numbers), then nonreal roots by isolation centre and precision. -/
+@[expose]
+def rootLe (a b : AlgebraicNumber) : Bool :=
+  match a.isReal, b.isReal with
+  | true, false => true
+  | false, true => false
+  | _, _ =>
+    let s := a.rep.1.square
+    let t := b.rep.1.square
+    if s.re = t.re then
+      if s.im = t.im then decide (s.prec ≤ t.prec) else decide (s.im < t.im)
+    else
+      decide (s.re < t.re)
+
+/-- A dyadic complex ball of radius at most `2^(-prec)` around the value,
+evaluated on the stored representative. -/
+@[expose]
+def approx (a : AlgebraicNumber) (prec : Int := 64) : DyadicComplexBall :=
+  (a.toQAdjoin.approx a.rep a.rep_mk prec).2
+
+end AlgebraicNumber
+
+namespace ZPoly
+
+/-- Every distinct complex root of `p` as a canonical algebraic number, or
+`none` if a certificate could not be produced. See `algebraicRoots`. -/
+@[expose]
+def algebraicRoots? (p : ZPoly) : Option (Array AlgebraicNumber) :=
+  if p.degree?.getD 0 = 0 then
+    some #[]
+  else
+    let q := ZPoly.squareFreeCore p
+    if hprim : ZPoly.content q = 1 then
+      if hpos : 0 < q.leadingCoeff then
+        if hdeg : 0 < q.degree?.getD 0 then
+          if hsimple : HasOnlySimpleRoots q then do
+            let isolations ← isolate q hsimple (separationDepth q : Int)
+            let refined ← isolations.mapM DyadicRootIsolation.toRefined?
+            let roots ← refined.mapM fun rep =>
+              ({ p := q
+                 prim := hprim
+                 pos_lc := hpos
+                 pos_degree := hdeg
+                 squarefree := hsimple
+                 x := SimpleRoot.mk rep
+                 rep := rep
+                 rep_mk := rfl } : AlgebraicRoot).exact?
+            some (roots.toList.mergeSort AlgebraicNumber.rootLe).toArray
+          else
+            none
+        else
+          none
+      else
+        none
+    else
+      none
+
+/-- Every distinct complex root of `p` as a canonical algebraic number: the
+squarefree primitive part of `p` is isolated, and each isolated root is
+exactified. Real roots come first, in increasing order, then the nonreal
+roots in a deterministic order set by their isolations. Multiplicities are
+not returned; use `AlgebraicPoly.roots` for them. A constant polynomial,
+including zero, has no roots here. -/
+@[expose]
+def algebraicRoots (p : ZPoly) : Array AlgebraicNumber :=
+  p.algebraicRoots?.getD (Hex.panicWith #[] "ZPoly.algebraicRoots: certification failed")
+
+end ZPoly
+
+namespace AlgebraicNumber
+
+namespace Display
+
+/-- `q` truncated toward zero to `digits` decimal places. A display helper
+for the `Repr` instance; it carries no contract. -/
+def decimal (q : Rat) (digits : Nat) : String :=
+  let scale := 10 ^ digits
+  let n := q.num.natAbs * scale / q.den
+  let whole := n / scale
+  let frac := n % scale
+  let fracDigits := toString frac
+  let padded := String.mk (List.replicate (digits - fracDigits.length) '0') ++ fracDigits
+  (if q.num < 0 && n ≠ 0 then "-" else "") ++ s!"{whole}.{padded}"
+
+/-- `p` written with descending powers of `X`. A display helper for the
+`Repr` instance; it carries no contract. -/
+def polynomial (p : ZPoly) : String :=
+  let coeffs := p.coeffs
+  let terms := (List.range coeffs.size).reverse.filterMap fun i =>
+    let c := coeffs.getD i 0
+    if c = 0 then none
+    else
+      let magnitude := c.natAbs
+      let body :=
+        if i = 0 then s!"{magnitude}"
+        else
+          (if magnitude = 1 then "" else s!"{magnitude}*") ++
+            (if i = 1 then "X" else s!"X^{i}")
+      some (decide (c < 0), body)
+  match terms with
+  | [] => "0"
+  | (negative, body) :: rest =>
+      rest.foldl (fun acc (neg, term) => acc ++ (if neg then " - " else " + ") ++ term)
+        ((if negative then "-" else "") ++ body)
+
+end Display
+
+instance : Repr AlgebraicNumber where
+  reprPrec a _ :=
+    let ball := a.approx 64
+    let re := Display.decimal ball.re.toRat 12
+    let value :=
+      if a.isReal then re
+      else
+        let im := Display.decimal ball.im.toRat 12
+        re ++ (if im.startsWith "-" then " - " ++ im.drop 1 else " + " ++ im) ++ "i"
+    Std.Format.text s!"root of {Display.polynomial a.p} near {value}"
+
+end AlgebraicNumber
+
+end Hex

--- a/HexNumberField/SPEC/hex-number-field.md
+++ b/HexNumberField/SPEC/hex-number-field.md
@@ -425,6 +425,56 @@ The displayed endpoint proves that the bounded search succeeds. The same
 construction, with the eliminant for each generator/factor evaluation, is used
 by tower adjoining. No API performs unbounded refinement.
 
+## Roots of integer polynomials
+
+```lean
+def ZPoly.algebraicRoots? (p : ZPoly) : Option (Array AlgebraicNumber)
+def ZPoly.algebraicRoots  (p : ZPoly) : Array AlgebraicNumber
+
+def DyadicSquare.meetsRealAxis (s : DyadicSquare) : Bool
+def AlgebraicRoot.isReal (a : AlgebraicRoot) : Bool
+def AlgebraicNumber.isReal (a : AlgebraicNumber) : Bool
+def AlgebraicNumber.rootLe (a b : AlgebraicNumber) : Bool
+def AlgebraicNumber.approx (a : AlgebraicNumber) (prec : Int := 64) :
+    DyadicComplexBall
+instance : Repr AlgebraicNumber
+```
+
+`algebraicRoots p` is every distinct complex root of `p` in canonical form.
+It takes the squarefree primitive part of `p`, isolates all of its roots with
+the fixed default strategy at `separationDepth`, builds one lazy
+`AlgebraicRoot` per isolation, and exactifies each. Multiplicities are not
+returned; `AlgebraicPoly.roots` on the cast polynomial supplies them. A
+constant, including zero, returns the empty array, and the correspondence
+theorem is stated for nonzero `p`, matching `Polynomial.roots 0 = 0`. `none`
+is reserved for certificate failure, and `algebraicRoots?_isSome` retires it.
+
+The array is sorted by `AlgebraicNumber.rootLe`: real roots first, in
+increasing order, then the nonreal roots ordered by isolation centre (real
+part, then imaginary part, then precision). The order of the real roots is a
+theorem about the values. The order among nonreal roots is deterministic,
+because isolation is deterministic, but it is not determined by the roots
+alone and no client may rely on it beyond determinism.
+
+`meetsRealAxis` tests whether the closed circumscribed disc meets the real
+axis, with the disc radius rounded up to the dyadic `radiusHi`: the centre's
+imaginary part is at most `radiusHi` in absolute value. At separation
+precision this is exact for a stored isolation: a real root lies in the
+closed disc, so its centre is within the true radius, which is below
+`radiusHi`, of the axis; a nonreal root and its conjugate are distinct roots
+of the same integer polynomial, so `radiusHi` itself is less than a quarter
+of their distance `2 |im z|` (the separation bound carries the `1449/1024`
+slack), and the centre is more than `radiusHi` from the axis. `isReal`
+applies it to the stored representative; the companion proves `isReal_iff`.
+
+`approx a prec` is `QAdjoin.approx` applied to `a.toQAdjoin` with the stored
+representative; its ball contains `a.toComplex` and has radius at most
+`2^(-prec)`. The `Repr` instance prints the minimal polynomial and the ball
+centre truncated to twelve decimal places (real part only when `isReal`); it
+is for display and carries no contract beyond `approx`. Its two helpers,
+`AlgebraicNumber.Display.decimal` and `AlgebraicNumber.Display.polynomial`,
+are public only because the instance is, and carry no contract either.
+
 ## Common-field construction
 
 The `Hex.AlgebraicPoly.Common` namespace is the public bounded
@@ -503,6 +553,8 @@ for diagnostics and staged proofs.
 `AlgebraicNumber` has canonical zero `p = X`, so it supplies the `Inhabited`
 fallback used by exactification. `RootSet.all` is the loud fallback for the two
 total root wrappers; their `_isSome` theorems make it unreachable.
+`ZPoly.algebraicRoots` falls back to the empty array, and
+`algebraicRoots?_isSome` makes that branch unreachable too.
 
 ## File organisation
 
@@ -516,6 +568,7 @@ HexNumberField/
   Disambiguate.lean   : candidate bounds and certified selection
   AlgebraicPoly.lean  : semantic coefficient-polynomial representation
   Roots.lean          : fixed-field and algebraic-coefficient root APIs
+  IntegerRoots.lean   : roots of integer polynomials, reality test, display
 ```
 
 Conformance and benchmark drivers live in the shared `conformance/` and
@@ -526,7 +579,11 @@ Conformance and benchmark drivers live in the shared `conformance/` and
 - *core*: at least three cases per public operation, including `√2 + √2`,
   `√2 * √2`, `√2 + (-√2)`, inversion of zero, equal values represented by
   different nonminimal polynomials, an enclosing polynomial with irrelevant
-  factors, repeated input roots, and a conjugate-embedding impostor.
+  factors, repeated input roots, and a conjugate-embedding impostor; for
+  `algebraicRoots`, `X² - 2` (order `-√2, √2`), `(X² - 2)² (X + 3)`
+  (multiplicity dropped, `-3` first), `X³ - 2` (one real root first, then
+  the conjugate pair), and the zero, constant, and `X` polynomials; for
+  `isReal`, a real root, a nonreal root, and zero.
 - *ci*: deterministic small-degree fixtures checked by cypari2. Use
   python-flint independently for integer resultants, factorization, and certified
   complex-root balls.

--- a/HexNumberField/SPEC/hex-number-field.md
+++ b/HexNumberField/SPEC/hex-number-field.md
@@ -428,6 +428,10 @@ by tower adjoining. No API performs unbounded refinement.
 ## Roots of integer polynomials
 
 ```lean
+def AlgebraicRoot.ofRefined (q : ZPoly) (prim : ZPoly.content q = 1)
+    (pos_lc : 0 < q.leadingCoeff) (pos_degree : 0 < q.degree?.getD 0)
+    (squarefree : HasOnlySimpleRoots q) (rep : RefinedIsolation q) :
+    AlgebraicRoot
 def ZPoly.algebraicRoots? (p : ZPoly) : Option (Array AlgebraicNumber)
 def ZPoly.algebraicRoots  (p : ZPoly) : Array AlgebraicNumber
 
@@ -443,7 +447,8 @@ instance : Repr AlgebraicNumber
 `algebraicRoots p` is every distinct complex root of `p` in canonical form.
 It takes the squarefree primitive part of `p`, isolates all of its roots with
 the fixed default strategy at `separationDepth`, builds one lazy
-`AlgebraicRoot` per isolation, and exactifies each. Multiplicities are not
+`AlgebraicRoot` per isolation with `AlgebraicRoot.ofRefined`, and exactifies
+each. Multiplicities are not
 returned; `AlgebraicPoly.roots` on the cast polynomial supplies them. A
 constant, including zero, returns the empty array, and the correspondence
 theorem is stated for nonzero `p`, matching `Polynomial.roots 0 = 0`. `none`

--- a/HexNumberFieldMathlib.lean
+++ b/HexNumberFieldMathlib.lean
@@ -10,6 +10,7 @@ public import HexNumberFieldMathlib.Roots
 public import HexNumberFieldMathlib.ComponentRoots
 public import HexNumberFieldMathlib.AlgebraicRoots
 public import HexNumberFieldMathlib.Field
+public import HexNumberFieldMathlib.IntegerRoots
 
 public section
 

--- a/HexNumberFieldMathlib/IntegerRoots.lean
+++ b/HexNumberFieldMathlib/IntegerRoots.lean
@@ -1,0 +1,447 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexNumberFieldMathlib.Exact
+
+public section
+
+/-!
+# Roots of integer polynomials
+
+`ZPoly.algebraicRoots` always succeeds, and its output is exactly the set of
+complex roots of the polynomial, each once. The reality test `isReal` is
+exact at the stored separation precision, and `approx` returns a ball around
+the represented value.
+-/
+
+namespace Hex
+
+open HexRootsMathlib
+
+namespace ZPoly
+
+/-- The squarefree primitive part of a polynomial of positive degree has
+positive degree. -/
+private theorem squareFreeCore_degree_pos (p : ZPoly)
+    (h0 : ¬ p.degree?.getD 0 = 0) :
+    0 < (ZPoly.squareFreeCore p).degree?.getD 0 := by
+  have hpne : p ≠ 0 := by
+    intro hp
+    apply h0
+    simp [hp]
+  have hcne : ZPoly.squareFreeCore p ≠ 0 := ZPoly.squareFreeCore_ne_zero p hpne
+  have hdeg : 0 < (toPolyℂ p).degree := by
+    rw [← Polynomial.natDegree_pos_iff_degree_pos, natDegree_toPolyℂ]
+    exact Nat.pos_of_ne_zero h0
+  obtain ⟨z, hz⟩ := Complex.exists_root hdeg
+  have hcore : (toPolyℂ (ZPoly.squareFreeCore p)).IsRoot z :=
+    HexPolyZMathlib.isRoot_squareFreeCore hpne hz
+  by_contra hn
+  have hsize : (ZPoly.squareFreeCore p).size ≠ 0 := by
+    intro hsize
+    exact hcne ((DensePoly.size_eq_zero_iff _).mp hsize)
+  exact not_isRoot_of_degree_not_pos (ZPoly.squareFreeCore p) hsize hn z hcore
+
+/-- The positive-degree branch of `algebraicRoots?`, with its certificate
+hypotheses named. -/
+private theorem algebraicRoots?_eq_of_pos (p : ZPoly)
+    (h0 : ¬ p.degree?.getD 0 = 0)
+    (hprim : ZPoly.content (ZPoly.squareFreeCore p) = 1)
+    (hpos : 0 < (ZPoly.squareFreeCore p).leadingCoeff)
+    (hdeg : 0 < (ZPoly.squareFreeCore p).degree?.getD 0)
+    (hsimple : HasOnlySimpleRoots (ZPoly.squareFreeCore p)) :
+    ZPoly.algebraicRoots? p =
+      (isolate (ZPoly.squareFreeCore p) hsimple
+          (separationDepth (ZPoly.squareFreeCore p) : Int)).bind fun isolations =>
+        (isolations.mapM DyadicRootIsolation.toRefined?).bind fun refined =>
+          (refined.mapM fun rep =>
+              (AlgebraicRoot.ofRefined (ZPoly.squareFreeCore p) hprim hpos hdeg
+                hsimple rep).exact?).bind fun roots =>
+            some (roots.toList.mergeSort AlgebraicNumber.rootLe).toArray := by
+  unfold ZPoly.algebraicRoots?
+  rw [if_neg h0]
+  dsimp only
+  rw [dif_pos hprim, dif_pos hpos, dif_pos hdeg, dif_pos hsimple]
+  rfl
+
+/-- The certificate hypotheses of the positive-degree branch all hold. -/
+private theorem squareFreeCore_hypotheses (p : ZPoly)
+    (h0 : ¬ p.degree?.getD 0 = 0) :
+    ZPoly.content (ZPoly.squareFreeCore p) = 1 ∧
+      0 < (ZPoly.squareFreeCore p).leadingCoeff ∧
+      0 < (ZPoly.squareFreeCore p).degree?.getD 0 ∧
+      HasOnlySimpleRoots (ZPoly.squareFreeCore p) := by
+  have hpne : p ≠ 0 := by
+    intro hp
+    apply h0
+    simp [hp]
+  refine ⟨?_, ZPoly.leadingCoeff_squareFreeCore_pos p hpne,
+    squareFreeCore_degree_pos p h0, ?_⟩
+  · simpa [ZPoly.Primitive] using ZPoly.squareFreeCore_primitive p hpne
+  · simpa [HasOnlySimpleRoots] using ZPoly.squareFreeRat_squareFreeCore p hpne
+
+/-- The root-set computation always produces a certificate. -/
+theorem algebraicRoots?_isSome (p : ZPoly) : (ZPoly.algebraicRoots? p).isSome := by
+  by_cases h0 : p.degree?.getD 0 = 0
+  · unfold ZPoly.algebraicRoots?
+    rw [if_pos h0]
+    rfl
+  · obtain ⟨hprim, hpos, hdeg, hsimple⟩ := squareFreeCore_hypotheses p h0
+    have hpne : p ≠ 0 := by
+      intro hp
+      apply h0
+      simp [hp]
+    have hcne : ZPoly.squareFreeCore p ≠ 0 := ZPoly.squareFreeCore_ne_zero p hpne
+    rw [algebraicRoots?_eq_of_pos p h0 hprim hpos hdeg hsimple]
+    have hisolateSome := isolate_isSome (ZPoly.squareFreeCore p) hsimple hcne
+      (separationDepth (ZPoly.squareFreeCore p) : Int) .nkThenPellet
+    obtain ⟨isolations, hisolate⟩ := Option.isSome_iff_exists.mp hisolateSome
+    rw [hisolate, Option.bind_some]
+    have hmapSome := array_mapM_isSome (xs := isolations)
+      (f := DyadicRootIsolation.toRefined?) (fun iso hiso => by
+        unfold DyadicRootIsolation.toRefined?
+        rw [dif_pos (isolate_refined (ZPoly.squareFreeCore p) hsimple
+          (separationDepth (ZPoly.squareFreeCore p) : Int) .nkThenPellet hisolate
+          iso hiso)]
+        rfl)
+    obtain ⟨refined, hmap⟩ := Option.isSome_iff_exists.mp hmapSome
+    rw [hmap, Option.bind_some]
+    have hexactSome := array_mapM_isSome (xs := refined)
+      (f := fun rep => (AlgebraicRoot.ofRefined (ZPoly.squareFreeCore p) hprim hpos
+        hdeg hsimple rep).exact?)
+      (fun rep _ => AlgebraicRoot.exact?_isSome _)
+    obtain ⟨roots, hroots⟩ := Option.isSome_iff_exists.mp hexactSome
+    rw [hroots, Option.bind_some]
+    rfl
+
+/-- The total wrapper is the checked computation. -/
+theorem algebraicRoots?_eq (p : ZPoly) :
+    ZPoly.algebraicRoots? p = some (ZPoly.algebraicRoots p) := by
+  obtain ⟨roots, hroots⟩ := Option.isSome_iff_exists.mp (algebraicRoots?_isSome p)
+  rw [ZPoly.algebraicRoots, hroots]
+  rfl
+
+/-- A root of the squarefree primitive part of a nonzero polynomial is a root
+of the polynomial. -/
+private theorem isRoot_of_isRoot_squareFreeCore {p : ZPoly} (hp : p ≠ 0) {z : ℂ}
+    (hz : (toPolyℂ (ZPoly.squareFreeCore p)).IsRoot z) :
+    (toPolyℂ p).IsRoot z := by
+  obtain ⟨ε, _, hre⟩ := ZPoly.primitiveSquareFreeDecomposition_reassembly_signed p hp
+  have hcore : (ZPoly.primitiveSquareFreeDecomposition p).squareFreeCore =
+      ZPoly.squareFreeCore p := rfl
+  have hfull := HexPolyZMathlib.toPolynomial_eq_C_content_mul_primitivePart p
+  have hprim : HexPolyZMathlib.toPolynomial (ZPoly.primitivePart p) =
+      Polynomial.C ε *
+        (HexPolyZMathlib.toPolynomial (ZPoly.squareFreeCore p) *
+          HexPolyZMathlib.toPolynomial
+            (ZPoly.primitiveSquareFreeDecomposition p).repeatedPart) := by
+    rw [← hre, ← Hex.ZPoly.C_mul_eq_scale, HexPolyZMathlib.toPolynomial_mul,
+      HexPolyZMathlib.toPolynomial_C, HexPolyZMathlib.toPolynomial_mul, hcore]
+  simp only [Polynomial.IsRoot.def, toPolyℂ, Polynomial.eval_map] at hz ⊢
+  rw [hfull, hprim]
+  simp only [Polynomial.eval₂_mul, hz, mul_zero, zero_mul]
+
+/-- The output lists exactly the roots of a nonzero polynomial. -/
+theorem mem_algebraicRoots_iff (p : ZPoly) (hp : p ≠ 0) (z : ℂ) :
+    (∃ a ∈ (ZPoly.algebraicRoots p).toList, a.toComplex = z) ↔
+      (toPolyℂ p).IsRoot z := by
+  by_cases h0 : p.degree?.getD 0 = 0
+  · have hroots : ZPoly.algebraicRoots p = #[] := by
+      have h := algebraicRoots?_eq p
+      unfold ZPoly.algebraicRoots? at h
+      rw [if_pos h0] at h
+      exact (Option.some.inj h).symm
+    have hsize : p.size ≠ 0 := by
+      intro hsize
+      exact hp ((DensePoly.size_eq_zero_iff _).mp hsize)
+    constructor
+    · rintro ⟨a, ha, _⟩
+      simp [hroots] at ha
+    · intro hz
+      exact absurd hz (not_isRoot_of_degree_not_pos p hsize (by omega) z)
+  · obtain ⟨hprim, hpos, hdeg, hsimple⟩ := squareFreeCore_hypotheses p h0
+    have hcne : ZPoly.squareFreeCore p ≠ 0 := ZPoly.squareFreeCore_ne_zero p hp
+    have heq := algebraicRoots?_eq p
+    rw [algebraicRoots?_eq_of_pos p h0 hprim hpos hdeg hsimple] at heq
+    have hisolateSome := isolate_isSome (ZPoly.squareFreeCore p) hsimple hcne
+      (separationDepth (ZPoly.squareFreeCore p) : Int) .nkThenPellet
+    obtain ⟨isolations, hisolate⟩ := Option.isSome_iff_exists.mp hisolateSome
+    rw [hisolate, Option.bind_some] at heq
+    have hmapSome := array_mapM_isSome (xs := isolations)
+      (f := DyadicRootIsolation.toRefined?) (fun iso hiso => by
+        unfold DyadicRootIsolation.toRefined?
+        rw [dif_pos (isolate_refined (ZPoly.squareFreeCore p) hsimple
+          (separationDepth (ZPoly.squareFreeCore p) : Int) .nkThenPellet hisolate
+          iso hiso)]
+        rfl)
+    obtain ⟨refined, hmap⟩ := Option.isSome_iff_exists.mp hmapSome
+    rw [hmap, Option.bind_some] at heq
+    have hexactSome := array_mapM_isSome (xs := refined)
+      (f := fun rep => (AlgebraicRoot.ofRefined (ZPoly.squareFreeCore p) hprim hpos
+        hdeg hsimple rep).exact?)
+      (fun rep _ => AlgebraicRoot.exact?_isSome _)
+    obtain ⟨roots, hroots⟩ := Option.isSome_iff_exists.mp hexactSome
+    rw [hroots, Option.bind_some] at heq
+    have hout : ZPoly.algebraicRoots p =
+        (roots.toList.mergeSort AlgebraicNumber.rootLe).toArray :=
+      (Option.some.inj heq).symm
+    obtain ⟨hsizeIso, hgetIso⟩ := array_mapM_some_get hmap
+    obtain ⟨hsizeRoots, hgetRoots⟩ := array_mapM_some_get hroots
+    -- Each refined isolation keeps its atom.
+    have hraw : ∀ (i : Nat) (hi : i < isolations.size) (hj : i < refined.size),
+        refined[i].1 = isolations[i] := by
+      intro i hi hj
+      have hto := hgetIso i hi hj
+      rw [DyadicRootIsolation.toRefined?] at hto
+      split at hto
+      · exact (congrArg Subtype.val (Option.some.inj hto)).symm
+      · exact absurd hto (by simp)
+    -- Each output value is the root of its atom.
+    have hvalue : ∀ (i : Nat) (hi : i < refined.size) (hj : i < roots.size),
+        roots[i].toComplex = RefinedIsolation.root refined[i] := by
+      intro i hi hj
+      have h := hgetRoots i hi hj
+      exact AlgebraicRoot.exact?_sound
+        (AlgebraicRoot.ofRefined (ZPoly.squareFreeCore p) hprim hpos hdeg hsimple
+          refined[i]) h
+    rw [hout]
+    simp only [List.toList_toArray, List.mem_mergeSort]
+    constructor
+    · rintro ⟨a, ha, rfl⟩
+      obtain ⟨i, hi, hai⟩ := List.mem_iff_getElem.mp ha
+      rw [Array.getElem_toList] at hai
+      have hi' : i < roots.size := by simpa using hi
+      have hi'' : i < refined.size := by omega
+      rw [← hai, hvalue i hi'' hi']
+      exact isRoot_of_isRoot_squareFreeCore hp (RefinedIsolation.isRoot refined[i])
+    · intro hz
+      have hcoreRoot : (toPolyℂ (ZPoly.squareFreeCore p)).IsRoot z :=
+        HexPolyZMathlib.isRoot_squareFreeCore hp hz
+      obtain ⟨iso, hiso, hisoRoot⟩ := isolate_root_mem_of_pos (ZPoly.squareFreeCore p)
+        hsimple (separationDepth (ZPoly.squareFreeCore p) : Int) .nkThenPellet hdeg
+        hisolate hcoreRoot
+      obtain ⟨i, hi, hidx⟩ := List.mem_iff_getElem.mp hiso
+      rw [Array.getElem_toList] at hidx
+      have hi' : i < isolations.size := by simpa using hi
+      have hj : i < refined.size := by omega
+      have hk : i < roots.size := by omega
+      refine ⟨roots[i], ?_, ?_⟩
+      · exact List.mem_iff_getElem.mpr ⟨i, by simpa using hk, by simp⟩
+      · rw [hvalue i hj hk, ← hisoRoot, ← hidx]
+        show (DyadicRootIsolation.sound refined[i].1).choose =
+          (DyadicRootIsolation.sound isolations[i]).choose
+        rw [hraw i hi' hj]
+
+/-- The output has no repeated value. -/
+theorem algebraicRoots_nodup (p : ZPoly) :
+    (ZPoly.algebraicRoots p).toList.Nodup := by
+  by_cases h0 : p.degree?.getD 0 = 0
+  · have hroots : ZPoly.algebraicRoots p = #[] := by
+      have h := algebraicRoots?_eq p
+      unfold ZPoly.algebraicRoots? at h
+      rw [if_pos h0] at h
+      exact (Option.some.inj h).symm
+    simp [hroots]
+  · obtain ⟨hprim, hpos, hdeg, hsimple⟩ := squareFreeCore_hypotheses p h0
+    have hpne : p ≠ 0 := by
+      intro hp
+      apply h0
+      simp [hp]
+    have hcne : ZPoly.squareFreeCore p ≠ 0 := ZPoly.squareFreeCore_ne_zero p hpne
+    have heq := algebraicRoots?_eq p
+    rw [algebraicRoots?_eq_of_pos p h0 hprim hpos hdeg hsimple] at heq
+    have hisolateSome := isolate_isSome (ZPoly.squareFreeCore p) hsimple hcne
+      (separationDepth (ZPoly.squareFreeCore p) : Int) .nkThenPellet
+    obtain ⟨isolations, hisolate⟩ := Option.isSome_iff_exists.mp hisolateSome
+    rw [hisolate, Option.bind_some] at heq
+    have hmapSome := array_mapM_isSome (xs := isolations)
+      (f := DyadicRootIsolation.toRefined?) (fun iso hiso => by
+        unfold DyadicRootIsolation.toRefined?
+        rw [dif_pos (isolate_refined (ZPoly.squareFreeCore p) hsimple
+          (separationDepth (ZPoly.squareFreeCore p) : Int) .nkThenPellet hisolate
+          iso hiso)]
+        rfl)
+    obtain ⟨refined, hmap⟩ := Option.isSome_iff_exists.mp hmapSome
+    rw [hmap, Option.bind_some] at heq
+    have hexactSome := array_mapM_isSome (xs := refined)
+      (f := fun rep => (AlgebraicRoot.ofRefined (ZPoly.squareFreeCore p) hprim hpos
+        hdeg hsimple rep).exact?)
+      (fun rep _ => AlgebraicRoot.exact?_isSome _)
+    obtain ⟨roots, hroots⟩ := Option.isSome_iff_exists.mp hexactSome
+    rw [hroots, Option.bind_some] at heq
+    have hout : ZPoly.algebraicRoots p =
+        (roots.toList.mergeSort AlgebraicNumber.rootLe).toArray :=
+      (Option.some.inj heq).symm
+    obtain ⟨hsizeIso, hgetIso⟩ := array_mapM_some_get hmap
+    obtain ⟨hsizeRoots, hgetRoots⟩ := array_mapM_some_get hroots
+    have hraw : ∀ (i : Nat) (hi : i < isolations.size) (hj : i < refined.size),
+        refined[i].1 = isolations[i] := by
+      intro i hi hj
+      have hto := hgetIso i hi hj
+      rw [DyadicRootIsolation.toRefined?] at hto
+      split at hto
+      · exact (congrArg Subtype.val (Option.some.inj hto)).symm
+      · exact absurd hto (by simp)
+    have hvalue : ∀ (i : Nat) (hi : i < refined.size) (hj : i < roots.size),
+        roots[i].toComplex = DyadicRootIsolation.root isolations[i] := by
+      intro i hi hj
+      have h := hgetRoots i hi hj
+      rw [AlgebraicRoot.exact?_sound
+        (AlgebraicRoot.ofRefined (ZPoly.squareFreeCore p) hprim hpos hdeg hsimple
+          refined[i]) h]
+      show (DyadicRootIsolation.sound refined[i].1).choose =
+        (DyadicRootIsolation.sound isolations[i]).choose
+      rw [hraw i (by omega) hi]
+    rw [hout, List.toList_toArray, (List.mergeSort_perm _ _).nodup_iff,
+      List.nodup_iff_injective_get]
+    intro i j hij
+    have hi : i.1 < roots.size := by simpa using i.2
+    have hj : j.1 < roots.size := by simpa using j.2
+    by_contra hne
+    have hne' : i.1 ≠ j.1 := fun h => hne (Fin.ext h)
+    have hroot := isolate_roots_ne (ZPoly.squareFreeCore p) hsimple
+      (separationDepth (ZPoly.squareFreeCore p) : Int) .nkThenPellet hisolate
+      (i := i.1) (j := j.1) (by omega) (by omega) hne'
+    have hij' : roots[i.1].toComplex = roots[j.1].toComplex := by
+      simp only [List.get_eq_getElem, Array.getElem_toList] at hij
+      rw [hij]
+    rw [hvalue i.1 (by omega) hi, hvalue j.1 (by omega) hj] at hij'
+    exact hroot hij'
+
+end ZPoly
+
+namespace AlgebraicNumber
+
+/-- The fixed-field coordinates of a canonical number evaluate to its value. -/
+theorem toQAdjoin_toComplex (a : AlgebraicNumber) :
+    QAdjoin.toComplex a.toQAdjoin a.rep a.rep_mk = a.toComplex := by
+  unfold QAdjoin.toComplex AlgebraicNumber.toQAdjoin
+  show Polynomial.eval₂ (algebraMap ℚ ℂ) a.rep.root
+    (HexPolyMathlib.toPolynomial (QAdjoin.reduceCoeffs a.p (DensePoly.ofList [0, 1]))) =
+      a.toComplex
+  rw [QAdjoin.eval_reduceCoeffs]
+  have hX : HexPolyMathlib.toPolynomial (DensePoly.ofList ([0, 1] : List Rat)) =
+      Polynomial.X := by
+    ext n
+    rw [HexPolyMathlib.coeff_toPolynomial, Polynomial.coeff_X]
+    simp only [DensePoly.coeff_ofList]
+    rcases n with _ | _ | n <;> simp [List.getD] <;> rfl
+  rw [hX, Polynomial.eval₂_X]
+  rfl
+
+/-- The approximation ball contains the represented value. -/
+theorem approx_mem (a : AlgebraicNumber) (prec : Int) :
+    a.toComplex ∈ (a.approx prec).set := by
+  have h := QAdjoin.approx_sound a.toQAdjoin a.rep a.rep_mk prec
+  rw [toQAdjoin_toComplex] at h
+  exact h
+
+/-- The approximation ball has the requested radius. -/
+theorem approx_radius (a : AlgebraicNumber) (prec : Int) :
+    (a.approx prec).realRadius ≤ (2 : ℝ) ^ (-prec) :=
+  QAdjoin.approx_radius a.toQAdjoin a.rep a.rep_mk prec
+
+/-- Complex roots of an integer polynomial are closed under conjugation. -/
+private theorem isRoot_conj {p : ZPoly} {z : ℂ} (hz : (toPolyℂ p).IsRoot z) :
+    (toPolyℂ p).IsRoot (starRingEnd ℂ z) := by
+  simp only [Polynomial.IsRoot.def, toPolyℂ, Polynomial.eval_map] at hz ⊢
+  have hcomp : (starRingEnd ℂ).comp (Int.castRingHom ℂ) = Int.castRingHom ℂ :=
+    RingHom.ext_int _ _
+  rw [← hcomp, ← Polynomial.hom_eval₂, hz, map_zero]
+
+/-- The imaginary part of a stored isolation's centre. -/
+private theorem center_im (s : DyadicSquare) :
+    (HexRootsMathlib.DyadicSquare.center s).im = Dyadic.toReal s.im := by
+  simp [HexRootsMathlib.DyadicSquare.center_eq, Hex.DyadicSquare.center]
+
+/-- The reality test is exact at the stored separation precision. -/
+theorem isReal_iff (a : AlgebraicNumber) : a.isReal = true ↔ a.toComplex.im = 0 := by
+  have hpne : a.p ≠ 0 := RefinedIsolation.poly_ne_zero a.rep
+  set s := a.rep.1.square with hs
+  have hmem : a.toComplex ∈ DyadicSquare.closedDisc s :=
+    RefinedIsolation.root_mem_closedDisc a.rep
+  have hdist : dist a.toComplex (HexRootsMathlib.DyadicSquare.center s) ≤
+      DyadicSquare.radius s := by
+    simpa only [DyadicSquare.closedDisc, Metric.mem_closedBall] using hmem
+  have hradiusHi : DyadicSquare.radius s < Dyadic.toReal s.radiusHi := by
+    rw [DyadicSquare.radius_eq, DyadicSquare.radiusHi_eq, DyadicSquare.halfWidth_eq]
+    exact mul_lt_mul_of_pos_left sqrt_two_lt_sqrt2Hi (zpow_pos (by norm_num) _)
+  have himDist : |a.toComplex.im - Dyadic.toReal s.im| ≤ DyadicSquare.radius s := by
+    have h := Complex.abs_im_le_norm (a.toComplex - HexRootsMathlib.DyadicSquare.center s)
+    rw [Complex.sub_im, center_im] at h
+    rw [dist_eq_norm] at hdist
+    exact h.trans hdist
+  have hHiSep : Dyadic.toReal s.radiusHi ≤
+      (2 : ℝ) ^ (-(mahlerPrec a.p : ℤ)) * (1449 / 1024 : ℝ) := by
+    rw [DyadicSquare.radiusHi_eq, DyadicSquare.halfWidth_eq]
+    have hsqrt : Dyadic.toReal Hex.sqrt2Hi = (1449 / 1024 : ℝ) := by
+      norm_num [Hex.sqrt2Hi, Dyadic.toReal_ofIntWithPrec]
+    rw [hsqrt]
+    apply mul_le_mul_of_nonneg_right _ (by norm_num)
+    apply zpow_le_zpow_right₀ (by norm_num : (1 : ℝ) ≤ 2)
+    have hprop := a.rep.property
+    rw [← hs] at hprop
+    omega
+  unfold AlgebraicNumber.isReal DyadicSquare.meetsRealAxis
+  rw [← hs]
+  simp only [Bool.and_eq_true, decide_eq_true_eq, ← Dyadic.toReal_le_toReal_iff,
+    Dyadic.toReal_neg]
+  constructor
+  · rintro ⟨hlo, hhi⟩
+    by_contra hne
+    have hconj := isRoot_conj (RefinedIsolation.isRoot a.rep)
+    have hne' : a.toComplex ≠ starRingEnd ℂ a.toComplex := by
+      intro h
+      exact hne (Complex.conj_eq_iff_im.mp h.symm)
+    have hsep := mahlerPrec_separates a.p hpne a.toComplex (starRingEnd ℂ a.toComplex)
+      (RefinedIsolation.isRoot a.rep) hconj hne'
+    rw [Complex.sub_conj, norm_mul, Complex.norm_real, Complex.norm_I, mul_one,
+      Real.norm_eq_abs, abs_mul, abs_two] at hsep
+    have himLarge : 2 * Dyadic.toReal s.radiusHi < |a.toComplex.im| := by
+      linarith
+    have hcenter : |Dyadic.toReal s.im| ≤ Dyadic.toReal s.radiusHi := abs_le.mpr ⟨hlo, hhi⟩
+    have htri := abs_sub_abs_le_abs_sub a.toComplex.im (Dyadic.toReal s.im)
+    linarith
+  · intro him
+    have : |Dyadic.toReal s.im| ≤ DyadicSquare.radius s := by
+      simpa [him] using himDist
+    exact abs_le.mp (this.trans hradiusHi.le)
+
+end AlgebraicNumber
+
+/--
+info: 'Hex.ZPoly.algebraicRoots?_isSome' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms ZPoly.algebraicRoots?_isSome
+
+/--
+info: 'Hex.ZPoly.mem_algebraicRoots_iff' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms ZPoly.mem_algebraicRoots_iff
+
+/--
+info: 'Hex.ZPoly.algebraicRoots_nodup' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms ZPoly.algebraicRoots_nodup
+
+/--
+info: 'Hex.AlgebraicNumber.isReal_iff' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms AlgebraicNumber.isReal_iff
+
+/--
+info: 'Hex.AlgebraicNumber.approx_mem' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms AlgebraicNumber.approx_mem
+
+end Hex

--- a/bench/HexNumberField/Bench.lean
+++ b/bench/HexNumberField/Bench.lean
@@ -589,6 +589,31 @@ setup_fixed_benchmark runAlgebraicIntPow where {
   apiFixedConfig with expectedHash := some 0x9feb9fb408e711ea
 }
 
+/-- Every root of `X⁴ - 10X² + 1` (the minimal polynomial of `√2 + √3`) as a
+canonical algebraic number: one isolation of the squarefree quartic, four
+exactifications, and the reality-first sort. -/
+initialize rootsInputRef : IO.Ref (Array Int) ← IO.mkRef #[1, 0, -10, 0, 1]
+
+def runAlgebraicRootsZ : Unit → IO UInt64 := fun _ => do
+  let roots := ZPoly.algebraicRoots (DensePoly.ofCoeffs (← rootsInputRef.get))
+  return roots.foldl (fun checksum a => mixHash checksum (algebraicChecksum a))
+    (hash roots.size)
+
+/-- The reality test on both canonical inputs: two dyadic comparisons. -/
+def runIsReal : Unit → IO UInt64 := fun _ => do
+  let (a, b) ← getCanonicalPair
+  return mixHash (hash a.isReal) (hash b.isReal)
+
+/- `ZPoly.algebraicRoots` composes the registered isolation and exactification
+routes on a fixed quartic; the whole public call is one advertised API case.
+`isReal` is a constant-time comparison grouped as a correctness anchor. -/
+setup_fixed_benchmark runAlgebraicRootsZ where {
+  apiFixedConfig with maxSecondsPerCall := 0.75, expectedHash := some 0x7d49297b09f35f3c
+}
+setup_fixed_benchmark runIsReal where {
+  apiFixedConfig with expectedHash := some 0x14c9f5d720a252cb
+}
+
 initialize zeroRepRef : IO.Ref (Option (RefinedIsolation ZPoly.X)) ←
   IO.mkRef (some AlgebraicNumber.zeroRep)
 

--- a/conformance/HexNumberField/Conformance.lean
+++ b/conformance/HexNumberField/Conformance.lean
@@ -21,7 +21,9 @@ Covered operations:
 - canonical `AlgebraicNumber` arithmetic through its public instances;
 - canonical rational construction, casts, scalar action, and powers;
 - semantic equality of lazy values represented by different polynomials;
-- checked and total fixed-field and algebraic-coefficient root APIs.
+- checked and total fixed-field and algebraic-coefficient root APIs;
+- `ZPoly.algebraicRoots?`/`algebraicRoots`, the reality test `isReal`, the
+  output order `rootLe`, `approx`, and the `Repr` display.
 
 Covered properties and edge cases:
 - `sqrt(2)^2 = 2`, `sqrt(2) * sqrt(2)^-1 = 1`, and `0^-1 = 0`;
@@ -31,7 +33,11 @@ Covered properties and edge cases:
 - exactification through an enclosing polynomial with an irrelevant factor;
 - equal values with different nonminimal polynomials and a conjugate-embedding
   impostor that must compare unequal;
-- zero, constant, linear, and repeated-root polynomial conventions.
+- zero, constant, linear, and repeated-root polynomial conventions;
+- `algebraicRoots` on `X^2 - 2` (order `-sqrt(2), sqrt(2)`), on
+  `(X^2 - 2)^2 (X + 3)` (multiplicity dropped, `-3` first), on `X^3 - 2` (the
+  real root first, then the conjugate pair), and on the zero, constant, and
+  `X` polynomials; `isReal` on a real root, a nonreal root, and zero.
 -/
 
 namespace Hex.NumberFieldConformance
@@ -473,5 +479,64 @@ private def algebraicRepeated? : Option AlgebraicPoly := do
             (total[0]?).map (fun root => root.multiplicity) = some 2
       | _, _ => false
   | none => false
+
+
+/-! # Roots of integer polynomials -/
+
+-- `X^2 - 2`: two real roots, `-sqrt(2)` before `sqrt(2)`, both canonical, and
+-- the total wrapper agrees with the checked form.
+#guard
+  let p : ZPoly := #p[-2, 0, 1]
+  match ZPoly.algebraicRoots? p with
+  | some roots =>
+      roots.size = 2 && ZPoly.algebraicRoots p == roots &&
+        roots.all (fun a => a.p = p && a.isReal) &&
+        (roots[0]?).map (fun a => decide ((a.approx 24).re < 0)) = some true &&
+        (roots[1]?).map (fun a => decide ((a.approx 24).re > 0)) = some true &&
+        (roots[0]?).map (fun a => a == -roots[1]!) = some true
+  | none => false
+
+-- `(X^2 - 2)^2 (X + 3)`: multiplicity is dropped, the rational root `-3`
+-- comes first because it is the smallest real root, and the two surds keep
+-- their canonical minimal polynomial.
+#guard
+  let p : ZPoly := #p[-2, 0, 1] * #p[-2, 0, 1] * #p[3, 1]
+  let roots := ZPoly.algebraicRoots p
+  roots.size = 3 &&
+    (roots[0]?).map (fun a => a == AlgebraicNumber.ofRat (-3)) = some true &&
+    (roots[1]?).map (fun a => a.p = #p[-2, 0, 1] && a.isReal) = some true &&
+    (roots[2]?).map (fun a => a.p = #p[-2, 0, 1] && a.isReal) = some true
+
+-- `X^3 - 2`: the real cube root first, then the conjugate pair, which is
+-- nonreal, and the three roots sum to zero.
+#guard
+  let p : ZPoly := #p[-2, 0, 0, 1]
+  let roots := ZPoly.algebraicRoots p
+  roots.size = 3 &&
+    (roots[0]?).map (fun a => a.isReal) = some true &&
+    (roots[1]?).map (fun a => !a.isReal) = some true &&
+    (roots[2]?).map (fun a => !a.isReal) = some true &&
+    roots.all (fun a => a.p = p) &&
+    (roots.foldl (· + ·) 0 == 0)
+
+-- The zero polynomial, a nonzero constant, and `X` take their stated
+-- branches: no roots, no roots, and the canonical zero (which is real).
+#guard
+  ZPoly.algebraicRoots? (0 : ZPoly) == some #[] &&
+    ZPoly.algebraicRoots? (#p[7] : ZPoly) == some #[] &&
+    (match ZPoly.algebraicRoots? (#p[0, 1] : ZPoly) with
+      | some roots => roots.size = 1 &&
+          (roots[0]?).map (fun a => a == 0 && a.isReal) = some true
+      | none => false)
+
+-- `sqrt(2) + sqrt(3)` through the public entry point has the expected
+-- minimal polynomial, its inverse is `sqrt(3) - sqrt(2)`, and the display
+-- names the polynomial and twelve decimals.
+#guard
+  let s2 := (ZPoly.algebraicRoots #p[-2, 0, 1])[1]!
+  let s3 := (ZPoly.algebraicRoots #p[-3, 0, 1])[1]!
+  (s2 + s3).p = #p[1, 0, -10, 0, 1] && (s2 + s3)⁻¹ == s3 - s2 &&
+    (repr s2).pretty == "root of X^2 - 2 near 1.414213562373" &&
+    (repr (s2 + s3)).pretty == "root of X^4 - 10*X^2 + 1 near 3.146264369941"
 
 end Hex.NumberFieldConformance

--- a/reports/hex-number-field-performance.md
+++ b/reports/hex-number-field-performance.md
@@ -40,7 +40,7 @@ fixed-mode choice. The contracts below are copied from the registration sites.
 | `runMergeRootListLadder` | parametric | duplicate-removal fold across the two Yun components of the fixed-field roots family, with component construction outside timing | `n ^ 2 * (Nat.log2 (n + 2) + 1)` |
 | `runQAdjoinRootsLadder` | fixed | `QAdjoin.roots?` on `g^2 * (X - 1)` over `ℚ(√2)` with `g` dense of degree 6 | 20 s ceiling |
 | `runAlgebraicRootsLadder` | fixed | `AlgebraicPoly.roots?` on the dense degree-6 polynomial with one `√2` coefficient | 15 s ceiling |
-| advertised fixed-degree API cases | fixed | lazy and canonical arithmetic, conversion, powers, casts, zero decisions, and `AlgebraicPoly.Common` primitives | 500 ms default; 750 ms for measured slower routes, zero grace |
+| advertised fixed-degree API cases | fixed | lazy and canonical arithmetic, conversion, powers, casts, zero decisions, `AlgebraicPoly.Common` primitives, the integer-polynomial root set `ZPoly.algebraicRoots` on `X⁴ - 10X² + 1`, and the reality test | 500 ms default; 750 ms for measured slower routes, zero grace |
 | `runNormEliminant`, `runEvalEliminant`, `runComponentRoots` | fixed | separable phases of the profiled repeated degree-6 component over `ℚ(√2)` | 1 s, 1.1 s, and 30 s whole-child ceilings, zero grace |
 
 The 76 fixed registrations comprise 51 internal API, phase, and fixed-problem
@@ -302,6 +302,9 @@ and adds only a constant-time projection.
 | `OfNat.ofNat` | `runAlgebraicConstructors` | same linear constructor route |
 | `Pow.pow Nat` | `runAlgebraicNatPow` | fixed exponent 7 |
 | `Pow.pow Int` | `runAlgebraicIntPow` | fixed exponent -5, including inverse |
+| `ZPoly.algebraicRoots?` / `ZPoly.algebraicRoots` | `runAlgebraicRootsZ` | fixed quartic `X⁴ - 10X² + 1`: one isolation, four exactifications, and the reality-first sort; 750 ms zero-grace |
+| `AlgebraicNumber.isReal` / `AlgebraicRoot.isReal` / `DyadicSquare.meetsRealAxis` | `runIsReal` | grouped constant-time comparison anchor |
+| `AlgebraicNumber.rootLe`, `approx`, `Repr` | `runAlgebraicRootsZ` and `runQAdjoinApprox` | the sort runs inside the roots case; `approx` is the registered fixed-field approximation on the stored representative; display carries no contract |
 | rational `SMul.smul` on `AlgebraicNumber` | `runAlgebraicScalars` | grouped canonical scalar route |
 | natural `SMul.smul` on `AlgebraicNumber` | `runAlgebraicScalars` | grouped canonical scalar route |
 | integer `SMul.smul` on `AlgebraicNumber` | `runAlgebraicScalars` | grouped canonical scalar route |


### PR DESCRIPTION
This PR adds `ZPoly.algebraicRoots`, the entry point a user of `HexNumberField` reaches for first: every distinct complex root of an integer polynomial as a canonical `AlgebraicNumber`, real roots first in increasing order, then the nonreal roots in the deterministic order of their isolations. The squarefree primitive part is isolated at separation depth, each isolation becomes a lazy root through the new `AlgebraicRoot.ofRefined`, and each is exactified. Constants, including zero, have no roots here; `AlgebraicPoly.roots` keeps multiplicities.

With it come the reality test (`DyadicSquare.meetsRealAxis`, `AlgebraicRoot.isReal`, `AlgebraicNumber.isReal`), which compares a stored isolation's centre with the dyadic upper bound of its disc radius and is exact at separation precision because a nonreal root and its conjugate are distinct roots of the same integer polynomial; the output order `AlgebraicNumber.rootLe`; `AlgebraicNumber.approx`, a dyadic ball on the stored representative; and a `Repr` instance that prints the minimal polynomial and twelve decimals of the ball centre, so that `√2 + √3` displays as `root of X^4 - 10*X^2 + 1 near 3.146264369941`.

The companion proves the contract: `algebraicRoots?_isSome` and `algebraicRoots?_eq` retire the fallback branch, `mem_algebraicRoots_iff` states that the output values are exactly the roots of a nonzero polynomial, `algebraicRoots_nodup` that none repeats, `isReal_iff` that the reality test is exact, and `approx_mem`/`approx_radius` transport the approximation contract. Every theorem depends only on `propext`, `Classical.choice` and `Quot.sound`. The SPEC gains the contract first; the conformance driver gains the cases it lists (`X² - 2`, `(X² - 2)² (X + 3)`, `X³ - 2`, the zero, constant and `X` polynomials, the reality test, and `√2 + √3` end to end); and the bench gains two fixed advertised-API cases with report rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsrsxR7daUgNCrQ6N2zKs6