### PR TITLE
fix(release): carry lean_lib build settings into released mirrors

### DIFF
--- a/PLAN/Releases.md
+++ b/PLAN/Releases.md
@@ -223,6 +223,20 @@ anything, to publish a library whose sources import `Batteries` or
 inside the monorepo those imports always resolve, in a mirror they resolve
 only through its own `require`s.
 
+How a library is *built* is decided by this monorepo's `lakefile.lean` and
+carried across the same way. The sync reads the `lean_lib <lib>` block here and
+writes `precompileModules` into the mirror's own `lean_lib` when the mirror has
+lost it: without it Lake never builds the module dynlib that carries the
+library's `@[extern]` symbols, so the mirror compiles while any downstream
+package that evaluates the library during elaboration fails to find the native
+implementation. `extraDepTargets` and `moreLinkArgs` are validated rather than
+written, since they name `extern_lib` targets defined only in the mirror's own
+skeleton and, in `HexLLL`'s case, take the form of a platform conditional that
+no `lakefile.toml` can express; a mirror missing one stops the publication.
+Deriving all of this from the lakefile rather than restating it in
+`released.yml` is deliberate: a hand-maintained copy of a build decision is one
+that can disagree with the build.
+
 ### Publishing a new library: widen a token first
 
 The sync authenticates with the `RELEASED_SYNC_PAT` and `RELEASED_SYNC_PAT_2`

--- a/scripts/release/BOOTSTRAP.md
+++ b/scripts/release/BOOTSTRAP.md
@@ -116,6 +116,15 @@ packages that ship native code. In particular:
 A skeleton that omits these targets can elaborate yet fail at executable link
 time, so a standalone `lake build` is required before the first real publish.
 
+The `lean_lib` build settings themselves are not part of the skeleton to
+maintain: this monorepo's `lakefile.lean` decides how a library is built, and
+the sync carries that decision across. It writes `precompileModules` into the
+mirror's `lean_lib` when the monorepo sets it, so a skeleton may omit it.
+`extraDepTargets` and `moreLinkArgs` name the mirror's own `extern_lib` targets
+and system libraries, so those the skeleton must still declare; the sync
+validates them against the monorepo and refuses to publish a library that has
+lost one.
+
 ## Baseline and first publish
 
 Do not add placeholder entries to `scripts/release/synced.json`. An absent

--- a/scripts/release/check_released_manifest.py
+++ b/scripts/release/check_released_manifest.py
@@ -21,6 +21,7 @@ from release.sync_released import (  # noqa: E402
     managed_paths,
     released_ci_workflows,
     removal_paths,
+    source_build_settings,
 )
 from release import aggregate_readme  # noqa: E402
 
@@ -54,6 +55,30 @@ def check_library_only(entry: dict) -> None:
             "to the mirror; benchmarks, conformance drivers, fixtures and "
             "oracles stay in hex-dev"
         )
+
+
+def check_build_settings(entry: dict) -> None:
+    """Keep the mirror's build settings derivable from hex-dev's lakefile.
+
+    The sync reads the `lean_lib <lib>` block here and carries its settings into
+    the mirror. Two things have to hold for that to be more than a no-op, and
+    neither is visible at sync time until a repository is already being
+    published: the manifest must not carry a competing hand-written copy of a
+    build decision, and the library must still be a `lean_lib` in this
+    monorepo's lakefile. A renamed or globbed-away target would otherwise leave
+    the sync deriving an empty settings map and publishing a mirror that quietly
+    stops precompiling.
+    """
+    repo = entry["repo"]
+    if "precompile_modules" in entry:
+        fail(
+            f"{repo}: precompile_modules is derived from lakefile.lean, not "
+            "declared here; drop the key"
+        )
+    try:
+        source_build_settings(entry["lib"])
+    except RuntimeError as error:
+        fail(f"{repo}: {error}")
 
 
 def parse_sync_baseline(text: str, source: str) -> set[str]:
