### PR TITLE
feat(release): compute what a mirror may contain instead of listing what to delete

### DIFF
--- a/PLAN/Releases.md
+++ b/PLAN/Releases.md
@@ -183,22 +183,40 @@ rewrites the lockfile but deliberately leaves that skeleton intact. The
 mirrors' CI workflows are managed centrally in
 `scripts/release/released-ci.yml` and published by the same guarded sync.
 
+"Nothing else" is computed, not listed. `allowed_paths` in `sync_released.py`
+derives what each mirror may contain from its manifest entry — the managed
+paths, the managed `.github/workflows/ci.yml`, and the skeleton the sync does
+not author — and `prune_unmanaged` deletes the rest of the clone before
+anything is copied in, so a library admitted to the manifest inherits the
+policy without a cleanup list of its own. Nothing else under `.github/`
+survives, so a mirror cannot accumulate a second workflow beside its build-only
+one, and a mirror carries neither a `reports/` tree nor `.claude/` notes beyond
+the figures its entry names. The `pins_only` aggregate is exempt, since its
+umbrella module, lakefile and documentation tree live only in the released
+repository. `keep_paths` is the
+escape hatch for a mirror-local file outside both sets; one entry uses it, for
+`hex-test-kit`'s fixed `HexTestKit.lean` umbrella. Because it can only
+preserve, a forgotten entry appears as a deletion in the dry run instead of as
+an over-published mirror, which is the failure mode a per-entry deletion list
+had backwards.
+
 ### The publish mechanism
 
 Five pieces, under `scripts/release/` and `.github/workflows/`:
 
-- `released.yml` — a per-repo manifest: which paths to copy, which obsolete
-  paths to delete, and which upstream repos to pin, in dependency order.
+- `released.yml` — a per-repo manifest: which paths to copy, which mirror-local
+  paths to keep, and which upstream repos to pin, in dependency order.
 - `released-ci.yml` — the complete per-repository mirror workflows. Each is one
   ubuntu job that builds the published library and its regression target;
   repository-specific build commands remain explicit while cache setup and
   policy are uniform. The explicit cache covers the library build plus
   published Hex dependency builds, while excluding the separately fetched
   Mathlib cache.
-- `sync_released.py` — the driver. For each repo it clones `main`,
-  overwrites the managed paths from this tree, rewrites the cross-repo
-  Lake revisions, and commits to `main`. `--dry-run` prints the planned
-  changes without pushing; run it first.
+- `sync_released.py` — the driver. For each repo it clones `main`, deletes
+  everything outside the entry's allowance, overwrites the managed paths from
+  this tree, rewrites the cross-repo Lake revisions, and commits to `main`.
+  `--dry-run` prints the planned changes, one line per deletion, without
+  pushing; run it first.
 - `synced.json` — the baseline seed (see below).
 - `sync-released.yml` — a manual workflow (`workflow_dispatch`, dry by
   default). One dispatch drives the whole publish.

--- a/scripts/release/BOOTSTRAP.md
+++ b/scripts/release/BOOTSTRAP.md
@@ -2,16 +2,41 @@
 
 `scripts/release/released.yml` is the authoritative publication graph for the
 split repositories and the `leanprover/hex` aggregate. The sync workflow
-clones each repository's `main`, overwrites its managed paths and CI workflow
-from this monorepo, copies the release toolchain, synchronizes external
-dependency locks, rewrites every published Hex revision, and pushes the result.
-It does not create repositories or author the remaining Lake skeleton.
+clones each repository's `main`, deletes everything the entry does not allow,
+overwrites its managed paths and CI workflow from this monorepo, copies the
+release toolchain, synchronizes external dependency locks, rewrites every
+published Hex revision, and pushes the result. It does not create repositories
+or author the remaining Lake skeleton.
 
 A released repository carries the library and nothing else: Lean source, the
 umbrella module, its SPEC and its README. Benchmarks, conformance drivers,
 fixtures and oracles are development instruments for the whole graph, so they
 live in this monorepo and run in its CI; each mirror's workflow builds what it
 publishes.
+
+That is enforced by construction, not by remembering. `allowed_paths` in
+`sync_released.py` computes what a mirror may hold — the entry's managed paths
+plus the skeleton below — and `prune_unmanaged` deletes everything else, so a
+newly admitted entry inherits the policy with no cleanup list of its own. The
+`pins_only` aggregate is exempt from the sweep: it manages no source, and its
+umbrella module, lakefile, `docs/` site and the workflow that publishes it live
+only in the released repository, where nothing here could tell them from an
+accident. It still loses `.claude/`, which no released repository has any use
+for and which is therefore deleted by name from every entry.
+
+The skeleton the sweep keeps is `lakefile.toml` or `lakefile.lean`,
+`lake-manifest.json`, `lean-toolchain`, `LICENSE`, `.gitignore`, `AGENTS.md`
+and `README.md`. Under `.github/` only the managed `workflows/ci.yml` survives,
+so a mirror cannot accumulate a second workflow beside its build-only one. A
+mirror carries no `reports/` tree and no `.claude/` notes: bench results,
+performance write-ups and agent orientation belong to the whole graph and stay
+here. The one exception is a figure a manifest entry names in its `figures:`
+list, which arrives as a managed file under `reports/figures/`.
+
+A mirror-local file outside all of that — `hex-test-kit`'s fixed
+`HexTestKit.lean` umbrella is the only one — needs a `keep_paths` entry in the
+manifest. That escape hatch can only preserve, so forgetting it shows up as a
+deletion in the dry run rather than as an over-published mirror.
 
 The manifest is checked locally by:
 
@@ -89,8 +114,9 @@ Source, the umbrella module, README, SPEC, and `.github/workflows/ci.yml` are
 managed by the sync. Do not duplicate or hand-edit those files in a released
 mirror. Add a new repository's complete workflow to
 `scripts/release/released-ci.yml`; the manifest checker rejects missing and
-extra workflow entries, and rejects an entry that asks to publish benchmarks,
-conformance drivers, fixtures or oracles.
+extra workflow entries, rejects an entry that asks to publish benchmarks,
+conformance drivers, fixtures or oracles, and rejects a `keep_paths` entry
+naming any tree no mirror publishes.
 
 `require`s list direct dependencies only; Lake resolves the rest transitively.
 The longer `pins` list in `released.yml` is deliberate: the sync rewrites the

