### PR TITLE
docs(graph-iso): content-only docstrings for the small-cell and equitable theories

### DIFF
--- a/HexGraphIso/Nauty/Equitable/Basic.lean
+++ b/HexGraphIso/Nauty/Equitable/Basic.lean
@@ -14,58 +14,52 @@ public import HexGraphIso.Nauty.Invariant.Refine
 public section
 
 /-!
-Equitable partitions (SPEC § Verified search refinement, the
-cheapautom clause of the store-validity obligation).
+Equitable partitions and the postconditions of the refinement passes.
 
-`refine` makes the partition at `level` equitable with respect to the
-exhausted active set. The manual chapter states this as prose; this
-file begins its formalization. The target theorem is: when
-`refineLoop` exits because `pickSplit` finds no active cell, the
-partition is `Equitable`. Discrete exits are covered separately by
-`equitable_of_singletons`.
+The partition at `level` is `Equitable` when every cell has constant
+neighbour counts into every cell's vertex set. This file defines that
+predicate and the predicates around it, and proves the postconditions
+of the two splitting passes `refine` runs. Discrete exits are covered
+by `equitable_of_singletons`.
 
-The intended loop invariant, recorded here for the follow-up work:
-for every cell `C` of the current partition and every cell `D` not in
-the active set, there is a set `U` of current cells with `D ∈ U` and
-every other member of `U` active, such that `C` has constant
-neighbour counts into the union of `U` (`SplitDone` on the union).
-At exit the certificate `U` collapses to `{D}`, giving equitability.
-The invariant survives a splitting pass because a pass leaves every
-current cell with constant counts into the captured splitter set
-(each processed cell is rearranged into constant-count groups, and a
-cell that does not split already had constant counts), and because
-`SplitDone` only strengthens under refinement of either cell. The
-fragment that the activation rule leaves inactive is covered by the
-certificate consisting of its active sibling fragments together with
-the parent's certificate, since counts into the parent are the sum of
-counts into the fragments. Exit by fuel is excluded by a potential
-argument: `popCount active + 2 * (n - numcells)` drops by at least
-one per pass, and starts at most `3 * n`, below the supplied
-`4 * n + 8`.
+The refinement loop's invariant: for every cell `C` of the current
+partition and every cell `D` not in the active set, there is a set `U`
+of current cells with `D ∈ U` and every other member of `U` active,
+such that `C` has constant neighbour counts into the union of `U`
+(`SplitDone` on the union). At exit the certificate `U` collapses to
+`{D}`, giving equitability. The invariant survives a splitting pass
+because a pass leaves every current cell with constant counts into the
+captured splitter set (each processed cell is rearranged into
+constant-count groups, and a cell that does not split already had
+constant counts), and because `SplitDone` only strengthens under
+refinement of either cell. The fragment that the activation rule
+leaves inactive is covered by the certificate consisting of its active
+sibling fragments together with the parent's certificate, since counts
+into the parent are the sum of counts into the fragments. Exit by fuel
+is excluded by a potential argument: `popCount active + 2 * (n -
+numcells)` drops by at least one per pass, and starts at most
+`3 * n`, below the supplied `4 * n + 8`.
 
-Proven: the predicate layer; the member-level `ConstOn` toolkit
+Proved here: the predicate layer; the member-level `ConstOn` toolkit
 (disjoint-union count additivity, union and difference transport,
 splitter-set disjointness and window splitting); both splitting
-passes' postconditions, culminating in `refineStep_cell_const`; the
-active-set bookkeeping of both passes (`refineTrivial_go_state`,
-`windowScan_active_state`, `nontrivialCell_outcome`,
-`refineNontrivial_go_state`) assembled into `refineStep_state` — the
-strict potential drop and the per-cell activation clauses (an active
-non-splitter cell activates every fragment start, any other cell
-leaves at most one start inactive); the certificate interface
-`CertInv`/`activeUnion`/`Saturated` with its collapse at exit; the
-injectivity and splitter-set structure (`LabInj` transport across the
-pass, `worksetOf_cells_disjoint`, `isCell_disj_or_eq`); the
-preservation theorem `certInv_refineStep`; and the fixpoint theorem
-`refine_equitable` — entering `refine` with an injective labelling,
-an active set of cell starts, an accurate cell count and the
-certificate invariant, the output partition is equitable. The
-certificate seed is vacuous at the root (every cell active) and is
-discharged at descent from the parent's equitability joined with the
-individualized singleton's splitter set.
+passes' postconditions, culminating in `refineStep_cell_const`; and
+the certificate interface `CertInv`/`activeUnion`/`Saturated` with its
+collapse at exit, where the certificate is a bitset constrained to lie
+under the active union and saturated cell by cell rather than a list
+of cells.
 