@@ -426,8 +451,7 @@ def main() -> int:
             if lib in library_names:
                 fail(f"duplicate released library {lib}")
             library_names.add(lib)
-            if not isinstance(entry.get("precompile_modules", False), bool):
-                fail(f"{repo}: precompile_modules must be a Boolean")
+            check_build_settings(entry)
             test_modules = entry.get("test_modules", [])
             if (
                 not isinstance(test_modules, list)

--- a/scripts/release/released.yml
+++ b/scripts/release/released.yml
@@ -51,6 +51,12 @@
 # root module. The sync refuses to publish when the skeleton is stale.
 # `pins` lists the upstream repos whose git rev is rewritten in this repo's root
 # lakefile (matched by their github URL); `lakefile` is that file's format.
+# The mirror's `lean_lib` build settings are deliberately *not* recorded here:
+# this monorepo's `lakefile.lean` is the source of truth for how a library is
+# built, so the sync reads the `lean_lib <lib>` block and carries the settings
+# across itself, writing `precompileModules` into the mirror when it is missing
+# and refusing to publish when a setting it cannot synthesize has gone. A second
+# copy of a build decision in this manifest only gives it somewhere to drift.
 # `announcements` maps a venue (`blog`, `zulip`, `linkedin`) to the https URL
 # where this library was announced; it renders as one line per library in the
 # aggregate README's Announcements section. Deliberately not a table column:
@@ -220,7 +226,6 @@ repos:
   - repo: leanprover/hex-hensel
     component: Hensel lifting
     lib: HexHensel
-    precompile_modules: true
     umbrella: true
     spec: hex-hensel
     remove_paths: [bench, conformance, conformance-fixtures, scripts/ci/check_bench_verify_budget.sh, scripts/oracle]
@@ -326,7 +331,6 @@ repos:
   - repo: leanprover/hex-gf2
     component: Packed GF(2) polynomials
     lib: HexGF2
-    precompile_modules: true
     umbrella: true
     spec: hex-gf2
     remove_paths: [bench, conformance, conformance-fixtures, scripts/ci/check_bench_verify_budget.sh, scripts/ci/check_clmul_paths.sh, scripts/oracle]

--- a/scripts/release/sync_released.py
+++ b/scripts/release/sync_released.py
@@ -4,7 +4,8 @@
 For each repo in scripts/release/released.yml (topological order), this:
   1. clones the repo's `main`,
   2. overwrites its *managed* paths and centrally owned CI workflow,
-  3. for managed-source repos, enables native Verso docstrings,
+  3. for managed-source repos, enables native Verso docstrings and carries the
+     `lean_lib` build settings this monorepo's lakefile gives the library,
   4. copies the stable Lean toolchain and exact external dependency pins,
   5. rewrites cross-repo Hex pins in the repo's Lake files,
   6. commits `chore: sync from hex-dev@<sha>` and pushes to `main`
@@ -88,6 +89,30 @@ TOKEN_HELP = (
     "https://github.com/organizations/leanprover/settings/personal-access-token-requests"
 )
 LAKE_MANIFEST = REPO_ROOT / "lake-manifest.json"
+LAKEFILE = REPO_ROOT / "lakefile.lean"
+
+# `lean_lib` settings a consumer of a released library sees. They are derived
+# from this monorepo's lakefile rather than declared in released.yml, because
+# hex-dev is the source of truth for how a library is built and a second,
+# hand-maintained copy of that decision drifts.
+#
+# `precompileModules` is the one the sync writes: it decides whether Lake builds
+# and ships the module dynlib carrying a library's `@[extern]` symbols, so a
+# mirror that drops it still compiles yet fails in any downstream package that
+# evaluates the library during elaboration ("Could not find native
+# implementation of external declaration"). It is a self-contained Boolean,
+# expressible in both Lake file flavours, so the sync can insert it.
+#
+# `extraDepTargets` and `moreLinkArgs` are validated but never written: they
+# name targets defined only in the mirror's own (unmanaged) Lake skeleton, such
+# as `hexlllffi`, and hex-dev spells `moreLinkArgs` as an arbitrary Lean
+# expression (HexLLL's is a platform conditional) that has no `lakefile.toml`
+# form. Synthesizing either would produce a Lake file that does not elaborate,
+# which is worse than the divergence, so the sync reports it and refuses to
+# publish instead.
+WRITTEN_LIB_SETTINGS = ("precompileModules",)
+CHECKED_LIB_SETTINGS = ("extraDepTargets", "moreLinkArgs")
+BUILD_LIB_SETTINGS = WRITTEN_LIB_SETTINGS + CHECKED_LIB_SETTINGS
 
 
 def run(cmd: list[str], cwd: Path | None = None, capture: bool = False) -> str:
@@ -428,6 +453,163 @@ def rewrite_toolchains(clone: Path) -> list[str]:
     return notes
 
 
+def _lean_lib_header(text: str, lib: str) -> re.Match[str] | None:
+    """The `lean_lib <lib>` declaration in a Lean Lake file, if it has one.
+
+    Group `where` is unset for a bare `lean_lib Foo`, which Lake accepts and
+    some mirror skeletons use; the settings block then has to be opened before a
+    setting can be added.
+    """
+    return re.search(
+        r"(?m)^lean_lib[ \t]+«?" + re.escape(lib)
+        + r"»?[ \t]*(?P<where>where)?[ \t]*$",
+        text,
+    )
+
+
+def _block_end(text: str, start: int) -> int:
+    """Where an indented Lean settings block starting at `start` ends."""
+    following = re.search(r"(?m)^\S", text[start:])
+    return start + following.start() if following is not None else len(text)
+
+
+def _lean_settings(body: str) -> dict[str, str]:
+    """Settings assigned in an indented Lean `lean_lib` body, values joined."""
+    settings: dict[str, str] = {}
+    current: str | None = None
+    for line in body.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("--"):
+            continue
+        assignment = re.match(r"[ \t]+([A-Za-z][A-Za-z0-9_']*)[ \t]*:=(.*)$", line)
+        if assignment is not None:
+            current = assignment.group(1)
+            settings[current] = assignment.group(2).strip()
+        elif current is not None:
+            settings[current] = f"{settings[current]} {stripped}".strip()
+    return settings
+
+
+def lean_lib_settings(text: str) -> dict[str, dict[str, str]]:
+    """Every `lean_lib` in a Lean Lake file, mapped to its assigned settings."""
+    libs: dict[str, dict[str, str]] = {}
+    for header in re.finditer(
+            r"(?m)^lean_lib[ \t]+«?([A-Za-z_][A-Za-z0-9_']*)»?[ \t]*(?:where)?[ \t]*$",
+            text):
+        body = text[header.end():_block_end(text, header.end())]
+        libs[header.group(1)] = _lean_settings(body)
+    return libs
+
+
+def source_build_settings(lib: str, path: Path | None = None) -> dict[str, str]:
+    """The build settings this monorepo's lakefile assigns to `lib`.
+
+    The single source of truth for how a released library is built. A released
+    library with no `lean_lib` here cannot have its settings carried into the
+    mirror at all, so that is an error rather than an empty answer.
+    """
+    source = path or LAKEFILE
+    libs = lean_lib_settings(source.read_text(encoding="utf-8"))
+    if lib not in libs:
+        raise RuntimeError(f"{source} declares no lean_lib {lib}")
+    return {name: value for name, value in libs[lib].items()
+            if name in BUILD_LIB_SETTINGS}
+
+
+def _toml_lib_block(text: str, lib: str) -> re.Match[str] | None:
+    """The `[[lean_lib]]` array-of-tables entry naming `lib`, if there is one."""
+    for block in re.finditer(r"(?ms)^\[\[lean_lib\]\][ \t]*\n(.*?)(?=^\[|\Z)", text):
+        if re.search(r'(?m)^[ \t]*name[ \t]*=[ \t]*"' + re.escape(lib) + r'"[ \t]*$',
+                     block.group(1)):
+            return block
+    return None
+
+
+def _toml_settings(body: str) -> dict[str, str]:
+    """Keys assigned in a TOML table body (single-line values suffice here)."""
+    return {match.group(1): match.group(2).strip() for match in re.finditer(
+        r"(?m)^[ \t]*([A-Za-z][A-Za-z0-9_]*)[ \t]*=(.*)$", body)}
+
+
+def rewrite_lib_settings(entry: dict, clone: Path) -> list[str]:
+    """Carry this monorepo's `lean_lib` build settings into the mirror.
+
+    The mirror's Lake skeleton is otherwise unmanaged, and a library built one
+    way here and another way there is a defect its own CI cannot see: the mirror
+    builds, and only a downstream consumer discovers the difference. So the sync
+    writes `precompileModules` into the mirror's `lean_lib` when this monorepo
+    sets it and the mirror does not, exactly as it rewrites pins, and refuses to
+    publish when a setting it cannot safely synthesize has gone missing. See
+    `BUILD_LIB_SETTINGS`.
+    """
+    if entry.get("pins_only"):
+        return []
+    lib = entry["lib"]
+    required = source_build_settings(lib)
+    if not required:
+        return []
+    lakefile = clone / f"lakefile.{entry['lakefile']}"
+    text = lakefile.read_text(encoding="utf-8")
+    toml = entry["lakefile"] == "toml"
+    block = _toml_lib_block(text, lib) if toml else _lean_lib_header(text, lib)
+    if block is None:
+        raise RuntimeError(
+            f"released Lake file {lakefile} declares no lean_lib {lib}, so the "
+            f"build settings hex-dev gives it ({', '.join(sorted(required))}) "
+            "cannot be carried across"
+        )
+    if toml:
+        body_start = block.start(1)
+        body = block.group(1)
+        present = _toml_settings(body)
+    else:
+        body_start = block.end()
+        body = text[body_start:_block_end(text, body_start)]
+        present = _lean_settings(body)
+    for setting in CHECKED_LIB_SETTINGS:
+        if setting in required and setting not in present:
+            raise RuntimeError(
+                f"released Lake file {lakefile} must set {setting} on lean_lib "
+                f"{lib}, as hex-dev's lakefile.lean does; the sync cannot write "
+                "it, because it names targets defined only in this repository's "
+                "own Lake skeleton"
+            )
+    notes: list[str] = []
+    for setting in WRITTEN_LIB_SETTINGS:
+        if setting not in required:
+            continue
+        if required[setting] != "true":
+            raise RuntimeError(
+                f"hex-dev's lakefile.lean sets {setting} on lean_lib {lib} to "
+                f"{required[setting]!r}; only `true` can be published"
+            )
+        if present.get(setting) == "true":
+            continue
+        if setting in present:
+            raise RuntimeError(
+                f"released Lake file {lakefile} sets {setting} on lean_lib "
+                f"{lib} to {present[setting]!r}, contradicting hex-dev's `true`"
+            )
+        if toml:
+            insert_at = body_start + len(body.rstrip())
+            text = f"{text[:insert_at]}\n{setting} = true{text[insert_at:]}"
+        else:
+            opener = "" if block.group("where") else " where"
+            text = f"{text[:body_start]}{opener}\n  {setting} := true{text[body_start:]}"
+        notes.append(f"  {setting} on lean_lib {lib} ({lakefile.name})")
+    if notes:
+        if toml:
+            try:
+                tomllib.loads(text)
+            except tomllib.TOMLDecodeError as err:
+                raise RuntimeError(
+                    f"build-setting rewrite produced invalid TOML in {lakefile}: "
+                    f"{err}"
+                ) from err
+        lakefile.write_text(text, encoding="utf-8")
+    return notes
+
+
 def validate_skeleton(entry: dict, clone: Path) -> None:
     """Check the unmanaged Lake file carries every release build root.
 
@@ -443,16 +625,6 @@ def validate_skeleton(entry: dict, clone: Path) -> None:
             f"{clone}"
         )
     text = lakefile.read_text(encoding="utf-8")
-    if entry.get("precompile_modules"):
-        assignment = (
-            r"(?m)^\s*precompileModules\s*=\s*true\s*$"
-            if entry["lakefile"] == "toml"
-            else r"(?m)^\s*precompileModules\s*:=\s*true\s*$"
-        )
-        if re.search(assignment, text) is None:
-            raise RuntimeError(
-                f"released Lake file {lakefile} must precompile modules"
-            )
     for module in entry.get("test_modules", []):
         if module not in text:
             raise RuntimeError(
@@ -1054,6 +1226,8 @@ def sync_repo(entry: dict, source_sha: str, token: str | None, dry_run: bool,
         validate_external_imports(entry, clone)
         if not entry.get("pins_only"):
             for line in rewrite_doc_verso(clone):
+                print(line)
+            for line in rewrite_lib_settings(entry, clone):
                 print(line)
         for line in rewrite_toolchains(clone):
             print(line)

--- a/scripts/release/test_check_released_manifest.py
+++ b/scripts/release/test_check_released_manifest.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from scripts.release.check_released_manifest import (
+    check_build_settings,
     check_ci_workflows,
     check_library_only,
     check_phase_admission,
@@ -34,6 +35,25 @@ class LibraryOnlyTests(unittest.TestCase):
                     check_library_only(
                         {"repo": "leanprover/hex-example", field: value}
                     )
+
+
+class BuildSettingTests(unittest.TestCase):
+    """The mirror's build settings are derived from lakefile.lean, not declared."""
+
+    def test_a_released_library_is_accepted(self) -> None:
+        check_build_settings({"repo": "leanprover/hex-lll", "lib": "HexLLL"})
+
+    def test_a_declared_precompile_flag_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "drop the key"):
+            check_build_settings({
+                "repo": "leanprover/hex-lll",
+                "lib": "HexLLL",
+                "precompile_modules": True,
+            })
+
+    def test_a_library_absent_from_the_lakefile_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "declares no lean_lib HexGone"):
+            check_build_settings({"repo": "leanprover/hex-gone", "lib": "HexGone"})
 
 
 class Phase7AdmissionTests(unittest.TestCase):