--- a/scripts/release/check_released_manifest.py
+++ b/scripts/release/check_released_manifest.py
@@ -18,9 +18,10 @@ sys.path.insert(0, str(REPO_ROOT / "scripts"))
 from libgraph import load_libraries, reachable_dependencies  # noqa: E402
 from release.sync_released import (  # noqa: E402
     MANIFEST,
+    SKELETON,
+    keep_paths,
     managed_paths,
     released_ci_workflows,
-    removal_paths,
     source_build_settings,
 )
 from release import aggregate_readme  # noqa: E402
@@ -41,6 +42,23 @@ RETIRED_FIELDS = (
     "oracles",
 )
 
+# Top-level names a mirror never carries: the development instruments, the
+# bench-result and performance-report ledgers, and mirror-local agent notes.
+# `keep_paths` exists for a file the mirror owns, not as a way back to
+# publishing what the sweep is there to remove. A published figure under
+# `reports/figures/` arrives as a managed destination from the entry's
+# `figures:` list, never through this hatch.
+UNPUBLISHED_TREES = (
+    ".claude",
+    ".github",
+    "bench",
+    "conformance",
+    "conformance-fixtures",
+    "reports",
+    "scripts",
+    "vendor",
+)
+
 
 def fail(message: str) -> NoReturn:
     raise ValueError(message)
@@ -55,6 +73,28 @@ def check_library_only(entry: dict) -> None:
             "to the mirror; benchmarks, conformance drivers, fixtures and "
             "oracles stay in hex-dev"
         )
+    if "remove_paths" in entry:
+        fail(
+            f"{entry['repo']}: remove_paths is retired; the sync now deletes "
+            "everything outside the entry's managed paths and the unmanaged "
+            "skeleton, so nothing needs enumerating per entry"
+        )
+
+
+def check_keep_paths(entry: dict) -> None:
+    """Reject an escape hatch that widens a mirror past its library."""
+    for path in keep_paths(entry):
+        if path.parts[0] in UNPUBLISHED_TREES:
+            fail(
+                f"{entry['repo']}: keep_paths entry {path} names a tree no "
+                "mirror publishes; benchmarks, conformance drivers, fixtures, "
+                "oracles, bench results and performance reports stay in hex-dev"
+            )
+        if path.parts[0] in SKELETON:
+            fail(
+                f"{entry['repo']}: keep_paths entry {path} is already kept as "
+                "part of every mirror's unmanaged skeleton"
+            )
 
 
 def check_build_settings(entry: dict) -> None:
@@ -510,16 +550,16 @@ def main() -> int:
                 if destination in destinations:
                     fail(f"{repo}: duplicate managed destination {destination}")
                 destinations.add(destination)
-            removals = removal_paths(entry)
-            for removal in removals:
+            check_keep_paths(entry)
+            for kept in keep_paths(entry):
                 if any(
-                    removal == destination
-                    or removal in destination.parents
-                    or destination in removal.parents
+                    kept == destination
+                    or kept in destination.parents
+                    or destination in kept.parents
                     for destination in destinations
                 ):
                     fail(
-                        f"{repo}: remove_paths entry {removal} overlaps a managed destination"
+                        f"{repo}: keep_paths entry {kept} overlaps a managed destination"
                     )
             if entry.get("readme", True):
                 readme = REPO_ROOT / lib / "README.md"

--- a/scripts/release/released.yml
+++ b/scripts/release/released.yml
@@ -2,18 +2,28 @@
 #
 # `hex-dev` is the source of truth. The sync (scripts/release/sync_released.py,
 # driven by .github/workflows/sync-released.yml) regenerates each released repo
-# from this monorepo: it overwrites the repo's *managed* paths from here, leaves
-# everything else except the release-wide toolchain and dependency locks
-# untouched, enables native Verso docstrings in each managed-source repo's
-# lakefile, copies the monorepo's Lean toolchain, synchronizes exact external
-# dependency locks, rewrites cross-repo Hex pins to the commits just synced,
-# and commits to the released repo's `main`.
+# from this monorepo: it deletes everything outside the repo's *managed* paths
+# and its unmanaged skeleton, overwrites the managed paths from here, enables
+# native Verso docstrings in each managed-source repo's lakefile, copies the
+# monorepo's Lean toolchain, synchronizes exact external dependency locks,
+# rewrites cross-repo Hex pins to the commits just synced, and commits to the
+# released repo's `main`.
 #
 # A released repo ships the library and nothing else: its Lean source, umbrella,
 # SPEC and README. Benchmarks, conformance drivers, fixtures and oracles are
 # development instruments that only make sense against the whole graph, so they
 # live here and run in this monorepo's CI; a mirror's own CI builds what it
 # publishes, which is what its users consume.
+#
+# That is a property of the driver, not of this file. `allowed_paths` in
+# sync_released.py computes what a mirror may contain -- the entry's managed
+# paths, the managed .github/workflows/ci.yml, and the skeleton the sync does
+# not author (root Lake files, lake-manifest.json, lean-toolchain, LICENSE,
+# .gitignore, AGENTS.md) -- and `prune_unmanaged` deletes the rest. A new entry
+# therefore inherits the whole policy, and there is nothing per-entry to
+# remember. Nothing else under .github/ survives, so a mirror cannot accumulate
+# a second workflow beside its build-only one; nor do `reports/` or `.claude/`,
+# beyond the figures an entry names below.
 #
 # Order is topological (upstream first) so each repo's freshly-pushed SHA is
 # known before its downstream consumers are processed.
@@ -40,11 +50,11 @@
 # `test_modules` lists verification-only modules copied with the source but
 # intentionally absent from the public umbrella; released CI builds them via a
 # non-public `lean_lib` target.
-# `remove_paths` lists obsolete released-repo paths that the sync must delete.
-# Entries must be explicit relative paths and cannot overlap managed paths. Most
-# entries name the bench and conformance sidecars, fixtures and oracles an
-# earlier shape published, together with the mirror-local helpers that only
-# served them; the sidecar Lake projects go with their directories.
+# `keep_paths` is the escape hatch out of that sweep: explicit relative paths a
+# mirror owns that are neither managed nor part of the common skeleton. One
+# entry uses it, for `hex-test-kit`'s fixed `HexTestKit.lean` umbrella. It can
+# only preserve, so a forgotten entry surfaces as a deletion in the dry run, not
+# as an over-published mirror; it may not name a development instrument.
 # `build_modules` lists complete development umbrellas that the released Lake
 # skeleton must build separately from the curated public umbrella.
 # `executables` maps an unmanaged released executable name to its mathematical
@@ -91,7 +101,7 @@ repos:
     paths:                 # explicit: only the shared helper source
       - { src: "Hex", dest: "Hex" }
     spec: null
