### PR TITLE
fix(release): synthesize missing lockfile entries and check external imports

### DIFF
--- a/PLAN/Releases.md
+++ b/PLAN/Releases.md
@@ -213,11 +213,15 @@ the old revision. A published dependency that the mirror's lockfile has
 never seen (a library split out upstream, or a companion that gained a
 requirement) is appended as a new lockfile entry at its synced revision,
 since Lake otherwise refuses to build with "dependency X of Y not in
-manifest". The sync also refuses, before pushing anything, to publish a
-library whose sources import `Batteries` or `Mathlib` when the mirror's
-Lake file requires no package providing them: inside the monorepo those
-imports always resolve, in a mirror they resolve only through its own
-`require`s.
+manifest". A published library that the sources import directly but the
+mirror's Lake file never required is added as a direct `require` at its
+synced revision, since otherwise the mirror builds only while some other
+dependency happens to pull that library in (hex-bareiss lost `HexArith`
+this way when it was split out). The sync also refuses, before pushing
+anything, to publish a library whose sources import `Batteries` or
+`Mathlib` when the mirror's Lake file requires no package providing them:
+inside the monorepo those imports always resolve, in a mirror they resolve
+only through its own `require`s.
 
 ### Publishing a new library: widen a token first
 

--- a/PLAN/Releases.md
+++ b/PLAN/Releases.md
@@ -209,7 +209,15 @@ does not build reports it directly, on the commit that caused it.
 Rewriting the cross-repo revisions touches **every** lakefile and
 `lake-manifest.json` in a repo, updating both `rev` and `inputRev`. Lake
 trusts the manifest, so a stale lockfile would otherwise rebuild against
-the old revision.
+the old revision. A published dependency that the mirror's lockfile has
+never seen (a library split out upstream, or a companion that gained a
+requirement) is appended as a new lockfile entry at its synced revision,
+since Lake otherwise refuses to build with "dependency X of Y not in
+manifest". The sync also refuses, before pushing anything, to publish a
+library whose sources import `Batteries` or `Mathlib` when the mirror's
+Lake file requires no package providing them: inside the monorepo those
+imports always resolve, in a mirror they resolve only through its own
+`require`s.
 
 ### Publishing a new library: widen a token first
 

