### PR TITLE
docs(number-field): use the current Verso flag syntax for the table header

### DIFF
--- a/HexManual/Chapters/HexNumberField.lean
+++ b/HexManual/Chapters/HexNumberField.lean
@@ -215,7 +215,7 @@ logarithmic factor for coefficient growth. Everything that isolates roots is
 dominated by the isolation, so those rows are fixed inputs rather than
 asymptotics.
 
-:::table (header := true)
+:::table +header
 * * operation
   * input
   * time


### PR DESCRIPTION
This PR switches the number-field manual chapter's table from `(header := true)` to `+header`, which is the last warning the build still emits apart from the 36 tracked `sorry`s.

The freshness repair this branch also carried is dropped: https://github.com/kim-em/hex-dev/pull/10012 landed the same four exemptions first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)