-Remaining for the cheapautom arm on top of this fixpoint: the
-small-cell subtree lemma and the arm-2 assembly in `Invariant/Store`.
+`Equitable/Step` proves the active-set and potential bookkeeping of one
+refinement step, together with the injectivity and splitter-set
+disjointness the certificate algebra rests on. `Equitable/Fix` proves
+the certificate invariant's preservation across a step and assembles
+the fixpoint theorem `refine_equitable`: entering `refine` with an
+injective labelling, an active set of cell starts, an accurate cell
+count and the certificate invariant, the output partition is
+equitable. The certificate seed is vacuous at the root, where every
+cell is active (`Equitable/Root`), and at descent it comes from the
+parent's equitability joined with the individualized singleton's
+splitter set (`SmallCell/Branch`).
 -/
 
 namespace Hex.GraphIso.Nauty

--- a/HexGraphIso/Nauty/Equitable/Fix.lean
+++ b/HexGraphIso/Nauty/Equitable/Fix.lean
@@ -11,14 +11,13 @@ public import HexGraphIso.Nauty.Equitable.Step
 public section
 
 /-!
-The equitability fixpoint theorem (SPEC § Verified search refinement,
-the cheapautom clause of the store-validity obligation).
+The equitability fixpoint theorem.
 
-`HexGraphIso.Nauty.Equitable.Basic` defines the predicates and proves the
-per-pass postconditions; this file proves the certificate invariant's
-preservation across a refinement step and assembles `refine_equitable`:
-when `refine` exits with its active set exhausted, the partition is
-equitable.
+`HexGraphIso.Nauty.Equitable.Basic` defines the predicates and proves
+the per-pass postconditions. This file proves the certificate
+invariant's preservation across a refinement step and assembles
+`refine_equitable`: when `refine` exits with its active set exhausted,
+the partition is equitable.
 -/
 
 namespace Hex.GraphIso.Nauty

--- a/HexGraphIso/Nauty/Equitable/Step.lean
+++ b/HexGraphIso/Nauty/Equitable/Step.lean
@@ -11,13 +11,16 @@ public import HexGraphIso.Nauty.Equitable.Basic
 public section
 
 /-!
-The equitability fixpoint theorem (SPEC § Verified search refinement,
-the cheapautom clause of the store-validity obligation).
+The active-set and potential bookkeeping of one refinement step.
 
-`HexGraphIso.Nauty.Equitable.Basic` defines the predicates and proves the
-per-pass postconditions; this file proves the active-set and potential
-bookkeeping of one refinement step, consumed by
-`HexGraphIso.Nauty.Equitable.Fix` for the fixpoint theorem.
+`HexGraphIso.Nauty.Equitable.Basic` defines the predicates and proves
+the per-pass postconditions. This file proves that one `refineStep`
+drops the potential strictly and activates the fragment starts the
+certificate argument needs, that distinct cells of an injective
+labelling have disjoint splitter sets, and that an injective bounded
+labelling on `n` positions hits every vertex.
+`HexGraphIso.Nauty.Equitable.Fix` consumes these for the fixpoint
+theorem.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -936,9 +939,9 @@ private theorem nontrivialFix_numcells (cell1 : Nat) (st : RefineSt n) :
 
 /-- One processed cell of the nontrivial pass, the bookkeeping half:
 active bits and boundaries outside the window untouched, the
-potential ledger balanced, and the two activation clauses — an active
-cell activates every fragment start, an inactive one every fragment
-start but one. -/
+potential ledger balanced, and the two activation clauses. An active
+cell activates every fragment start, and an inactive one every
+fragment start but one. -/
 theorem nontrivialCell_outcome {ctx : Ctx n}
     {level cell1 cell2 : Nat} {workset : VSet n} {st : RefineSt n}
     (h12 : cell1 ≤ cell2) (hsz : cell2 < st.ptn.size) (hnb : cell2 < n)

--- a/HexGraphIso/Nauty/SmallCell/Branch.lean
+++ b/HexGraphIso/Nauty/SmallCell/Branch.lean
@@ -16,15 +16,14 @@ import all HexGraphIso.Nauty.Equitable.Fix
 public section
 
 /-!