--- a/scripts/release/sync_released.py
+++ b/scripts/release/sync_released.py
@@ -794,7 +794,8 @@ def rewrite_pins(entry: dict, clone: Path, synced: dict[str, str],
 
 def rewrite_manifest(entry: dict, clone: Path, synced: dict[str, str],
                      dep_owner: dict[str, str],
-                     pins: dict[str, dict[str, str]]) -> list[str]:
+                     pins: dict[str, dict[str, str]],
+                     catalog: dict[str, dict[str, str]] | None = None) -> list[str]:
     """Pin the synced SHAs in every lake-manifest.json, so Lake's lockfile points
     at the new revisions, not a stale checkout: Lake trusts the manifest, and a
     lockfile left alone keeps resolving the upstream commit it was written
@@ -830,9 +831,116 @@ def rewrite_manifest(entry: dict, clone: Path, synced: dict[str, str],
                         pkg["inputRev"] = synced[dep]
                     changed += 1
                     notes.append(f"  manifest {dep} -> {synced[dep][:12]} ({mf.relative_to(clone)})")
+        if mf == clone / "lake-manifest.json":
+            changed += _synthesize_manifest_packages(
+                entry, clone, doc, synced, dep_owner, catalog, notes)
         if changed:
             mf.write_text(_json.dumps(doc, indent=2) + "\n", encoding="utf-8")
     return notes
+
+
+def _manifest_catalog() -> dict[str, dict[str, str]]:
+    """Short name -> library name and Lake file format, from released.yml."""
+    manifest = yaml.safe_load(MANIFEST.read_text(encoding="utf-8"))
+    return {e["repo"].split("/")[-1]: {"lib": e.get("lib", ""),
+                                       "lakefile": e.get("lakefile", "toml")}
+            for e in manifest["repos"]}
+
+
+def _synthesize_manifest_packages(entry: dict, clone: Path, doc: dict,
+                                  synced: dict[str, str],
+                                  dep_owner: dict[str, str],
+                                  catalog: dict[str, dict[str, str]] | None,
+                                  notes: list[str]) -> int:
+    """Add lockfile entries for pinned published dependencies the mirror's
+    manifest has never seen.
+
+    A mirror's `lake-manifest.json` is written by `lake update` in that mirror
+    and only ever rewritten here, so a dependency that enters the published
+    closure later (a library split out upstream, or a companion that gains a
+    requirement) is absent from it, and Lake refuses to build: "dependency X
+    of Y not in manifest". The sync knows every published dependency's exact
+    revision, owner and Lake file format, which is all a lockfile entry holds,
+    so it appends the missing entries itself. A pin the mirror's own Lake file
+    requires directly is recorded as such; every other pin is inherited from
+    a dependency. Entries already present are left to the rewrite above.
+    """
+    pins = entry.get("pins") or []
+    if not pins:
+        return 0
+    if catalog is None:
+        catalog = _manifest_catalog()
+    packages = doc.setdefault("packages", [])
+    present = {pkg.get("name") for pkg in packages}
+    lake_text = ""
+    for lf in _lake_files(clone, ["lakefile.toml", "lakefile.lean"]):
+        if lf.parent == clone:
+            lake_text = lf.read_text(encoding="utf-8")
+    added = 0
+    for dep in pins:
+        spec = catalog.get(dep)
+        if spec is None or not spec["lib"] or dep not in synced:
+            continue
+        if spec["lib"] in present:
+            continue
+        owner = dep_owner.get(dep, "leanprover")
+        url = f"https://github.com/{owner}/{dep}.git"
+        packages.append({
+            "url": url,
+            "type": "git",
+            "subDir": None,
+            "scope": "",
+            "rev": synced[dep],
+            "name": spec["lib"],
+            "manifestFile": "lake-manifest.json",
+            "inputRev": synced[dep],
+            "inherited": f"{dep}.git" not in lake_text,
+            "configFile": f"lakefile.{spec['lakefile']}",
+        })
+        present.add(spec["lib"])
+        added += 1
+        notes.append(f"  manifest + {dep} ({spec['lib']}) -> {synced[dep][:12]} "
+                     "(lake-manifest.json)")
+    return added
+
+
+def validate_external_imports(entry: dict, clone: Path) -> None:
+    """Require the mirror's Lake file to provide every non-Hex import root.
+
+    Inside the monorepo every library can import Batteries or Mathlib because
+    the root Lake file requires both; a mirror only has what its own Lake file
+    requires. Scan the synced library sources for `Batteries` and `Mathlib`
+    import roots and fail before anything is pushed when the mirror requires
+    neither the package nor Mathlib (which brings Batteries with it).
+    """
+    if entry.get("pins_only"):
+        return
+    lakefile = clone / f"lakefile.{entry['lakefile']}"
+    text = lakefile.read_text(encoding="utf-8") if lakefile.is_file() else ""
+    provided: set[str] = set()
+    if re.search(r'(?i)mathlib4?\.git|name\s*=\s*"mathlib"|require\s+mathlib\b', text):
+        provided.update({"Mathlib", "Batteries"})
+    if re.search(r'(?i)batteries\.git|name\s*=\s*"batteries"|require\s+batteries\b', text):
+        provided.add("Batteries")
+    roots: dict[str, str] = {}
+    pattern = re.compile(
+        r"^\s*(?:(?:public|private|meta)\s+)*import\s+(?:all\s+)?(Batteries|Mathlib)\b",
+        re.M)
+    for src, dest_rel, is_dir in managed_paths(entry):
+        dest = clone / dest_rel
+        files = list(dest.rglob("*.lean")) if is_dir else (
+            [dest] if dest.suffix == ".lean" else [])
+        for lean in files:
+            if not lean.is_file():
+                continue
+            for root in pattern.findall(lean.read_text(encoding="utf-8")):
+                roots.setdefault(root, str(lean.relative_to(clone)))
+    missing = {root: where for root, where in roots.items() if root not in provided}
+    if missing:
+        raise RuntimeError(
+            f"released repository {entry['repo']} imports "
+            + ", ".join(f"{root} ({where})" for root, where in sorted(missing.items()))
+            + f" but {lakefile.name} requires no package providing it")
 
 
 def sync_repo(entry: dict, source_sha: str, token: str | None, dry_run: bool,
@@ -862,6 +970,7 @@ def sync_repo(entry: dict, source_sha: str, token: str | None, dry_run: bool,
         validate_ci_helpers(entry, clone)
         for line in apply_paths(entry, clone):
             print(line)
+        validate_external_imports(entry, clone)
         if not entry.get("pins_only"):
             for line in rewrite_doc_verso(clone):
                 print(line)

--- a/scripts/release/sync_released.py
+++ b/scripts/release/sync_released.py
@@ -904,6 +904,87 @@ def _synthesize_manifest_packages(entry: dict, clone: Path, doc: dict,
     return added
 
 
+def _hex_import_roots(entry: dict, clone: Path) -> set[str]:
+    """Hex library roots the synced sources import directly."""
+    pattern = re.compile(
+        r"^\s*(?:(?:public|private|meta)\s+)*import\s+(?:all\s+)?(Hex[A-Za-z0-9]*)",
+        re.M)
+    roots: set[str] = set()
+    for src, dest_rel, is_dir in managed_paths(entry):
+        dest = clone / dest_rel
+        files = list(dest.rglob("*.lean")) if is_dir else (
+            [dest] if dest.suffix == ".lean" else [])
+        for lean in files:
+            if lean.is_file():
+                roots.update(pattern.findall(lean.read_text(encoding="utf-8")))
+    roots.discard(entry.get("lib", ""))
+    return roots
+
+
+def rewrite_requires(entry: dict, clone: Path, synced: dict[str, str],
+                     dep_owner: dict[str, str],
+                     catalog: dict[str, dict[str, str]] | None = None) -> list[str]:
+    """Require directly every published library the sources import directly.
+
+    Inside the monorepo one root Lake file requires everything, so a library
+    may import an upstream that its own mirror's Lake file has never
+    required, and the mirror only builds while some other dependency happens
+    to pull that upstream in. Once the upstream is split out (hex-arith from
+    hex-bareiss) or a dependency stops requiring it, the mirror fails with
+    "unknown module prefix". A direct require for each direct import is
+    always correct and never redundant enough to matter, so the sync appends
+    the missing ones at the synced revision: a `[[require]]` block before the
+    first target in `lakefile.toml`, or a `require ... from git` after the
+    last one in `lakefile.lean`.
+    """
+    notes: list[str] = []
+    pins = entry.get("pins") or []
+    if entry.get("pins_only") or not pins:
+        return notes
+    if catalog is None:
+        catalog = _manifest_catalog()
+    lakefile = clone / f"lakefile.{entry['lakefile']}"
+    if not lakefile.is_file():
+        return notes
+    text = lakefile.read_text(encoding="utf-8")
+    roots = _hex_import_roots(entry, clone)
+    additions: list[tuple[str, str, str]] = []
+    for dep in pins:
+        spec = catalog.get(dep)
+        if spec is None or not spec["lib"] or spec["lib"] not in roots:
+            continue
+        if f"{dep}.git" in text or dep not in synced:
+            continue
+        owner = dep_owner.get(dep, "leanprover")
+        additions.append((dep, spec["lib"], f"https://github.com/{owner}/{dep}.git"))
+    if not additions:
+        return notes
+    if entry["lakefile"] == "toml":
+        block = "".join(
+            f'[[require]]\nname = "{lib}"\ngit = "{url}"\nrev = "{synced[dep]}"\n\n'
+            for dep, lib, url in additions)
+        anchor = re.search(r"(?m)^\[\[(?:lean_lib|lean_exe)\]\]", text)
+        if anchor:
+            text = text[:anchor.start()] + block + text[anchor.start():]
+        else:
+            text = text.rstrip("\n") + "\n\n" + block
+    else:
+        block = "".join(
+            f'\nrequire {lib} from git\n  "{url}" @ "{synced[dep]}"\n'
+            for dep, lib, url in additions)
+        requires = list(re.finditer(r"(?m)^require\b.*(?:\n[ \t]+.*)*\n", text))
+        if requires:
+            end = requires[-1].end()
+        else:
+            package = re.search(r"(?ms)^package\b.*?(?=^\S|\Z)", text)
+            end = package.end() if package else len(text)
+        text = text[:end] + block + text[end:]
+    lakefile.write_text(text, encoding="utf-8")
+    for dep, lib, _url in additions:
+        notes.append(f"  require + {dep} ({lib}) -> {synced[dep][:12]} ({lakefile.name})")
+    return notes
+
+
 def validate_external_imports(entry: dict, clone: Path) -> None:
     """Require the mirror's Lake file to provide every non-Hex import root.
 
