### PR TITLE
docs(graph-iso): content-only docstrings for the correctness proof

### DIFF
--- a/HexGraphIso/Nauty/Correct/Base.lean
+++ b/HexGraphIso/Nauty/Correct/Base.lean
@@ -19,6 +19,11 @@ These lemmas keep node fuel and child-loop fuel visibly separate.  In
 particular, loop-fuel exhaustion is represented by `LoopResult.exhausted`,
 whereas reaching the end cursor with positive fuel is a genuine completed
 sweep.
+
+The lemmas here are stated against the outcome types of
+`Correct.Outcome`.  `Correct.Unwind.Located` and the node and loop
+modules that follow it use them wherever the induction reaches a leaf, a
+zero-fuel call, or an empty child sweep.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -468,8 +473,8 @@ theorem incKey_max_nonempty {ctx : Ctx n} {bs cs bs' : List Nat}
     exact hcs (List.length_eq_zero_iff.mp (by omega))
 
 /-- The faithful off-path leaf event can be read through `stInc` even in
-the row-rejection arm, where `compCanon` is deliberately reused as a row
-comparison result. -/
+the row-rejection arm, where `compCanon` holds a row comparison result
+rather than a canonical one. -/
 theorem processnode_leaf_read {nn : Nat} {ctx : Ctx n}
     {cs bs : List Nat} {numcells : Nat} {st : SearchSt n}
     (hcinv : CodeCmpInv nn cs bs st.canoncode st.canonlevel
@@ -947,8 +952,8 @@ theorem otherNode_leaf_firstFail {ctx : Ctx n}
 
 /-- An early non-first-path leaf return has already absorbed its whole
 (singleton) specification subtree.  Its signed comparison return is a
-local prune outcome; generator returns can subsequently be strengthened to
-`unwind` by the carrier/guide layer. -/
+local prune outcome.  The carrier and guide lemmas strengthen a generator
+return to `unwind`. -/
 theorem otherNode_leaf_pruned {ctx : Ctx n} {nn inf tcLevel specFuel fuel
     level numcells : Nat} {cs bs : List Nat} {st : SearchSt n}
     (hlevel : level = cs.length + 1) (hlevelN : level ≤ nn)

--- a/HexGraphIso/Nauty/Correct/Certify.lean
+++ b/HexGraphIso/Nauty/Correct/Certify.lean
@@ -17,10 +17,15 @@ public section
 Totality of the certified canonicalization.
 
 The root instance of first-path totality identifies the unpruned
-specification key with the key the transcription installs; the
-certificate check then succeeds, `certifyCanon` is the resulting total
+specification key with the key the transcription installs.  The
+certificate check then succeeds.  `certifyCanon` is the resulting total
 certificate-checked canonical form, and `searchResult?` is total because
 it agrees with it.
+
+This module builds on `Correct.OffPath.Node` and `Correct.FirstPath.Sweep`,
+whose two totality steps it combines.  It is the last module of
+`HexGraphIso.Nauty.Correct`, and `HexGraphIso.Ops` exposes `certifyCanon`
+from here.
 -/
 
 /-!
@@ -36,9 +41,9 @@ namespace Hex.GraphIso.Nauty
 
 variable {n k : Nat}
 
-/-- The corrected first-path root result proves equality between the
-unpruned specification key and the key installed by the transcription,
-whatever event trail the run reports. -/
+/-- The first-path root result proves equality between the unpruned
+specification key and the key installed by the transcription, whatever
+event trail the run reports. -/
 theorem keyEq_of_firstRun {G : Colored n k} (hn0 : n ≠ 0)
     {fs : List Nat} {best : Option (Key n)} {eventTrail : FrameTrail}
     (hroot : FirstRun G { g := rowsOf G } 100 n (n + 2) 1 [] fs
@@ -160,10 +165,10 @@ theorem certifyCanon?_isSome_zero (G : Colored 0 k) :
 end Hex.GraphIso.Nauty
 
 /-!
-Totality of the certified canonicalization.
+The certified canonical form.
 
 The two node statements are proved together by induction on the
-executable recursion fuel; the root instance identifies the specification
+executable recursion fuel.  The root instance identifies the specification
 key with the traced key, and the certificate check then succeeds.
 `certifyCanon` is the resulting total, certificate-checked canonical
 form, and the transcription `searchResult?` is total because it agrees

--- a/HexGraphIso/Nauty/Correct/Exit/Classify.lean
+++ b/HexGraphIso/Nauty/Correct/Exit/Classify.lean
@@ -15,12 +15,16 @@ public section
 Comparison-prune producers and the classification of why a node
 returned early.
 
-Local exactness and the reason for an early return are deliberately
-separate: a comparison-frozen or cheap-cell child may be exact at its own
-node while still causing its parent loop to skip a suffix.
+Local exactness and the reason for an early return are separate: a
+comparison-frozen or cheap-cell child may be exact at its own node while
+still causing its parent loop to skip a suffix.
+
+This module builds on `Correct.Exit.Final`.  `Correct.Sweep.Base` and
+`Correct.Sweep.Carry` carry `NodeRun`, `LoopRun`, and the exit types
+defined here through the sibling-sweep induction.
 -/
 
-/-! Comparison-prune producers for the corrected search outcomes. -/
+/-! Comparison-prune producers for the search outcomes. -/
 
 namespace Hex.GraphIso.Nauty
 
@@ -36,17 +40,17 @@ shape or parks the boundary at the child. -/
 
 namespace CheapDesc
 
-/-- A boundary created at the current node has no strict descendant
-obligation yet. -/
+/-- A boundary created at the current node imposes no condition on its
+strict descendants yet. -/
 theorem same (ctx : Ctx n) (level : Nat) (st : RefineSt n) :
     CheapDesc ctx level level st := by
   intro h
   omega
 
 /-- At an entered sibling sweep, a saved boundary at or above the current
-node supplies the small-cell subtree fact.  A strictly older boundary uses
-the inherited descent invariant; equality is exactly the case in which the
-current cheap-cell guard must have succeeded. -/
+node supplies the small-cell subtree fact.  A strictly shallower boundary
+uses the inherited descent invariant.  Equality is exactly the case in
+which the current cheap-cell guard must have succeeded. -/
 theorem atLevel {ctx : Ctx n} {level boundary : Nat} {st : RefineSt n}
     (h : CheapDesc ctx level boundary st)
     (hit : IterOk ctx level st) (heq : Equitable ctx level st.lab st.ptn)
@@ -217,12 +221,12 @@ end RunPrep
 end Hex.GraphIso.Nauty
 
 /-!
-Return classifications for the corrected mutual search induction.
+Return classifications for the mutual search induction.
 
-Local exactness and the reason for an early return are deliberately
-separate.  A comparison-frozen or cheap-cell child may be exact at its own
-node while still causing its parent loop to skip a suffix; the extra
-payload is what justifies that skipped suffix.
+Local exactness and the reason for an early return are separate.  A
+comparison-frozen or cheap-cell child may be exact at its own node while
+still causing its parent loop to skip a suffix.  The extra payload is what
+justifies that skipped suffix.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -298,9 +302,9 @@ theorem trans {level : Nat} {a b c : SearchSt n}
 
 end GuideRel
 
-/-- Result of one node call.  `done` is the ordinary one-level return;
+/-- Result of one node call.  `done` is the ordinary one-level return.
 `frozen` and `cheap` retain the distinct witnesses needed when the return
-crosses more than one loop; `unwind` is reserved for stored generators. -/
+crosses more than one loop, and `unwind` carries a stored generator. -/
 inductive NodeExit (ctx : Ctx n) (tcLevel specFuel runFuel level : Nat)
     (codes : List Nat) (st out : SearchSt n) (numcells : Nat)
     (best outBest : Option (Key n)) (trail : FrameTrail) (r : Int) : Prop where
@@ -410,8 +414,8 @@ theorem below {ctx : Ctx n} {tcLevel specFuel runFuel level numcells : Nat}
       rw [returned]
       exact Int.natCast_pos.mpr hlevel
 
-/-- The final first-path counter adjustment preserves every corrected node
-exit, including the payload of a located unwind. -/
+/-- The final first-path counter adjustment preserves every node exit,
+including the payload of a located unwind. -/
 theorem firstFinish {ctx : Ctx n}
     {tcLevel specFuel runFuel level numcells size index : Nat}
     {codes : List Nat} {st out : SearchSt n} {best outBest : Option (Key n)}
@@ -481,7 +485,7 @@ inductive LoopExit (ctx : Ctx n) (tcLevel specFuel runFuel loopFuel level : Nat)
       (progress : cursorRank cursor + loopFuel ≤ cursorRank finalCursor)
       (bounded : ∀ v, finalCursor = some v → v < n)
 
-/-- Concrete node result paired with the corrected return classification.
+/-- Concrete node result paired with its return classification.
 The event and trail clauses are independent of the semantic maximum and
 remain reusable from the established leaf machinery. -/
 structure NodeRun (G : Colored n k) (ctx : Ctx n)
@@ -511,9 +515,9 @@ structure OtherRun (G : Colored n k) (ctx : Ctx n)
       (level ≤ out.gcaCanon ∧ cellsPerm st.ptn level st.lab out.canonlab)
   coset : out.cosetindex = st.cosetindex
 
-/-- A sibling-loop proof paired with its corrected exit reason.  The
-established proof retains coverage, event, and recovery facts; `exit`
-separately records why an unfinished suffix is nevertheless absorbed. -/
+/-- A sibling-loop proof paired with its exit reason.  The established
+proof retains coverage, event, and recovery facts.  `exit` separately
+records why an unfinished suffix is nevertheless absorbed. -/
 structure LoopRun (G : Colored n k) (ctx : Ctx n)
     (tcLevel specFuel runFuel loopFuel level : Nat)
     (stem codes fs : List Nat) (rsLab rsPtn : Array Nat)
@@ -546,7 +550,7 @@ structure OtherLoopRun (G : Colored n k) (ctx : Ctx n)
     r = some value ∧ ShortSource G ctx out eventTrail value
 
 /-- The first-path sibling sweep retains both reference histories in its
-established proof and the corrected reason for abandoning any suffix. -/
+established proof, together with the reason for abandoning any suffix. -/
 structure FirstLoopRun (G : Colored n k) (ctx : Ctx n)
     (tcLevel specFuel runFuel loopFuel level : Nat)
     (stem codes fs : List Nat) (rsLab rsPtn : Array Nat)
@@ -564,11 +568,10 @@ structure FirstLoopRun (G : Colored n k) (ctx : Ctx n)
 
 namespace NodeRun
 
-/-- A corrected node run can be viewed through the older local outcome
-interface.  This conversion is safe at one node: both early exit variants
-already carry exactness for that node.  What is deliberately not recovered
-is the old loop rule that treated such an exit as coverage of every later
-sibling. -/
+/-- A node run can be viewed through the local outcome interface.  The
+conversion holds at a single node, where both early exit variants already
+carry exactness.  It says nothing about the enclosing loop: an early exit
+is not coverage of the later siblings. -/
 theorem toOutcome {G : Colored n k} {ctx : Ctx n}
     {tcLevel specFuel runFuel level numcells : Nat} {codes fs : List Nat}
     {st out : SearchSt n} {best outBest : Option (Key n)}
@@ -605,7 +608,7 @@ theorem toOutcome {G : Colored n k} {ctx : Ctx n}
   exact ⟨hreceipt, h.event, h.preserved⟩
 
 /-- Restore the established result interface used by the invariant
-transport lemmas after the corrected exit has been classified. -/
+transport lemmas after the exit has been classified. -/
 theorem toProof {G : Colored n k} {ctx : Ctx n}
     {tcLevel specFuel runFuel level numcells : Nat} {codes fs : List Nat}
     {st out : SearchSt n} {best outBest : Option (Key n)}
@@ -882,9 +885,9 @@ end RunPrep
 
 namespace NodeInv
 
-/-- A negative, non-generator discrete leaf produces the corrected exit:
-ordinary comparison pruning retains its frozen prefix, while the only
-remaining return is the explicit cheap-cell jump. -/
+/-- A negative, non-generator discrete leaf produces its exit
+classification: ordinary comparison pruning retains its frozen prefix, and
+the other return is the explicit cheap-cell jump. -/
 theorem negativeLeaf {G : Colored n k} {ctx : Ctx n}
     {inf tcLevel specFuel fuel level numcells : Nat}
     {codes bs fs : List Nat} {st : SearchSt n} {best : Option (Key n)}

--- a/HexGraphIso/Nauty/Correct/Exit/Final.lean
+++ b/HexGraphIso/Nauty/Correct/Exit/Final.lean
@@ -12,13 +12,19 @@ import all HexGraphIso.Nauty.Search.Search
 public section
 
 /-!
-The final corrected mutual induction for the transcribed search.
+The mutual induction for the transcribed search, coupled to its frame
+equations.
 
 The semantic outcomes distinguish completed subtrees, located unwinds,
-comparison prunes, and exhausted runtime fuel.  This file couples those
+comparison prunes, and exhausted runtime fuel.  This module couples those
 outcomes to the one extra executable frame fact needed by the induction:
 every recursive node call restores the fixed-point bitset with which it
-was entered.
+was entered.  It also records the two unconditional leaf histories
+`FirstTrail` and `CanonTrail` and the frozen comparison verdict
+`FrozenOut`.
+
+This module builds on `Correct.RunInv.Coset`.  `Correct.Exit.Classify`
+classifies the exits of the node and loop proofs defined here.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -26,9 +32,9 @@ namespace Hex.GraphIso.Nauty
 variable {n k : Nat}
 
 /-- At a loop boundary, an implicit small-cell pair is available even
-when `noncheaplevel` is exactly the loop level.  `CheapOk` deliberately
-omits this equality case at general node entries; the loop guards restore
-it before beginning a sibling sweep. -/
+when `noncheaplevel` is exactly the loop level.  `CheapOk` omits this
+equality case at general node entries.  The loop guards restore it before
+beginning a sibling sweep. -/
 @[expose] def BoundaryOk (G : Colored n k) (ctx : Ctx n)
     (level : Nat) (st : SearchSt n) : Prop :=
   st.noncheaplevel = level →
@@ -40,7 +46,7 @@ it before beginning a sibling sweep. -/
 
 namespace BoundaryOk
 
-/-- Parking strictly past a loop makes its equality obligation vacuous. -/
+/-- Parking strictly past a loop makes its equality case vacuous. -/
 theorem parked {G : Colored n k} {ctx : Ctx n} {level : Nat}
     {st : SearchSt n} :
     BoundaryOk G ctx level { st with noncheaplevel := level + 1 } := by
@@ -294,8 +300,8 @@ structure OtherLoopProof (G : Colored n k) (ctx : Ctx n)
   coset : out.cosetindex = st.cosetindex
 
 /-- The first leaf remembers every child selected on the unique initial
-descent.  Unlike `RefTrail.first`, this history is deliberately independent
-of the mutable `gcaFirst` return control: outer first-path loops reset that
+descent.  Unlike `RefTrail.first`, this history is independent of the
+mutable `gcaFirst` return control: outer first-path loops reset that
 control while the leaf remains a descendant of all their frozen frames. -/
 structure FirstTrail (ctx : Ctx n) (current : Nat) (st : SearchSt n)
     (trail : FrameTrail) : Prop where
@@ -312,7 +318,7 @@ structure FirstTrail (ctx : Ctx n) (current : Nat) (st : SearchSt n)
 /-- Before the enclosing first-path node returns, its canonical reference
 also remains inside every strictly older guiding child.  The current loop
 frame is excluded because later siblings may replace the canonical child
-there; `FrameRefs` owns that changing boundary. -/
+there.  `FrameRefs` states what holds at that changing boundary. -/
 structure CanonTrail (ctx : Ctx n) (current : Nat) (st : SearchSt n)
     (trail : FrameTrail) : Prop where
   reach : ∀ target entry, target < current →
@@ -425,10 +431,10 @@ theorem exactLoop {ctx : Ctx n} {stem : List Nat} {out : SearchSt n}
 
 end FrozenOut
 
-/-- What a first-path node may export.  A locally absorbed/pruned node
-exports its exact maximum; a genuine generator unwind directly names the
-first or canonical reference child.  The orbit-pointer arm is resolved by
-`firstChildLoop` and is intentionally absent. -/
+/-- What a first-path node may export.  A locally absorbed or pruned node
+exports its exact maximum, and a genuine generator unwind directly names
+the first or canonical reference child.  The orbit-pointer arm is resolved
+by `firstChildLoop` and does not appear here. -/
 inductive NodeEscape (ctx : Ctx n) (tcLevel specFuel level : Nat)
     (cs : List Nat) (st out : SearchSt n) (numcells : Nat)
     (best outBest : Option (Key n)) (trail : FrameTrail) (r : Int) : Prop where
@@ -444,8 +450,8 @@ inductive NodeEscape (ctx : Ctx n) (tcLevel specFuel level : Nat)
       (located : anchor.Located trail)
 
 /-- The corresponding first-path loop exit.  Fuel-exhausted intermediate
-tails may still return `none`; sufficient outer cursor fuel later rules
-that arm out. -/
+tails may still return `none`, and sufficient outer cursor fuel rules that
+arm out. -/
 inductive LoopEscape (ctx : Ctx n) (tcLevel level : Nat) (bound : Key n)
     (out : SearchSt n) (best outBest : Option (Key n)) (trail : FrameTrail)
     (r : Option Int) : Prop where
@@ -1563,7 +1569,7 @@ theorem recoverRefs {G : Colored n k} {ctx : Ctx n}
 
 /-- Cleanup, first-control installation, and recovery change neither leaf
 reference.  The first trail therefore keeps the current frozen frame,
-while the canonical trail can be lowered to the older frames owned by the
+while the canonical trail can be lowered to the shallower frames of the
 enclosing first-path node. -/
 theorem recoverTrails {G : Colored n k} {ctx : Ctx n}
     {tcLevel specFuel runFuel level numcells tv1 inf : Nat} {fixedpts : VSet n}

--- a/HexGraphIso/Nauty/Correct/FirstPath/Hyp.lean
+++ b/HexGraphIso/Nauty/Correct/FirstPath/Hyp.lean
@@ -15,6 +15,9 @@ public section
 The first-path sibling sweep, part two: the hypotheses carried through the
 sweep after its guiding child has been absorbed, and their transport across
 an off-path child that stays at the loop level.
+
+This module builds on `Correct.FirstPath.Loop`.  `Correct.FirstPath.Sweep`
+runs the cursor-fuel induction over `FirstSweepHyp`.
 -/
 
 namespace Hex.GraphIso.Nauty

--- a/HexGraphIso/Nauty/Correct/FirstPath/Loop.lean
+++ b/HexGraphIso/Nauty/Correct/FirstPath/Loop.lean
@@ -17,9 +17,13 @@ iteration of `firstChildLoop`, the packaged sweep result `FirstSweepRun`,
 and the constructors for early exits and for continuing after a child.
 
 `FirstSweepRun` keeps the first leaf's history only below the loop level.
-The library's `FirstLoopRun` additionally pins the frame entry at the loop
-level to the guiding child, which an off-path child's event trail
-contradicts, so that package is not used here.
+`FirstLoopRun` additionally fixes the frame entry at the loop level to the
+guiding child.  An off-path child's event trail contradicts that, so this
+sweep carries `FirstSweepRun` instead.
+
+This module builds on `Correct.OffPath.Loop`.  `Correct.FirstPath.Hyp`
+carries the hypotheses of these iteration lemmas through the rest of the
+sweep.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -171,8 +175,8 @@ theorem firstChildLoop_stayGuide (ctx : Ctx n)
 /-! # The sweep package -/
 
 /-- A first-path sibling sweep result: the established loop proof, the
-corrected exit classification, the one-shot short-prune provenance, and
-the first-leaf and canonical histories strictly below the loop level. -/
+exit classification, the one-shot short-prune provenance, and the
+first-leaf and canonical histories strictly below the loop level. -/
 structure FirstSweepRun (G : Colored n k) (ctx : Ctx n)
     (tcLevel specFuel runFuel loopFuel level : Nat)
     (stem codes fs : List Nat) (rsLab rsPtn : Array Nat)

--- a/HexGraphIso/Nauty/Correct/FirstPath/Sweep.lean
+++ b/HexGraphIso/Nauty/Correct/FirstPath/Sweep.lean
@@ -15,10 +15,13 @@ public section
 The cursor-fuel induction that finishes the first-path sibling sweep,
 and the first-path node step of the totality induction.
 
-The guiding child is absorbed first and the sweep converted back to its
-enclosing node; the node's discrete arm installs the first leaf and its
-internal arm runs the sweep, each carrying the facts the enclosing sweep
-needs.
+The guiding child is absorbed first, and the sweep is then converted back
+to its enclosing node.  The node's discrete arm installs the first leaf
+and its internal arm runs the sweep, each carrying the facts the enclosing
+sweep needs.
+
+This module builds on `Correct.FirstPath.Hyp`.  `Correct.Certify` uses
+`FirstTotal.succ` as the first-path half of the totality induction.
 -/
 
 /-!

--- a/HexGraphIso/Nauty/Correct/Frames.lean
+++ b/HexGraphIso/Nauty/Correct/Frames.lean
@@ -19,6 +19,10 @@ The two frame invariants of the search induction.
 installs the first leaf and the comparison, leaf and guide ledgers exist.
 `LoopInv` freezes the refined frame used by the specification and relates
 every later state of a mutable child sweep to it by vertex membership.
+
+This module builds on `Correct.State.Ledger` and the located guides of
+`Correct.Unwind.Located`.  `Correct.RunInv.History` and every node module
+after it carry one of these two frame invariants.
 -/
 
 /-!
@@ -663,7 +667,7 @@ theorem SearchOut.recoverOk {G : Colored n k}
     · exact hle
 
 /-- Invariant of one imperative child loop.  `base` is the refined state
-whose labelling and partition were frozen for `specNode`; `st` is the
+whose labelling and partition were frozen for `specNode`.  `st` is the
 current recovered state after zero or more children and pruning steps. -/
 structure LoopInv (G : Colored n k) (ctx : Ctx n)
     (tcLevel specFuel level : Nat) (codes bs fs : List Nat)
@@ -892,9 +896,9 @@ theorem nextOffsets {G : Colored n k} {ctx : Ctx n}
     hatCurrent⟩
 
 /-- Every vertex returned by a verified sibling sweep lies in the graph
-vertex range.  This is the cursor bound threaded by the fuel induction;
-it is intentionally derived from the frozen target-cell membership rather
-than from the mutable bitset alone. -/
+vertex range.  This is the cursor bound used by the fuel induction, and
+it is derived from the frozen target-cell membership rather than from the
+mutable bitset alone. -/
 theorem nextLt {G : Colored n k} {ctx : Ctx n}
     {tcLevel specFuel level numcells tc len : Nat} {tcell : VSet n} {tv : Nat}
     {codes bs fs : List Nat} {rsLab rsPtn : Array Nat}

--- a/HexGraphIso/Nauty/Correct/OffPath/Loop.lean
+++ b/HexGraphIso/Nauty/Correct/OffPath/Loop.lean
@@ -18,8 +18,12 @@ One off-path sibling sweep and the off-path leaves it reaches.
 The sweep is total by induction on its cursor fuel, assuming totality of
 every off-path child at the current recursion fuel.  The leaves split
 into those that never enter the first-path admission test, those admitted
-by it, and those it rejects; the last are transported from the twin state
-whose first-path agreement depth is zero.
+by it, and those it rejects.  The rejected leaves are transported from the
+twin state whose first-path agreement depth is zero.
+
+This module builds on `Correct.Sweep.Node`.  `Correct.OffPath.Node` uses
+the sweep induction proved here, and `Correct.FirstPath.Loop` reuses its
+leaf runs on the first path.
 -/
 
 /-!
@@ -739,12 +743,12 @@ end Hex.GraphIso.Nauty
 
 /-!
 Packaged runs for the off-path leaves that do not enter the first-path
-admission gate.
+admission test.
 
 The comparison arms of `processnode` at a discrete off-path leaf are the
 frozen-downward prune, the row tie, and the install or rejection of the
-leaf against the incumbent.  The first two already have corrected runs;
-the install and rejection arms return to the saved cheap-cell boundary and
+leaf against the incumbent.  The first two already have packaged runs.
+The install and rejection arms return to the saved cheap-cell boundary and
 are classified here as cheap exits.  The admitted first-path-agreeing leaf
 is packaged as well, with the nonpositive comparison it needs derived from
 domination of the first leaf by the incumbent.
@@ -1072,7 +1076,7 @@ theorem OtherRun.leafKeep {G : Colored n k} {ctx : Ctx n}
   · intro _
     rw [processnode_noncheaplevel', hf9]
 
-/-- Every off-path leaf outside the first-path admission gate is a
+/-- Every off-path leaf outside the first-path admission test is a
 packaged run that keeps its node's carried facts. -/
 theorem NodeInv.leafOther {G : Colored n k} {ctx : Ctx n}
     {inf tcLevel specFuel fuel level numcells : Nat}
@@ -1196,7 +1200,7 @@ theorem NodeInv.leafOther {G : Colored n k} {ctx : Ctx n}
     exact ⟨outBest, hrun, hrun.leafKeep hnum hearly hsound⟩
 
 /-- The admitted first-path-agreeing leaf is a packaged run that keeps its
-node's carried facts; domination of the first leaf rules out a comparison
+node's carried facts.  Domination of the first leaf rules out a comparison
 above the incumbent. -/
 theorem NodeInv.leafFirstOther {G : Colored n k} {ctx : Ctx n}
     {inf tcLevel specFuel fuel level numcells : Nat}
@@ -1268,14 +1272,14 @@ theorem NodeInv.leafFirstOther {G : Colored n k} {ctx : Ctx n}
 end Hex.GraphIso.Nauty
 
 /-!
-Off-path leaves whose first-path admission gate fails.
+Off-path leaves that fail the first-path admission test.
 
 A leaf whose codes agree with the first path through its own level, but
 whose stored first code is not the sentinel or whose first-leaf
 relabelling is not an automorphism, runs the ordinary comparison arm of
-`processnode`.  The corrected leaf lemmas are stated for leaves off the
-first path, so this file transports their conclusions from the twin state
-whose first-path agreement depth is zero: the two runs differ only in the
+`processnode`.  The leaf lemmas are stated for leaves off the first path,
+so this section transports their conclusions from the twin state whose
+first-path agreement depth is zero: the two runs differ only in the
 initial workspace permutation, which the canonical scatter overwrites, and
 in the recorded agreement depth itself.
 -/
@@ -1313,11 +1317,11 @@ private theorem firstScatter_fold (n : Nat) (flab lab : Array Nat) :
     (List.range n).foldl (fun w i => w.set! flab[i]! lab[i]!)
       (Array.replicate n 0) = firstScatter n flab lab := rfl
 
-/-! # The comparison arm at a gate-failing leaf -/
+/-! # The comparison arm at a leaf that fails admission -/
 
 set_option maxHeartbeats 4000000 in
-/-- Failing the admission gate runs exactly the comparison arm of the
-twin state with agreement depth zero; only the recorded depth differs. -/
+/-- Failing the admission test runs exactly the comparison arm of the
+twin state with agreement depth zero.  Only the recorded depth differs. -/
 theorem processnode_gateFail_state {ctx : Ctx n} {level numcells : Nat}
     {st : SearchSt n}
     (hcanonSize : st.canonlab.size = n)
@@ -1432,8 +1436,8 @@ theorem leafFinish_setEqlev (level e : Nat) (st : SearchSt n) :
   dsimp only
   split <;> split <;> rfl
 
-/-- A gate-failing off-path leaf runs as its twin with the recorded
-agreement depth restored. -/
+/-- An off-path leaf that fails admission runs as its twin with the
+recorded agreement depth restored. -/
 theorem otherNode_gateFail_state (ctx : Ctx n)
     (inf tcLevel fuel level numcells : Nat) (st : SearchSt n)
     (hlevel : 2 ≤ level)
@@ -1600,7 +1604,7 @@ theorem NodeSound.setEqlev {ctx : Ctx n} {tcLevel specFuel level numcells : Nat}
   have := h.upper b hb
   rwa [hkey] at this
 
-/-- The corrected exit classification transports from the twin. -/
+/-- The exit classification transports from the twin. -/
 theorem NodeExit.setEqlev {ctx : Ctx n}
     {tcLevel specFuel runFuel level numcells e : Nat} {codes : List Nat}
     {st out : SearchSt n} {best outBest : Option (Key n)} {trail : FrameTrail}
@@ -1627,10 +1631,10 @@ theorem NodeExit.setEqlev {ctx : Ctx n}
   | exhausted returned state incumbent emptyFuel =>
       exact (hfuel emptyFuel).elim
 
-/-! # The gate-failing leaf -/
+/-! # The leaf that fails admission -/
 
 set_option maxHeartbeats 800000 in
-/-- The corrected off-path result of a gate-failing leaf follows from the
+/-- The off-path result of a leaf that fails admission follows from the
 result of its twin.  The event package is rebuilt directly from the leaf
 comparison, because the twin's event only records agreement depth zero. -/
 theorem OtherRun.ofGateFail {G : Colored n k} {ctx : Ctx n}

--- a/HexGraphIso/Nauty/Correct/OffPath/Node.lean
+++ b/HexGraphIso/Nauty/Correct/OffPath/Node.lean
@@ -17,19 +17,23 @@ the totality induction.
 
 Such a node either exits at once, sweeps the specification's target cell,
 or, when the path is frozen below the incumbent but still agrees with the
-first path, sweeps the first path's hinted target cell; the hinted sweep
+first path, sweeps the first path's hinted target cell.  The hinted sweep
 does not compute the node key, so its loop bound is converted through the
 common incumbent that dominates both.
+
+This module builds on `Correct.OffPath.Loop`.  `Correct.Certify` uses
+`OtherTotal.succ` as the off-path half of the totality induction.
 -/
 
 /-!
 Totality of one off-path internal node, assembled from the totality of
 its sibling sweep.
 
-An off-path internal node either exits at once (the frozen gate and the
-hinted target-cell mismatch), sweeps the specification's target cell, or,
-when the path is frozen below the incumbent but still agrees with the
-first path, sweeps the first path's hinted target cell.  The hinted sweep
+An off-path internal node either exits at once (the broken first-path
+agreement and the hinted target-cell mismatch), sweeps the
+specification's target cell, or, when the path is frozen below the
+incumbent but still agrees with the first path, sweeps the first path's
+hinted target cell.  The hinted sweep
 does not compute the node key, so its loop bound is converted through the
 common incumbent that dominates both.
 -/

--- a/HexGraphIso/Nauty/Correct/Outcome.lean
+++ b/HexGraphIso/Nauty/Correct/Outcome.lean
@@ -16,7 +16,7 @@ import HexGraphIso.Nauty.Invariant.Closure
 public section
 
 /-!
-Outcome types for the verified search refinement.
+Outcome types for the search correctness proof.
 
 The return integer alone does not distinguish a completed sweep, a
 generator unwind, a comparison prune, and exhausted loop fuel.  In
@@ -28,12 +28,17 @@ A generator or comparison unwind carries the ancestor child it has already
 shown to be bounded by the incumbent.  Intermediate calls merely transport
 that anchor.  At its indexed target loop, the anchor becomes ordinary child
 coverage and the sweep continues.
+
+This is the first module of `HexGraphIso.Nauty.Correct`.  `Correct.Base`
+and `Correct.Unwind.Target` build on the types defined here, and every
+later module of the correctness proof states its results in terms of
+them.
 -/
 
 namespace Hex.GraphIso.Nauty
 
 /-- Public eliminator for injective labellings in downstream outcome
-modules, where the defining predicate is intentionally opaque. -/
+modules, where the defining predicate is opaque. -/
 theorem LabInj.eq {lab : Array Nat} {nn i j : Nat} (h : LabInj lab nn)
     (hi : i < nn) (hj : j < nn) (heq : lab[i]! = lab[j]!) : i = j := by
   unfold LabInj at h
@@ -46,8 +51,8 @@ theorem LabInj.eq {lab : Array Nat} {nn i j : Nat} (h : LabInj lab nn)
     ∀ i, i < n → γ[ref[i]!]! = cur[i]!
 
 /-- A checked carrier whose witnessing generator stabilizes one ancestor
-frame. Direct generator unwinds need only this witness; requiring every
-historical generator to stabilize the frame is stronger and false away
+frame.  Direct generator unwinds need only this witness.  Requiring every
+recorded generator to stabilize the frame is stronger, and it fails away
 from the first-path loop that consumes an orbit closure. -/
 @[expose] def CellCarrier (ctx : Ctx n) (ptn : Array Nat) (level : Nat)
     (base ref cur : Array Nat) (store : Array (Array Nat)) : Prop :=
@@ -440,7 +445,7 @@ theorem ChildDone.ofEq {ctx : Ctx n} {tcLevel specFuel level : Nat}
 /-- A filter preserves sweep coverage when every old live child is either
 absorbed or carried to a key-equivalent new survivor, and filtering adds no
 vertices.  A carried survivor before the cursor is discharged through
-`past`; it need not remain in the live suffix. -/
+`past`.  It need not remain in the live suffix. -/
 theorem SweepCover.filter {ctx : Ctx n} {tcLevel specFuel level : Nat}
     {cs : List Nat} {rsLab rsPtn : Array Nat} {tc len numcells : Nat}
     {tcell tcell' : VSet n} {cursor : Option Nat} {best : Option (Key n)}
@@ -479,7 +484,7 @@ theorem after_or_not (cursor : Option Nat) (v : Nat) :
 
 /-- A filter's natural preservation rule: every old live child is carried
 to a key-equivalent member of the filtered set.  The member may lie before
-the cursor; `past` converts that case to completed coverage. -/
+the cursor, and `past` converts that case to completed coverage. -/
 theorem SweepCover.filterCarried {ctx : Ctx n}
     {tcLevel specFuel level : Nat} {cs : List Nat}
     {rsLab rsPtn : Array Nat} {tc len numcells : Nat}
@@ -747,7 +752,7 @@ theorem nextElem_le {s : VSet n} {v w : Nat} {cursor : Option Nat}
 
 /-- Advancing to the least remaining vertex preserves sweep coverage once
 that vertex's child is absorbed.  The `hcur` premise identifies every
-offset carrying the chosen vertex; callers normally discharge it from
+offset carrying the chosen vertex.  Callers normally discharge it from
 labelling injectivity. -/
 theorem SweepCover.advance {ctx : Ctx n} {tcLevel specFuel level : Nat}
     {cs : List Nat} {rsLab rsPtn : Array Nat} {tc len numcells tv : Nat}
@@ -818,7 +823,7 @@ theorem SweepCover.done_of_smaller {ctx : Ctx n}
     omega
 
 /-- The non-root arm of the first-path orbit test is a covered skip.  Orbit
-soundness supplies a smaller word-connected pointer target; cell
+soundness supplies a smaller word-connected pointer target.  Cell
 stabilization keeps that target in the sibling cell, and ranked coverage
 shows it was already absorbed. -/
 theorem SweepCover.orbitSkip {ctx : Ctx n}
@@ -975,11 +980,11 @@ structure OrbitUnwind (ctx : Ctx n) (target : Nat) (out : SearchSt n) : Prop whe
   smaller : out.orbits[out.cosetindex]! < out.cosetindex
   sound : OrbSound (OrbConn out.genTrace.toList n) out.orbits n
 
-/-- Why a generator return is sound.  Code one and the ordinary code-two
-return retain their different reference labellings.  Code two's special
-`gcaFirst` return retains the sound orbit pointer that selected an earlier
-child. Non-generator pruning instead returns a locally complete maximum and
-therefore has its own result constructor. -/
+/-- The evidence carried by a generator unwind.  Code one and the
+ordinary code-two return retain their different reference labellings.
+Code two's special `gcaFirst` return retains the sound orbit pointer that
+selected an earlier child.  Non-generator pruning instead returns a
+locally complete maximum and therefore has its own result constructor. -/
 inductive Unwind (ctx : Ctx n) (tcLevel target : Nat)
     (out : SearchSt n) (best : Option (Key n)) where
   | first (anchor : Anchor ctx tcLevel target best)
@@ -1232,9 +1237,9 @@ theorem Guide.tiedUnwind {ctx : Ctx n} {tcLevel level numcells : Nat}
   { g with done := g.done.mono hinc }
 
 /-- The first and canonical generator guides that are live strictly above
-the current node.  A guide at the current level is deliberately not
-required: leaf installation temporarily sets a gca to the leaf level, and
-the parent loop replaces it with a concrete explored-child guide. -/
+the current node.  A guide at the current level is not required: leaf
+installation temporarily sets a gca to the leaf level, and the parent
+loop replaces it with a concrete explored-child guide. -/
 structure Guides (ctx : Ctx n) (tcLevel level : Nat) (st : SearchSt n)
     (best : Option (Key n)) : Prop where
   first : 0 < st.gcaFirst → st.gcaFirst < level →
@@ -1282,7 +1287,7 @@ theorem IncGrows.refl (best : Option (Key n)) : IncGrows best best := by
   intro b hb
   exact ⟨b, hb, keyLe_refl b⟩
 
-/-- Folding one key into an incumbent preserves the old incumbent. -/
+/-- Folding one key into an incumbent preserves the incoming incumbent. -/
 theorem IncGrows.incMax (best : Option (Key n)) (K : Key n) :
     IncGrows best (some (incMax best K)) := by
   intro b hb

--- a/HexGraphIso/Nauty/Correct/RunInv/Coset.lean
+++ b/HexGraphIso/Nauty/Correct/RunInv/Coset.lean
@@ -14,8 +14,12 @@ public section
 /-!
 `cosetindex` is a first-path loop cursor.  The first-path loop overwrites
 it when it chooses a new sibling, but the whole `otherNode` subtree below
-that sibling leaves it unchanged.  These equations isolate that executable
-fact; orbit-return coverage may use the cursor only on the off-path side.
+that sibling leaves it unchanged.  These equations state that executable
+fact.  Orbit-return coverage may use the cursor only on the off-path
+side.
+
+This module builds on `Correct.RunInv.Mutual`.  `Correct.Exit.Final` uses
+these equations when an orbit return crosses an off-path subtree.
 -/
 
 namespace Hex.GraphIso.Nauty

--- a/HexGraphIso/Nauty/Correct/RunInv/History.lean
+++ b/HexGraphIso/Nauty/Correct/RunInv/History.lean
@@ -20,6 +20,12 @@ active frame, which the mutable `gcaFirst` and `gcaCanon` controls do not
 say by themselves.  `EventOut` existentially carries the full comparison
 path a returned state reached, exposing only the prefix its caller
 needs.
+
+This module builds on the frame invariants of `Correct.Frames` and the
+return-stabilization predicate of `Correct.Unwind.Target`.
+`Correct.RunInv.Mutual` states the live hypotheses of the mutual
+induction in terms of `RefTrail`, `EventOut`, and the node and loop
+outcomes defined here.
 -/
 
 /-!
@@ -28,9 +34,9 @@ Reference-leaf history along the active search trail.
 The mutable controls `gcaFirst` and `gcaCanon` say how far a leaf
 reference may be used during an unwind.  They do not by themselves record
 that the referenced leaf descends from every intervening active frame.
-`RefTrail` supplies exactly that missing path history.  It is deliberately
-separate from `RunInv`: the first leaf seeds it only after the initial
-descent has finished.
+`RefTrail` supplies exactly that missing path history.  It is separate
+from `RunInv`: the first leaf seeds it only after the initial descent has
+finished.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -96,7 +102,7 @@ theorem otherLeaf_noncheaplevel (ctx : Ctx n) (level numcells : Nat)
   simpa only [otherLeafSt, rs, base] using
     (otherNodePrep_frames level rs.longcode base).2.2.2.2.2.2.2.2.1
 
-/-- The empty trail has no reference-history obligations. -/
+/-- The empty trail imposes no reference history. -/
 theorem empty (ctx : Ctx n) (current : Nat) (st : SearchSt n) :
     RefTrail ctx current st FrameTrail.empty := by
   constructor
@@ -190,7 +196,7 @@ theorem otherLeaf_order {ctx : Ctx n} {level numcells : Nat}
 
 /-- Recovering an ancestor preserves both reference histories.  The
 canonical control may be clamped to the recovered level, which only
-weakens its reach obligation. -/
+weakens the reach it asserts. -/
 theorem recover {ctx : Ctx n} {current level inf : Nat} {st : SearchSt n}
     {trail : FrameTrail} (h : RefTrail ctx current st trail)
     (hle : level ≤ current) :
@@ -320,8 +326,8 @@ theorem push {ctx : Ctx n} {level : Nat} {st : SearchSt n}
       omega
 
 /-- The concrete child state created by a verified sweep inherits both
-reference histories.  `FrameRefs` supplies the new parent-frame case;
-all older frames come directly from the incoming history. -/
+reference histories.  `FrameRefs` supplies the new parent-frame case.
+All shallower frames come directly from the incoming history. -/
 theorem LoopInv.childHistory {G : Colored n k} {ctx : Ctx n}
     {tcLevel specFuel level numcells tc len : Nat} {tcell : VSet n} {coset : Nat}
     {codes bs fs : List Nat} {rsLab rsPtn : Array Nat}
@@ -373,8 +379,8 @@ theorem firstStab {ctx : Ctx n} {current : Nat} {st : SearchSt n}
     (h.first target entry hlt hnat hentry)
     (htrail.reach target entry hlt hentry) hmap
 
-/-- Appending a first-reference scatter preserves the complete
-return-stabilization obligation at `gcaFirst`. -/
+/-- Appending a first-reference scatter preserves complete return
+stabilization at `gcaFirst`. -/
 theorem firstPushStab {ctx : Ctx n} {current : Nat} {st out : SearchSt n}
     {trail : FrameTrail} {gamma : Array Nat}
     (h : RefTrail ctx current st trail)
@@ -415,9 +421,8 @@ theorem canonStabTo {ctx : Ctx n} {current limit : Nat} {st : SearchSt n}
     (h.canon target entry hlt hnat hentry)
     (htrail.reach target entry hlt hentry) hmap
 
-/-- Appending a canonical-reference scatter preserves the complete
-return-stabilization obligation through any resumable bound below its
-GCA. -/
+/-- Appending a canonical-reference scatter preserves complete return
+stabilization through any resumable bound below its GCA. -/
 theorem canonPushStabTo {ctx : Ctx n} {current limit : Nat}
     {st out : SearchSt n} {trail : FrameTrail} {gamma : Array Nat}
     (h : RefTrail ctx current st trail)
@@ -565,7 +570,7 @@ namespace Hex.GraphIso.Nauty
 variable {n k : Nat}
 
 /-- A recursive result state with a faithful comparison path and every
-ancestor stabilization obligation enabled by its returned level. -/
+ancestor stabilization enabled by its returned level. -/
 inductive EventOut (G : Colored n k) (ctx : Ctx n) (tcLevel : Nat)
     (stem fs : List Nat) (out : SearchSt n) (best : Option (Key n))
     (trail : FrameTrail) (r : Int) : Prop where
@@ -582,8 +587,8 @@ inductive EventOut (G : Colored n k) (ctx : Ctx n) (tcLevel : Nat)
 namespace RunEvent
 
 /-- Every event state reads back the semantic incumbent recorded by its
-comparison machine.  The row-rejection arm uses its deliberately reset
-zero-sign machine. -/
+comparison machine.  The row-rejection arm uses its reset zero-sign
+machine. -/
 theorem read {G : Colored n k} {ctx : Ctx n}
     {tcLevel current : Nat} {cs bs fs : List Nat} {st : SearchSt n}
     {best : Option (Key n)} {trail : FrameTrail}
@@ -907,7 +912,7 @@ end EventOut
 end Hex.GraphIso.Nauty
 
 /-!
-Corrected node outcomes coupled to their result-side invariants.
+Node outcomes coupled to their result-side invariants.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -1000,8 +1005,8 @@ structure NodeOutcome (G : Colored n k) (ctx : Ctx n)
   event : EventOut G ctx tcLevel cs fs out outBest eventTrail r
   preserved : TrailExt level receiptTrail eventTrail
 
-/-- Forgetting the concrete result invariant recovers the corrected
-semantic node result consumed by the root reduction. -/
+/-- Forgetting the concrete result invariant recovers the semantic node
+result consumed by the root reduction. -/
 theorem NodeOutcome.toResult {G : Colored n k} {ctx : Ctx n}
     {tcLevel specFuel runFuel level numcells : Nat} {cs fs : List Nat}
     {st out : SearchSt n} {best outBest : Option (Key n)}
@@ -1078,7 +1083,7 @@ theorem NodeOutcome.parentEq {G : Colored n k} {ctx : Ctx n}
   | exhausted empty => exact (hfuel empty).elim
 
 /-- An off-path node additionally leaves the first-path guide unchanged.
-It also preserves live guide ordering; unlike a first-path node, it never
+It also preserves live guide ordering.  Unlike a first-path node, it never
 raises `gcaFirst` while returning through its child loop.  These are the
 facts its parent needs before recovering a completed child. -/
 structure OtherOutcome (G : Colored n k) (ctx : Ctx n)
@@ -1101,8 +1106,8 @@ sweep completes its parent node one level up. -/
   | none => Int.ofNat level - 1
 
 /-- A loop receipt coupled to the concrete result invariant ultimately
-returned by its parent node.  `stem` is the parent node's entry prefix;
-the loop's own `codes` include that node's refinement code. -/
+returned by its parent node.  `stem` is the parent node's entry prefix.
+The loop's own `codes` include that node's refinement code. -/
 structure LoopOutcome (G : Colored n k) (ctx : Ctx n)
     (tcLevel specFuel runFuel loopFuel level : Nat)
     (stem codes fs : List Nat) (rsLab rsPtn : Array Nat)
@@ -1229,7 +1234,7 @@ theorem LoopOutcome.retrail {G : Colored n k} {ctx : Ctx n}
       dest eventTrail r :=
   ⟨h.receipt.retrail htrail, h.event, htrail.trans h.preserved⟩
 
-/-- First-path exit bookkeeping preserves a corrected node outcome. -/
+/-- First-path exit bookkeeping preserves a node outcome. -/
 theorem NodeOutcome.firstFinish {G : Colored n k} {ctx : Ctx n}
     {tcLevel specFuel runFuel level numcells size index : Nat}
     {cs fs : List Nat} {st out : SearchSt n} {best outBest : Option (Key n)}
@@ -1248,9 +1253,9 @@ theorem NodeOutcome.firstFinish {G : Colored n k} {ctx : Ctx n}
     · exact h.event
   · exact h.preserved
 
-/-- The first discrete leaf closes the corrected result package.  Its
-generator store is still empty, so every return-frame stabilization
-obligation is vacuous. -/
+/-- The first discrete leaf closes the result package.  Its generator
+store is still empty, so every return-frame stabilization holds
+vacuously. -/
 theorem FirstInv.terminalOutcome {G : Colored n k} {ctx : Ctx n}
     {inf tcLevel specFuel fuel level numcells : Nat}
     {cs : List Nat} {st : SearchSt n} {trail : FrameTrail}

--- a/HexGraphIso/Nauty/Correct/RunInv/Mutual.lean
+++ b/HexGraphIso/Nauty/Correct/RunInv/Mutual.lean
@@ -12,11 +12,17 @@ import all HexGraphIso.Nauty.Search.Search
 public section
 
 /-!
-The live hypotheses shared by the corrected mutual search induction.
+The live hypotheses shared by the mutual search induction.
 
-These clauses deliberately describe a state at which search may continue.
-GCA ordering is not a result-side invariant: the first-child loop raises
-`gcaFirst` before an early unwind, so a returned state need not satisfy it.
+These clauses describe a state at which search may continue.  Ordering of
+the two GCA controls is one of them: it holds on entry to a node and
+throughout its child loops.  A first-child loop raises `gcaFirst` before
+an early unwind, so a returned state carries instead the result-side
+package of `Correct.RunInv.History`.
+
+This module builds on `Correct.RunInv.History`.  `Correct.RunInv.Coset`
+and the node and loop modules after it carry `Live`, `OtherLive`, and
+`FirstLive`.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -442,9 +448,9 @@ theorem firstFinish_fixedpts (level size index : Nat) (st : SearchSt n) :
   rw [firstFinish]
   split <;> rfl
 
-/-- The two path facts threaded only by the corrected mutual induction:
-fixed vertices are singleton cells, and root-valid automorphisms fixing
-them stabilize the current cells. -/
+/-- The two path facts carried by the mutual induction: fixed vertices are
+singleton cells, and root-valid automorphisms fixing them stabilize the
+current cells. -/
 structure PathOk (ctx : Ctx n) (rootPtn rootLab : Array Nat)
     (level : Nat) (st : SearchSt n) : Prop where
   fixed : FixedCells level st
@@ -744,16 +750,16 @@ theorem rowTieBack {G : Colored n k} {ctx : Ctx n}
 end RunPrep
 
 /-- The live state of an off-path sweep.  `gcaFirst` stays strictly above
-the divergence ancestor, so a child push introduces no new stabilization
-obligation at the current frame. -/
+the divergence ancestor, so a child push requires no new stabilization at
+the current frame. -/
 structure OtherLive (ctx : Ctx n) (level : Nat) (st : SearchSt n)
     (trail : FrameTrail) : Prop extends Live ctx level st trail where
   firstBelow : st.gcaFirst < level
 
 /-- The live state of a first-path sweep.  Once generators exist, the
 guiding child has already been absorbed, and every recorded generator
-stabilizes this frozen frame; before that point the store is empty and the
-same clause is vacuous. -/
+stabilizes this frozen frame.  Before that point the store is empty and
+the same clause holds vacuously. -/
 structure FirstLive (ctx : Ctx n) (level : Nat) (st : SearchSt n)
     (trail : FrameTrail) (rsLab rsPtn : Array Nat) : Prop
     extends Live ctx level st trail where
@@ -843,7 +849,8 @@ theorem cover {G : Colored n k} {ctx : Ctx n}
 
 /-- After recovery, the first guide remains strictly older and the
 canonical guide names either an earlier covered child or the child just
-absorbed.  Thus both current-frame reference obligations are restored. -/
+absorbed.  Both current-frame reference conditions therefore hold
+again. -/
 theorem refs {G : Colored n k} {ctx : Ctx n}
     {tcLevel specFuel runFuel level numcells tc len tv offset currentOffset inf : Nat} {tcell fixedpts : VSet n}
     {codes bs fs : List Nat} {rsLab rsPtn : Array Nat}

--- a/HexGraphIso/Nauty/Correct/State/Induction.lean
+++ b/HexGraphIso/Nauty/Correct/State/Induction.lean
@@ -17,6 +17,18 @@ public section
 
 /-!
 Semantic state carried by the outcome-indexed search induction.
+
+`RunInv` is the state available once the first leaf has been installed,
+`RunPrep` the state after refinement and the off-path comparison step,
+and `NodeInv` the extra certificate state a node holds when it is about
+to call `refine`.  Around them sit the cheap-automorphism ledger
+boundary, the first-leaf phase transition out of the pre-incumbent
+descent, the framing rules for `recover`, and the leaf-admission
+hypotheses that preserve the generator store through `processnode`.
+
+This module builds on the frame preservation rules of
+`Correct.Unwind.Trail`.  `Correct.State.Ledger` and every later module
+state their hypotheses in terms of the records defined here.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -24,7 +36,7 @@ namespace Hex.GraphIso.Nauty
 variable {n k : Nat}
 
 /-- Elimination form of `LabInj`, exported so downstream outcome modules
-need not unfold its intentionally opaque definition. -/
+need not unfold its opaque definition. -/
 theorem LabInj.eq_of_getElem! {lab : Array Nat} {n i j : Nat}
     (h : LabInj lab n) (hi : i < n) (hj : j < n)
     (heq : lab[i]! = lab[j]!) : i = j := by
@@ -102,9 +114,9 @@ theorem SearchOut.leafRefs {G : Colored n k} {B level numcells : Nat}
 
 /-- The implicit automorphism pair remains valid while search stays
 strictly below the level at which that pair was frozen.  At the frozen
-level itself the implication is deliberately dormant: `processnode` does
-not insert an implicit pair there, and a failed cheap-automorphism guard
-will move the boundary before the next descent. -/
+level itself the implication is dormant: `processnode` does not insert an
+implicit pair there, and a failed cheap-automorphism guard will move the
+boundary before the next descent. -/
 structure CheapOk (ctx : Ctx n) (rlab rptn : Array Nat) (level : Nat)
     (st : SearchSt n) : Prop where
   positive : 0 < st.noncheaplevel
@@ -177,7 +189,7 @@ theorem recover_fmptn {st : SearchSt n} {inf level saved : Nat}
   exact cellsPerm_refl _ _ _
 
 /-- Recovery either parks the boundary just below the next child, where
-the strict obligation is dormant, or retains an older frozen pair. -/
+the strict pair condition is dormant, or retains an older frozen pair. -/
 theorem CheapOk.recover {ctx : Ctx n} {rlab rptn : Array Nat}
     {current level inf : Nat} {st : SearchSt n}
     (h : CheapOk ctx rlab rptn current st) (hle : level ≤ current)
@@ -255,7 +267,7 @@ theorem CheapOk.otherNodePrep {ctx : Ctx n} {rlab rptn : Array Nat}
   exact h.ofFrames hlab hptn hncl
 
 /-- Writing a boundary at or above the logical level suspends the pair
-obligation without changing the partition facts needed to revive it. -/
+condition without changing the partition facts needed to revive it. -/
 theorem CheapOk.park {ctx : Ctx n} {rlab rptn : Array Nat}
     {old current boundary : Nat} {st : SearchSt n}
     (h : CheapOk ctx rlab rptn old st) (hpos : 0 < boundary)
@@ -416,7 +428,7 @@ theorem CheapOk.breakout {ctx : Ctx n} {rlab rptn : Array Nat}
     rw [hlab, hptn, hncl, ← hfm]
     exact h.pair hlt
 
-/-- The initial search boundary is one, so its strict pair obligation is
+/-- The initial search boundary is one, so its strict pair condition is
 empty at the root. -/
 theorem CheapOk.root {G : Colored n k} {ctx : Ctx n} {numcells : Nat}
     {st : SearchSt n} (hn0 : 0 < n)
@@ -436,11 +448,11 @@ theorem CheapOk.root {G : Colored n k} {ctx : Ctx n} {numcells : Nat}
 /-- The semantic state available after the first leaf has been installed.
 
 The explicit `level` makes the package usable both at node entries and
-inside their child loops. At a node entry, `level = cs.length + 1`
-recovers `DomOk`; a loop instead carries the code path through its current
-node, so its path has length `level`. The comparison sign is deliberately
+inside their child loops.  At a node entry, `level = cs.length + 1`
+recovers `DomOk`.  A loop instead carries the code path through its
+current node, so its path has length `level`.  The comparison sign is
 unrestricted: an internal node whose code first exceeds the incumbent can
-enter its child loop with sign one. Consumers that read the mutable
+enter its child loop with sign one.  Consumers that read the mutable
 incumbent or return an event supply the appropriate sign premise. -/
 structure RunInv (G : Colored n k) (ctx : Ctx n)
     (tcLevel level : Nat) (cs bs fs : List Nat) (numcells : Nat)
@@ -562,9 +574,8 @@ theorem Equitable.ofCellsPerm {ctx : Ctx n} {level : Nat}
   exact (splitDone_iff_constOn.mp (heq cd hcd de hde)).perm hcdPerm.symm
 
 /-- The extra certificate state needed exactly where a node is about to
-call `refine`.  `RunInv` is deliberately weaker because it also describes
-recovered parent-loop states, whose stale `active` field is never refined
-again. -/
+call `refine`.  `RunInv` is weaker because it also describes recovered
+parent-loop states, whose stale `active` field is never refined again. -/
 structure NodeInv (G : Colored n k) (ctx : Ctx n)
     (tcLevel level : Nat) (cs bs fs : List Nat) (numcells : Nat)
     (st : SearchSt n) (best : Option (Key n)) (trail : FrameTrail) : Prop where
@@ -993,8 +1004,8 @@ theorem SearchOk.firstterminal {G : Colored n k} {level numcells : Nat}
     exact Or.inr ⟨h.labSize, h.reach⟩
 
 /-- The first leaf changes the pre-incumbent descent into the stable
-post-install invariant. Both mutable stores are still empty at this point;
-all later store growth is handled by the ordinary node induction. -/
+post-install invariant.  Both mutable stores are still empty at this
+point.  The ordinary node induction handles all later store growth. -/
 theorem RunInv.firstterminal {G : Colored n k} {ctx : Ctx n}
     {tcLevel level numcells : Nat}
     {cs : List Nat} {st : SearchSt n} {trail : FrameTrail}
@@ -1157,8 +1168,8 @@ theorem GuideStore.processnode {ctx : Ctx n} {tcLevel level : Nat}
 
 /-- State returned by a node event before its caller applies `recover`.
 The second comparison-machine case is the row-rejection reset: the
-mutable sign is negative while the retained proof is deliberately stated
-at sign zero, exactly as required by `recover_codeInv_reset`. -/
+mutable sign is negative while the retained proof is stated at sign zero,
+exactly as required by `recover_codeInv_reset`. -/
 structure RunEvent (G : Colored n k) (ctx : Ctx n)
     (tcLevel current : Nat)
     (cs bs fs : List Nat) (st : SearchSt n) (best : Option (Key n))
@@ -1260,9 +1271,9 @@ theorem RunEvent.recover {G : Colored n k} {ctx : Ctx n}
 
 /-- Valid installed leaf references, a valid current search labelling, and
 the row store are the exact hypotheses needed to preserve the generator
-store through `processnode`. This avoids packaging the post-refinement
-state in `DomOk`, whose path index intentionally describes a node before
-its next refinement code is appended. -/
+store through `processnode`.  This avoids packaging the post-refinement
+state in `DomOk`, whose path index describes a node before its next
+refinement code is appended. -/
 theorem LeafRefsOk.processnodeGen {G : Colored n k} {ctx : Ctx n}
     {level numcells : Nat} {st : SearchSt n}
     (hn0 : 0 < n)

--- a/HexGraphIso/Nauty/Correct/State/Ledger.lean
+++ b/HexGraphIso/Nauty/Correct/State/Ledger.lean
@@ -15,6 +15,17 @@ public section
 /-!
 Root-ledger preservation and leaf admission for the outcome-indexed search
 induction.
+
+Every branch of `processnode` preserves the root automorphism ledger and
+the bounded pair workspace: checked scatters between reached labellings,
+the scan-free pair recorded at a small-cell node, the code-one and
+code-two generator admissions, and the shared comparison-prune tail.  The
+leaf lemmas then turn a prepared state into an event state whose
+incumbent is the maximum of the incoming incumbent and the new leaf.
+
+This module builds on the state records of `Correct.State.Induction`.
+`Correct.Frames` and the node modules that follow it use these results at
+every leaf event.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -642,9 +653,9 @@ theorem AutosOk.processnodeOff {ctx : Ctx n} {G : Colored n k}
         rw [processnode_upInstall_autos hef hnc' hcc]
         exact hprune
 
-/-- A failed first-path generator gate reduces to the ordinary off-path
-ledger proof once canonical-labelling validity discharges the reused
-workspace overwrite. -/
+/-- A failed first-path generator admission test reduces to the ordinary
+off-path ledger proof once canonical-labelling validity discharges the
+reused workspace overwrite. -/
 theorem AutosOk.processnodeGateFail {ctx : Ctx n} {G : Colored n k}
     {level numcells : Nat} {cs bs : List Nat} {st : SearchSt n}
     (hn0 : 0 < n)
@@ -753,9 +764,9 @@ theorem AutosOk.processnode {ctx : Ctx n} {G : Colored n k}
         · exact hprev.processnodeAuto hn0 hsymm hloop hok hrefs
             heq hsent' hnc' hpass
 
-/-- The stable search invariant now discharges the last independent
-ledger premise of `processnode`: the runtime bound selects the frozen
-pair carried by `CheapOk`. -/
+/-- The stable search invariant discharges the one ledger premise of
+`processnode` that no other hypothesis supplies: the runtime bound
+selects the frozen pair carried by `CheapOk`. -/
 theorem RunInv.processnodeAutos {ctx : Ctx n} {G : Colored n k}
     {tcLevel level numcells : Nat} {cs bs fs : List Nat}
     {st : SearchSt n} {best : Option (Key n)} {trail : FrameTrail}
@@ -775,7 +786,7 @@ theorem RunInv.processnodeAutos {ctx : Ctx n} {G : Colored n k}
   exact h.cheap.ready hbound hne
 
 /-- The prepared state also discharges the root-ledger premise of a leaf
-event; unlike `RunInv`, it permits the positive comparison sign produced
+event.  Unlike `RunInv`, it permits the positive comparison sign produced
 by the immediately preceding code comparison. -/
 theorem RunPrep.processnodeAutos {ctx : Ctx n} {G : Colored n k}
     {tcLevel level numcells : Nat} {cs bs fs : List Nat}
@@ -796,7 +807,7 @@ theorem RunPrep.processnodeAutos {ctx : Ctx n} {G : Colored n k}
   exact h.cheap.ready hbound hne
 
 /-- An ordinary off-first-path discrete leaf turns the prepared state
-into an event state whose incumbent is exactly the maximum of the old
+into an event state whose incumbent is exactly the maximum of the incoming
 incumbent and that leaf.  The return disjunction is retained for the
 node outcome split. -/
 theorem RunPrep.leaf {ctx : Ctx n} {G : Colored n k}

--- a/HexGraphIso/Nauty/Correct/Sweep/Base.lean
+++ b/HexGraphIso/Nauty/Correct/Sweep/Base.lean
@@ -11,7 +11,16 @@ public import HexGraphIso.Nauty.Correct.Exit.Classify
 public section
 
 /-!
-Base cases and transport for the corrected sibling-sweep induction.
+Base cases and transport for the sibling-sweep induction.
+
+Zero cursor fuel is retained as exhaustion, a positive-fuel loop with no
+next vertex has covered its fixed target cell, and the composition lemmas
+prepend one resolved child to a recursively proved tail.  Between them sit
+the two executable filters: `longprune` uses the root ledger, and
+`shortprune` uses the newest pair carried by the returning child.
+
+This module builds on `Correct.Exit.Classify`.  `Correct.Sweep.Carry` and
+`Correct.Sweep.Node` compose these steps into whole sibling sweeps.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -279,8 +288,8 @@ theorem restrict {G : Colored n k} {ctx : Ctx n}
 
 /-- Every fixed vertex of the receiving parent lies in the `fix` set of
 an implicit pair frozen at a deeper cheap-cell boundary.  The result trail
-identifies the parent's frozen frame; its two closed singleton boundaries
-are unchanged in the deeper event partition. -/
+identifies the parent's frozen frame, whose two closed singleton
+boundaries are unchanged in the deeper event partition. -/
 theorem fmptnFix {G : Colored n k} {ctx : Ctx n}
     {tcLevel specFuel level numcells tc len : Nat} {tcell : VSet n} {offset : Nat}
     {codes bs fs : List Nat} {rsLab rsPtn : Array Nat}
@@ -395,7 +404,7 @@ namespace ShortSource
 
 /-- A live short-prune source that reaches a receiving loop without a
 lower return is valid in that loop's frozen frame.  The child exit bound
-identifies the recorded target with the receiver; explicit pairs then use
+identifies the recorded target with the receiver.  Explicit pairs then use
 their stored frame, while implicit pairs are localized from the root. -/
 theorem atReceiver {G : Colored n k} {ctx : Ctx n}
     {tcLevel specFuel runFuel level numcells tc len : Nat} {tcell : VSet n} {offset : Nat}
@@ -495,7 +504,7 @@ theorem longprune {G : Colored n k} {ctx : Ctx n}
     h.frozenPtnSize h.frozenEnd h.values h.cell h.range h.fuelBound haut
 
 /-- The short-prune filter may read the newest pair from a descendant
-state; validity at the frozen parent frame is the only fact needed to
+state.  Validity at the frozen parent frame is the only fact needed to
 preserve the mutable sweep invariant. -/
 theorem shortpruneWith {G : Colored n k} {ctx : Ctx n}
     {tcLevel specFuel level numcells tc len : Nat} {tcell : VSet n}
@@ -1115,8 +1124,8 @@ theorem childCheap {G : Colored n k} {ctx : Ctx n}
     apply hchild.node.short
     simpa only [cleaned, value] using hshort
 
-/-- Package an already established frozen early return as a corrected
-off-path loop result. -/
+/-- Package an already established frozen early return as an off-path
+loop result. -/
 theorem frozen {G : Colored n k} {ctx : Ctx n}
     {inf tcLevel specFuel runFuel loopFuel level numcells tc len tv tv1 : Nat} {tcell : VSet n}
     {stem codes fs : List Nat} {rsLab rsPtn : Array Nat}
@@ -1157,8 +1166,8 @@ theorem frozen {G : Colored n k} {ctx : Ctx n}
   · intro hshort
     exact ⟨value, rfl, hsource hshort⟩
 
-/-- Package an already established cheap-cell jump as a corrected
-off-path loop result. -/
+/-- Package an already established cheap-cell jump as an off-path loop
+result. -/
 theorem cheap {G : Colored n k} {ctx : Ctx n}
     {inf tcLevel specFuel runFuel loopFuel level numcells tc len tv tv1 boundary : Nat} {tcell : VSet n}
     {stem codes fs : List Nat} {rsLab rsPtn : Array Nat}

--- a/HexGraphIso/Nauty/Correct/Sweep/Carry.lean
+++ b/HexGraphIso/Nauty/Correct/Sweep/Carry.lean
@@ -14,18 +14,23 @@ import all HexGraphIso.Nauty.Invariant.Orbits
 public section
 
 /-!
-Assembly of the corrected search induction, and the facts carried
-alongside it that no other package records.
+Assembly of the search induction, and the facts carried alongside it that
+no other package records.
 
 `FirstRun` pairs the established first-path package with the explicit
-exit classification that justifies every abandoned sweep.  Beside it:
-leaf events keep the orbit array sound, small-cell subtree facts survive
-a within-cell relabelling, guide relations compose across a refinement,
-and a frozen comparison bounds every key below the current path.
+exit classification that justifies every abandoned sweep.  The remaining
+sections record four independent facts: leaf events keep the orbit array
+sound, small-cell subtree facts survive a within-cell relabelling, guide
+relations compose across a refinement, and a frozen comparison bounds
+every key below the current path.
+
+This module builds on `Correct.Sweep.Base` and `Correct.Exit.Classify`.
+`Correct.Sweep.Node` and the first-path modules consume `FirstRun` and
+these carried facts.
 -/
 
 /-!
-Assembly of the corrected search induction.
+Assembly of the search induction.
 
 The first descent needs more result-side history than an ordinary node.
 `FirstRun` keeps the established first-path package while pairing it with
@@ -36,8 +41,8 @@ namespace Hex.GraphIso.Nauty
 
 variable {n k : Nat}
 
-/-- A first-path result with both its reference histories and the corrected
-reason for its return. -/
+/-- A first-path result with both its reference histories and the reason
+for its return. -/
 structure FirstRun (G : Colored n k) (ctx : Ctx n)
     (tcLevel specFuel runFuel level : Nat) (codes fs : List Nat)
     (st out : SearchSt n) (numcells : Nat) (outBest : Option (Key n))
@@ -52,7 +57,7 @@ structure FirstRun (G : Colored n k) (ctx : Ctx n)
 namespace FirstRun
 
 /-- The final first-path counter adjustment preserves the complete
-corrected first-node result. -/
+first-node result. -/
 theorem firstFinish {G : Colored n k} {ctx : Ctx n}
     {tcLevel specFuel runFuel level numcells size index : Nat}
     {codes fs : List Nat} {st out : SearchSt n} {outBest : Option (Key n)}
@@ -134,7 +139,7 @@ end FirstLoopRun
 
 namespace FirstInv
 
-/-- The first discrete leaf is an ordinary exact return in the corrected
+/-- The first discrete leaf is an ordinary exact return in the exit
 classification. -/
 theorem terminalRun {G : Colored n k} {ctx : Ctx n}
     {inf tcLevel specFuel fuel level numcells : Nat}
@@ -179,8 +184,8 @@ theorem terminalRun {G : Colored n k} {ctx : Ctx n}
 
 end FirstInv
 
-/-- The corrected first-path root result proves equality between the
-unpruned specification key and the key installed by the transcription. -/
+/-- The first-path root result proves equality between the unpruned
+specification key and the key installed by the transcription. -/
 theorem dominated_of_firstRun {G : Colored n k} (hn0 : n ≠ 0)
     {fs : List Nat} {best : Option (Key n)}
     (hroot : FirstRun G { g := rowsOf G } 100 n (n + 2) 1 [] fs
@@ -228,11 +233,11 @@ theorem dominated_of_firstRun {G : Colored n k} (hn0 : n ≠ 0)
 end Hex.GraphIso.Nauty
 
 /-!
-Facts carried alongside the corrected search induction that no existing
-package records: leaf events keep the orbit array sound, small-cell
-subtree facts survive a within-cell relabelling, guide relations compose
-across a refinement, and a frozen comparison bounds every key below the
-current path.
+Facts carried alongside the search induction that no other package
+records: leaf events keep the orbit array sound, small-cell subtree facts
+survive a within-cell relabelling, guide relations compose across a
+refinement, and a frozen comparison bounds every key below the current
+path.
 -/
 
 namespace Hex.GraphIso.Nauty

--- a/HexGraphIso/Nauty/Correct/Sweep/Node.lean
+++ b/HexGraphIso/Nauty/Correct/Sweep/Node.lean
@@ -20,6 +20,11 @@ The logical fuel in `nodeKey`, the node recursion fuel and a sibling
 loop's cursor fuel are kept distinct, and the strict node-fuel bound
 makes the executable zero-fuel branch unreachable at every well-formed
 node.
+
+This module builds on `Correct.Sweep.Carry`.  `Correct.OffPath.Loop`
+runs one sibling sweep with these per-child transport lemmas, and
+`Correct.OffPath.Node` proves the off-path step of the totality
+induction stated here.
 -/
 
 /-!
@@ -29,7 +34,8 @@ When the refined code is already below the incumbent's, `othernode`
 either prunes at once (the first-path agreement is broken) or descends
 through the first path's own target cell looking for automorphisms.  The
 subtree is dominated in both cases, so its exact maximum is the unchanged
-incumbent; what remains is the executable state bookkeeping.
+incumbent.  These lemmas record the accompanying executable state
+bookkeeping.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -990,9 +996,9 @@ end Hex.GraphIso.Nauty
 Fuel-separated totality statements for the transcribed search.
 
 The logical fuel in `nodeKey`, the node recursion fuel, and a sibling
-loop's cursor fuel are deliberately kept distinct.  The strict node-fuel
-bound is preserved by descent and makes the executable zero-fuel branch
-unreachable at every well-formed node.
+loop's cursor fuel are kept distinct.  The strict node-fuel bound is
+preserved by descent and makes the executable zero-fuel branch unreachable
+at every well-formed node.
 
 Beyond the packaged run, each node statement carries the facts the
 enclosing loops thread through it: the saved cheap-cell boundary, the

--- a/HexGraphIso/Nauty/Correct/Unwind/Located.lean
+++ b/HexGraphIso/Nauty/Correct/Unwind/Located.lean
@@ -19,15 +19,15 @@ the executable state does not retain the frozen labelling of those
 ancestors.  `GuideStore` strengthens `Guides` by locating every live
 guide in the explicit active-frame trail, and the operational lemmas
 compose the resulting receipts across a refinement.
+
+This module combines the active-frame trail of `Correct.Unwind.Target`
+with the leaf and node base cases of `Correct.Base`.
+`Correct.Unwind.Trail` and `Correct.Frames` consume `GuideStore` and the
+located node and loop receipts defined here.
 -/
 
 /-!
-Frame-aware generator guides for the search induction.
-
-The scalar `gcaFirst` and `gcaCanon` controls name ancestor levels, but
-the executable state does not retain the frozen labelling of those
-ancestors.  `GuideStore` strengthens `Guides` by locating every live
-guide in the explicit active-frame trail used to consume an unwind.
+The located guide ledgers and the receipts that carry them.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -90,8 +90,8 @@ theorem GuideStore.root {n : Nat} (g : Array (VSet n)) (lab : Array Nat)
 /-- Descending through a newly recorded parent child preserves every
 older guide and installs any guide whose control points at the parent.
 
-The two last premises isolate the only new obligations: a control equal
-to `level` must be backed by a guide in the newly extended trail. -/
+The two last premises state the only new requirement: a control equal to
+`level` must be backed by a guide in the newly extended trail. -/
 theorem GuideStore.push {ctx : Ctx n} {tcLevel level : Nat}
     {st : SearchSt n} {best : Option (Key n)} {trail : FrameTrail}
     (h : GuideStore ctx tcLevel level st best trail)
@@ -206,9 +206,10 @@ theorem SweepCover.advanceKey {ctx : Ctx n}
     exact hdone.mono (hfull ▸ IncGrows.incMax best _)
 
 /-- A node outcome whose generator unwind, when present, is tied to the
-active frame trail.  The constructors mirror `NodeResult`; keeping the
-location in the unwind constructor prevents a caller from forgetting the
-only evidence that lets the receiving loop consume that return. -/
+active frame trail.  The constructors match those of `NodeResult`.
+Keeping the location in the unwind constructor prevents a caller from
+forgetting the only evidence that lets the receiving loop consume that
+return. -/
 inductive NodeReceipt (trail : FrameTrail) (ctx : Ctx n)
     (tcLevel specFuel runFuel level : Nat) (cs : List Nat)
     (st out : SearchSt n) (numcells : Nat) (best outBest : Option (Key n))
@@ -355,9 +356,9 @@ theorem NodeReceipt.parentReturn {trail : FrameTrail} {ctx : Ctx n}
   | exhausted empty returned unchanged bestUnchanged => exact (hfuel empty).elim
 
 /-- A resolved child receipt advances its parent's coverage.  Exact
-children may use cell-permutation key equivalence; generator children use
-their location in the just-pushed parent frame, with stabilization required
-only by an orbit-pointer unwind. -/
+children may use cell-permutation key equivalence.  Generator children
+use their location in the just-pushed parent frame, and only an
+orbit-pointer unwind requires stabilization. -/
 theorem SweepCover.receipt {ctx : Ctx n}
     {tcLevel specFuel runFuel level tc len numcells : Nat} {tcell : VSet n} {tv offset : Nat}
     {codes : List Nat} {rsLab rsPtn : Array Nat}
@@ -818,8 +819,8 @@ theorem split_starts {ptn : Array Nat} {level tc len : Nat}
       omega
 
 /-- Individualizing the same frozen vertex after a recovered within-cell
-permutation produces the same specification child key. This is the bridge
-from `SearchOut.breakoutPerm` to the exact key premise consumed by
+permutation produces the same specification child key.  This carries
+`SearchOut.breakoutPerm` to the exact key premise consumed by
 `SweepCover.receipt`. -/
 theorem SearchOut.breakoutKey {G : Colored n k} {ctx : Ctx n}
     {level numcells tc len o specFuel tcLevel : Nat}

--- a/HexGraphIso/Nauty/Correct/Unwind/Target.lean
+++ b/HexGraphIso/Nauty/Correct/Unwind/Target.lean
@@ -16,17 +16,21 @@ on the way there.
 
 A direct unwind names the frozen child-loop frame it targets by an
 explicit anchor, since the executable state does not retain a parent
-loop's refined labelling; an orbit unwind resolves through the receiving
+loop's refined labelling.  An orbit unwind resolves through the receiving
 loop's evolving coverage instead.  `ReturnStab` states generator
 stabilization at the executable return level.
+
+This module uses the outcome types of `Correct.Outcome`.
+`Correct.Unwind.Located` and `Correct.RunInv.History` consume the
+active-frame trail and the return-stabilization predicate defined here.
 -/
 
 /-!
 Consumption rules for search unwinds at their target child loop.
 
 The executable state does not retain a parent loop's refined labelling:
-`recover` reopens the partition but deliberately leaves the descendant
-labelling in `SearchSt n`.  A direct unwind therefore needs an explicit
+`recover` reopens the partition but leaves the descendant labelling in
+`SearchSt n`.  A direct unwind therefore needs an explicit
 relation between its stored anchor and the frozen loop frame.  Orbit
 unwinds instead resolve through the receiving loop's evolving coverage.
 -/
@@ -147,8 +151,8 @@ theorem Guide.Located.push {ctx : Ctx n} {tcLevel target level : Nat}
   exact ⟨old, by rw [FrameTrail.push_of_ne _ entry hne]; exact hold,
     hframe⟩
 
-/-- A guide for the newly pushed frame is located there immediately;
-the active descent offset need not be the guide's own explored offset. -/
+/-- A guide for the newly pushed frame is located there immediately.  The
+active descent offset need not be the guide's own explored offset. -/
 theorem Guide.Located.pushSelf {ctx : Ctx n} {tcLevel level : Nat}
     {best : Option (Key n)} (trail : FrameTrail)
     (g : Guide ctx tcLevel level best) (offset : Nat) :
@@ -437,7 +441,7 @@ theorem SweepCover.orbitUnwind {ctx : Ctx n}
     hok hsp hend hvals hic hrange hlf payload.sound hne
 
 /-- Every located generator unwind addressed to this loop consumes the
-active child.  Direct carriers use their stored frame and offset; the
+active child.  Direct carriers use their stored frame and offset.  The
 special code-two arm uses its sound orbit pointer. -/
 theorem SweepCover.unwind {ctx : Ctx n}
     {tcLevel specFuel level tc len numcells : Nat} {tcell : VSet n} {tv offset : Nat}
@@ -490,7 +494,7 @@ A generator present after a recursive call need not stabilize every
 intermediate node crossed by an early unwind.  It must stabilize precisely
 the active ancestor frames at or below the returned level.  This is the
 form needed both when a first-path loop continues and when an orbit unwind
-lands at its target frame.
+reaches its target frame.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -505,8 +509,8 @@ level permits the caller to resume. -/
 
 namespace ReturnStab
 
-/-- Lowering the advertised return level weakens the stabilization
-obligation. -/
+/-- Lowering the advertised return level requires stabilization of fewer
+frames. -/
 theorem lower {trail : FrameTrail} {r r' : Int} {st : SearchSt n}
     (h : ReturnStab trail r st) (hle : r' ≤ r) :
     ReturnStab trail r' st := by
@@ -560,7 +564,7 @@ theorem setAllsame {trail : FrameTrail} {r : Int} {st : SearchSt n}
   exact h
 
 /-- Recovering a parent changes no recorded generator, so it preserves
-every return-indexed stabilization obligation. -/
+return stabilization at every level. -/
 theorem recover {trail : FrameTrail} {r : Int} {st : SearchSt n}
     (h : ReturnStab trail r st) (inf level : Nat) :
     ReturnStab trail r (Nauty.recover n inf level st) := by
@@ -569,9 +573,9 @@ theorem recover {trail : FrameTrail} {r : Int} {st : SearchSt n}
   have hstore := recover_store n inf level st
   rwa [hstore.1] at hγ
 
-/-- Appending one generator preserves return stabilization when the old
-store already satisfies it and the new generator stabilizes every
-resumable frame. -/
+/-- Appending one generator preserves return stabilization when the
+existing store already satisfies it and the new generator stabilizes
+every resumable frame. -/
 theorem pushGen {trail : FrameTrail} {r : Int} {st out : SearchSt n}
     {gamma : Array Nat} (h : ReturnStab trail r st)
     (hpush : out.genTrace = st.genTrace.push gamma)
@@ -587,8 +591,9 @@ theorem pushGen {trail : FrameTrail} {r : Int} {st out : SearchSt n}
     subst delta
     exact hnew level entry hlevel hentry
 
-/-- Pushing a child frame preserves all older return obligations.  The
-new frame is required only when the return reaches it. -/
+/-- Pushing a child frame preserves return stabilization at every
+shallower frame.  The new frame is required only when the return reaches
+it. -/
 theorem push {trail : FrameTrail} {r : Int} {st : SearchSt n}
     {level : Nat} {entry : TrailEntry}
     (h : ReturnStab trail r st)

--- a/HexGraphIso/Nauty/Correct/Unwind/Trail.lean
+++ b/HexGraphIso/Nauty/Correct/Unwind/Trail.lean
@@ -12,6 +12,16 @@ public section
 
 /-!
 Preservation rules for the active-frame reach ledger.
+
+Refinement, leaf processing, reopening an ancestor, and individualization
+each preserve reach from every active ancestor frame and leave the closed
+boundaries of those frames untouched.  Descending into a sweep child
+extends both guide ledgers, and a leaf admission at a reached active
+child yields a located unwind payload and a located node receipt.
+
+This module builds on the located guides of `Correct.Unwind.Located`.
+`Correct.State.Induction` uses these preservation rules wherever the
+search induction crosses a state update.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -533,9 +543,9 @@ canonical leaf. -/
     refSize := hrefSize
     refReach := hrefReach }
 
-/-- Descending into a sweep child extends both guide ledgers. A guide
+/-- Descending into a sweep child extends both guide ledgers.  A guide
 whose control is the current level is supplied by an already-covered
-child of that sweep; older guides are transported automatically. -/
+child of that sweep.  Guides at shallower levels transport unchanged. -/
 theorem GuideStore.pushSweep {ctx : Ctx n}
     {tcLevel specFuel level numcells tc len activeOffset : Nat}
     {codes : List Nat} {rsLab rsPtn : Array Nat}


### PR DESCRIPTION
This PR rewrites the module and declaration docstrings under `HexGraphIso/Nauty/Correct/` so they state content only: what each declaration is and what its theorem says. Chronology, embedded plans and narration of earlier drafts are gone, along with the "corrected", "obligation", "deliberately" and "admission gate" phrasings and the reference to a nonexistent SPEC section; every technical statement they carried is preserved, restated directly. Each of the 22 module docstrings now also records which modules it builds on and which consume it, so the chain from `Correct.Outcome` through `Correct.Certify` reads in order. Semicolon-joined run-ons are split into sentences per `SPEC/writing-style.md`. No code, name, statement, proof, import or `set_option` changes: `scripts/bench/check_graphiso_sweep_freshness.py` passes without a new sweep, which is the mechanical check that the `.lean` blobs are equal once comments are stripped.

Stacked on #10052.

Closes #10036

🤖 Prepared with Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