-    remove_paths: [scripts/oracle]
+    keep_paths: [HexTestKit.lean]   # mirror-local umbrella, authored there
     pins: []
     lakefile: toml
 
@@ -100,7 +110,6 @@ repos:
     lib: HexArith
     umbrella: true
     spec: hex-arith
-    remove_paths: [bench, conformance, scripts/ci/check_bench_verify_budget.sh]
     pins: []
     lakefile: lean
 
@@ -109,7 +118,6 @@ repos:
     lib: HexPrimality
     umbrella: true
     spec: hex-primality
-    remove_paths: [bench, conformance, conformance-fixtures, scripts/bench, scripts/ci/check_bench_verify_budget.sh, scripts/oracle]
     pins: [hex-basic, hex-arith]
     lakefile: toml
 
@@ -117,7 +125,6 @@ repos:
     lib: HexPrimalityMathlib
     umbrella: true
     spec: hex-primality-mathlib
-    remove_paths: [conformance]
     pins: [hex-basic, hex-arith, hex-primality]
     lakefile: toml
 
@@ -126,7 +133,6 @@ repos:
     lib: HexPoly
     umbrella: true
     spec: hex-poly
-    remove_paths: [bench, conformance, conformance-fixtures, scripts/ci/check_bench_verify_budget.sh, scripts/oracle]
     pins: []
     lakefile: toml
 
@@ -136,7 +142,6 @@ repos:
     test_modules: [HexMvPoly.KernelTests]
     umbrella: true
     spec: hex-mv-poly
-    remove_paths: [bench, conformance, conformance-fixtures, scripts/ci/check_bench_verify_budget.sh, scripts/oracle]
     pins: [hex-basic, hex-poly]
     lakefile: toml
 
@@ -145,7 +150,6 @@ repos:
     lib: HexModArith
     umbrella: true
     spec: hex-mod-arith
-    remove_paths: [bench, conformance, scripts/ci/check_bench_verify_budget.sh]
     pins: [hex-arith]
     lakefile: lean
 
@@ -160,7 +164,6 @@ repos:
     lib: HexMvPolyMathlib
     umbrella: true
     spec: hex-mv-poly-mathlib
-    remove_paths: [conformance]
     pins: [hex-basic, hex-poly, hex-mv-poly, hex-poly-mathlib]
     lakefile: toml
 
@@ -169,7 +172,6 @@ repos:
     lib: HexPolyFp
     umbrella: true
     spec: hex-poly-fp
-    remove_paths: [bench, conformance, conformance-fixtures, scripts/ci/check_bench_verify_budget.sh, scripts/oracle]
     pins: [hex-basic, hex-arith, hex-poly, hex-mod-arith]
     lakefile: toml
 
@@ -179,7 +181,6 @@ repos:
     test_modules: [HexSparsePoly.KernelTests]
     umbrella: true
     spec: hex-sparse-poly
-    remove_paths: [bench, conformance, conformance-fixtures, scripts/ci/check_bench_verify_budget.sh, scripts/oracle]
     pins: [hex-basic, hex-poly]
     lakefile: toml
 
@@ -187,7 +188,6 @@ repos:
     lib: HexSparsePolyMathlib
     umbrella: true
     spec: hex-sparse-poly-mathlib
-    remove_paths: [conformance]
     pins: [hex-basic, hex-poly, hex-sparse-poly, hex-poly-mathlib]
     lakefile: toml
 
@@ -196,7 +196,6 @@ repos:
     lib: HexPolyZ
     umbrella: true
     spec: hex-poly-z
-    remove_paths: [bench, conformance, conformance-fixtures, scripts/ci/check_bench_verify_budget.sh, scripts/oracle]
     pins: [hex-basic, hex-arith, hex-poly, hex-mod-arith]
     lakefile: toml
 
@@ -219,7 +218,6 @@ repos:
     lib: HexGFqRing
     umbrella: true
     spec: hex-gfq-ring
-    remove_paths: [bench, conformance, conformance-fixtures, scripts/ci/check_bench_verify_budget.sh, scripts/oracle]
     pins: [hex-basic, hex-arith, hex-poly, hex-mod-arith, hex-poly-fp]
     lakefile: toml
 
@@ -228,7 +226,6 @@ repos:
     lib: HexHensel
     umbrella: true
     spec: hex-hensel
-    remove_paths: [bench, conformance, conformance-fixtures, scripts/ci/check_bench_verify_budget.sh, scripts/oracle]
     pins: [hex-basic, hex-arith, hex-poly, hex-mod-arith, hex-poly-z, hex-poly-fp]
     lakefile: toml
 
@@ -251,7 +248,6 @@ repos:
     lib: HexRoots
     umbrella: true
     spec: hex-roots
-    remove_paths: [bench, conformance, conformance-fixtures, scripts/ci/check_bench_verify_budget.sh, scripts/oracle]
     pins: [hex-basic, hex-arith, hex-poly, hex-mod-arith, hex-poly-z]
     lakefile: toml
 
@@ -261,7 +257,6 @@ repos:
     test_modules: [HexRealRoots.ReplayTest]
     umbrella: true
     spec: hex-real-roots
-    remove_paths: [bench, conformance, conformance-fixtures, scripts/ci/check_bench_verify_budget.sh, scripts/oracle]
     pins: [hex-basic, hex-arith, hex-poly, hex-mod-arith, hex-poly-z]
     lakefile: toml
 
@@ -278,7 +273,6 @@ repos:
     test_modules: [HexRealRootsMathlib.IsolateRootsTests, HexRealRootsMathlib.IsolateRootsElabTests]
     umbrella: true
     spec: hex-real-roots-mathlib
-    remove_paths: [conformance]
     pins: [hex-basic, hex-arith, hex-poly, hex-mod-arith, hex-poly-z, hex-poly-fp, hex-hensel, hex-poly-mathlib, hex-mod-arith-mathlib, hex-poly-z-mathlib, hex-real-roots]
     lakefile: toml
 
@@ -287,7 +281,6 @@ repos:
     lib: HexMatrix
     umbrella: true
     spec: hex-matrix
-    remove_paths: [bench, conformance, scripts/ci/check_bench_verify_budget.sh, scripts/ci/run_oracles.sh, scripts/oracle]
     pins: [hex-basic]
     lakefile: toml
 
@@ -296,7 +289,6 @@ repos:
     lib: HexRowReduce
     umbrella: true
     spec: hex-row-reduce