@@ -977,6 +1058,8 @@ def sync_repo(entry: dict, source_sha: str, token: str | None, dry_run: bool,
         for line in rewrite_toolchains(clone):
             print(line)
         for line in rewrite_external_pins(clone, pins):
+            print(line)
+        for line in rewrite_requires(entry, clone, synced, dep_owner):
             print(line)
         for line in rewrite_pins(entry, clone, synced, dep_owner):
             print(line)

--- a/scripts/release/test_sync_released.py
+++ b/scripts/release/test_sync_released.py
@@ -414,6 +414,62 @@ class SyncReleasedTests(unittest.TestCase):
             "import Mathlib.Tactic\nimport Batteries.Data.Vector\n")
         sync_released.validate_external_imports(entry, self.repo)
 
+    def test_direct_imports_gain_direct_requires_in_toml(self) -> None:
+        lib = self.repo / "HexProbe"
+        lib.mkdir()
+        (lib / "Basic.lean").write_text(
+            "module\n\npublic import HexArith.Basic\nimport HexMatrix\n"
+            "import HexProbe.Other\n", encoding="utf-8")
+        (self.repo / "lakefile.toml").write_text(
+            'name = "hex-probe"\n\n[[require]]\nname = "HexMatrix"\n'
+            'git = "https://github.com/leanprover/hex-matrix.git"\nrev = "0"\n\n'
+            '[[lean_lib]]\nname = "HexProbe"\n', encoding="utf-8")
+        entry = {"repo": "leanprover/hex-probe", "lib": "HexProbe",
+                 "lakefile": "toml", "readme": False,
+                 "pins": ["hex-basic", "hex-arith", "hex-matrix"]}
+        synced = {"hex-basic": "a" * 40, "hex-arith": "b" * 40,
+                  "hex-matrix": "c" * 40}
+        catalog = {"hex-basic": {"lib": "HexBasic", "lakefile": "toml"},
+                   "hex-arith": {"lib": "HexArith", "lakefile": "lean"},
+                   "hex-matrix": {"lib": "HexMatrix", "lakefile": "toml"}}
+        notes = sync_released.rewrite_requires(
+            entry, self.repo, synced, {}, catalog)
+        text = (self.repo / "lakefile.toml").read_text()
+        self.assertEqual(notes, [
+            f'  require + hex-arith (HexArith) -> {"b" * 12} (lakefile.toml)'])
+        self.assertNotIn("hex-basic.git", text)
+        block = ('[[require]]\nname = "HexArith"\n'
+                 'git = "https://github.com/leanprover/hex-arith.git"\n'
+                 f'rev = "{"b" * 40}"\n\n[[lean_lib]]')
+        self.assertIn(block, text)
+        self.assertEqual(text.count("[[require]]"), 2)
+        self.assertEqual(
+            sync_released.rewrite_requires(entry, self.repo, synced, {}, catalog),
+            [])
+
+    def test_direct_imports_gain_direct_requires_in_lean(self) -> None:
+        lib = self.repo / "HexProbe"
+        lib.mkdir()
+        (lib / "Basic.lean").write_text(
+            "import HexBasic.Core\n", encoding="utf-8")
+        (self.repo / "lakefile.lean").write_text(
+            "import Lake\n\nopen Lake DSL\n\npackage «hex-probe» where\n"
+            "  leanOptions := #[]\n\nrequire HexArith from git\n"
+            '  "https://github.com/leanprover/hex-arith.git" @ "0"\n\n'
+            "@[default_target]\nlean_lib HexProbe\n", encoding="utf-8")
+        entry = {"repo": "leanprover/hex-probe", "lib": "HexProbe",
+                 "lakefile": "lean", "readme": False,
+                 "pins": ["hex-basic", "hex-arith"]}
+        sync_released.rewrite_requires(
+            entry, self.repo, {"hex-basic": "a" * 40, "hex-arith": "b" * 40}, {},
+            {"hex-basic": {"lib": "HexBasic", "lakefile": "toml"},
+             "hex-arith": {"lib": "HexArith", "lakefile": "lean"}})
+        text = (self.repo / "lakefile.lean").read_text()
+        self.assertIn(
+            '@ "0"\n\nrequire HexBasic from git\n'
+            f'  "https://github.com/leanprover/hex-basic.git" @ "{"a" * 40}"\n\n'
+            "@[default_target]", text)
+
     def test_missing_root_toolchain_fails_closed(self) -> None:
         (self.repo / "lean-toolchain").unlink()
         with self.assertRaisesRegex(RuntimeError, "no root lean-toolchain"):

