### PR TITLE
chore: record the linter-cleanup exemptions against the demotion sweep baseline

### DIFF
--- a/scripts/bench/proof_only_runtime_exemptions/hexbareiss-bareiss-lean-67fc1e5c-c230ced9.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexbareiss-bareiss-lean-67fc1e5c-c230ced9.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexBareiss/Bareiss.lean",
+ "baseline_blob": "67fc1e5c12ce1ea2388f209b52c20b5842001ffc",
+ "current_blob": "c230ced97dc4e6a54b6ba8fdbf929d68444903e3",
+ "reason": "Omits the unused `[One R]`/`[Neg R]` section variables from eighteen loop lemmas and drops a no-op `@[expose]` on the `exactDiv` compatibility alias, which is already exposed by default. Proof and attribute metadata only; the compiled Bareiss loop and the factorization service runtime are unchanged. Same edit as the 1ff1f240 -> c230ced9 exemption, restated from the baseline the fast-kernel demotion sweep recorded."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-primeselection-lean-53f062d0-1a6be940.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexberlekampzassenhaus-primeselection-lean-53f062d0-1a6be940.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexBerlekampZassenhaus/PrimeSelection.lean",
+ "baseline_blob": "53f062d0adf2cd9d53b427ed37fa3a155bffe4ad",
+ "current_blob": "1a6be94092cc3fbec21a3042eeb607aade42bd8e",
+ "reason": "Replaces two `<;>` with `;` where the preceding tactic leaves a single goal. Inside proofs only; no executable definition changes. Same edit as the a6fee73d -> 1a6be940 exemption, restated from the baseline the fast-kernel demotion sweep recorded."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexmatrix-basic-lean-d9e73a19-630108e3.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexmatrix-basic-lean-d9e73a19-630108e3.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexMatrix/Basic.lean",
+ "baseline_blob": "d9e73a1912f20e777575abf25c03e6bfe00cc412",
+ "current_blob": "630108e30a374946cd1d908c50133f1a0d444a41",
+ "reason": "Drops two no-op `@[expose]` attributes from `GetElem` instances that are already exposed by default. No definition body changes. Same edit as the 76cf5715 -> 630108e3 exemption, restated from the baseline the fast-kernel demotion sweep recorded."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexpolyfp-nttmul-lean-e8ddbe8e-a2e3dd49.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexpolyfp-nttmul-lean-e8ddbe8e-a2e3dd49.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexPolyFp/NttMul.lean",
+ "baseline_blob": "e8ddbe8e6d896b2a5a1a2730ab3ec556edc4e8bc",
+ "current_blob": "a2e3dd492addd5d0d9b0e10bc9640fcef1f73ed9",
+ "reason": "Turns two `simpa ... using` into the `simp` the linter reports as sufficient. Both are index-bound proof terms; no executable definition changes. Same edit as the 240e6784 -> 2b6995e6 exemption, restated from the baseline the fast-kernel demotion sweep recorded."
+}


### PR DESCRIPTION
This PR records four proof-only runtime exemptions so the hex-factor sweep freshness check passes on `main` again. The fast-kernel demotion (#10002) re-measured the sweep on a merge that predates the Lean 4.34 linter cleanup (#10004), so its recorded fingerprint carries the pre-cleanup blobs of `HexBareiss/Bareiss.lean`, `HexBerlekampZassenhaus/PrimeSelection.lean`, `HexMatrix/Basic.lean` and `HexPolyFp/NttMul.lean`, while the cleanup's own exemptions name an older baseline. The new files restate the same four transitions (omitted section variables, dropped no-op `@[expose]`, `<;>` to `;`, `simpa` to `simp`) from the blobs the demotion sweep recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsrsxR7daUgNCrQ6N2zKs6
