### PR TITLE
docs(number-field): rewrite the number-field, tower and rcf manual chapters for release

### DIFF
--- a/HexManual/Chapters/HexNumberField.lean
+++ b/HexManual/Chapters/HexNumberField.lean
@@ -152,7 +152,7 @@ representation. Its roots are lazy roots with multiplicities: the polynomial
 polynomial `X⁴ − 2`.
 
 ```lean
-/-- The finite root list; the zero polynomial has none listed. -/
+/-- The finite root list; empty for the zero polynomial. -/
 def finiteRoots : RootSet → Array RootCount
   | .finite rs => rs
   | .all => #[]

--- a/HexManual/Chapters/HexNumberField.lean
+++ b/HexManual/Chapters/HexNumberField.lean
@@ -23,221 +23,287 @@ tag := "hex-number-field"
 tag := "hex-number-field-intro"
 %%%
 
-`HexNumberField` provides executable exact arithmetic for selected complex
-algebraic roots, both in a fixed rational presentation and in a canonical
-minimal-polynomial form.
+`HexNumberField` computes with algebraic numbers exactly. An algebraic number
+is stored as its minimal polynomial over the integers together with a
+certified disc that singles out one complex root: `√2 + √3` is the polynomial
+`X⁴ − 10X² + 1` and a small disc around `3.146`. Addition, multiplication,
+inversion and powers return numbers in the same normal form, and equality is a
+comparison of that data. There are no floating-point numbers anywhere. The
+discs have dyadic rational centres and radii, and each carries a certificate,
+checked by ordinary evaluation, that it contains exactly one root.
 
-# Three representations
+Two cheaper forms sit beside the canonical one. An {name}`Hex.AlgebraicRoot`
+is a root of some squarefree integer polynomial that need not be minimal: the
+sum of two roots is a root of a resultant, and factoring that resultant is
+postponed until a canonical answer is requested with
+{name}`Hex.AlgebraicRoot.exact`. A {name}`Hex.QAdjoin` is the field `ℚ(x)` for
+one fixed root `x` of an irreducible polynomial, with elements written as
+rational coordinates in the power basis; arithmetic there is polynomial
+arithmetic modulo the defining polynomial and involves no root isolation at
+all. Roots of polynomials whose coefficients are themselves algebraic numbers
+are found with {name}`Hex.AlgebraicPoly.roots`.
+
+The correspondence library `HexNumberFieldMathlib` interprets every
+representation in `ℂ`. It proves that the interpretation of canonical numbers
+is injective, that each executable operation computes the corresponding
+complex operation, and it installs a `Field` instance on
+{name}`Hex.AlgebraicNumber` whose operations are the executable ones. The
+place to start is {name}`Hex.ZPoly.algebraicRoots`, which turns an integer
+polynomial into its roots as canonical algebraic numbers.
+
+{docstring Hex.AlgebraicNumber}
+
+{docstring Hex.ZPoly.algebraicRoots}
+
+# Square roots and the golden ratio
 %%%
-tag := "hex-number-field-representations"
+tag := "hex-number-field-examples"
 %%%
 
-`HexNumberField` provides three complementary exact representations.
-{name}`Hex.QAdjoin` stores rational power-basis coordinates in one fixed
-irreducible presentation. {name}`Hex.AlgebraicRoot` stores a certified selected
-root of a squarefree integer polynomial without requiring that polynomial to
-be minimal. {name}`Hex.AlgebraicNumber` is the canonical form: a selected root
-of its normalized irreducible minimal polynomial.
-
-The distinction makes routine arithmetic cheaper. Addition and multiplication
-first build a resultant eliminant and isolate the intended result; factoring
-to a minimal polynomial is postponed until a caller requests
-{name}`Hex.AlgebraicRoot.exact`.
-
-# Fixed-field arithmetic and approximation
-%%%
-tag := "hex-number-field-fixed"
-%%%
-
-Fixed-presentation coordinates are always reduced modulo the defining integer
-polynomial. Inversion uses polynomial extended gcd and follows the total field
-convention `0⁻¹ = 0`.
-
-{docstring Hex.QAdjoin.reduce}
-
-{docstring Hex.QAdjoin.inv}
-
-Approximation takes a root representative, refines it, and evaluates the
-reduced coordinate polynomial with dyadic complex-ball Horner arithmetic. The
-returned representative can be threaded into the next request so earlier work
-is not repeated.
-
-{docstring Hex.QAdjoin.approx}
-
-Here is fixed-field multiplication and inversion in `ℚ(√2)`:
+`#p[a₀, a₁, …]` writes an integer polynomial by its coefficients in increasing
+degree, so `#p[-2, 0, 1]` is `X² − 2`. Its roots come back real first and in
+increasing order, so index `1` is `+√2`:
 
 ```lean
 open Hex
 
 namespace HexNumberFieldChapter
 
-private def sqrtTwoPoly : ZPoly :=
-  DensePoly.ofList [-2, 0, 1]
+def sqrt2 : AlgebraicNumber :=
+  (ZPoly.algebraicRoots #p[-2, 0, 1])[1]!
+def sqrt3 : AlgebraicNumber :=
+  (ZPoly.algebraicRoots #p[-3, 0, 1])[1]!
 
-private def sqrtTwoSquare : DyadicSquare :=
-  ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
-
-private def sqrtTwoRep : RefinedIsolation sqrtTwoPoly :=
-  ⟨⟨sqrtTwoSquare, .ofWitness (by decide)⟩, by decide⟩
-
-private def sqrtTwoRoot : SimpleRoot sqrtTwoPoly :=
-  SimpleRoot.mk sqrtTwoRep
-
-#guard
-  if hirred : ZPoly.isIrreducible sqrtTwoPoly = true then
-    letI : ZPoly.CheckedIrreducible sqrtTwoPoly :=
-      ⟨hirred, by decide⟩
-    let xPoly :=
-      DensePoly.ofList ([0, 1] : List Rat)
-    let x : QAdjoin sqrtTwoPoly sqrtTwoRoot :=
-      QAdjoin.reduce sqrtTwoPoly sqrtTwoRoot xPoly
-    let two : QAdjoin sqrtTwoPoly sqrtTwoRoot :=
-      QAdjoin.reduce sqrtTwoPoly sqrtTwoRoot
-        (DensePoly.C 2)
-    x * x = two && x * x⁻¹ = 1
-  else
-    false
-
-end HexNumberFieldChapter
+#guard (ZPoly.algebraicRoots #p[-2, 0, 1]).size = 2
+#guard sqrt2 * sqrt2 == 2
+#guard (sqrt2 + sqrt3).p = #p[1, 0, -10, 0, 1]
+#guard (sqrt2 + sqrt3)⁻¹ == sqrt3 - sqrt2
 ```
 
-# Lazy arithmetic and exactification
+The field `p` of a canonical number is its minimal polynomial, so the third
+check is the classical fact that `√2 + √3` has minimal polynomial
+`X⁴ − 10X² + 1`, and the fourth is `1 / (√2 + √3) = √3 − √2`. Printing a
+number shows that polynomial and twelve decimals of a certified approximation:
+
+```lean (name := sqrtSumEval)
+#eval sqrt2 + sqrt3
+```
+```leanOutput sqrtSumEval
+root of X^4 - 10*X^2 + 1 near 3.146264369941
+```
+
+The golden ratio is the positive root of `X² − X − 1`. Its defining identity,
+its reciprocal, and the tenth Lucas number all fall out of decidable equality:
+
+```lean
+def φ : AlgebraicNumber :=
+  (ZPoly.algebraicRoots #p[-1, -1, 1])[1]!
+
+#guard φ * φ == φ + 1
+#guard φ⁻¹ == φ - 1
+-- φ¹⁰ + φ⁻¹⁰ is the Lucas number L₁₀ = 123, so φ¹⁰ is a
+-- root of X² − 123X + 1.
+#guard (φ ^ (10 : Nat)).p = #p[1, -123, 1]
+```
+
+# Lazy roots and exactification
 %%%
 tag := "hex-number-field-lazy"
 %%%
 
-Every certificate-producing operation has an `Option` form. The total form is
-the primary algebraic API; its loud fallback is paired with a companion
-completeness contract. In particular, the Mathlib companion proves that the
-bounded searches for addition, multiplication, inversion, and division always
-return a certificate. Their total wrappers therefore compute the corresponding
-complex operations, including the convention `0⁻¹ = 0`. Subtraction composes
-addition with certificate-free polynomial reflection.
+Canonical arithmetic is built on a cheaper intermediate form. Adding two lazy
+roots builds the resultant whose roots are all sums of a root of the first
+polynomial with a root of the second, and isolates the one that is the actual
+sum; nothing is factored. The sum of `√2` with itself is a root of
+`X³ − 8X`, whose three roots `0`, `±2√2` are the sums of pairs of conjugates.
+Requesting the canonical form factors that polynomial and keeps `X² − 8`:
 