-    remove_paths: [bench, conformance, conformance-fixtures, scripts/ci/check_bench_verify_budget.sh, scripts/ci/run_oracles.sh, scripts/oracle]
     pins: [hex-basic, hex-matrix]
     lakefile: toml
 
@@ -306,7 +298,6 @@ repos:
     test_modules: [HexBerlekamp.FactorTacticTests]
     umbrella: true
     spec: hex-berlekamp
-    remove_paths: [bench, conformance, conformance-fixtures, scripts/ci/check_bench_verify_budget.sh, scripts/oracle]
     pins: [hex-basic, hex-arith, hex-poly, hex-matrix, hex-row-reduce, hex-mod-arith, hex-poly-fp, hex-gfq-ring]
     lakefile: toml
 
@@ -315,7 +306,6 @@ repos:
     lib: HexConway
     umbrella: true
     spec: hex-conway
-    remove_paths: [bench, conformance, conformance-fixtures, scripts/ci/check_bench_verify_budget.sh, scripts/oracle]
     pins: [hex-basic, hex-arith, hex-poly, hex-matrix, hex-row-reduce, hex-mod-arith, hex-poly-fp, hex-gfq-ring, hex-berlekamp]
     lakefile: toml
 
@@ -324,7 +314,6 @@ repos:
     lib: HexGFqField
     umbrella: true
     spec: hex-gfq-field
-    remove_paths: [bench, conformance, conformance-fixtures, scripts/ci/check_bench_verify_budget.sh, scripts/oracle]
     pins: [hex-basic, hex-arith, hex-poly, hex-matrix, hex-row-reduce, hex-mod-arith, hex-poly-fp, hex-gfq-ring, hex-berlekamp]
     lakefile: toml
 
@@ -333,7 +322,6 @@ repos:
     lib: HexGF2
     umbrella: true
     spec: hex-gf2
-    remove_paths: [bench, conformance, conformance-fixtures, scripts/ci/check_bench_verify_budget.sh, scripts/ci/check_clmul_paths.sh, scripts/oracle]
     pins: [hex-basic]
     lakefile: lean
 
@@ -349,7 +337,6 @@ repos:
     lib: HexGFq
     umbrella: true
     spec: hex-gfq
-    remove_paths: [bench, conformance, conformance-fixtures, scripts/ci/check_bench_verify_budget.sh, scripts/oracle]
     pins: [hex-basic, hex-arith, hex-poly, hex-matrix, hex-row-reduce, hex-mod-arith, hex-poly-fp, hex-gfq-ring, hex-berlekamp, hex-conway, hex-gfq-field, hex-gf2]
     lakefile: toml
 
@@ -365,7 +352,6 @@ repos:
     lib: HexDeterminant
     umbrella: true
     spec: hex-determinant
-    remove_paths: [bench, conformance, conformance-fixtures, scripts/ci/check_bench_verify_budget.sh, scripts/ci/run_oracles.sh, scripts/oracle]
     pins: [hex-basic, hex-matrix]
     lakefile: toml
 
@@ -374,7 +360,6 @@ repos:
     lib: HexBareiss
     umbrella: true
     spec: hex-bareiss
-    remove_paths: [bench, conformance, conformance-fixtures, scripts/ci/check_bench_verify_budget.sh, scripts/ci/run_oracles.sh, scripts/oracle]
     pins: [hex-basic, hex-arith, hex-determinant, hex-matrix]
     lakefile: toml
 
@@ -419,7 +404,6 @@ repos:
     lib: HexGramSchmidt
     umbrella: true
     spec: hex-gram-schmidt
-    remove_paths: [bench, conformance, conformance-fixtures, scripts/ci/check_bench_verify_budget.sh, scripts/ci/run_oracles.sh, scripts/oracle]
     pins: [hex-basic, hex-arith, hex-row-reduce, hex-determinant, hex-bareiss, hex-matrix]
     lakefile: toml
 
@@ -440,7 +424,6 @@ repos:
     executables: {hexlll_external_reduction: HexLLL.ExternalReduction}
     umbrella: true
     spec: hex-lll
-    remove_paths: [bench, conformance, conformance-fixtures, scripts/ci/check_bench_verify_budget.sh, scripts/ci/hexlll_probe_provider.c, scripts/ci/run_oracles.sh, scripts/oracle, scripts/plots]
     pins: [hex-basic, hex-arith, hex-gram-schmidt, hex-row-reduce, hex-determinant, hex-bareiss, hex-matrix]
     lakefile: lean
     # user-facing performance doc (HexLLL/PERFORMANCE.md -> repo-root PERFORMANCE.md)
@@ -465,7 +448,6 @@ repos:
     build_modules: [HexBerlekampZassenhaus.All]
     umbrella: true
     spec: hex-berlekamp-zassenhaus
-    remove_paths: [bench, conformance, conformance-fixtures, scripts/ci/check_bench_verify_budget.sh, scripts/oracle]
     pins: [hex-basic, hex-arith, hex-primality, hex-poly, hex-matrix, hex-row-reduce, hex-determinant, hex-bareiss, hex-mod-arith, hex-gram-schmidt, hex-poly-z, hex-lll, hex-poly-fp, hex-gfq-ring, hex-berlekamp, hex-hensel]
     lakefile: lean
 
@@ -529,7 +511,6 @@ repos:
     lib: HexResultant
     umbrella: true
     spec: hex-resultant
-    remove_paths: [bench, conformance, scripts/ci/check_bench_verify_budget.sh]
     pins: [hex-basic, hex-poly, hex-matrix, hex-determinant]
     lakefile: toml
 
@@ -545,7 +526,6 @@ repos:
     lib: HexNumberField
     umbrella: true
     spec: hex-number-field
-    remove_paths: [bench, conformance, conformance-fixtures, scripts/ci/check_bench_verify_budget.sh, scripts/oracle]
     pins: [hex-basic, hex-arith, hex-primality, hex-poly, hex-mod-arith, hex-poly-fp, hex-poly-z, hex-gfq-ring, hex-hensel, hex-roots, hex-matrix, hex-row-reduce, hex-berlekamp, hex-determinant, hex-bareiss, hex-gram-schmidt, hex-lll, hex-berlekamp-zassenhaus, hex-resultant]
     lakefile: toml
 
@@ -565,7 +545,6 @@ repos:
     test_modules: [HexNumberFieldTower.Embed]
     umbrella: true
     spec: hex-number-field-tower