--- a/scripts/release/test_sync_released.py
+++ b/scripts/release/test_sync_released.py
@@ -9,6 +9,8 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+import yaml
+
 from scripts.release import aggregate_readme, sync_released
 
 
@@ -298,21 +300,6 @@ class SyncReleasedTests(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "lakefile.toml"):
             sync_released.validate_skeleton({"lakefile": "toml"}, self.repo)
 
-    def test_release_skeleton_checks_module_precompilation(self) -> None:
-        lakefile = self.repo / "lakefile.toml"
-        lakefile.write_text(
-            '[[lean_lib]]\nname = "Consumer"\n',
-            encoding="utf-8",
-        )
-        entry = {"lakefile": "toml", "precompile_modules": True}
-        with self.assertRaisesRegex(RuntimeError, "must precompile modules"):
-            sync_released.validate_skeleton(entry, self.repo)
-        lakefile.write_text(
-            '[[lean_lib]]\nname = "Consumer"\nprecompileModules = true\n',
-            encoding="utf-8",
-        )
-        sync_released.validate_skeleton(entry, self.repo)
-
     def test_manifest_uses_exact_external_commit(self) -> None:
         manifest = {
             "version": "1.1.0",
@@ -561,6 +548,142 @@ class SyncReleasedTests(unittest.TestCase):
         advanced = json.loads(baseline.read_text(encoding="utf-8"))
         self.assertEqual(advanced["upstream"], "new-upstream")
         self.assertEqual(advanced["downstream"], "new-downstream")
+
+
+class LibBuildSettingTests(unittest.TestCase):
+    """The mirror's `lean_lib` must be built the way hex-dev builds it.
+
+    A mirror that drops `precompileModules` still compiles; the failure surfaces
+    only downstream, where an `@[extern]` declaration has no native
+    implementation because its module dynlib was never built.
+    """
+
+    SOURCE = (
+        "lean_lib Plain where\n"
+        "\n"
+        "lean_lib Consumer where\n"
+        "  -- comment lines are not settings\n"
+        "  precompileModules := true\n"
+        "\n"
+        "lean_lib Linked where\n"
+        "  precompileModules := true\n"
+        "  extraDepTargets := #[`consumerffi]\n"
+        "  moreLinkArgs :=\n"
+        "    if System.Platform.isOSX then\n"
+        "      #[]\n"
+        "    else\n"
+        "      #[\"-ldl\"]\n"
+    )
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        # The monorepo lakefile and the mirror clone are separate trees, and
+        # both are called lakefile.lean.
+        self.repo = Path(self.temporary.name) / "clone"
+        self.repo.mkdir()
+        self.source = Path(self.temporary.name) / "hex-dev" / "lakefile.lean"
+        self.source.parent.mkdir()
+        self.source.write_text(self.SOURCE, encoding="utf-8")
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def settings(self, lib: str) -> dict[str, str]:
+        return sync_released.source_build_settings(lib, self.source)
+
+    def rewrite(self, entry: dict) -> list[str]:
+        with patch.object(sync_released, "LAKEFILE", self.source):
+            return sync_released.rewrite_lib_settings(entry, self.repo)
+
+    def test_settings_are_read_from_the_monorepo_lakefile(self) -> None:
+        self.assertEqual(self.settings("Plain"), {})
+        self.assertEqual(self.settings("Consumer"), {"precompileModules": "true"})
+        self.assertEqual(self.settings("Linked"), {
+            "precompileModules": "true",
+            "extraDepTargets": "#[`consumerffi]",
+            "moreLinkArgs": 'if System.Platform.isOSX then #[] else #["-ldl"]',
+        })
+
+    def test_a_released_library_must_be_a_lean_lib_here(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "declares no lean_lib Absent"):
+            self.settings("Absent")
+
+    def test_toml_mirror_gains_precompilation(self) -> None:
+        lakefile = self.repo / "lakefile.toml"
+        lakefile.write_text(
+            'name = "consumer"\n\n[[lean_lib]]\nname = "Consumer"\n\n'
+            '[[lean_lib]]\nname = "ConsumerTests"\nglobs = ["Consumer.Tests"]\n',
+            encoding="utf-8")
+        entry = {"lib": "Consumer", "lakefile": "toml"}
+        notes = self.rewrite(entry)
+        self.assertEqual(notes, ["  precompileModules on lean_lib Consumer "
+                                 "(lakefile.toml)"])
+        text = lakefile.read_text(encoding="utf-8")
+        self.assertIn('name = "Consumer"\nprecompileModules = true\n', text)
+        self.assertNotIn("ConsumerTests\"\nprecompileModules", text)
+        self.assertEqual(self.rewrite(entry), [])
+
+    def test_lean_mirror_gains_precompilation(self) -> None:
+        lakefile = self.repo / "lakefile.lean"
+        lakefile.write_text(
+            "@[default_target]\nlean_lib Consumer where\n"
+            "  moreLinkArgs := #[]\n\nlean_exe check where\n"
+            "  root := `Consumer.Check\n",
+            encoding="utf-8")
+        entry = {"lib": "Consumer", "lakefile": "lean"}
+        self.assertEqual(self.rewrite(entry),
+                         ["  precompileModules on lean_lib Consumer "
+                          "(lakefile.lean)"])
+        self.assertIn("lean_lib Consumer where\n  precompileModules := true\n"
+                      "  moreLinkArgs := #[]\n",
+                      lakefile.read_text(encoding="utf-8"))
+        self.assertEqual(self.rewrite(entry), [])
+
+    def test_a_bare_lean_lib_gains_a_settings_block(self) -> None:
+        lakefile = self.repo / "lakefile.lean"
+        lakefile.write_text(
+            "@[default_target]\nlean_lib Consumer\n\nlean_lib Other where\n",
+            encoding="utf-8")
+        self.rewrite({"lib": "Consumer", "lakefile": "lean"})
+        self.assertIn("lean_lib Consumer where\n  precompileModules := true\n",
+                      lakefile.read_text(encoding="utf-8"))
+
+    def test_a_library_without_settings_is_left_alone(self) -> None:
+        lakefile = self.repo / "lakefile.toml"
+        original = '[[lean_lib]]\nname = "PlainLib"\n'
+        lakefile.write_text(original, encoding="utf-8")
+        self.assertEqual(self.rewrite({"lib": "Plain", "lakefile": "toml"}), [])
+        self.assertEqual(lakefile.read_text(encoding="utf-8"), original)
+
+    def test_a_missing_link_setting_stops_the_publication(self) -> None:
+        lakefile = self.repo / "lakefile.lean"
+        lakefile.write_text(
+            "lean_lib Linked where\n  extraDepTargets := #[`consumerffi]\n",
+            encoding="utf-8")
+        with self.assertRaisesRegex(RuntimeError, "must set moreLinkArgs"):
+            self.rewrite({"lib": "Linked", "lakefile": "lean"})
+
+    def test_a_missing_mirror_library_stops_the_publication(self) -> None:
+        (self.repo / "lakefile.toml").write_text(
+            '[[lean_lib]]\nname = "Other"\n', encoding="utf-8")
+        with self.assertRaisesRegex(RuntimeError, "declares no lean_lib Consumer"):
+            self.rewrite({"lib": "Consumer", "lakefile": "toml"})
+
+    def test_a_contradicting_mirror_setting_stops_the_publication(self) -> None:
+        (self.repo / "lakefile.toml").write_text(
+            '[[lean_lib]]\nname = "Consumer"\nprecompileModules = false\n',
+            encoding="utf-8")
+        with self.assertRaisesRegex(RuntimeError, "contradicting"):
+            self.rewrite({"lib": "Consumer", "lakefile": "toml"})
+
+    def test_every_released_library_keeps_its_monorepo_lean_lib(self) -> None:
+        manifest = yaml.safe_load(
+            sync_released.MANIFEST.read_text(encoding="utf-8"))
+        for entry in manifest["repos"]:
+            if entry.get("pins_only"):
+                continue
+            with self.subTest(repo=entry["repo"]):
+                sync_released.source_build_settings(entry["lib"])
 
 
 class TokenPreflightTests(unittest.TestCase):


### PR DESCRIPTION
This PR makes the release sync publish mirrors that are built the way `hex-dev` builds them, by deriving each released library's `lean_lib` settings from this monorepo's `lakefile.lean` and writing `precompileModules` into the mirror's own `lean_lib` when it is missing, alongside the existing pin rewrites. A mirror that has lost `precompileModules` still compiles, so its own CI is green, while Lake never builds the module dynlib carrying the library's `@[extern]` symbols and any downstream package that evaluates the library during elaboration fails with "Could not find native implementation of external declaration"; https://github.com/kim-em/hex-dev/issues/10018 records that happening to a consumer of released `hex-lll`. A dry run against the live `release-sync-baseline` shows the three mirrors that had drifted — `hex-lll`, `hex-poly-fp` and `hex-graph-iso` — gaining the setting, and no other mirror changing.

`extraDepTargets` and `moreLinkArgs` are validated rather than written: they name `extern_lib` targets defined only in a mirror's own unmanaged skeleton, and `HexLLL` spells `moreLinkArgs` as a platform conditional that no `lakefile.toml` can express, so synthesizing either would produce a Lake file that does not elaborate. A mirror that has lost one stops the publication instead. The hand-maintained `precompile_modules:` key in `released.yml` — which is what drifted, being set on only two of the ten released libraries the lakefile precompiles — is removed, and the manifest checker now rejects it and requires every released library to still be a `lean_lib` here, so a rename cannot leave the sync deriving nothing. Both new test suites and the manifest checker already run in the single ubuntu job, so no workflow changes.

🤖 Prepared with Claude Code