--- a/scripts/release/test_sync_released.py
+++ b/scripts/release/test_sync_released.py
@@ -331,6 +331,89 @@ class SyncReleasedTests(unittest.TestCase):
         self.assertEqual(package["rev"], self.mathlib["rev"])
         self.assertEqual(package["inputRev"], self.mathlib["inputRev"])
 
+    def test_manifest_gains_entries_for_unseen_pins(self) -> None:
+        (self.repo / "lakefile.toml").write_text(
+            '[[require]]\n'
+            'name = "HexPoly"\n'
+            'git = "https://github.com/leanprover/hex-poly.git"\n'
+            'rev = "0000000"\n',
+            encoding="utf-8",
+        )
+        manifest = {"version": "1.2.0", "packages": [{
+            "name": "HexPoly",
+            "url": "https://github.com/leanprover/hex-poly.git",
+            "rev": "0000000",
+            "inputRev": "0000000",
+        }]}
+        path = self.repo / "lake-manifest.json"
+        path.write_text(json.dumps(manifest), encoding="utf-8")
+        synced = {"hex-basic": "a" * 40, "hex-poly": "b" * 40,
+                  "hex-arith": "c" * 40}
+        catalog = {"hex-basic": {"lib": "HexBasic", "lakefile": "toml"},
+                   "hex-poly": {"lib": "HexPoly", "lakefile": "toml"},
+                   "hex-arith": {"lib": "HexArith", "lakefile": "lean"}}
+        notes = sync_released.rewrite_manifest(
+            {"pins": ["hex-basic", "hex-arith", "hex-poly"]}, self.repo,
+            synced, {}, self.pins, catalog)
+        packages = {pkg["name"]: pkg
+                    for pkg in json.loads(path.read_text())["packages"]}
+        self.assertEqual(set(packages), {"HexPoly", "HexBasic", "HexArith"})
+        self.assertEqual(packages["HexPoly"]["rev"], "b" * 40)
+        basic = packages["HexBasic"]
+        self.assertEqual(basic["url"], "https://github.com/leanprover/hex-basic.git")
+        self.assertEqual(basic["rev"], "a" * 40)
+        self.assertEqual(basic["inputRev"], "a" * 40)
+        self.assertTrue(basic["inherited"])
+        self.assertEqual(basic["configFile"], "lakefile.toml")
+        self.assertEqual(packages["HexArith"]["configFile"], "lakefile.lean")
+        self.assertTrue(any("manifest + hex-basic" in note for note in notes))
+        # A second pass finds everything present and adds nothing.
+        again = sync_released.rewrite_manifest(
+            {"pins": ["hex-basic", "hex-arith", "hex-poly"]}, self.repo,
+            synced, {}, self.pins, catalog)
+        self.assertFalse(any("manifest +" in note for note in again))
+
+    def test_manifest_records_direct_pins_as_not_inherited(self) -> None:
+        (self.repo / "lakefile.toml").write_text(
+            '[[require]]\n'
+            'name = "HexBasic"\n'
+            'git = "https://github.com/leanprover/hex-basic.git"\n'
+            'rev = "0000000"\n',
+            encoding="utf-8",
+        )
+        path = self.repo / "lake-manifest.json"
+        path.write_text(json.dumps({"version": "1.2.0", "packages": []}),
+                        encoding="utf-8")
+        sync_released.rewrite_manifest(
+            {"pins": ["hex-basic"]}, self.repo, {"hex-basic": "a" * 40}, {},
+            self.pins, {"hex-basic": {"lib": "HexBasic", "lakefile": "toml"}})
+        package = json.loads(path.read_text())["packages"][0]
+        self.assertFalse(package["inherited"])
+
+    def _external_import_entry(self, lakefile: str, source: str) -> dict:
+        lib = self.repo / "HexProbe"
+        lib.mkdir(exist_ok=True)
+        (lib / "Basic.lean").write_text(source, encoding="utf-8")
+        (self.repo / "lakefile.toml").write_text(lakefile, encoding="utf-8")
+        return {"repo": "leanprover/hex-probe", "lib": "HexProbe",
+                "lakefile": "toml", "readme": False}
+
+    def test_batteries_import_without_provider_fails_closed(self) -> None:
+        entry = self._external_import_entry(
+            '[[require]]\nname = "HexBasic"\n'
+            'git = "https://github.com/leanprover/hex-basic.git"\nrev = "0"\n',
+            "module\n\npublic import HexBasic\nimport Batteries.Data.Vector\n")
+        with self.assertRaisesRegex(RuntimeError, "imports Batteries"):
+            sync_released.validate_external_imports(entry, self.repo)
+
+    def test_mathlib_requirement_provides_batteries(self) -> None:
+        entry = self._external_import_entry(
+            '[[require]]\nname = "mathlib"\n'
+            'git = "https://github.com/leanprover-community/mathlib4.git"\n'
+            'rev = "0"\n',
+            "import Mathlib.Tactic\nimport Batteries.Data.Vector\n")
+        sync_released.validate_external_imports(entry, self.repo)
+
     def test_missing_root_toolchain_fails_closed(self) -> None:
         (self.repo / "lean-toolchain").unlink()
         with self.assertRaisesRegex(RuntimeError, "no root lean-toolchain"):


### PR DESCRIPTION
This PR makes the release sync complete each mirror's Lake configuration and lockfile from what the synced sources need, and refuse to publish sources whose imports the mirror cannot resolve. After today's sync, twenty mirrors failed with "dependency X of Y not in manifest" because a mirror's lockfile is only ever rewritten by the sync, never extended, so published dependencies that entered the closure later (hex-arith, hex-primality, hex-mod-arith, hex-basic, and for the new repos hex-determinant and hex-poly-fp-mathlib) were absent. Others, hex-bareiss among them, failed with "unknown module prefix" because their Lake file never required a library their sources import directly and nothing else in their graph pulls it in any more. The sync now appends a direct `require` at the synced revision for every published library the synced sources import directly, and a lockfile entry for every pinned published dependency the manifest lacks, marked inherited unless the mirror's Lake file requires it. It also scans the synced library sources for `Batteries` and `Mathlib` import roots and fails before any push when the mirror's Lake file requires neither the package nor Mathlib, the defect behind the hex-row-reduce family's failures that #10016 fixes at the source. A fresh hex-bareiss mirror clone with the synthesized require and lockfile entry builds with Lake. Unit tests cover the three behaviours, and `PLAN/Releases.md` records them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsrsxR7daUgNCrQ6N2zKs6