-{docstring Hex.AlgebraicRoot.add?}
+```lean
+def lazySum : AlgebraicRoot :=
+  sqrt2.toRoot.add sqrt2.toRoot
 
-{docstring Hex.AlgebraicRoot.sub?}
+#guard lazySum.p = #p[0, -8, 0, 1]
+#guard lazySum.exact.p = #p[-8, 0, 1]
 
-{docstring Hex.AlgebraicRoot.mul?}
+def lazyProduct : AlgebraicRoot :=
+  sqrt2.toRoot.mul sqrt2.toRoot
 
-{docstring Hex.AlgebraicRoot.inv?}
+#guard lazyProduct.p = #p[-4, 0, 1]
+#guard lazyProduct.exact.p = #p[-2, 1]
+#guard lazyProduct.exact == 2
+```
 
-{docstring Hex.AlgebraicRoot.div?}
-
-{docstring Hex.AlgebraicRoot.exact?}
+A chain of lazy operations therefore costs a chain of resultants and one
+factorization at the end, instead of a factorization at every step. Canonical
+numbers use the same route and exactify each result, which is what makes their
+equality decidable.
 
 {docstring Hex.AlgebraicRoot.exact}
 
-{docstring Hex.AlgebraicRoot.add?_isSome}
-
-{docstring Hex.AlgebraicRoot.mul?_isSome}
-
-{docstring Hex.AlgebraicRoot.inv?_isSome}
-
-{docstring Hex.AlgebraicRoot.div?_isSome}
-
-{docstring Hex.AlgebraicRoot.mul_toComplex}
-
-{docstring Hex.AlgebraicRoot.inv_toComplex}
-
-Canonical algebraic numbers reuse these lazy operations and exactify the
-answer. Their Boolean equality compares represented values rather than record
-layout. Lazy roots deliberately have no `BEq`; the root driver uses checked
-{name}`Hex.QAdjoin.Roots.sameValue?` instead.
-
-# Canonical field arithmetic
-%%%
-tag := "hex-number-field-canonical"
-%%%
-
-Canonical algebraic numbers also provide executable rational construction,
-casts, scalar multiplication, and natural and integer powers. The Mathlib
-companion proves that the complex interpretation is injective and installs a
-lawful {name}`Field` instance on {name}`Hex.AlgebraicNumber` whose data fields
-are these same executable operations.
-
-{docstring Hex.AlgebraicNumber.ofRat}
-
-{docstring Hex.AlgebraicNumber.ofRat_toComplex}
-
-{docstring Hex.AlgebraicNumber.toComplex_injective}
-
-```lean
-open Hex
-
-example : (2 : AlgebraicNumber) =
-    AlgebraicNumber.ofRat 2 := rfl
-example (a b : AlgebraicNumber) : a + b =
-    AlgebraicNumber.add a b := rfl
-example (a : AlgebraicNumber) : a ^ (3 : Nat) =
-    AlgebraicNumber.natPow a 3 := rfl
-```
-
-# Polynomials and roots
+# Polynomials with algebraic coefficients
 %%%
 tag := "hex-number-field-roots"
 %%%
 
-An {name}`Hex.AlgebraicPoly` owns semantic trailing-zero normalization. This is
-separate from `DensePoly AlgebraicNumber`, whose normalizer would require a
-structural equality decision that is not the intended algebraic equality.
-
-{docstring Hex.AlgebraicPoly.ofArray}
+An {name}`Hex.AlgebraicPoly` has canonical algebraic numbers as coefficients;
+trailing coefficients equal to zero are dropped by value, not by
+representation. Its roots are lazy roots with multiplicities: the polynomial
+`X² − √2` has the two real fourth roots of `2`, each simple, each with minimal
+polynomial `X⁴ − 2`.
 
 ```lean
-open Hex
-
--- Trailing canonical zeros are removed semantically.
 #guard
-  let f := AlgebraicPoly.ofArray
-    #[AlgebraicNumber.zero, AlgebraicNumber.zero]
-  f.isZero && f.coeffs.isEmpty
+  match (AlgebraicPoly.ofArray #[-sqrt2, 0, 1]).roots with
+  | .finite rs =>
+      rs.size = 2 && rs.all fun r =>
+        r.multiplicity = 1 &&
+          r.root.exact.p = #p[-2, 0, 0, 0, 1]
+  | .all => false
 ```
 
-Root APIs distinguish the zero polynomial, whose root set is universal, from a
-finite root array carrying positive multiplicities.
+The `.all` branch is the zero polynomial, every number being a root of it.
 
-{docstring Hex.QAdjoin.roots?}
+{docstring Hex.AlgebraicPoly.roots}
 
-{docstring Hex.AlgebraicPoly.roots?}
+# A fixed field: ℚ(∛2)
+%%%
+tag := "hex-number-field-fixed"
+%%%
+
+When every computation lives in one field `ℚ(x)`, the coordinates of
+{name}`Hex.QAdjoin` are cheaper than canonical numbers: an element is a
+rational polynomial in `x` reduced modulo the defining polynomial, and
+inversion is an extended gcd. The irreducibility evidence stored in a
+canonical number is what licenses inversion, so it is registered as an
+instance first.
+
+```lean
+def cbrt2 : AlgebraicNumber :=
+  (ZPoly.algebraicRoots #p[-2, 0, 0, 1])[0]!
+
+instance : ZPoly.CheckedIrreducible cbrt2.p := cbrt2.checked
+
+def c : QAdjoin cbrt2.p cbrt2.x := cbrt2.toQAdjoin
+
+#guard c ^ (3 : Nat) = (2 : Rat) • 1
+#guard c⁻¹ = (1 / 2 : Rat) • (c * c)
+#guard c.toAlgebraicNumber cbrt2.rep cbrt2.rep_mk == cbrt2
+
+end HexNumberFieldChapter
+```
+
+The last check converts the coordinate form back to a canonical number and
+recovers the number it came from.
+
+{docstring Hex.QAdjoin}
+
+# Performance
+%%%
+tag := "hex-number-field-performance"
+%%%
+
+Fixed-field arithmetic is polynomial arithmetic and scales as the degree
+suggests: multiplication is quadratic in the degree and inversion cubic with a
+logarithmic factor for coefficient growth. Everything that isolates roots is
+dominated by the isolation, so those rows are fixed inputs rather than
+asymptotics.
+
+:::table (header := true)
+* * operation
+  * input
+  * time
+* * `QAdjoin` multiplication
+  * degree 16, dense coordinates
+  * 0.12 ms
+* * `QAdjoin` inversion
+  * degree 16, dense coordinates
+  * 0.71 ms
+* * `QAdjoin.approx`
+  * degree 128, fixed precision
+  * 17 ms
+* * `ZPoly.algebraicRoots`
+  * `X⁴ − 10X² + 1`, four roots
+  * 44 ms
+* * `AlgebraicRoot.exact`
+  * a root of `∏ (X² − p)`, `p ≤ 13`, degree 12
+  * 1.9 ms
+* * `AlgebraicRoot.exact`
+  * a root of `X⁸ − 2` inside `(X⁸ − 2)(X + 3)`
+  * 310 ms
+* * `AlgebraicRoot.add`
+  * a root of `X⁶ − 2` plus `√3`, degree product 12
+  * 4.5 s
+* * `AlgebraicPoly.roots`
+  * dense degree 6, one `√2` coefficient
+  * 6.0 s
+:::
+
+Medians on chungus2 from the exports recorded in
+`reports/hex-number-field-performance.md` in the `hex-dev` repository;
+regenerate with `.lake/build/bin/hexnumberfield_bench run
+Hex.NumberFieldBench.<target>`. The last three rows spend over ninety percent
+of their time in root isolation of the resultant or eliminant, and the
+`X⁸ − 2` exactification spends its time re-isolating candidates rather than
+factoring; the SPEC's complexity section records the bounds.
 
 # The Mathlib correspondence
 %%%
 tag := "hex-number-field-correspondence"
 %%%
 
-`HexNumberFieldMathlib` interprets selected roots in `ℂ`. For a checked fixed
-presentation, the reduced coordinates are ring-equivalent to the monic
-rational {name}`AdjoinRoot` quotient. Their executable extended-GCD inverse is
-validated, and an opt-in {name}`Field` instance preserves the existing
-computational operations and rational scalar action. Open the
-`Hex.QAdjoin.QAdjoinField` scope when Mathlib field notation and laws are
-wanted. Opening this scope makes that notation proof-bearing and
-noncomputable; executable code continues to use the unscoped operations.
+`HexNumberFieldMathlib` interprets every representation in `ℂ`. Two canonical
+numbers with the same complex value are equal, the executable operations
+compute the complex ones, and the `Field` instance on
+{name}`Hex.AlgebraicNumber` is built from those very operations, so a theorem
+proved with the instance is a theorem about the code that ran.
 
