### PR TITLE
fix(row-reduce): drop the Batteries import from the row-reduction API

### DIFF
--- a/HexRowReduce/Api.lean
+++ b/HexRowReduce/Api.lean
@@ -8,7 +8,6 @@ module
 
 public import HexRowReduce.Nullspace
 public import HexMatrix.Submatrix
-import Batteries.Data.Vector.Lemmas
 import HexMatrix.Pad
 import all HexRowReduce.Nullspace
 
@@ -112,11 +111,10 @@ theorem rowReduce_rank_eq_n_of_rightInverse [Lean.Grind.Field R] [DecidableEq R]
         (Matrix.row (Matrix.identity (R := R) n) i).get i :=
       congrArg (fun v : Vector R n => v.get i) hrowIdentity
     have hz : (0 : Vector R n).get i = 0 := by
-      rw [Vector.get_eq_getElem, Vector.getElem_zero]
+      simp [Vector.get]
     have hu : (Vector.unit R i).get i = 1 := by
-      unfold Vector.unit
-      rw [Vector.get_ofFn, ite_eq_left rfl]
-      rfl
+      simp only [Vector.unit, Vector.get, Vector.toArray_ofFn, Array.getElem_ofFn]
+      exact ite_eq_left (Fin.ext rfl)
     have huRow : (Matrix.row (Matrix.identity (R := R) n) i).get i = 1 := by
       rw [Matrix.row_identity]
       exact hu

--- a/bench/HexGFqField/Bench.lean
+++ b/bench/HexGFqField/Bench.lean
@@ -442,9 +442,9 @@ private theorem sparseModulus_size {n k constant : Nat} (hn : 0 < n) :
   apply Nat.le_antisymm
   · exact Nat.le_trans (DensePoly.size_ofCoeffs_le _) (by simp)
   · apply Nat.succ_le_of_lt
-    by_contra hlt
+    refine Nat.lt_of_not_ge fun hle => ?_
     have hzero := DensePoly.coeff_eq_zero_of_size_le
-      (sparseModulus n k constant) (Nat.le_of_not_gt hlt)
+      (sparseModulus n k constant) hle
     rw [sparseModulus_coeff_top hn] at hzero
     exact (by decide : (1 : ZMod64 7) ≠ 0) hzero
 


### PR DESCRIPTION
This PR removes the only Batteries import in `HexRowReduce`. The published hex-row-reduce mirror does not require Batteries, so after today's sync every mirror that builds `HexRowReduce.Api` (hex-row-reduce, hex-berlekamp, hex-conway, hex-gfq-field, hex-bareiss and their downstream repos) failed with "unknown module prefix 'Batteries'". The two `Vector.get` facts the import supplied are proved from core's `Vector.get`, `Vector.toArray_ofFn` and `Array.getElem_ofFn` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsrsxR7daUgNCrQ6N2zKs6