-The cheapautom descent and branch step (SPEC § Verified search
-refinement, the code-1 arm of the store-validity obligation).
+The cheapautom descent and the branch step at a pair target.
 
-`HexGraphIso.Nauty.SmallCell.Guard` proves the guard characterization and
-the flip theorem; this file carries them down the search subtree: the
-descent seed (individualize-and-refine preserves equitability), the
-guard's cell-size consequences, and the branch step -- the two
-children of a pair target cell refine to states related by the flip,
-collapsing at a discrete child to equal leaf rows.
+`HexGraphIso.Nauty.SmallCell.Guard` proves the guard characterization
+and the flip theorem. This file carries them down the search subtree:
+the descent seed (individualize-and-refine preserves equitability),
+the guard's cell-size consequences, and the branch step, in which the
+two children of a pair target cell refine to states related by the
+flip and collapse at a discrete child to equal leaf rows.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -1517,7 +1516,7 @@ theorem stPerm_lab_eq {level : Nat} {st st' : RefineSt n}
   exact (cellsPerm_singleton h.cells hc).symm
 
 /-- The leaf collapse: when the second child's refinement is discrete,
-the two children's leaf rows coincide -- the flip is absorbed by
+the two children's leaf rows coincide. The flip is absorbed by
 `leafRows_map`. -/
 theorem branch_leafRows {numcells : Nat}
     (hgsz : ctx.g.size = n)

--- a/HexGraphIso/Nauty/SmallCell/Descent.lean
+++ b/HexGraphIso/Nauty/SmallCell/Descent.lean
@@ -16,11 +16,10 @@ import all HexGraphIso.Nauty.Equitable.Fix
 public section
 
 /-!
-The cheapautom subtree iteration (SPEC § Verified search refinement,
-the code-1 arm of the store-validity obligation).
+The bisimulation carrying the branch step down a cheapautom subtree.
 
 `HexGraphIso.Nauty.SmallCell.Branch` relates the two children of a pair
-target cell by the flip at a single level; this file carries the
+target cell by the flip at a single level. This file carries the
 relation down the subtree. The mechanism is a bisimulation: a state
 whose labelling is cell-equivalent to a renamed copy of another
 state's stays so after both individualize corresponding vertices and
@@ -31,14 +30,6 @@ renaming is absorbed by `leafRows_map` (`descends_leafRows`). Gluing
 theorem: any leaf reached below the second child of a pair target has
 the same leaf rows as the mirrored leaf below the first child
 (`deviation_leafRows`).
-
-Remaining on top of this file: the triple analogues (the unique
-triple's transpositions preserve rows, giving the branch step at
-triple targets), the all-leaves induction over the fixed target
-policy, the `noncheaplevel` event lemma, and the arm-2 assembly in
-`Invariant/Store` — plus the exotic defect-four configurations, which
-the probe showed are conformance-reachable and need their own flip
-analogues.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -590,7 +581,7 @@ theorem descends_transport {σ : Renaming n}
     exact ⟨V', .step tc e oV hlvl hcellV hne (by omega) hdesc, hspL⟩
 
 /-- The leaf collapse: a descent to a discrete state below one side
-mirrors below the other with equal leaf rows — the renaming is
+mirrors below the other with equal leaf rows. The renaming is
 absorbed at the leaf. -/
 theorem descends_leafRows {σ : Renaming n}
     (hg : RowsMap σ ctx.g ctx.g)

--- a/HexGraphIso/Nauty/SmallCell/Exotic.lean
+++ b/HexGraphIso/Nauty/SmallCell/Exotic.lean
@@ -16,20 +16,17 @@ import all HexGraphIso.Nauty.Equitable.Fix
 public section
 
 /-!
-The exotic defect-four flip data (SPEC § Verified search refinement,
-the code-1 arm of the store-validity obligation).
+The exotic defect-four flip data.
 
 `cheapautom`'s second branch passes on partitions whose defect
 (vertices minus cells) is at most four without the all-pairs-and-one-
-triple shape of the first branch; the possible nontrivial cell
-multisets are `{4}`, `{5}`, `{4,2}` and `{3,3}`, and the probe showed
-admissions governed by such passes are pervasive on the conformance
-corpus. This file proves the flip data for those configurations: for
-any two members of any nontrivial cell, a row-preserving self-symmetry
-of the node carrying one to the other, entering the deviation doors
-exactly as the pair and triple instances do.
+triple shape of the first branch. The possible nontrivial cell
+multisets are `{4}`, `{5}`, `{4,2}` and `{3,3}`. This file proves the
+flip data for those configurations: for any two members of any
+nontrivial cell, a row-preserving self-symmetry of the node carrying
+one to the other, in the shape the pair and triple deviations consume.
 
-No shape enumeration is needed; everything is forced by counting:
+No shape enumeration is needed. Everything is forced by counting:
 
 * the differ set of two cell members (the other members whose bits at
   the two differ) always has even size, one half adjacent to the

--- a/HexGraphIso/Nauty/SmallCell/Flips.lean
+++ b/HexGraphIso/Nauty/SmallCell/Flips.lean
@@ -22,20 +22,17 @@ to the other.
 -/
 
 /-!
-The cheapautom triple analogues (SPEC § Verified search refinement,
-the code-1 arm of the store-validity obligation).
-
 The first guard branch (`defect ≤ nontrivial + 1`) forces every cell
 of the partition to be a singleton, a pair, or one triple, and any two
 size-three cells to coincide. On that shape these lemmas prove the
 triple analogues of the pair flip theory:
 
 * `triple_const`: the triple's members have identical bits at every
-  member of any other cell of size at most two -- the count into a
+  member of any other cell of size at most two. The count into a
   singleton is the adjacency bit, and the count into a pair is twice
   it by `pair_odd_eq`'s both-or-neither;
 * `triple_internal`: the induced graph on the triple is empty or
-  complete -- the off-diagonal bits are all equal, by the three row-sum
+  complete. The off-diagonal bits are all equal, by the three row-sum
   equalities of equitability (a one-regular graph on three vertices
   is impossible);
 * `triple_flip_rows`: the transposition of any two triple members,
@@ -45,44 +42,19 @@ triple analogues of the pair flip theory:
 
 The surjectivity hypothesis the flip theorems consume is
 `labInj_surj` in `Equitable/Step`. Also here: the transposition's
-self-equivalence (`cellsPerm_self_tripleSwap`/`stPerm_self_tripleSwap`:
-the mapped labelling is cell-contents equivalent to the original), the
-generalized single-deviation theorem (`deviation_leafRows_self`: ANY
-row-preserving self-symmetry of a node carrying one child's
-individualized vertex to another's mirrors discrete descents with
-equal leaf rows -- the uniform door both pair and triple deviations
-enter), and its packaged triple instance (`triple_deviation_leafRows`,
-which constructs the concrete transposition and discharges every
-hypothesis from `IterOk` + equitability + the first-branch shape).
-The pair-matching closure `PairReach` and its position toolkit
-(start-determinacy, start-never-second, closure members are pairs,
-distinct pairs disjoint) close the file.
-
-Remaining on top of this file, in dependency order. (1) The
-pair-closure involution: define the swap of every `PairReach`-closure
-pair via `Classical.choose` on "some closure pair has this vertex as
-its first/second member" -- the position toolkit makes the witness
-unique (start-determinacy + `pair_start_ne_second` give the two
-existentials' exclusivity, `pair_cells_disj` gives distinctness of
-partners) -- then discharge the S-closure hypotheses of `flip_rows` and a
-`cellsPerm_self_pairFlip` (mirror of the triple one: closure pairs
-swap by `List.Perm.swap`, other cells are fixed because a member of a
-closure pair would place its position inside that pair's window), and
-package `pair_deviation_leafRows` through `deviation_leafRows_self`
-exactly as the triple instance. (2) The node invariant for the
-all-leaves induction: `IterOk` + `Equitable` + the first-branch shape
-(every cell size ≤ 3, one triple -- descends because `refine_frozen`
-keeps closed positions closed, so every child cell sits inside a
-parent cell and child triples are parent triples positionally) +
-`bcount` accuracy (`bcount_breakout_eq` + `refine_bcount`), with
-equitability descending by `equitable_breakout`. (3) The all-leaves
-induction: two descents with the same target-position path and
-discrete ends have equal leaf rows -- induction on the path; equal
-offsets recurse, distinct offsets glue a deviation (pair or triple by
-the target's size) and recurse below the second child on the
-transported path. (4) The `noncheaplevel` event lemma and the arm-2
-assembly in `Invariant/Store`. (5) The exotic defect-four
-configurations outside the first branch, per the probe.
+self-equivalence (`cellsPerm_self_tripleSwap`/`stPerm_self_tripleSwap`,
+stating that the mapped labelling is cell-contents equivalent to the
+original), the generalized single-deviation theorem
+(`deviation_leafRows_self`: any row-preserving self-symmetry of a node
+carrying one child's individualized vertex to another's mirrors
+discrete descents with equal leaf rows, which is the form both the
+pair and the triple deviation use), and its packaged triple instance
+(`triple_deviation_leafRows`, which constructs the concrete
+transposition and discharges every hypothesis from `IterOk`,
+equitability and the first-branch shape). The pair-matching closure
+`PairReach` and its position toolkit (start-determinacy,
+start-never-second, closure members are pairs, distinct pairs
+disjoint) follow.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -902,24 +874,23 @@ end PairClosure
 end Hex.GraphIso.Nauty
 
 /-!
-The pair-closure involution (SPEC § Verified search refinement, the
-code-1 arm of the store-validity obligation).
+The pair-closure involution.
 
 The pair deviation swaps every pair cell in the `PairMatch`-reachability
-closure of the target pair at once. This module constructs that involution
-(`pairFlip`: a member of a closure pair maps to its partner, every other
-vertex is fixed — a `Classical.choose` over the closure, made
-well-defined by the position toolkit's uniqueness facts), proves its
-evaluation laws, bounds, and involutivity, and discharges the
-`S`-hypotheses of `flip_rows` for it: closure pairs swap
+closure of the target pair at once. This part of the file constructs
+that involution (`pairFlip`: a member of a closure pair maps to its
+partner and every other vertex is fixed, a `Classical.choose` over the
+closure made well defined by the position toolkit's uniqueness facts),
+proves its evaluation laws, bounds, and involutivity, and discharges
+the `S`-hypotheses of `flip_rows` for it: closure pairs swap
 (`pairFlip_first`/`pairFlip_second`), members of non-closure cells are
 fixed (`pairFlip_fix_cell`), and the closure is `PairMatch`-closed by
 construction (`PairReach.step`). The self-equivalence
 (`cellsPerm_self_flip`, stated for any renaming swapping `S`-pairs and
-fixing the other cells pointwise, so future flips reuse it) and the
-packaged pair deviation (`pair_deviation_leafRows`, through
-`deviation_leafRows_self` exactly as the triple instance) complete the
-pair analogue of the triple theory.
+fixing the other cells pointwise) and the packaged pair deviation
+(`pair_deviation_leafRows`, through `deviation_leafRows_self` exactly
+as the triple instance) complete the pair analogue of the triple
+theory.
 -/
 
 namespace Hex.GraphIso.Nauty

--- a/HexGraphIso/Nauty/SmallCell/FourCell.lean
+++ b/HexGraphIso/Nauty/SmallCell/FourCell.lean
@@ -16,12 +16,11 @@ import all HexGraphIso.Nauty.Equitable.Fix
 public section
 
 /-!
-The four-cell-beside-a-pair configuration (SPEC § Verified search
-refinement, the code-1 arm of the store-validity obligation).
+The four-cell-beside-a-pair configuration.
 
 Under a defect-four cheapautom pass the last shape is a four-cell
 coexisting with a pair. The four-cell's members carry a constant count
-into the pair; a uniform count (`0` or `2`) leaves the pair fixed, and
+into the pair. A uniform count (`0` or `2`) leaves the pair fixed, and
 the matched count `1` splits the four-cell into the two pairs of
 neighbours of the pair's members, so a flip across that split has to
 carry the pair along. The triple swap `sw3` is the resulting map.

--- a/HexGraphIso/Nauty/SmallCell/Guard.lean
+++ b/HexGraphIso/Nauty/SmallCell/Guard.lean
@@ -13,8 +13,7 @@ import all HexGraphIso.Nauty.Equitable.Basic
 public section
 
 /-!
-The cheapautom small-cell theory (SPEC § Verified search refinement,
-the code-1 arm of the store-validity obligation).
+The cheapautom guard and the flip theorem at pair cells.
 
 `cheapautom` is nauty's cheap sufficient condition for every leaf of
 the subtree below a node to realize an automorphism with the first
@@ -34,27 +33,14 @@ builds the theory justifying it on top of `refine_equitable`:
   preserves the adjacency rows, so any array realizing it passes
   `checkAutom`.
 
-Remaining layers on top of this file, in dependency order. (1) The
-descent plumbing: re-establish `refine_equitable`'s entry hypotheses
-at each subtree node (the certificate seed at descent is designed in
-the equitability file's docstring; the labelling and count facts come
-from the landed search invariants). (2) The branch step: at a cheap
-equitable node whose target cell is a pair, the two children are
-related by the flip of the target pair's matching component — `S` is
-the `PairMatch`-reachability closure, `hSclosed` holds by
-construction, `hOdd` follows from `cheapautom_iff` and
-`cells_go_sizes_sum` in the all-pairs-and-one-triple branch, and the
-flip carries one child's refined labelling to the other's positionwise
-by refine equivariance. (3) Individualization inside non-pair cells
-and the exotic defect-four configurations (a four-cell, a five-cell,
-two triples), which `hOdd` excludes: triple analogues of `PairMatch`
-and the flip. (4) The composition down the subtree: the current
-leaf's `leafRows` equal the first leaf's by chaining branch steps, and
-the admitted scatter then passes `checkAutom` through the landed
-`checkAutom_scatter_of_leafRows_eq` — no per-flip `checkAutom` wrapper
-is needed, which is why this file exports rows preservation only.
-(5) The `noncheaplevel` bookkeeping event lemma (the three write
-sites) and the arm-2 assembly in `Invariant/Store`.
+`SmallCell/Branch` carries these results down the search subtree and
+`SmallCell/Transitive` assembles them into `stabilizer_transitive`.
+This file states rows preservation only, with no per-flip `checkAutom`
+wrapper: the admitted scatter passes `checkAutom` through
+`checkAutom_scatter_of_leafRows_eq`.
+
+The file ends with the cell-membership facts the descent
+classification consumes.
 -/
 
 namespace Hex.GraphIso.Nauty

--- a/HexGraphIso/Nauty/SmallCell/Leaves.lean
+++ b/HexGraphIso/Nauty/SmallCell/Leaves.lean
@@ -16,8 +16,7 @@ import all HexGraphIso.Nauty.Equitable.Fix
 public section
 
 /-!
-The all-leaves node invariant (SPEC § Verified search refinement, the
-code-1 arm of the store-validity obligation).
+The node invariant the all-leaves induction carries.
 
 Every deviation below a cheapautom node consumes the same node facts:
 the iteration invariant, equitability, an accurate boundary count, and
@@ -26,8 +25,7 @@ carries their disjunction: the first-branch shape (every cell a
 singleton, a pair, or one triple), or a defect of at most four. The
 second is not a special case of the first. The four-vertex empty
 graph's root is one cell of size four, so it has a defect of three and
-no first-branch shape, and the instrumentation probe records it as a
-reachable admission witness.
+no first-branch shape.
 
 This file packages those facts as `SubtreeOk` and proves the invariant
 descends through one individualize-and-refine step
@@ -44,8 +42,8 @@ the cell count grows; `cells_length_eq_bcount` reads that count off
 the boundary count, where `bcount_breakout_eq` and `refine_frozen`
 already measure it.
 
-Turning either shape into flip data belongs to `SmallCell/Transitive`, above
-the exotic layer where the defect-four analogues are proved.
+Turning either shape into flip data belongs to `SmallCell/Transitive`,
+above the exotic layer where the defect-four analogues are proved.
 -/
 
 namespace Hex.GraphIso.Nauty

--- a/HexGraphIso/Nauty/SmallCell/Transitive.lean
+++ b/HexGraphIso/Nauty/SmallCell/Transitive.lean
@@ -19,15 +19,20 @@ public section
 /-!
 `stabilizer_transitive`: for an equitable partition satisfying
 `cheapautom`, the cell stabilizer in the automorphism group acts
-transitively on every cell.
+transitively on every cell. This is what justifies the `(fix, mcr)`
+pair nauty reads off the partition at a `noncheaplevel` node
+(`pairOk_fmptn_of_subtree` in `Correct/State/Ledger`).
 
 A passing guard leaves the node in one of two shapes, and either one
 yields the flip data a deviation consumes. `stabilizer_transitive`
 reads a pair or triple target off the first-branch shape, and a target
 of any size at most five off a defect of at most four, where the exotic
-analogues apply. The all-leaves induction over a target-position path
-then recurses on equal choices and glues one deviation at a differing
-choice, and the imperative descents below apply it.
+analogues apply. The all-leaves theorem `descPath_leafRows_all` then
+states that every leaf below such a node realizes an automorphism with
+the first leaf: the induction over a target-position path recurses on
+equal choices and glues one deviation at a differing choice, and the
+imperative descents below apply it. That is what admits a code-1 exit
+with no `isautom` scan.
 
 This module sits above the exotic layer because that is where the
 defect-four flip data is proved. Everything else the induction needs
@@ -178,11 +183,10 @@ theorem descPath_leafRows_all
 end Hex.GraphIso.Nauty
 
 /-!
-The imperative tie and the code-1 assembly (SPEC § Verified search
-refinement, the code-1 arm of the store-validity obligation).
+The imperative tie and the code-1 assembly.
 
 The search's child loops perform `breakout` at the parent and then the
-child node's `refine`; that composite is exactly `childSt`
+child node's `refine`. That composite is exactly `childSt`
 (`childSt_eq_search_step`), and each surviving target-cell vertex is a
 window member of the target cell (`maketargetcell_mem`), so an
 imperative descent below a node is a `DescPath` step by step. Both
@@ -190,7 +194,7 @@ children of one imperative node use the same `maketargetcell` result,
 so the first-path leaf and a code-1-tested leaf below the greatest
 common ancestor are same-target descents, and
 `descPath_leafRows_all` gives them equal leaf rows
-(`leafRows_eq_of_descPaths`); the admitted scatter then passes
+(`leafRows_eq_of_descPaths`). The admitted scatter then passes
 `checkAutom` through `checkAutom_scatter_of_leafRows_eq`
 (`checkAutom_scatter_of_descPaths`).
 
@@ -200,15 +204,15 @@ branches of `cheapautom_iff` are exactly the two disjuncts of
 `NodeShape` (`cheapautom_shape_or_exotic`). The second branch, a
 defect of at most four with a cell of size four or five or with two
 triples, keeps its own shape rather than being forced into the first,
-which it need not have; `stabilizer_transitive` hands it to the
-defect-four flip analogues (`SmallCell/FourCell`).
+which it need not have. `stabilizer_transitive` proves that case
+from the defect-four flip analogues (`SmallCell/FourCell`).
 
-The run-level facts these theorems consume — the two descents from
-the ancestor with equal target paths, equitability and the boundary
-count at the ancestor, and the guard having held there — are exactly
-the bookkeeping the domination induction carries (`gcaFirst`,
-`eqlevFirst`, `firsttc`, `noncheaplevel`); it discharges them when
-threading `processnode`'s admission event.
+These theorems consume four run-level facts: the two descents from the
+ancestor with equal target paths, equitability at the ancestor, the
+boundary count at the ancestor, and the guard having held there. They
+are exactly the bookkeeping the domination induction carries
+(`gcaFirst`, `eqlevFirst`, `firsttc`, `noncheaplevel`), which
+discharges them at `processnode`'s admission event.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -217,10 +221,10 @@ variable {ctx : Ctx n}
 
 /-! # The imperative step is `childSt` -/
 
-/-- The composite the search's child loops perform — `breakout` at the
-parent, then the child node's `refine` on the returned labelling,
-split partition, and singleton active set — is `childSt` of the
-parent's post-refine state. -/
+/-- The search's child loops perform `breakout` at the parent and then
+the child node's `refine` on the returned labelling, split partition,
+and singleton active set. That composite is `childSt` of the parent's
+post-refine state. -/
 theorem childSt_eq_search_step (r : RefineSt n) (level tc tv : Nat) :
     refine ctx (level + 1)
       (breakout n r.lab r.ptn (level + 1) tc tv).1
@@ -261,10 +265,9 @@ theorem maketargetcell_mem {r : RefineSt n} {level tcLevel : Nat}
 /-! # The node shape from the guard -/
 
 /-- A passing guard gives the first-branch shape or the exotic
-defect-at-most-four configuration. The second disjunct is the
-explicitly surfaced exotic arm: a cell of size four or five, or two
-triples, conformance-reachable per the probe, discharged by the
-defect-four flip analogues. -/
+defect-at-most-four configuration: a cell of size four or five, or two
+triples. The defect-four flip analogues discharge the second
+disjunct. -/
 theorem cheapautom_shape_or_exotic {ptn : Array Nat} {level : Nat}
     (hps : ptn.size = n) (hend : ptn[ptn.size - 1]! ≤ level)
     (hch : cheapautom ptn level n = true) :
@@ -316,7 +319,7 @@ theorem leafRows_eq_of_descPaths
   (descPath_leafRows_all hgsz hsymm hloop (p₁.map Prod.fst)
     hS hU rfl hUd hV htcs hVd).2
 
-/-- The code-1 gate admission is a checked automorphism: the scatter
+/-- The code-1 admission is a checked automorphism: the scatter
 of the second descent's leaf labelling over the first's passes
 `checkAutom`, with no `isautom` scan. -/
 theorem checkAutom_scatter_of_descPaths

--- a/HexGraphIso/Nauty/SmallCell/TwoTriple.lean
+++ b/HexGraphIso/Nauty/SmallCell/TwoTriple.lean
@@ -16,18 +16,17 @@ import all HexGraphIso.Nauty.Equitable.Fix
 public section
 
 /-!
-The two-triple configuration (SPEC § Verified search refinement, the
-code-1 arm of the store-validity obligation).
+The two-triple configuration.
 
 Under a defect-four cheapautom pass with two triple cells, the flip at
-either triple couples across to the other: the constant cross-counts
-between the triples are `0`, `1`, `2` or `3`; the uniform counts leave
-the other triple fixed and reduce to the bare transposition, and the
-matched counts pair each member with its unique minority partner, the
-transposition swapping the two partners along. Everything is forced by
-counting exactly as in the lone-cell file: the reverse counts make the
-two partners distinct, and both triples' internal structure is
-off-diagonally constant (`triple_internal`).
+one triple may have to move the other triple as well. The constant
+cross-count between the triples is `0`, `1`, `2` or `3`. The uniform
+counts leave the other triple fixed and reduce to the bare
+transposition, and the matched counts pair each member with its unique
+minority partner, the transposition swapping the two partners along.
+Everything is forced by counting exactly as in `SmallCell/Exotic`: the
+reverse counts make the two partners distinct, and both triples'
+internal structure is off-diagonally constant (`triple_internal`).
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -679,7 +678,7 @@ theorem twoTriple_flip_data
       omega
     refine twoTriple_sw2 hIt hgsz hsymm hloop hE hT1 hT2 hT12
       hsing hoU hoV hne hpu hpv hpuv ?_ ?_ ?_ ?_
-    · -- the third target member is blind to the partner pair
+    · -- the third target member has equal bits at the partner pair
       intro w hw hwu hwv
       have hwW : w = 3 - oU - oV := by omega
       constructor
@@ -691,7 +690,7 @@ theorem twoTriple_flip_data
         have hz1 := hpwz pu hpu (fun h => hpwu h.symm)
         have hz2 := hpwz pv hpv (fun h => hpwv h.symm)
         rw [bitCnt_eq_zero.mp hz1, bitCnt_eq_zero.mp hz2]
-    · -- the third partner is blind to the chosen pair
+    · -- the third partner has equal bits at the chosen pair
       intro w hw hwa hwb
       constructor
       · have hz1 := hpuz w hw hwa


### PR DESCRIPTION
This PR rewrites the module and declaration docstrings under `HexGraphIso/Nauty/SmallCell/` and `HexGraphIso/Nauty/Equitable/` so they state content only: what each declaration is and what its theorem says. `SmallCell/Guard` states nauty's `cheapautom` condition (defect at most the number of nontrivial cells plus one, or at most four) together with the small-cell structure of an equitable partition and the pair flip theorem; `SmallCell/Transitive` states `stabilizer_transitive`, that under `cheapautom` the cell stabilizer in the automorphism group acts transitively on every cell, which is what justifies the `(fix, mcr)` pair nauty reads off the partition at a `noncheaplevel` node, and `descPath_leafRows_all`, that every leaf below such a node realizes an automorphism with the first leaf, which is what admits a code-1 exit with no `isautom` scan; the `Equitable/` docstrings state that `refine` reaches an equitable partition and how `Basic`, `Step`, `Fix` and `Root` divide that proof. The embedded numbered plans, the chronology, the references to a SPEC section that does not exist, and the em-dashes and semicolon-joined run-ons go. Every technical claim in the old text is preserved. The diff is comment-only, which `scripts/bench/check_graphiso_sweep_freshness.py` confirms without a new sweep.

Stacked on #10052.

Closes #10037

🤖 Prepared with Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