-{docstring Hex.AlgebraicRoot.toComplex}
+```lean
+open Hex HexNumberFieldChapter
 
-{docstring Hex.QAdjoin.toComplex}
+example (a b : AlgebraicNumber)
+    (h : a.toComplex = b.toComplex) : a = b :=
+  AlgebraicNumber.toComplex_injective h
 
-{docstring Hex.QAdjoin.adjoinRootEquiv}
+example : (sqrt2 + sqrt3).toComplex =
+    sqrt2.toComplex + sqrt3.toComplex :=
+  AlgebraicNumber.add_toComplex sqrt2 sqrt3
 
-{docstring Hex.QAdjoin.embedding}
+-- The instance's operations are the executable ones.
+example (a b : AlgebraicNumber) :
+    a * b = AlgebraicNumber.mul a b := rfl
+example (a : AlgebraicNumber) :
+    a⁻¹ = AlgebraicNumber.inv a := rfl
+```
 
-{docstring Hex.AlgebraicRoot.exact_toComplex}
+The roots returned by {name}`Hex.ZPoly.algebraicRoots` are exactly the
+complex roots of the polynomial, each once, and the reality test is exact:
+
+{docstring Hex.ZPoly.mem_algebraicRoots_iff}
+
+{docstring Hex.AlgebraicNumber.isReal_iff}
 
 {docstring Hex.AlgebraicPoly.contains_roots_iff}
+
+For a checked fixed presentation, the coordinates of {name}`Hex.QAdjoin` are
+ring-equivalent to Mathlib's `AdjoinRoot` of the defining polynomial, and
+opening the scope `Hex.QAdjoin.QAdjoinField` gives them Mathlib's field
+notation and laws, noncomputably; executable code keeps the unscoped
+operations.
 
 # Cross-references
 %%%
 tag := "hex-number-field-cross-references"
 %%%
 
-* {ref "hex-poly-z"}[HexPolyZ] supplies the integer-polynomial presentation.
-* {ref "hex-roots"}[HexRoots] supplies certified complex-root isolation and
-  {name}`Hex.SimpleRoot`.
-* {ref "hex-resultant"}[HexResultant] supplies the eliminants used by lazy
-  arithmetic and fixed-field norm candidates.
-* {ref "hex-matrix"}[HexMatrix] and {ref "hex-row-reduce"}[HexRowReduce]
-  supply exact span coordinates for fixed-field minimal polynomials.
-* {ref "hex-number-field-tower"}[HexNumberFieldTower] builds successive
-  extensions when one primitive presentation is not convenient.
+* {ref "hex-poly-z"}[HexPolyZ] provides integer polynomials, the `#p[…]`
+  literal, and squarefree parts.
+* {ref "hex-roots"}[HexRoots] isolates complex roots and certifies the discs
+  every algebraic number carries.
+* {ref "hex-resultant"}[HexResultant] computes the resultants behind lazy
+  addition and multiplication.
+* {ref "factor-tactics"}[Factor tactics] describes the integer factorization
+  behind `exact`.
+* {ref "hex-real-roots"}[HexRealRoots] isolates real roots with a statement
+  of how many there are; `isReal` here only tests one root.
+* {ref "hex-number-field-tower"}[HexNumberFieldTower] works with several
+  generators at once and flattens them to one.

--- a/HexManual/Chapters/HexNumberField.lean
+++ b/HexManual/Chapters/HexNumberField.lean
@@ -158,7 +158,8 @@ def finiteRoots : RootSet → Array RootCount
   | .all => #[]
 
 def quarticRoots : Array RootCount :=