-    remove_paths: [bench, conformance, conformance-fixtures, scripts/ci/check_bench_verify_budget.sh, scripts/oracle]
     pins: [hex-basic, hex-arith, hex-primality, hex-poly, hex-mod-arith, hex-poly-fp, hex-poly-z, hex-gfq-ring, hex-hensel, hex-roots, hex-matrix, hex-row-reduce, hex-berlekamp, hex-determinant, hex-bareiss, hex-gram-schmidt, hex-lll, hex-berlekamp-zassenhaus, hex-resultant, hex-number-field]
     lakefile: toml
 
@@ -587,7 +566,6 @@ repos:
     test_modules: [HexRCF.LanguageTests, HexRCF.SturmBuilderTests, HexRCF.CarrierTests, HexRCF.IsolationsTests, HexRCF.SeparationTests, HexRCF.CellsTests, HexRCF.CommonRootTests, HexRCF.SignMatrixTests, HexRCF.BuilderTests, HexRCF.CertificateTests, HexRCF.DecisionTests, HexRCF.ReifyTests, HexRCF.LintTests]
     umbrella: true
     spec: hex-rcf
-    remove_paths: [bench, conformance, scripts/ci/check_bench_verify_budget.sh]
     pins: [hex-basic, hex-arith, hex-poly, hex-mod-arith, hex-poly-mathlib, hex-poly-fp, hex-poly-z, hex-mod-arith-mathlib, hex-hensel, hex-poly-z-mathlib, hex-real-roots, hex-real-roots-mathlib]
     lakefile: toml
 

--- a/scripts/release/sync_released.py
+++ b/scripts/release/sync_released.py
@@ -3,7 +3,9 @@
 
 For each repo in scripts/release/released.yml (topological order), this:
   1. clones the repo's `main`,
-  2. overwrites its *managed* paths and centrally owned CI workflow,
+  2. removes everything outside the entry's managed paths and the unmanaged
+     skeleton, then overwrites its *managed* paths and centrally owned CI
+     workflow,
   3. for managed-source repos, enables native Verso docstrings and carries the
      `lean_lib` build settings this monorepo's lakefile gives the library,
   4. copies the stable Lean toolchain and exact external dependency pins,
@@ -219,21 +221,137 @@ def managed_paths(entry: dict) -> list[tuple[Path, Path, bool]]:
     return out
 
 
-def removal_paths(entry: dict) -> list[Path]:
-    """Return validated released-repo paths explicitly scheduled for deletion."""
+# The Lake and repository skeleton a mirror owns and the sync deliberately does
+# not author: the root Lake project files, the repository's licence, ignore
+# rules and agent notes. `.git` and `.lake` are named so no walk can reach into
+# them. `.github/` is deliberately absent: only the managed
+# `.github/workflows/ci.yml` survives, so a mirror cannot accumulate a second
+# workflow beside the build-only one published from `released-ci.yml`.
+SKELETON = (
+    ".git",
+    ".gitignore",
+    ".lake",
+    "AGENTS.md",
+    "LICENSE",
+    "README.md",
+    "lake-manifest.json",
+    "lakefile.lean",
+    "lakefile.toml",
+    "lean-toolchain",
+)
+
+# The one path under `.github/` a mirror keeps, written by `apply_ci_workflow`
+# rather than by the managed-path copy.
+MANAGED_WORKFLOW = Path(".github") / "workflows" / "ci.yml"
+
+# Removed from every released repository, the `pins_only` aggregate included.
+# The aggregate is otherwise exempt from the sweep, because its umbrella module,
+# lakefile, `docs/` site and the workflow that publishes it live only there and
+# nothing here can tell them from an accident. Agent notes are the one thing no
+# released repository has any use for, so they are named rather than swept.
+NEVER_PUBLISHED = (".claude",)
+
+
+def keep_paths(entry: dict) -> list[Path]:
+    """Return validated mirror-local paths the sweep must leave alone.
+
+    The escape hatch for a file a mirror owns that is neither managed nor part
+    of the common skeleton, such as `hex-test-kit`'s fixed `HexTestKit.lean`
+    umbrella. It can only preserve, never delete, so a forgotten entry shows up
+    as a deletion in the dry run and a broken mirror build rather than as a
+    silently over-published repository.
+    """
     paths: list[Path] = []
-    for raw in entry.get("remove_paths") or []:
+    for raw in entry.get("keep_paths") or []:
         if not isinstance(raw, str):
-            raise ValueError("remove_paths entries must be strings")
+            raise ValueError("keep_paths entries must be strings")
         path = Path(raw)
         if path.is_absolute() or not path.parts or any(
             part in {".", ".."} for part in path.parts
         ):
-            raise ValueError(f"unsafe remove_paths entry: {raw!r}")
+            raise ValueError(f"unsafe keep_paths entry: {raw!r}")
         paths.append(path)
     if len(paths) != len(set(paths)):
-        raise ValueError("remove_paths contains duplicate entries")
+        raise ValueError("keep_paths contains duplicate entries")
     return paths
+
+
+def allowed_paths(entry: dict) -> tuple[set[Path], set[Path]]:
+    """Everything one mirror may contain, as (subtrees, files).
+
+    A path is allowed when it is one of these, or lies under one of the
+    subtrees. Computing the allowance from the entry, rather than enumerating
+    the leftovers to delete, is what makes "a mirror ships the library and
+    nothing else" a property of the tooling: a new entry inherits the whole
+    policy, and an entry can only widen its mirror by declaring the widening
+    here. `reports/` is not allowed wholesale: a mirror publishes exactly the
+    figures its manifest entry names, which arrive as managed files under it.
+    """
+    subtrees = {Path(name) for name in SKELETON}
+    subtrees.update(keep_paths(entry))
+    files = {MANAGED_WORKFLOW}
+    for _src, dest_rel, is_dir in managed_paths(entry):
+        (subtrees if is_dir else files).add(dest_rel)
+    return subtrees, files
+
+
+def prune_unmanaged(entry: dict, clone: Path) -> list[str]:
+    """Delete everything in a released clone outside `allowed_paths`.
+
+    Benchmarks, conformance drivers, fixtures, oracles and the sidecar Lake
+    projects that carried them are development instruments for the whole graph;
+    they live in this monorepo and never reach a mirror. So do the bench-result
+    ledgers and performance write-ups under `reports/`, the agent notes under
+    `.claude/`, and any workflow beside the managed build-only one. The sweep
+    enforces that by construction instead of by a per-entry list of things to
+    forget.
+
+    A `pins_only` aggregate is exempt from the sweep, since its umbrella module,
+    lakefile and documentation site live only in the released repository, but it
+    still loses everything in `NEVER_PUBLISHED`.
+    """
+    notes: list[str] = []
+    for name in NEVER_PUBLISHED:
+        target = clone / name
+        if target.is_symlink() or target.is_file():
+            target.unlink()
+        elif target.is_dir():
+            shutil.rmtree(target)
+        else:
+            continue
+        notes.append(f"  remove {name}")
+    if entry.get("pins_only"):
+        return notes
+    subtrees, files = allowed_paths(entry)
+    ancestors = {
+        parent
+        for path in subtrees | files
+        for parent in path.parents
+        if parent != Path(".")
+    }
+
+    def sweep(directory: Path) -> None:
+        for child in sorted(directory.iterdir()):
+            relative = child.relative_to(clone)
+            if relative in subtrees or relative in files:
+                continue
+            if (
+                relative in ancestors
+                and child.is_dir()
+                and not child.is_symlink()
+            ):
+                sweep(child)
+                continue
+            if child.is_symlink() or child.is_file():
+                child.unlink()
+            elif child.is_dir():
+                shutil.rmtree(child)
+            else:
+                continue
+            notes.append(f"  remove {relative}")
+
+    sweep(clone)
+    return notes
 
 
 def apply_paths(entry: dict, clone: Path) -> list[str]:
@@ -245,27 +363,10 @@ def apply_paths(entry: dict, clone: Path) -> list[str]:
         (clone / "README.md").write_text(rendered, encoding="utf-8")
         notes.append(f"  {template} + released.yml -> README.md (generated)")
     notes.append(apply_ci_workflow(entry, clone))
+    notes.extend(prune_unmanaged(entry, clone))
     if entry.get("pins_only"):
         return notes
     lib = entry["lib"]
-    clone_root = clone.resolve()
-    for dest_rel in removal_paths(entry):
-        dest = clone / dest_rel
-        resolved_parent = dest.parent.resolve()
-        if (
-            resolved_parent != clone_root
-            and clone_root not in resolved_parent.parents
-        ):
-            raise ValueError(
-                f"unsafe remove_paths destination escapes clone: {dest_rel}"
-            )
-        if dest.is_symlink() or dest.is_file():
-            dest.unlink()
-        elif dest.is_dir():
-            shutil.rmtree(dest)
-        else:
-            continue
-        notes.append(f"  remove {dest_rel}")
     for src, dest_rel, is_dir in managed_paths(entry):
         dest = clone / dest_rel
         if not src.exists():

--- a/scripts/release/test_check_released_manifest.py
+++ b/scripts/release/test_check_released_manifest.py
@@ -15,6 +15,7 @@ from types import SimpleNamespace
 from scripts.release.check_released_manifest import (
     check_build_settings,
     check_ci_workflows,
+    check_keep_paths,
     check_library_only,
     check_phase_admission,
     parse_sync_baseline,
@@ -34,6 +35,39 @@ class LibraryOnlyTests(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, "stay in hex-dev"):
                     check_library_only(
                         {"repo": "leanprover/hex-example", field: value}
+                    )
+
+    def test_remove_paths_is_retired(self) -> None:
+        with self.assertRaisesRegex(ValueError, "remove_paths is retired"):
+            check_library_only(
+                {"repo": "leanprover/hex-example", "remove_paths": ["bench"]}
+            )
+
+
+class KeepPathsTests(unittest.TestCase):
+    def test_mirror_local_file_is_accepted(self) -> None:
+        check_keep_paths(
+            {"repo": "leanprover/hex-test-kit", "keep_paths": ["HexTestKit.lean"]}
+        )
+
+    def test_unpublished_trees_are_rejected(self) -> None:
+        for path in ("bench", "conformance/HexExample",
+                     "conformance-fixtures", "scripts/oracle/example.py",
+                     "reports/hex-example-performance.md",
+                     "reports/figures/hex-example.svg",
+                     ".claude/CLAUDE.md", ".github/workflows/bench.yml"):
+            with self.subTest(path=path):
+                with self.assertRaisesRegex(ValueError, "stay in hex-dev"):
+                    check_keep_paths(
+                        {"repo": "leanprover/hex-example", "keep_paths": [path]}
+                    )
+
+    def test_skeleton_paths_are_rejected_as_redundant(self) -> None:
+        for path in ("LICENSE", "lean-toolchain"):
+            with self.subTest(path=path):
+                with self.assertRaisesRegex(ValueError, "unmanaged skeleton"):
+                    check_keep_paths(
+                        {"repo": "leanprover/hex-example", "keep_paths": [path]}
                     )
 
 

--- a/scripts/release/test_sync_released.py
+++ b/scripts/release/test_sync_released.py
@@ -41,43 +41,171 @@ class SyncReleasedTests(unittest.TestCase):
             (self.repo / "bench" / "lean-toolchain").read_text(), expected)
         self.assertEqual(len(notes), 2)
 
-    def test_apply_paths_removes_obsolete_released_path(self) -> None:
+    def _bridge_clone(self) -> Path:
+        """A mirror carrying the skeleton, its library, and stale extras."""
+        clone = self.repo / "clone"
+        (clone / "HexBridge").mkdir(parents=True)
+        (clone / "HexBridge" / "Basic.lean").write_text("--\n", encoding="utf-8")
+        for name in ("LICENSE", "AGENTS.md", ".gitignore", "README.md",
+                     "lakefile.toml", "lake-manifest.json", "lean-toolchain"):
+            (clone / name).write_text("skeleton\n", encoding="utf-8")
+        (clone / ".github" / "workflows").mkdir(parents=True)
+        (clone / ".github" / "workflows" / "ci.yml").write_text(
+            "name: CI\n", encoding="utf-8")
+        (clone / ".github" / "workflows" / "bench.yml").write_text(
+            "name: bench\n", encoding="utf-8")
+        (clone / ".github" / "dependabot.yml").write_text(
+            "version: 2\n", encoding="utf-8")
+        (clone / ".claude").mkdir()
+        (clone / ".claude" / "CLAUDE.md").write_text("notes\n", encoding="utf-8")
+        (clone / "reports" / "bench-results").mkdir(parents=True)
+        (clone / "reports" / "bench-results" / "run.json").write_text(
+            "{}\n", encoding="utf-8")
+        (clone / "reports" / "hex-bridge-performance.md").write_text(
+            "report\n", encoding="utf-8")
+        for stale in ("bench/HexBridge", "conformance/HexBridge",
+                      "conformance-fixtures/HexBridge", "scripts/oracle"):
+            (clone / stale).mkdir(parents=True)
+            (clone / stale / "file").write_text("stale\n", encoding="utf-8")
+        (clone / "conformance" / "lakefile.toml").write_text(
+            "name = \"conformance\"\n", encoding="utf-8")
+        (clone / "SPEC").mkdir()
+        (clone / "SPEC" / "hex-bridge.md").write_text("spec\n", encoding="utf-8")
+        (clone / "SPEC" / "obsolete.md").write_text("stale\n", encoding="utf-8")
+        return clone
+
+    def _bridge_entry(self) -> dict:
+        return {
+            "repo": "leanprover/hex-bridge",
+            "lib": "HexBridge",
+            "readme": False,
+            "umbrella": False,
+            "spec": "hex-bridge",
+        }
+
+    def test_prune_removes_everything_outside_the_allowance(self) -> None:
+        clone = self._bridge_clone()
         with tempfile.TemporaryDirectory() as source_directory:
             source = Path(source_directory)