-  finiteRoots (AlgebraicPoly.ofArray #[-sqrt2, 0, 1]).roots
+  finiteRoots
+    (AlgebraicPoly.ofArray #[-sqrt2, 0, 1]).roots
 
 #guard quarticRoots.size = 2
 #guard quarticRoots.all fun r =>

--- a/HexManual/Chapters/HexNumberField.lean
+++ b/HexManual/Chapters/HexNumberField.lean
@@ -152,16 +152,22 @@ representation. Its roots are lazy roots with multiplicities: the polynomial
 polynomial `X⁴ − 2`.
 
 ```lean
-#guard
-  match (AlgebraicPoly.ofArray #[-sqrt2, 0, 1]).roots with
-  | .finite rs =>
-      rs.size = 2 && rs.all fun r =>
-        r.multiplicity = 1 &&
-          r.root.exact.p = #p[-2, 0, 0, 0, 1]
-  | .all => false
+/-- The finite root list; the zero polynomial has none listed. -/
+def finiteRoots : RootSet → Array RootCount
+  | .finite rs => rs
+  | .all => #[]
+
+def quarticRoots : Array RootCount :=
+  finiteRoots (AlgebraicPoly.ofArray #[-sqrt2, 0, 1]).roots
+
+#guard quarticRoots.size = 2
+#guard quarticRoots.all fun r =>
+  r.multiplicity = 1 &&
+    r.root.exact.p = #p[-2, 0, 0, 0, 1]
 ```
 
-The `.all` branch is the zero polynomial, every number being a root of it.
+The `.all` case of a root set is the zero polynomial, every number being a
+root of it.
 
 {docstring Hex.AlgebraicPoly.roots}
 

--- a/HexManual/Chapters/HexNumberFieldTower.lean
+++ b/HexManual/Chapters/HexNumberFieldTower.lean
@@ -112,13 +112,10 @@ def gMinus : Poly T2 := #p[-1, (-2 : Rat) • r2, 1]
 
 #guard gPlus * gMinus = quartic
 
-#guard
-  match factor? T2 quartic with
-  | some F =>
-      coeffs F.scalar = #[1, 0] &&
-        F.factors.all (fun g => g.2 = 1) &&
-        F.factors.map (·.1) == #[gMinus, gPlus]
-  | none => false
+#guard (factor? T2 quartic).any fun F =>
+  coeffs F.scalar = #[1, 0] &&
+    F.factors.all (fun g => g.2 = 1) &&
+    F.factors.map (·.1) == #[gMinus, gPlus]
 ```
 
 At each level `K(α)/K` the method searches a fixed list of integer shifts for
@@ -140,18 +137,18 @@ has dimension four and the four roots square to `2` or `3`:
 def biquadratic : Poly rat :=
   liftZPoly rat #p[6, 0, -5, 0, 1]
 
-#guard
-  match split? rat biquadratic with
-  | some S =>
-      S.extension.tower.dim = 4 &&
-        match S.roots with
-        | .finite rs =>
-            rs.size = 4 && rs.all fun r =>
-              r.2 = 1 &&
-                (coeffs (r.1 * r.1) = #[2, 0, 0, 0] ||
-                  coeffs (r.1 * r.1) = #[3, 0, 0, 0])
-        | .all => false
-  | none => false
+/-- The finite root list of a splitting; the zero polynomial has none. -/
+def finiteRoots {T : NumberTower} : Roots T → Array (Elem T × Nat)
+  | .finite rs => rs
+  | .all => #[]
+
+#guard (split? rat biquadratic).any fun S =>
+  S.extension.tower.dim = 4 &&
+    let rs := finiteRoots S.roots
+    rs.size = 4 && rs.all fun r =>
+      r.2 = 1 &&
+        (coeffs (r.1 * r.1) = #[2, 0, 0, 0] ||
+          coeffs (r.1 * r.1) = #[3, 0, 0, 0])
 ```
 
 Building the same field by hand, `ℚ(√2)(√3)`, and flattening it recovers the
@@ -168,16 +165,11 @@ def s3 : Elem T23 := Q23.gen
 #guard T23.dim = 4
 #guard (s2 + s3) * (s2 - s3) = ofRat T23 (-1)
 
-#guard
-  match flatten? T23 with
-  | some F =>
-      F.root.p = #p[1, 0, -10, 0, 1] &&
-        (F.toPrimitive s2).coeffs =
-          #p[0, -9 / 2, 0, 1 / 2] &&
-        (F.toPrimitive s3).coeffs =
-          #p[0, 11 / 2, 0, -1 / 2] &&
-        F.fromPrimitive (F.toPrimitive s3) == s3
-  | none => false
+#guard (flatten? T23).any fun F =>
+  F.root.p = #p[1, 0, -10, 0, 1] &&
+    (F.toPrimitive s2).coeffs = #p[0, -9 / 2, 0, 1 / 2] &&
+    (F.toPrimitive s3).coeffs = #p[0, 11 / 2, 0, -1 / 2] &&
+    F.fromPrimitive (F.toPrimitive s3) == s3
 
 end HexNumberFieldTowerChapter
 ```

--- a/HexManual/Chapters/HexNumberFieldTower.lean
+++ b/HexManual/Chapters/HexNumberFieldTower.lean
@@ -138,7 +138,8 @@ def biquadratic : Poly rat :=
   liftZPoly rat #p[6, 0, -5, 0, 1]
 
 /-- The finite root list; empty for the zero polynomial. -/
-def finiteRoots {T : NumberTower} : Roots T → Array (Elem T × Nat)
+def finiteRoots {T : NumberTower} :
+    Roots T → Array (Elem T × Nat)
   | .finite rs => rs
   | .all => #[]
 

--- a/HexManual/Chapters/HexNumberFieldTower.lean
+++ b/HexManual/Chapters/HexNumberFieldTower.lean
@@ -137,7 +137,7 @@ has dimension four and the four roots square to `2` or `3`:
 def biquadratic : Poly rat :=
   liftZPoly rat #p[6, 0, -5, 0, 1]
 
-/-- The finite root list of a splitting; the zero polynomial has none. -/
+/-- The finite root list; empty for the zero polynomial. -/
 def finiteRoots {T : NumberTower} : Roots T → Array (Elem T × Nat)
   | .finite rs => rs
   | .all => #[]

--- a/HexManual/Chapters/HexNumberFieldTower.lean
+++ b/HexManual/Chapters/HexNumberFieldTower.lean
@@ -23,148 +23,240 @@ tag := "hex-number-field-tower"
 tag := "hex-number-field-tower-intro"
 %%%
 
-`HexNumberFieldTower` performs exact arithmetic, factorization, adjoining, and
-splitting in a sequence of relative algebraic extensions.
+`HexNumberFieldTower` builds number fields one generator at a time: `ℚ`, then
+`ℚ(α₁)`, then `ℚ(α₁, α₂)`, each step adjoining a root of a polynomial that is
+irreducible over the field so far. Elements are stored as rational coordinates
+in the product basis of the tower, and arithmetic is polynomial arithmetic
+modulo the defining polynomials. Every tower also comes with a fixed embedding
+into `ℂ`, so a tower is a particular subfield of `ℂ` rather than a field known
+up to isomorphism. The embedding is what lets the library answer questions an
+abstract presentation cannot: which root of `X² − 2` the generator denotes, and
+therefore whether a given algebraic number already lies in the field.
 
-# Validated towers and coordinates
+Four operations do the work. {name}`Hex.NumberTower.factor?` factors a
+polynomial over a tower by Trager's method, one level at a time.
+{name}`Hex.NumberTower.adjoin?` adjoins a specified algebraic number and
+recognises when it is already present. {name}`Hex.NumberTower.split?`
+alternates factoring and adjoining until a polynomial splits into linear
+factors, and returns the splitting field together with all of the roots.
+{name}`Hex.NumberTower.flatten?` replaces a tower by a single primitive element
+with exact coordinate changes in both directions, so a computation can move
+between the tower and the one-generator form {name}`Hex.QAdjoin` of
+`HexNumberField`.
+
+Each operation checks its own result before returning it, and returns `none`
+otherwise. The correspondence library `HexNumberFieldTowerMathlib` proves that
+`none` never occurs, that arithmetic in a tower computes the corresponding
+complex arithmetic, and it states what each result means: the factors are
+irreducible and multiply back to the input, the adjoined generator has the
+requested complex value, and the splitting field contains every root.
+
+{docstring Hex.NumberTower.Extension}
+
+# ℚ(√2)
 %%%
-tag := "hex-number-field-tower-data"
+tag := "hex-number-field-tower-adjoin"
 %%%
 
-`HexNumberFieldTower` represents a fixed embedding of a successive extension
-`ℚ(α₁,…,αₙ)`. Levels are stored newest first; element coordinates use the
-mixed-radix order in which the oldest generator varies fastest. Constructors
-validate coefficient widths, relative irreducibility, and vanishing at the
-chosen absolute root before a level enters a public tower.
-
-{docstring Hex.NumberTower.ofQAdjoin}
-
-The rational base tower is useful on its own and illustrates the coordinate
-normalization and total arithmetic conventions:
-
-```lean
-open Hex Hex.NumberTower
-
-#guard rat.dim = 1
-#guard coeffs (ofRat rat 7 / ofRat rat 3) = #[7 / 3]
-#guard coeffs ((0 : Elem rat)⁻¹) = #[0]
-```
-
-# Factorization by relative norms
-%%%
-tag := "hex-number-field-tower-factor"
-%%%
-
-{name}`Hex.NumberTower.factor?` performs Yun decomposition and then recursively
-applies Trager's algorithm one level at a time. At `K(α)/K`, it searches a
-deterministic finite list of integer shifts for a squarefree relative norm,
-factors that norm over `K`, and recovers the factors over `K(α)` by gcd. It does
-not replace this step with an absolute norm, which would duplicate factors
-defined over an intermediate subfield. The rational base case delegates to
-the `HexBerlekampZassenhaus` integer factorizer.
-
-{docstring Hex.NumberTower.Norm.oneLevel}
-
-{docstring Hex.NumberTower.factor?}
-
-The returned payload keeps the scalar separate and records each distinct
-factor once with a positive multiplicity.
-
-The following example constructs `ℚ(√2)` and factors `X² - 2` there; the
-two linear factors correspond to the already-present roots `±√2`.
+A tower starts from an algebraic number. The extension returned by
+{name}`Hex.NumberTower.adjoin?` carries the new tower, its generator `gen`, and
+the inclusion `embed` of the field below. Coordinates in `ℚ(√2)` are the pair
+`#[a, b]` standing for `a + b√2`:
 
 ```lean
 open Hex Hex.NumberTower
 
 namespace HexNumberFieldTowerChapter
 
-private def sqrtTwoPoly : ZPoly :=
-  DensePoly.ofList [-2, 0, 1]
+def sqrt2 : AlgebraicNumber :=
+  (ZPoly.algebraicRoots #p[-2, 0, 1])[1]!
+def sqrt3 : AlgebraicNumber :=
+  (ZPoly.algebraicRoots #p[-3, 0, 1])[1]!
 
-private def sqrtTwoSquare : DyadicSquare :=
-  ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
+-- `adjoin?` never returns `none` (`adjoin?_isSome`), so
+-- unwrapping it is safe.
+private instance (T : NumberTower) :
+    Inhabited (Extension T) :=
+  ⟨Extension.identity T⟩
 
-private def sqrtTwoRep : RefinedIsolation sqrtTwoPoly :=
-  ⟨⟨sqrtTwoSquare, .ofWitness (by decide)⟩, by decide⟩
+def Q2 : Extension rat := (adjoin? rat sqrt2.toRoot).get!
+abbrev T2 : NumberTower := Q2.tower
+def r2 : Elem T2 := Q2.gen
 
-private def sqrtTwoRoot : SimpleRoot sqrtTwoPoly :=
-  SimpleRoot.mk sqrtTwoRep
+#guard T2.dim = 2
+#guard coeffs (r2 * r2) = #[2, 0]
+#guard coeffs (Q2.embed (ofRat rat 5)) = #[5, 0]
 
-#guard
-  if hirred : ZPoly.isIrreducible sqrtTwoPoly = true then
-    letI : ZPoly.CheckedIrreducible sqrtTwoPoly :=
-      ⟨hirred, by decide⟩
-    if hsimple : HasOnlySimpleRoots sqrtTwoPoly then
-      let extension := ofQAdjoin (x := sqrtTwoRoot)
-        hsimple sqrtTwoRep rfl
-      let f : Poly extension.tower :=
-        DensePoly.ofCoeffs
-          #[ofRat extension.tower (-2), 0, 1]
-      match factor? extension.tower f with
-      | some result =>
-          result.factors.size = 2 &&
-            result.factors.all fun entry =>
-              entry.1.degree? = some 1 && entry.2 = 1
-      | none => false
-    else
-      false
-  else
-    false
-
-end HexNumberFieldTowerChapter
+-- √2 is already there: adjoining it again changes nothing.
+#guard (adjoin? T2 sqrt2.toRoot).any fun E =>
+  E.tower.dim = 2
 ```
 
-# Adjoining and splitting
+{docstring Hex.NumberTower.adjoin?}
+
+# Factoring over ℚ(√2)
+%%%
+tag := "hex-number-field-tower-factor"
+%%%
+
+`X⁴ − 10X² + 1` is irreducible over `ℚ`: it is the minimal polynomial of
+`√2 + √3`. Over `ℚ(√2)` it splits into two quadratics, because
+`(X² − 1)² − 8X² = X⁴ − 10X² + 1` and `8 = (2√2)²`. The tower's factorization
+finds exactly those two factors, with the scalar `1` kept separate:
+
+```lean
+def quartic : Poly T2 :=
+  liftZPoly T2 #p[1, 0, -10, 0, 1]
+def gPlus : Poly T2 := #p[-1, (2 : Rat) • r2, 1]
+def gMinus : Poly T2 := #p[-1, (-2 : Rat) • r2, 1]
+
+#guard gPlus * gMinus = quartic
+
+#guard
+  match factor? T2 quartic with
+  | some F =>
+      coeffs F.scalar = #[1, 0] &&
+        F.factors.all (fun g => g.2 = 1) &&
+        F.factors.map (·.1) == #[gMinus, gPlus]
+  | none => false
+```
+
+At each level `K(α)/K` the method searches a fixed list of integer shifts for
+a squarefree relative norm, factors that norm over `K`, and recovers the
+factors over `K(α)` by gcd; the base case over `ℚ` is the
+{ref "factor-tactics"}[integer factorizer].
+
+{docstring Hex.NumberTower.factor?}
+
+# Splitting and flattening
 %%%
 tag := "hex-number-field-tower-split"
 %%%
 
-Adjoining selects the unique relative factor that contains the requested
-absolute algebraic root under the tower's fixed embedding. If that factor is
-linear, the root was already present and the result is an identity extension.
+`(X² − 2)(X² − 3)` needs two genuine extensions to split. The splitting field
+has dimension four and the four roots square to `2` or `3`:
 
-{docstring Hex.NumberTower.adjoin?}
+```lean
+def biquadratic : Poly rat :=
+  liftZPoly rat #p[6, 0, -5, 0, 1]
 
-Splitting alternates factorization and genuine adjoining steps until every
-factor is linear. The zero polynomial uses `.all`; a nonzero constant returns
-an empty finite root array.
+#guard
+  match split? rat biquadratic with
+  | some S =>
+      S.extension.tower.dim = 4 &&
+        match S.roots with
+        | .finite rs =>
+            rs.size = 4 && rs.all fun r =>
+              r.2 = 1 &&
+                (coeffs (r.1 * r.1) = #[2, 0, 0, 0] ||
+                  coeffs (r.1 * r.1) = #[3, 0, 0, 0])
+        | .all => false
+  | none => false
+```
+
+Building the same field by hand, `ℚ(√2)(√3)`, and flattening it recovers the
+classical primitive element: `√2 + √3` generates the field, its minimal
+polynomial is the quartic above, and `√2 = (γ³ − 9γ)/2` in terms of the
+generator `γ`:
+
+```lean
+def Q23 : Extension T2 := (adjoin? T2 sqrt3.toRoot).get!
+abbrev T23 : NumberTower := Q23.tower
+def s2 : Elem T23 := Q23.embed r2
+def s3 : Elem T23 := Q23.gen
+
+#guard T23.dim = 4
+#guard (s2 + s3) * (s2 - s3) = ofRat T23 (-1)
+
+#guard
+  match flatten? T23 with
+  | some F =>
+      F.root.p = #p[1, 0, -10, 0, 1] &&
+        (F.toPrimitive s2).coeffs =
+          #p[0, -9 / 2, 0, 1 / 2] &&
+        (F.toPrimitive s3).coeffs =
+          #p[0, 11 / 2, 0, -1 / 2] &&
+        F.fromPrimitive (F.toPrimitive s3) == s3
+  | none => false
+
+end HexNumberFieldTowerChapter
+```
 
 {docstring Hex.NumberTower.split?}
 
-# Flattening to one primitive element
-%%%
-tag := "hex-number-field-tower-flatten"
-%%%
-
-{name}`Hex.NumberTower.flatten?` replaces a tower by one canonical
-{name}`Hex.QAdjoin` presentation. It combines the fixed generators in deterministic
-signed-shift order. A direct full-degree search and validated linear-gcd
-recovery form the fast path. The total fallback retains a bounded
-maximum-degree primitive candidate and recovers the old generators by exact
-trace pairing. It then checks direct-evaluation coordinate maps, a tower-basis
-round trip, and the primitive polynomial relation before returning maps. The
-Mathlib companion proves that this checked operation returns `some` for every
-valid tower.
-
 {docstring Hex.NumberTower.flatten?}
+
+# Performance
+%%%
+tag := "hex-number-field-tower-performance"
+%%%
+
+Coordinate arithmetic scales with the dimension `D` of the tower: addition is
+linear, multiplication quadratic, and inversion runs an extended gcd over the
+field below. The composite operations mix factoring, root isolation and
+adjoining, whose relative weights change with the degree, so they are recorded
+on fixed inputs rather than as asymptotics.
+
+:::table +header
+* * operation
+  * input
+  * time
+* * `adjoin?`
+  * `2^{1/4}` to `ℚ(√2)`
+  * 311 ms
+* * `adjoin?`
+  * `√2` to `ℚ(√2)`, already present
+  * 18 ms
+* * `factor?`
+  * `X² − X − 1` over `ℚ(√2, √3)`
+  * 7.9 ms
+* * `factor?`
+  * `X²⁴ − X − 1` over `ℚ(√2)`
+  * 250 ms
+* * `split?`
+  * `(X² − 2)(X² − 3)` over `ℚ`
+  * 68 ms
+* * `flatten?`
+  * `ℚ(√2, √3)`
+  * 21 ms
+* * inversion
+  * dimension 24, `ℚ(3^{1/12}, √2)`
+  * 7.0 ms
+:::
+
+Per-call medians on chungus2 from the exports recorded in
+`reports/hex-number-field-tower-performance.md` in the `hex-dev` repository;
+regenerate with `.lake/build/bin/hexnumberfieldtower_bench run
+Hex.NumberTowerBench.<target>`. Factoring over a number field is far slower
+than PARI's `nffactor` on the same inputs (fifty to three hundred times on
+the Selmer family `Xⁿ − X − 1` over `ℚ(√2)`); the report records the
+comparison and its provenance.
 
 # The Mathlib correspondence
 %%%
 tag := "hex-number-field-tower-correspondence"
 %%%
 
-`HexNumberFieldTowerMathlib` interprets mixed-radix coordinates in the stored
-complex embedding, states the arithmetic and relative-resultant
-correspondence, and characterizes complete factorization, adjoining,
-splitting, and flattening.
+`HexNumberFieldTowerMathlib` interprets every element of a validated tower in
+`ℂ` through the stored embedding. That interpretation is injective and
+respects the executable arithmetic, and each of the four operations has a
+soundness theorem describing its result and a completeness theorem stating
+that it never returns `none` on a valid tower.
 
-{docstring Hex.NumberTower.toComplex}
+```lean
+open Hex Hex.NumberTower HexNumberFieldTowerChapter
 
-{docstring Hex.NumberTower.factor?_sound}
+example (a b : Elem T23) :
+    T23.toComplex (a * b) =
+      T23.toComplex a * T23.toComplex b :=
+  map_mul T23 a b
+
+example (a b : Elem T23)
+    (h : T23.toComplex a = T23.toComplex b) : a = b :=
+  toComplex_injective T23 h
+```
 
 {docstring Hex.NumberTower.adjoin?_sound}
-
-{docstring Hex.NumberTower.split?_sound}
 
 {docstring Hex.NumberTower.flatten?_sound}
 
@@ -173,8 +265,8 @@ splitting, and flattening.
 tag := "hex-number-field-tower-cross-references"
 %%%
 
-* {ref "hex-number-field"}[HexNumberField] supplies selected algebraic roots,
-  canonical exactification, and the one-generator target of flattening.
-* {ref "hex-resultant"}[HexResultant] supplies one-level relative elimination.
-* {ref "factor-tactics"}[Factor tactics] describes the
-  `HexBerlekampZassenhaus` integer factorizer used at the rational base case.
+* {ref "hex-number-field"}[HexNumberField] supplies the algebraic numbers
+  that are adjoined, and the one-generator form that flattening targets.
+* {ref "hex-resultant"}[HexResultant] computes the norms in Trager's method.
+* {ref "factor-tactics"}[Factor tactics] describes the integer factorization
+  at the bottom of every tower.

--- a/HexManual/Chapters/HexRCF.lean
+++ b/HexManual/Chapters/HexRCF.lean
@@ -23,16 +23,33 @@ tag := "hex-rcf"
 tag := "hex-rcf-intro"
 %%%
 
-The `rcf` tactic proves closed propositions about exactly one quantified real
-variable by exact decision. Its input is one universal or existential
-quantifier over `ℝ`, or over a half-open interval `Set.Ioc a b`, with no other
-free variables. The quantifier body may use Boolean combinations of
-comparisons between univariate polynomials with rational coefficients.
+`rcf` decides statements about one real variable. Give it a sentence such as
+`∀ x : ℝ, x⁴ − 4x + 3 ≥ 0` or `∃ x ∈ (1, 2], x³ − x − 1 = 0`: one universal or
+existential quantifier over `ℝ`, or over a half-open interval `Set.Ioc a b`
+with dyadic endpoints, followed by any Boolean combination of polynomial
+equations and inequalities with rational coefficients. If the sentence is
+true, `rcf` proves it. If it is false, `rcf` reports that, and for a universal
+sentence names an interval on which the body fails.
 
-The computation uses exact integer and rational arithmetic. It isolates the
-real roots that can change an atom's sign, evaluates the formula on the
-resulting cells, and emits a certificate for Lean's kernel to check. No
-floating-point approximation occurs.
+This is Tarski's decision procedure in its simplest case. The real roots of
+the polynomials in the sentence cut the line into finitely many intervals and
+points, each polynomial keeps a constant sign on each piece, and so a
+statement about every real number, or about some real number, becomes a
+finite check. The tactic performs that check with exact integer arithmetic:
+it isolates the roots with certified Sturm counts, records the sign of each
+polynomial on each piece, and hands the kernel a certificate containing those
+signs and counts. The kernel replays the certificate by evaluation, never
+repeats the search, and the resulting proof uses no axiom beyond the three
+that Mathlib always uses.
+
+The tactics Mathlib already provides do something different. `nlinarith` and
+`positivity` are heuristics: they succeed on many true inequalities of this
+shape, may need hints such as `sq_nonneg (x - 1)` supplied by hand, and give
+no verdict when they fail. `polyrith` proves equalities only. `decide` does
+not apply to quantifiers over `ℝ`. None of them proves an existential
+statement without a named witness, and the witness in the cubic above is
+irrational. `rcf` needs neither hints nor a witness, and on this fragment it
+always answers.
 
 Import `HexRCF` and write `rcf` at the goal:
 
@@ -40,6 +57,48 @@ Import `HexRCF` and write `rcf` at the goal:
 example : ∀ x : ℝ, x ^ 2 + 1 > 0 := by
   rcf
 ```
+
+# Three facts a mathematician might want
+%%%
+tag := "hex-rcf-examples"
+%%%
+
+The Chebyshev polynomial `T₅` is bounded by one on `(−1, 1]` and attains the
+bound; a cubic has a root in a dyadic interval and none outside it; a quartic
+is nonnegative with equality at exactly one point. Each is one call:
+
+```lean
+example : ∀ x : ℝ, x ∈ Set.Ioc (-1 : ℝ) 1 →
+    -1 ≤ 16 * x ^ 5 - 20 * x ^ 3 + 5 * x ∧
+      16 * x ^ 5 - 20 * x ^ 3 + 5 * x ≤ 1 := by
+  rcf
+
+example : ∃ x : ℝ, x ∈ Set.Ioc (-1 : ℝ) 1 ∧
+    16 * x ^ 5 - 20 * x ^ 3 + 5 * x = 1 := by
+  rcf
+
+-- The real root of x³ − x − 1 lies in (21/16, 43/32], and
+-- nothing outside that interval is a root.
+example : ∃ x : ℝ, x ^ 3 - x - 1 = 0 ∧
+    21 / 16 < x ∧ x ≤ 43 / 32 := by
+  rcf
+
+example : ∀ x : ℝ, x ^ 3 - x - 1 = 0 →
+    21 / 16 < x ∧ x ≤ 43 / 32 := by
+  rcf
+
+-- x⁴ − 4x + 3 = (x − 1)² (x² + 2x + 3) is nonnegative,
+-- and zero only at x = 1.
+example : ∀ x : ℝ, x ^ 4 - 4 * x + 3 ≥ 0 := by
+  rcf
+
+example : ∀ x : ℝ, x ^ 4 - 4 * x + 3 = 0 → x = 1 := by
+  rcf
+```
+
+The statement that the cubic has exactly one real root mentions two
+variables and is outside this fragment; {ref "hex-real-roots"}[HexRealRoots]
+proves counts of that kind.
 
 # The four quantifier forms
 %%%
@@ -151,11 +210,10 @@ rcf: the existential sentence is false. Every relevant decomposition
 cell was checked and found false, so there is no witness
 ```
 
-A supported sentence may be false even though reification and certified
-decision both succeed. Such a checked `false` verdict never becomes a proof
-term: `rcf` reports the relevant false-sentence diagnostic above. An
-out-of-fragment goal is different: reification fails before the decision
-procedure runs. Both are ordinary tactic failures, so tactic combinators may
+A sentence can be well formed and false. `rcf` then reports the failure
+shown above and produces no proof. A goal outside the fragment is different:
+it is not recognised as a sentence at all, and `rcf` fails before any
+computation. Both are ordinary tactic failures, so tactic combinators may
 fall through to another method. Here the unquantified goal is outside the
 fragment and `norm_num` handles it:
 
@@ -218,19 +276,16 @@ example : ∃ x : ℝ,
 When `rcf` sees `Set.Icc` or `Set.Ioo` directly, its error message includes
 the corresponding rewrite above.
 
-# The reflected and compiled APIs
+# Sentences as data
 %%%
 tag := "hex-rcf-reflected-api"
 %%%
 
 Most users only need the `rcf` tactic. Programs that construct or inspect
-sentences directly use the reflected language below. A comparison applies to
-one integer polynomial, formulas combine comparisons, and a sentence adds the
-one quantifier supported by the decision procedure.
-
-{docstring Hex.RCF.Cmp}
-
-{docstring Hex.RCF.Atom}
+sentences directly use the data types below. An atom compares one integer
+polynomial with zero under one of the six comparison signs, formulas combine
+atoms with the Boolean connectives, and a sentence adds the one quantifier
+the decision procedure supports.
 
 {docstring Hex.RCF.Formula}
 
@@ -278,8 +333,6 @@ the certificate together with its replay verdict:
 
 {docstring Hex.RCF.build?}
 
-{docstring Hex.RCF.BuildResult}
-
 ```lean
 open Hex.RCF
 
@@ -293,31 +346,70 @@ example (s : Sentence) (result : BuildResult)
 `build? s = none` means certificate construction or replay failed. It is
 distinct from a successful result whose `verdict` is `false`.
 
-# Certificates and the trust boundary
+# Performance
+%%%
+tag := "hex-rcf-performance"
+%%%
+
+The cost of `rcf` is the cost of elaborating the tactic: running the compiled
+search, building the certificate as a literal, and having the kernel replay
+it. The table gives the median added time of a fresh module containing one
+`by rcf` theorem over the same module without it, so it includes elaboration
+and kernel replay but not the fixed cost of loading Mathlib.
+
+:::table +header
+* * goal
+  * polynomial degree
+  * atoms
+  * tactic time
+* * quadratic
+  * 2
+  * 1
+  * 0.26 s
+* * degree ten
+  * 10
+  * 3
+  * 4.4 s
+* * adversarial
+  * 50
+  * 1
+  * 4.3 s
+:::
+
+The compiled decision procedure on its own, {name}`Hex.RCF.decide` with no
+proof, takes 32 ms, 85 ms, 184 ms, 333 ms and 541 ms on one-atom sentences
+whose polynomial has 16, 20, 24, 28 and 32 real roots, consistent with the
+declared quartic model in the root count. Measured on chungus2; the
+artefacts and their provenance are recorded in `reports/hex-rcf-performance.md`
+in the `hex-dev` repository, and the three tactic budgets they sit under are
+2 s, 12 s and 30 s.
+
+# Certificates and what the kernel checks
 %%%
 tag := "hex-rcf-trust"
 %%%
 
-The four certificate shapes correspond to empty bounded domains, formulas
-with no nonconstant atom polynomial, root-free carriers, and positive-root
-cell decompositions:
+A certificate has one of four shapes: the interval is empty; every polynomial
+in the sentence is constant; the polynomial that governs the sign changes has
+no real root in the domain; or, in the general case, a list of the pieces into
+which its real roots cut the domain, with the sign of every polynomial on each
+piece.
 
 {docstring Hex.RCF.Certificate}
 
-`HexRCF` is classified as a Mathlib-facing library because its reifier, tactic,
-real semantics, and soundness theorem use Mathlib. There is no separate
-`HexRCFMathlib` library. By contrast, `HexRCF.DecisionCheck` exposes the
-complete compiled search, certificate construction, replay, and
-{name}`Hex.RCF.decide` path, with a mechanically checked Mathlib-free import
-closure. The soundness theorem remains on the Mathlib-facing side of this
-boundary.
+Unlike the other libraries in this manual, `HexRCF` imports Mathlib: the
+tactic works on `ℝ`, and its soundness theorem is a statement about real
+numbers. The search, the certificate checker and {name}`Hex.RCF.decide` do not
+need Mathlib. They are collected in the module `HexRCF.DecisionCheck`, which
+a build-time check keeps free of Mathlib imports, so the executable part can
+be run and tested on its own.
 
 Certificate construction runs as compiled elaboration code. That search is
-not trusted. The tactic embeds its reflected sentence and a literal
+not trusted. The tactic embeds its sentence and a literal
 {name}`Hex.RCF.Certificate`, reduces the public Boolean checker
-{name}`Hex.RCF.Certificate.check`, and applies the soundness theorem
-{name}`Hex.RCF.check_sound`. Lean's kernel also checks the reifier's proof
-that the reflected sentence is equivalent to the source goal.
+{name}`Hex.RCF.Certificate.check` to `true` in the kernel, and applies the
+soundness theorem {name}`Hex.RCF.check_sound`. Lean's kernel also checks the
+proof that the sentence as data is equivalent to the source goal.
 
 The public soundness boundary can be used independently of the tactic:
 
@@ -346,8 +438,9 @@ A `none` from {name}`Hex.RCF.decide` means the compiled path did not produce a
 checker-accepted certificate. It does not mean that the sentence is false.
 
 The kernel replays polynomial identities, signs, root counts, endpoint
-comparisons, and Boolean folds on literal data. It does not repeat root
-isolation, polynomial gcd computation, or interval refinement. The emitted
+comparisons, and the Boolean structure of the sentence, all on the concrete
+numbers in the certificate. It does not repeat root isolation, polynomial gcd
+computation, or interval refinement. The emitted
 proof uses ordinary kernel reduction and does not use `native_decide`:
 
 ```lean
@@ -370,7 +463,8 @@ tag := "hex-rcf-cross-references"
 * {ref "hex-poly-z"}[HexPolyZ] provides the dense integer polynomial
   operations used to normalize atoms and check polynomial identities.
 * {ref "hex-real-roots"}[HexRealRoots] provides the exact real-root isolator
-  used by `HexRCF` during compiled certificate construction. The generalized
-  multiplication-only Sturm certificates in `HexRCF` are kernel-replay
-  evidence for the resulting root-count facts, not a separate compiled
-  isolation algorithm.
+  that `HexRCF` uses during the search. `HexRCF` then re-derives each root
+  count inside the certificate with a Sturm sequence the kernel can check; it
+  does not isolate roots a second time.
+* {ref "hex-number-field"}[HexNumberField] gives exact values for the roots
+  a sentence talks about, when the values themselves are wanted.

--- a/HexManual/Chapters/HexRCF.lean
+++ b/HexManual/Chapters/HexRCF.lean
@@ -310,7 +310,7 @@ private def positiveQuadratic : Sentence :=
 #guard Hex.RCF.decide positiveQuadratic == some true
 ```
 
-Bounded sentences use Lean's core {name}`Dyadic` endpoints and the half-open
+Bounded sentences use Lean's built-in {name}`Dyadic` endpoints and the half-open
 interval `(a, b]`. This sentence represents
 `∀ x ∈ Set.Ioc (0 : ℝ) 1, x ≥ 0`:
 

--- a/HexNumberField/README.md
+++ b/HexNumberField/README.md
@@ -29,11 +29,20 @@ import HexNumberField
 
 open Hex
 
-def a : AlgebraicNumber := AlgebraicNumber.ofRat (3/2)
+-- The roots of an integer polynomial, real roots first in
+-- increasing order: index 1 of `X² - 2` is `+√2`.
+def sqrt2 : AlgebraicNumber :=
+  (ZPoly.algebraicRoots #p[-2, 0, 1])[1]!
+def sqrt3 : AlgebraicNumber :=
+  (ZPoly.algebraicRoots #p[-3, 0, 1])[1]!
 
-#guard a + a == AlgebraicNumber.ofRat 3
-#guard a * a⁻¹ == 1
-#guard (0 : AlgebraicNumber)⁻¹ == 0
+-- Arithmetic is exact and equality is decidable; `p` is the
+-- minimal polynomial.
+#guard (sqrt2 + sqrt3).p = #p[1, 0, -10, 0, 1]
+#guard (sqrt2 + sqrt3)⁻¹ == sqrt3 - sqrt2
+
+#eval sqrt2 + sqrt3
+-- root of X^4 - 10*X^2 + 1 near 3.146264369941
 ```
 
 # Functionality
@@ -52,9 +61,12 @@ Three complementary exact representations:
   normalized irreducible minimal polynomial, with rational construction,
   casts, powers, and Boolean equality that compares represented values.
 
-`Hex.AlgebraicPoly` supplies polynomials with algebraic coefficients and
-semantic trailing-zero normalization, with root APIs (`roots?`) for both
-fixed-field and algebraic-coefficient polynomials.
+`Hex.ZPoly.algebraicRoots` turns an integer polynomial into its distinct
+complex roots as canonical algebraic numbers, real roots first in increasing
+order, with `isReal`, a dyadic `approx`, and a `Repr` that prints the minimal
+polynomial and twelve decimals. `Hex.AlgebraicPoly` supplies polynomials with
+algebraic coefficients and semantic trailing-zero normalization, with root
+APIs (`roots?`) for both fixed-field and algebraic-coefficient polynomials.
 
 # Verification
 

--- a/HexNumberField/SPEC/hex-number-field.md
+++ b/HexNumberField/SPEC/hex-number-field.md
@@ -171,7 +171,7 @@ compare refined isolations with `sameRoot`.
 The nonconstant-gcd fallback can factor twice and is not a fast arithmetic
 primitive. The gcd guard prevents repeated factorization for coprime
 enclosing polynomials during cross-component root merging without changing
-the v1 semantics. It is a discriminator, not a constant-time operation:
+the semantics. It is a discriminator, not a constant-time operation:
 computing a rational gcd between two high-degree enclosing polynomials can
 itself incur coefficient growth.
 
@@ -604,7 +604,7 @@ computations and therefore use the compiled Phase-4 evidence track; the
 library owns no elaboration, tactic, emitted-proof, or kernel-checking surface.
 Grouped constant-time accessors and total wrappers remain on that same track.
 The performance report's
-[current inventory](../../reports/hex-number-field-performance.md#track-assignment-re-audit)
+[current inventory](https://github.com/kim-em/hex-dev/blob/main/reports/hex-number-field-performance.md#track-assignment-re-audit)
 records the measurements implementing this assignment.
 
 - Fixed-field arithmetic has the existing dense-polynomial costs; a compiled
@@ -644,7 +644,7 @@ records the measurements implementing this assignment.
   These project-internal canonical inputs come from the shared `n = 6` rung of
   the former schedules. Full timing runs check the ceilings; merge-gating
   smoke verification checks the result hashes. The measured reference timings
-  live in the [performance report](../../reports/hex-number-field-performance.md).
+  live in the [performance report](https://github.com/kim-em/hex-dev/blob/main/reports/hex-number-field-performance.md).
   None of the registrations makes a one-parameter scaling claim.
 - Exactification adds one Berlekamp-Zassenhaus factorization and factor-root
   selection. Root APIs add Yun decomposition, one norm eliminant, and one

--- a/HexNumberFieldMathlib/SPEC/hex-number-field-mathlib.md
+++ b/HexNumberFieldMathlib/SPEC/hex-number-field-mathlib.md
@@ -292,7 +292,7 @@ The proof follows the executable stages:
 4. The internal common-field construction preserves every canonical coefficient,
    reducing `AlgebraicPoly.roots` to the fixed-field theorem.
 
-## Required new developments
+## Developments
 
 1. Canonical primitive-positive integer representatives of rational minimal
    polynomials and canonicity of `AlgebraicNumber`.
@@ -307,8 +307,10 @@ The proof follows the executable stages:
 7. Yun multiplicity transfer, norm candidate completeness, and embedding
    filtering for both root APIs.
 
-Items 1 through 4 do not depend on tower support. Items 5 and 7 require the
-staged resultant theorems specified by `hex-resultant-mathlib`.
+Items 1 through 4 do not depend on tower support. Items 5 and 7 rest on the
+resultant correspondence of `hex-resultant-mathlib`
+(`resultant_eq_zero_iff_common_root` and
+`resultant_eq_leadingCoeff_mul_prod_roots`).
 
 ## File organisation
 

--- a/HexNumberFieldTowerMathlib/SPEC/hex-number-field-tower-mathlib.md
+++ b/HexNumberFieldTowerMathlib/SPEC/hex-number-field-tower-mathlib.md
@@ -107,8 +107,10 @@ substitute: for example, in `ℚ(√2, √3)`, a factor defined over `ℚ(√3)`
 duplicated by the unused `√2` embeddings, so every absolute norm after shifting
 only by `√3` has repeated factors.
 
-The Stage 1 vanishing theorem from `hex-resultant-mathlib` is insufficient for
-steps 2 and 5. These theorems depend on its Stage 2 full value correspondence.
+The vanishing criterion of `hex-resultant-mathlib`
+(`resultant_eq_zero_iff_common_root`) is insufficient for steps 2 and 5; they
+rest on its full value correspondence
+(`resultant_eq_leadingCoeff_mul_prod_roots`).
 
 ## Adjoining
 
@@ -179,7 +181,7 @@ dimensions yield the opposite round trip and multiplicativity.
 `AlgebraicRoot.exact_toComplex` identifies the canonical primitive root stored
 in the result.
 
-## Required developments
+## Developments
 
 1. Iterated quotient-field semantics and fixed complex embeddings.
 2. Coordinate basis, dimension, and arithmetic correspondence.
@@ -189,8 +191,7 @@ in the result.
 6. Splitting termination, reconstruction, and generated-field minimality.
 7. Primitive-element degree test and flattening coordinate equivalences.
 
-Items 3 through 7 begin only after Stage 2 of `hex-resultant-mathlib` is
-available.
+Items 3 through 7 rest on that resultant value correspondence.
 
 ## File organisation
 

--- a/HexRCF/SPEC/hex-rcf.md
+++ b/HexRCF/SPEC/hex-rcf.md
@@ -672,8 +672,9 @@ free to change.
   in the shared sub-project.
 
 The public `HexRCF` umbrella imports only the supported implementation and
-proof API. The `*Tests.lean` regression modules above are compiled through the
-separate `HexRCFTests` Lake target and are not re-exported to consumers.
+proof API. The `*Tests.lean` regression modules above are compiled through a
+separate non-public test target (`HexRCFTests` in the published repository,
+`HexReleaseTests` in hex-dev) and are not re-exported to consumers.
 
 ## Phase-4 evidence tracks
 
@@ -862,16 +863,14 @@ therefore `no-comparable-surface-in-named-comparator` rather than assigned a
 fake ratio. The Phase-3 `local` emitter exercises related compiled workloads
 but is neither an elaboration benchmark nor Phase-4 asymptotic evidence.
 
-This contract and the pure-module extraction did not by themselves advance the
-phase marker. `HexRCF.done_through` could advance from `3` to `4` only after
-every dependency, including HexRealRootsMathlib, completed Phase 4 and both
-evidence tracks had their required structural wiring and scientific artifacts.
-The committed HexRCF Phase-4 headline report records satisfaction of those
-gates and licenses the current marker value `4`.
+`HexRCF.done_through` is `7`. Its Phase-4 record required every dependency,
+including HexRealRootsMathlib, to complete Phase 4 and both evidence tracks
+to have their structural wiring and scientific artifacts; the committed
+HexRCF Phase-4 headline report records that.
 
 ## Conformance fixtures
 
-Per [SPEC/testing.md](../testing.md):
+Per [SPEC/testing.md](../../SPEC/testing.md):
 
 - *core* (Lean-only):
   - The five example sentences above, as `example … := by rcf`.
@@ -894,7 +893,7 @@ Per [SPEC/testing.md](../testing.md):
   sentences over random small-coefficient
   polynomials from a deterministic seed, serialised with expected
   verdicts. `scripts/oracle/rcf_flint.py` uses python-flint as required
-  by [testing.md](../testing.md). It independently forms and
+  by [testing.md](../../SPEC/testing.md). It independently forms and
   squarefrees the atom product. Following
   `scripts/oracle/realroots_flint.py`, its exact tier extracts rational
   roots from `fmpz_poly.factor()` and compares them with `Fraction`;
@@ -915,12 +914,12 @@ Per [SPEC/testing.md](../testing.md):
   case. They cover every comparison and Boolean form, true and false
   quantifiers, constants, no-root cases, shared and endpoint roots,
   close roots, and equal/reversed intervals. CI cases stay around
-  degrees 8–12; the degree-50 stress case remains local. Phase-3
-  wiring adds the `hex-rcf` assignment to `SPEC/testing.md` and one
-  tuple to `scripts/ci/run_oracles.sh`, the repository's oracle registry;
-  it advances `HexRCF.done_through` in `libraries.yml` but adds no unsupported
-  manifest block, job, matrix, workflow, or dependency beyond the existing
-  python-flint install.
+  degrees 8–12; the degree-50 stress case remains local. The `hex-rcf`
+  oracle assignment is recorded in `SPEC/testing.md` and as one tuple in
+  `scripts/ci/run_oracles.sh`, the repository's oracle registry, in hex-dev;
+  the published repository carries neither the oracle nor the fixtures, and
+  nothing adds a manifest block, job, matrix, workflow, or dependency beyond
+  the existing python-flint install.
 - *local*: Mignotte-cluster atoms and degree-50 sentences exercise the
   pipeline where the isolation layer is under stress. Run
   `lake exe hexrcf_emit_fixtures local > /tmp/hexrcf-local.jsonl` and feed

--- a/HexRealRoots/SPEC/hex-real-roots.md
+++ b/HexRealRoots/SPEC/hex-real-roots.md
@@ -467,7 +467,7 @@ re-refine from a stored coarse representative. See
 
 ## Conformance fixtures
 
-Per [SPEC/testing.md](../testing.md), fixtures are tiered into
+Per [SPEC/testing.md](../../SPEC/testing.md), fixtures are tiered into
 `core` / `ci` / `local`.
 
 - *core* (Lean-only, runs on every push):

--- a/libraries.yml
+++ b/libraries.yml
@@ -1051,7 +1051,7 @@ libraries:
   HexNumberField:
     deps: [HexPolyZ, HexRoots, HexResultant, HexBerlekampZassenhaus, HexMatrix, HexRowReduce]
     mathlib: false
-    done_through: 4
+    done_through: 7
     status: active
     phase4:
       comparators:

--- a/reports/hex-number-field-performance.md
+++ b/reports/hex-number-field-performance.md
@@ -1466,3 +1466,5 @@ random seed, so a rung is identified by its parameter and the salt named in
 the bench source rather than by a seed.
 
 ## Concerns
+
+None.


### PR DESCRIPTION
This PR rewrites the three manual chapters for `HexNumberField`, `HexNumberFieldTower` and `HexRCF` to the standard of the released chapters, advances `HexNumberField` to Phase 7, and applies the SPEC and README hygiene the published mirrors need. It is stacked on the roots-API PR, whose `ZPoly.algebraicRoots` the examples use.

The number-field chapter leads with what an algebraic number is and what makes it trustworthy, then computes: `√2 + √3` and its minimal polynomial, the golden ratio's identities and the tenth Lucas number, lazy sums and products before and after exactification, the fourth roots of two as roots of `X² − √2`, fixed-field arithmetic in `ℚ(∛2)`, a measured performance table, and the Mathlib correspondence with the definitional pinning of the `Field` instance. The tower chapter builds `ℚ(√2)` by adjoining, factors `X⁴ − 10X² + 1` into two quadratics over it, splits `(X² − 2)(X² − 3)`, and flattens `ℚ(√2, √3)` to the primitive element `√2 + √3` with its exact coordinate changes. The rcf chapter gains an introduction placing the tactic against Tarski's procedure and Mathlib's heuristics, a section of worked facts (Chebyshev's `T₅` on `(−1, 1]`, the Pisot cubic's root in a dyadic interval, a quartic's unique zero), a performance section from the fresh-module measurements, and a trust section written without the monorepo's library taxonomy. Every example typechecks in the manual build; the hand-built isolation ceremony and the SPEC-voice prose are gone.

`HexNumberField` moves to `done_through: 7` (Phase 5 has nothing to fill, the Phase-6 pass is closed as #9418, and the chapter is the Phase-7 artifact), its report records no Concern, and its README quickstart shows the new entry point. The SPECs of `hex-rcf`, `hex-real-roots`, `hex-number-field` and the two Mathlib companions get the link paths, tenses and cross-references that read correctly from a published mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsrsxR7daUgNCrQ6N2zKs6