-            (source / "HexBridge").mkdir()
-            clone = self.repo / "clone"
-            stale = clone / "conformance" / "HexBridge"
-            stale.mkdir(parents=True)
-            (stale / "Conformance.lean").write_text("stale\n", encoding="utf-8")
-            entry = {
-                "repo": "leanprover/hex-bridge",
-                "lib": "HexBridge",
-                "readme": False,
-                "umbrella": False,
-                "spec": None,
-                "remove_paths": ["conformance"],
-            }
-            workflows = self.repo / "released-ci.yml"
-            workflows.write_text(
-                "workflows:\n  hex-bridge: |\n    name: CI\n", encoding="utf-8"
-            )
-            with (
-                patch.object(sync_released, "REPO_ROOT", source),
-                patch.object(sync_released, "RELEASED_CI", workflows),
-            ):
-                notes = sync_released.apply_paths(entry, clone)
-            self.assertFalse((clone / "conformance").exists())
-            self.assertIn("  remove conformance", notes)
-            self.assertEqual(
-                (clone / ".github" / "workflows" / "ci.yml").read_text(),
-                "name: CI\n",
-            )
-            with (
-                patch.object(sync_released, "REPO_ROOT", source),
-                patch.object(sync_released, "RELEASED_CI", workflows),
-            ):
-                notes = sync_released.apply_paths(entry, clone)
-            self.assertNotIn("  remove conformance", notes)
+            with patch.object(sync_released, "REPO_ROOT", source):
+                notes = sync_released.prune_unmanaged(self._bridge_entry(), clone)
+        for gone in ("bench", "conformance", "conformance-fixtures", "scripts",
+                     "SPEC/obsolete.md", ".claude", "reports",
+                     ".github/workflows/bench.yml", ".github/dependabot.yml"):
+            self.assertFalse((clone / gone).exists(), gone)
+            self.assertIn(f"  remove {gone}", notes)
+        for kept in ("HexBridge/Basic.lean", "SPEC/hex-bridge.md", "LICENSE",
+                     "AGENTS.md", ".gitignore", "README.md", "lakefile.toml",
+                     "lake-manifest.json", "lean-toolchain",
+                     ".github/workflows/ci.yml"):
+            self.assertTrue((clone / kept).exists(), kept)
+
+    def test_prune_keeps_only_the_figures_the_entry_publishes(self) -> None:
+        """`reports/` goes, except the figures the manifest names."""
+        clone = self.repo / "clone"
+        (clone / "reports" / "figures").mkdir(parents=True)
+        (clone / "reports" / "figures" / "hex-bridge-scaling.svg").write_text(
+            "<svg/>", encoding="utf-8")
+        (clone / "reports" / "figures" / "stale.svg").write_text(
+            "<svg/>", encoding="utf-8")
+        (clone / "reports" / "bench-results").mkdir()
+        (clone / "reports" / "bench-results" / "run.json").write_text(
+            "{}\n", encoding="utf-8")
+        (clone / "reports" / "hex-bridge-performance.md").write_text(
+            "report\n", encoding="utf-8")
+        entry = dict(self._bridge_entry(), performance=True,
+                     figures=["hex-bridge-scaling.svg"])
+        with tempfile.TemporaryDirectory() as source_directory:
+            with patch.object(sync_released, "REPO_ROOT", Path(source_directory)):
+                notes = sync_released.prune_unmanaged(entry, clone)
+        self.assertTrue(
+            (clone / "reports" / "figures" / "hex-bridge-scaling.svg").is_file())
+        for gone in ("reports/figures/stale.svg", "reports/bench-results",
+                     "reports/hex-bridge-performance.md"):
+            self.assertFalse((clone / gone).exists(), gone)
+            self.assertIn(f"  remove {gone}", notes)
+
+    def test_prune_is_idempotent(self) -> None:
+        clone = self._bridge_clone()
+        entry = self._bridge_entry()
+        with tempfile.TemporaryDirectory() as source_directory:
+            source = Path(source_directory)
+            with patch.object(sync_released, "REPO_ROOT", source):
+                sync_released.prune_unmanaged(entry, clone)
+                self.assertEqual(sync_released.prune_unmanaged(entry, clone), [])
+
+    def test_prune_leaves_the_pins_only_aggregate_alone(self) -> None:
+        clone = self.repo / "clone"
+        (clone / "docs").mkdir(parents=True)
+        (clone / "docs" / "index.html").write_text("<p>", encoding="utf-8")
+        (clone / "Hex.lean").write_text("import HexBasic\n", encoding="utf-8")
+        (clone / ".github" / "workflows").mkdir(parents=True)
+        (clone / ".github" / "workflows" / "docs.yml").write_text(
+            "name: docs\n", encoding="utf-8")
+        (clone / ".claude").mkdir()
+        (clone / ".claude" / "CLAUDE.md").write_text("notes\n", encoding="utf-8")
+        entry = {"repo": "leanprover/hex", "pins_only": True}
+        self.assertEqual(
+            sync_released.prune_unmanaged(entry, clone), ["  remove .claude"])
+        self.assertFalse((clone / ".claude").exists())
+        self.assertTrue((clone / "Hex.lean").is_file())
+        self.assertTrue((clone / "docs" / "index.html").is_file())
+        self.assertTrue((clone / ".github" / "workflows" / "docs.yml").is_file())
+
+    def test_prune_honours_the_keep_paths_escape_hatch(self) -> None:
+        clone = self.repo / "clone"
+        clone.mkdir()
+        (clone / "HexTestKit.lean").write_text("import Hex\n", encoding="utf-8")
+        (clone / "Stale.lean").write_text("--\n", encoding="utf-8")
+        entry = {
+            "repo": "leanprover/hex-test-kit",
+            "lib": "Hex",
+            "readme": False,
+            "umbrella": False,
+            "spec": None,
+            "paths": [{"src": "Hex", "dest": "Hex"}],
+            "keep_paths": ["HexTestKit.lean"],
+        }
+        with tempfile.TemporaryDirectory() as source_directory:
+            with patch.object(sync_released, "REPO_ROOT", Path(source_directory)):
+                notes = sync_released.prune_unmanaged(entry, clone)
+        self.assertTrue((clone / "HexTestKit.lean").is_file())
+        self.assertEqual(notes, ["  remove Stale.lean"])
+
+    def test_every_manifest_entry_sweeps_development_instruments(self) -> None:
+        """The policy holds for every entry, including ones added later.
+
+        This is the regression the per-entry deletion list could not carry: an
+        entry admitted to the manifest without its own cleanup list published
+        the sidecars anyway.
+        """
+        document = yaml.safe_load(
+            sync_released.MANIFEST.read_text(encoding="utf-8"))
+        instruments = ("bench", "conformance", "conformance-fixtures",
+                       "scripts/oracle", "scripts/ci", "reports/bench-results",
+                       ".claude")
+        for entry in document["repos"]:
+            if entry.get("pins_only"):
+                continue
+            with self.subTest(repo=entry["repo"]):
+                clone = self.repo / "sweep" / entry["repo"].split("/")[-1]
+                for instrument in instruments:
+                    (clone / instrument).mkdir(parents=True)
+                    (clone / instrument / "file").write_text(
+                        "stale\n", encoding="utf-8")
+                (clone / "reports" / "performance.md").write_text(
+                    "report\n", encoding="utf-8")
+                workflows = clone / ".github" / "workflows"
+                workflows.mkdir(parents=True)
+                for name in ("ci.yml", "bench.yml"):
+                    (workflows / name).write_text("name: x\n", encoding="utf-8")
+                sync_released.prune_unmanaged(entry, clone)
+                for instrument in instruments:
+                    self.assertFalse((clone / instrument).exists(), instrument)
+                self.assertFalse((clone / "scripts").exists())
+                self.assertFalse((clone / "reports" / "performance.md").exists())
+                self.assertFalse((workflows / "bench.yml").exists())
+                self.assertTrue((workflows / "ci.yml").is_file())
 
     def test_apply_paths_copies_explicit_supporting_file(self) -> None:
         with tempfile.TemporaryDirectory() as source_directory:
@@ -112,44 +240,28 @@ class SyncReleasedTests(unittest.TestCase):
                 "print('checked')\n",
             )
 
-    def test_apply_paths_rejects_symlinked_removal_parent(self) -> None:
+    def test_prune_unlinks_a_symlink_without_following_it(self) -> None:
+        clone = self.repo / "clone"
+        clone.mkdir()
+        outside = self.repo / "outside"
+        outside.mkdir()
+        (outside / "kept").write_text("keep\n", encoding="utf-8")
+        (clone / "linked").symlink_to(outside, target_is_directory=True)
         with tempfile.TemporaryDirectory() as source_directory:
             source = Path(source_directory)
             (source / "HexBridge").mkdir()
-            clone = self.repo / "clone"
-            clone.mkdir()
-            outside = self.repo / "outside"
-            outside.mkdir()
-            (outside / "kept").write_text("keep\n", encoding="utf-8")
-            (clone / "linked").symlink_to(outside, target_is_directory=True)
-            entry = {
-                "repo": "leanprover/hex-bridge",
-                "lib": "HexBridge",
-                "readme": False,
-                "umbrella": False,
-                "spec": None,
-                "remove_paths": ["linked/kept"],
-            }
-            workflows = self.repo / "released-ci.yml"
-            workflows.write_text(
-                "workflows:\n  hex-bridge: |\n    name: CI\n", encoding="utf-8"
-            )
-            with (
-                patch.object(sync_released, "REPO_ROOT", source),
-                patch.object(sync_released, "RELEASED_CI", workflows),
-                self.assertRaisesRegex(
-                    ValueError, "unsafe remove_paths destination escapes clone"
-                ),
-            ):
-                sync_released.apply_paths(entry, clone)
-            self.assertEqual((outside / "kept").read_text(), "keep\n")
+            with patch.object(sync_released, "REPO_ROOT", source):
+                notes = sync_released.prune_unmanaged(self._bridge_entry(), clone)
+        self.assertEqual(notes, ["  remove linked"])
+        self.assertFalse((clone / "linked").exists())
+        self.assertEqual((outside / "kept").read_text(), "keep\n")
 
-    def test_removal_paths_rejects_unsafe_destinations(self) -> None:
+    def test_keep_paths_rejects_unsafe_destinations(self) -> None:
         for path in (".", "..", "../outside", "/absolute"):
             with self.subTest(path=path), self.assertRaisesRegex(
-                ValueError, "unsafe remove_paths entry"
+                ValueError, "unsafe keep_paths entry"
             ):
-                sync_released.removal_paths({"remove_paths": [path]})
+                sync_released.keep_paths({"keep_paths": [path]})
 
     def test_released_ci_workflow_requires_complete_text_mapping(self) -> None:
         source = self.repo / "released-ci.yml"


### PR DESCRIPTION
This PR derives each released mirror's allowance from its manifest entry -- the managed paths plus the skeleton the sync does not author -- and deletes everything else, so "a released repo ships the library and nothing else" holds for an entry admitted tomorrow without anyone remembering a cleanup list. `remove_paths` is retired; `keep_paths` replaces it as an escape hatch that can only preserve.

The allowance is narrow in three further places. `.github/` is no longer a skeleton subtree: only the `workflows/ci.yml` published from `released-ci.yml` survives, so a mirror cannot accumulate a second workflow beside its build-only one. `reports/` is not allowed wholesale either, so a mirror publishes exactly the figures and performance page its entry names. And `.claude/` is deleted by name from every entry, the `pins_only` aggregate included: agent notes are the one thing no released repository has a use for, and the aggregate is otherwise exempt because its umbrella module, lakefile and documentation site live only there.

Against the currently published set the dry run removes `.claude/` from hex-poly, hex-mv-poly, hex-poly-mathlib, hex-mv-poly-mathlib and the `leanprover/hex` aggregate, and `conformance/` from hex-graph-iso. No mirror carries an unmanaged `reports/` tree or a second workflow today.

🤖 Prepared with Claude Code