### PR TITLE
docs(graph-iso): content-only docstrings for the rest of the library

### DIFF
--- a/HexGraphIso/Autos.lean
+++ b/HexGraphIso/Autos.lean
@@ -15,36 +15,34 @@ public section
 /-!
 Automorphism generators, vertex orbits and the group order.
 
-The pinned nauty traversal discovers automorphisms as it runs: each
-one is a `workperm` recorded at a code-1 or code-2 leaf, in discovery
-order, and the same permutations drive the search's own orbit pruning.
-`Aut.trace` is that list, transcribed; because the transcription
-replays nauty's traversal exactly, the list is deterministic and
-conformance-pinnable, not merely the group it generates.
+The nauty traversal discovers automorphisms as it runs: each one is a
+`workperm` recorded at a code-1 or code-2 leaf, in discovery order, and
+the search prunes with the same permutations. `Aut.trace` is that list,
+transcribed. The transcription replays nauty's traversal exactly, so
+the list itself is determined, not just the group it generates, and
+conformance compares it against nauty entry by entry.
 
-Nothing from the search is believed. Each raw array passes through
-`autom?`, which rebuilds it as a `Perm n` and runs the same
-`checkIso` the isomorphism surface uses, so `autos_isIso` reads the
-membership guarantee straight off the check rather than off the
-producer. This is the library's usual producer/checker split, with
-`checkIso` as the sole trusted step.
+No permutation from the search is trusted as given. Each raw array
+passes through `autom?`, which rebuilds it as a `Perm n` and runs the
+same `checkIso` the isomorphism operations use, so `autos_isIso` reads
+the membership guarantee off the check rather than off the search. The
+search is the producer and `checkIso` is the only trusted step.
 
-The orbit array replays nauty's `orbjoin` over the checked
-generators, which is exactly what the search does with them, so it is
-the array nauty reports. `sameOrbit_of_orbits_eq` is its guarantee:
-vertices sharing an orbit representative really are carried onto each
-other by an automorphism. The converse, that the generators generate
-the whole group so that distinct representatives really are distinct
-orbits, is the counting argument, and is not yet proved here.
+The orbit array replays nauty's `orbjoin` over the checked generators,
+which is what the search itself does with them, so it is the array
+nauty reports. `sameOrbit_of_orbits_eq` is its guarantee: vertices
+sharing an orbit representative really are carried onto each other by
+an automorphism. The converse, that the generators generate the whole
+group so that distinct representatives are distinct orbits, needs a
+counting argument and is not proved here.
 
 `Aut.order` is the orbit-stabilizer chain: individualize a vertex of
 a non-singleton orbit, recurse on the stabilizer (the search on the
 individualized colouring computes it, since a vertex alone in its
 cell is fixed by every colour-preserving automorphism), and multiply
 the orbit lengths. It is the order of the automorphism group exactly
-when each level's orbit array is the true orbit partition, and a
-lower bound otherwise; it is pinned against nauty's `grpsize` by
-conformance.
+when each level's orbit array is the true orbit partition, and a lower
+bound otherwise. Conformance compares it against nauty's `grpsize`.
 -/
 
 namespace Hex.GraphIso
@@ -101,7 +99,7 @@ theorem Perm.val_get_of_ofNatArray? {a : Array Nat} {p : Perm n}
 
 /-- Accept one raw generator array from the traversal: rebuild it as a
 permutation of `Fin n` and check that it is an automorphism. This is
-the only place a generator is believed, and it believes only
+the only step that admits a generator, and the admission test is
 `checkIso`. -/
 @[expose] def autom? (G : Colored n k) (γ : Array Nat) : Option (Perm n) :=
   match Perm.ofNatArray? n γ with
@@ -182,8 +180,8 @@ theorem inj_of_mem_raw {G : Colored n k} {γ : Array Nat} (h : γ ∈ raw G) :
   exact congrArg Fin.val (p.get_inj (Fin.ext hab))
 
 /-- Every checked generator is an automorphism. This is the membership
-guarantee on the cheap projection; `autos_isIso` is the same fact on the
-packaged result. -/
+guarantee stated on `Aut.gens`. `autos_isIso` is the same fact on the
+packaged `AutResult`. -/
 theorem gens_isIso {G : Colored n k} {p : Perm n} (h : p ∈ gens G) :
     IsIso G G p := by
   rw [gens, List.mem_map] at h
@@ -312,7 +310,7 @@ for a second traversal.
 
 `fuel = n` is enough. Each step individualizes a vertex of a
 non-singleton orbit, so that vertex and every vertex individualized
-before it are singletons in the next level's orbit array; the number of
+before it are singletons in the next level's orbit array. The number of
 vertices in non-singleton orbits therefore drops by at least one per
 step and never passes through one, so at most `n - 1` steps precede the
 call that finds no non-singleton orbit. The `indiv?` failure arm cannot
@@ -336,10 +334,10 @@ termination_by fuel
 /-- The orbit-stabilizer product for `G`: the order of its automorphism
 group exactly when each level's orbit array is the true orbit
 partition. Without that, each computed orbit is contained in the true
-one, so the product is a lower bound; it is not the order of the group
+one, so the product is a lower bound. It is not the order of the group
 generated by the reported generators either, since the stabilizer
 factors come from separate runs rather than from that list. Conformance
-pins it against nauty's `grpsize`. -/
+compares it against nauty's `grpsize`. -/
 @[expose] def order (G : Colored n k) : Nat := orderAux n G (orbits G)
 
 end Aut
@@ -364,10 +362,10 @@ structure AutResult (n : Nat) where
 /-- Generators of the automorphism group of a coloured graph, with the
 vertex orbits, the orbit count and the orbit-stabilizer product for the
 group order. Every returned permutation is an automorphism
-(`autos_isIso`); vertices sharing an orbit representative are in one
-orbit (`autos_sameOrbit`). The order and the orbit count are the
-reported numbers rather than theorems, for the reason `Aut.order`
-gives. Computing the order runs one traversal per base point, so a
+(`autos_isIso`). Vertices sharing an orbit representative are in one
+orbit (`autos_sameOrbit`). The order and the orbit count are reported
+numbers rather than theorems, for the reason `Aut.order` gives.
+Computing the order runs one traversal per base point, so a
 caller who wants only the generators or the orbits should take
 `Aut.gens` or `Aut.orbits`. -/
 @[expose] def autos (G : Colored n k) : AutResult n :=

--- a/HexGraphIso/Colored.lean
+++ b/HexGraphIso/Colored.lean
@@ -26,8 +26,8 @@ colour vector, which keeps fixture comparison kernel-reducible.
 
 `CanonResult` pairs a canonical form with the label producing it, and
 `ColorSorted` says the colour classes are contiguous in vertex order, the
-shape every canonical form has. Both are stated here because the whole
-canonicalization stack above builds on them.
+shape every canonical form has. Both are stated here because every module
+that computes a canonical form uses them.
 -/
 
 namespace Hex.GraphIso
@@ -40,8 +40,10 @@ structure Coloring (n k : Nat) where
   /-- Every colour is used. -/
   onto : Function.Surjective cells.get
 
-/-- `Vector.get` agrees with element access; core states no lemmas about
-`Vector.get`, so the `onto` field is used through this bridge. -/
+/-- `Vector.get` agrees with element access. The Lean standard library
+states its `Vector` lemmas about `getElem` rather than about
+`Vector.get`, so uses of the `onto` field rewrite with this equation
+first. -/
 theorem _root_.Hex.Vector.get_eq_getElem {α : Type u} {m : Nat} (v : Vector α m) (i : Fin m) :
     v.get i = v[i] := rfl
 
@@ -77,13 +79,13 @@ theorem isSome_ofVector? (v : Vector (Fin k) n) :
 
 /-- The constant zero colouring: the one-cell colouring of a nonempty vertex
 set. -/
--- The size side conditions here and below try `decide` before `omega`.
--- At a literal size `decide` closes the goal with a self-contained term,
--- whereas `omega` lifts an auxiliary theorem into the ambient namespace;
--- at a command that has no enclosing declaration (a `#guard` or `#eval`,
--- as in the manual chapters) that theorem is named in the root namespace
--- and two modules that produce one cannot both be imported. `omega`
--- remains the fallback, and is what runs at a symbolic size.
+-- The size side conditions here and below try `decide` before `omega`. At a
+-- literal size `decide` closes the goal with a self-contained term, whereas
+-- `omega` lifts an auxiliary theorem into the ambient namespace. At a command
+-- with no enclosing declaration (a `#guard` or `#eval`, as in the manual
+-- chapters) that namespace is the root one, and two modules that each produce
+-- such a theorem cannot both be imported. `omega` stays as the fallback, and
+-- is what runs at a symbolic size.
 @[expose] def trivial (n : Nat) (h : 0 < n := by first | decide | omega) :
     Coloring n 1 where
   cells := Hex.Vector.ofFn' fun _ => 0

--- a/HexGraphIso/Families.lean
+++ b/HexGraphIso/Families.lean
@@ -11,16 +11,16 @@ public import HexGraphIso.Colored
 public section
 
 /-!
-Deterministic graph families for the conformance and benchmark corpus,
-per HexGraphIso/SPEC/hex-graph-iso.md § Reproducible generators. Each
-generator documents its mathematical definition and its stable
-vertex-numbering rule; none uses randomness. This module carries the
-first slice — paths, cycles, circulants, generalized Petersen graphs,
-complete multipartite graphs, repeated components, grids, hypercubes,
-Johnson, Kneser, triangular, Paley, and cyclic Latin-square graphs —
-with the remaining incidence-geometry families (Hadamard matrices,
-projective planes) and the CFI, Miyazaki, and multipede instances to
-follow in the staged corpus.
+Deterministic graph families for the conformance and benchmark corpus.
+These are the reproducible generators the `hex-graph-iso` SPEC
+describes. Each one documents its mathematical definition and its
+stable vertex-numbering rule, and none uses randomness.
+
+The families defined here are paths, cycles, circulants, generalized
+Petersen graphs, complete multipartite graphs, complete bipartite
+graphs, disjoint copies of a graph, grids, hypercubes, Johnson graphs,
+Kneser graphs, triangular graphs, the Latin-square graph of the cyclic
+Latin square, and Paley graphs.
 -/
 
 namespace Hex.GraphIso.Families
@@ -31,7 +31,7 @@ open Hex
 @[expose] def path (n : Nat) : Graph n :=
   Graph.ofRel fun i j => j.val == i.val + 1
 
-/-- The cycle on `n` vertices in their natural order; for `n ≤ 2` this
+/-- The cycle on `n` vertices in their natural order. For `n ≤ 2` this
 degenerates to the path. -/
 @[expose] def cycle (n : Nat) : Graph n :=
   Graph.ofRel fun i j => j.val == (i.val + 1) % n
@@ -136,9 +136,10 @@ in colexicographic order, adjacent when the subsets are disjoint. -/
 `(r, c) ↦ (r + c) mod m`: vertices are the `m²` cells numbered
 `r * m + c`, adjacent when they share a row, a column, or a symbol.
 For `m ≥ 2` this is strongly regular with parameters
-`(m², 3(m−1), m, 6)`; at `m = 5` it shares its parameters
-`(25, 12, 5, 6)` with the Paley graph on 25 vertices while remaining
-non-isomorphic to it, the classic strongly regular negative pair. -/
+`(m², 3(m−1), m, 6)`. At `m = 5` its parameters `(25, 12, 5, 6)` are
+those of the Paley graph on 25 vertices, but the two graphs are not
+isomorphic. That is the standard example of two non-isomorphic
+strongly regular graphs with the same parameters. -/
 @[expose] def latinSquare (m : Nat) : Graph (m * m) :=
   Graph.ofRel fun i j =>
     (i.val != j.val) &&

--- a/HexGraphIso/Iso.lean
+++ b/HexGraphIso/Iso.lean
@@ -17,9 +17,10 @@ Isomorphism of coloured graphs.
 transports `G` onto `H`, preserving each ordered colour index. `checkIso`
 is the executable Boolean checker, sound and complete for `IsIso`.
 
-The section ends with the two bridges between isomorphism and relabelling:
-every labelling produces an isomorphic graph, and every isomorphism arises
-from a labelling. These carry the reference canonical-form proofs.
+The last section relates isomorphism to relabelling: every labelling
+produces an isomorphic graph, and every isomorphism arises from a
+labelling. The canonical-form proofs are stated through these two
+theorems.
 -/
 
 namespace Hex.GraphIso
@@ -48,7 +49,7 @@ theorem checkIso_iff (G H : Colored n k) (p : Perm n) :
     forall_const]
   exact Iff.rfl
 
-/-- Introduce `IsIso` from its two clauses; the definition is not
+/-- Introduce `IsIso` from its two clauses. The definition is not
 exposed across module boundaries, so consumers use this. -/
 theorem IsIso.mk {G H : Colored n k} {p : Perm n}
     (hc : ∀ i, H.coloring.cells[p.get i] = G.coloring.cells[i])

--- a/HexGraphIso/Kernel/CheckKey.lean
+++ b/HexGraphIso/Kernel/CheckKey.lean
@@ -12,28 +12,28 @@ public import HexGraphIso.Kernel.Packed
 public section
 
 /-!
-The negative route's kernel obligation, `Kernel.checkKey`.
+`Kernel.checkKey`, the proposition the negative route asks the kernel to reduce.
 
-The trusted `Nauty.checkKey` walks `Array` labelling and partition
-state, and every kernel access pays the core `getElem!`/`set!` bounds
+The trusted `Nauty.checkKey` reads `Array` labelling and partition state
+by index, and every kernel access pays the `getElem!`/`set!` bounds
 machinery on top of a spine walk. `Kernel.checkKey` replays the same
 certificate over `lab` and `ptn` packed into fixed-width fields of one
-`Nat` and the adjacency rows packed with width `n`, with every
-arithmetic step spelled as the raw kernel-accelerated function, so a
-read is a shift and a mask, a write a handful of arithmetic steps, and
-a refinement pass linear in the kernel.
+`Nat` and the adjacency rows packed with width `n`, every arithmetic
+step spelled as the raw kernel-accelerated function. A read is then a
+shift and a mask, a write a handful of arithmetic steps, and a
+refinement pass linear in the kernel.
 
-The equality with `Nauty.checkKey` is threaded through two internal
-layers, neither of which the kernel evaluates: the replay's call tree
-over `List Nat` state, and the same tree over the rows rebuilt from the
-tied flat literal. The packed clones are proven equal to the list ones
-under the correspondence `Rep` between a packed number and the list it
-encodes, threaded through the state by `RepSt`; the list ones are
-proven equal to the `Array` originals by the unconditional
-`Array`/`List` correspondences. `Kernel.checkKey_eq` composes the
-chain, and `Kernel.not_isomorphic_of_checkKeys` is the theorem the
-tactic applies. The compiled search and the `Array` definitions the
-soundness proofs mention are untouched.
+The equality with `Nauty.checkKey` goes through two internal layers,
+neither of which the kernel evaluates: the replay's call tree over
+`List Nat` state, and the same tree over the rows rebuilt from the flat
+adjacency literal. Each packed definition is proven equal to its list
+counterpart under `Rep`, the correspondence between a packed number and
+the list it encodes, carried through the refinement state by `RepSt`.
+Each list definition is proven equal to its `Array` original by the
+`Array`/`List` correspondences. `Kernel.checkKey_eq` composes the chain,
+and `Kernel.not_isomorphic_of_checkKeys` is the theorem the tactic
+applies. The compiled search and the soundness proofs stay on the
+`Array` definitions.
 -/
 
 namespace Hex.GraphIso.Kernel
@@ -130,9 +130,9 @@ structure RefineStL where
 
 /-! # The refine tower over list state
 
-Each clone mirrors its original body exactly, with `atD` for reads and
-`List.set` for writes; the equalities are structural inductions over
-the same recursions, rewriting through the access correspondences. -/
+Each definition mirrors its `Array` original body for body, with `atD`
+for reads and `List.set` for writes, and each equality is a structural
+induction rewritten through the access correspondences above. -/
 
 def cellEndGoL (ptn : List Nat) (level : Nat) :
     Nat → Nat → Nat
@@ -912,8 +912,8 @@ theorem leafRowsL_eq (ctx : Ctx n) (lab : Array Nat) :
 
 /-! # Literal keys
 
-The kernel replay compares keys whose rows are bitsets: `Kernel.Key` is
-the literal the tactic emits, `Key.toL` its reading of a packed key, and
+The kernel replay compares keys whose rows are bitsets. `Kernel.Key` is
+the literal the tactic emits, `Key.toL` reads a `Nauty.Key` as one, and
 `keyCmpL` mirrors `keyCmp` through `NatSet.rowCmp`. -/
 
 /-- The literal reading of a packed key. -/
@@ -1245,7 +1245,7 @@ theorem checkNodeL_eq (ctx : Ctx n) (tcLevel : Nat) (brows : List (VSet n))
         · rfl
   termination_by structural fuel => fuel
 
-/-! # The negative kernel obligation over list state -/
+/-! # The replay over `lab`, `ptn` and the rows packed into `Nat` fields -/
 /-! # Packed context and state -/
 
 /-- The replay context over packed rows: `w`/`m` are the field width
@@ -2787,7 +2787,7 @@ theorem checkNodeP_eq {ctx : CtxP} {ctxL : CtxL} (h : CtxRep ctx ctxL)
   termination_by structural fuel => fuel
 
 
-/-! # The negative kernel obligation over packed state -/
+/-! The packed replay agrees with the list replay: `checkNodeP_eq`. -/
 end Hex.GraphIso.Nauty
 namespace Hex.GraphIso
 
@@ -2795,12 +2795,12 @@ open Nauty
 
 variable {n k : Nat}
 
-/-! # The negative kernel obligation
+/-! # What the kernel evaluates
 
-The obligation is stated over the rows tied as one packed number and
-proven equal to `Nauty.checkKey` through two internal layers: the rows
-rebuilt from the tied flat literal (`checkKeyFlat`), and the whole
-replay over list state (`checkKeyLit`). -/
+`Kernel.checkKey` is stated over the adjacency rows packed as one number
+and proven equal to `Nauty.checkKey` through two internal layers: the
+rows rebuilt from the flat adjacency literal (`checkKeyFlat`), and the
+whole replay over list state (`checkKeyLit`). -/
 
 /-- `Nauty.checkKey` with the adjacency rows rebuilt from a flat
 literal instead of forcing `rowsOf`. -/
@@ -2823,8 +2823,8 @@ private theorem checkKeyFlat_eq (G : Colored n k) (cert : Nauty.CertNode)
   rw [checkKeyFlat, Nauty.checkKey, rowsOfFlat_eq_rowsOf]
 
 /-- `checkKeyFlat` with list state end to end: the rows are rebuilt
-once from the tied flat literal as bitsets and the whole replay walks
-bare lists. -/
+once from the flat adjacency literal as bitsets, and the whole replay
+runs on bare lists. -/
 private def checkKeyLit (G : Colored n k) (flat : List Bool)
     (cert : CertNode) (K : Kernel.Key) : Bool :=
   K.rows.all (fun r => r < 2 ^ n) &&
@@ -2918,10 +2918,10 @@ theorem initRep (G : Colored n k) (flat : List Bool) (hn0 : 0 < n) :
 
 namespace Kernel
 
-/-- The negative route's kernel obligation: the certificate replayed
-over packed state, with the rows packed once from the tied adjacency
-matrix (`Kernel.packRows`) and the labelling and partition packed with
-the field width `initW n`. -/
+/-- The proposition the tactic's negative route reduces in the kernel:
+the certificate replayed over packed state, with the rows packed once
+from the adjacency matrix (`Kernel.packRows`) and the labelling and
+partition packed with the field width `initW n`. -/
 @[expose] def checkKey (G : Colored n k) (rows : Nat)
     (cert : CertNode) (K : Key) : Bool :=
   K.rows.all (fun r => r < 2 ^ n) &&
@@ -2947,7 +2947,7 @@ private theorem checkKey_eq_lit (G : Colored n k) (flat : List Bool)
     rw [checkNodeP_eq hctx 100 K.rows (containsGammaP_eq hctx cert) n 1
       (by show 1 + n ≤ n + 1; omega) hlab hptn]
 
-/-- The kernel obligation is the trusted `Nauty.checkKey`, for a
+/-- `Kernel.checkKey` agrees with the trusted `Nauty.checkKey`, for a
 literal key whose rows are bitsets over `n` vertices. -/
 theorem checkKey_eq (G : Colored n k) (cert : CertNode) (K : Key)
     (h : ∀ r ∈ K.rows, r < 2 ^ n) :
@@ -2960,9 +2960,9 @@ theorem checkKey_eq (G : Colored n k) (cert : CertNode) (K : Key)
 def certifyKey? (budget : Nat) (G : Colored n k) : Option (CertNode × Key) :=
   (Nauty.certifyKey? G (some budget)).map fun p => (p.1, p.2.toL)
 
-/-- Tying equalities plus two packed-state key certificates with
-differing keys prove non-isomorphism: the kernel evaluates each graph
-once into its packed rows and replays one certificate per side. -/
+/-- Equalities identifying each graph's packed rows, plus two key
+certificates with differing keys, prove non-isomorphism: one kernel
+evaluation of the rows per graph, then one certificate replay per side. -/
 theorem not_isomorphic_of_checkKeys {G H : Colored n k}
     {certG certH : CertNode} {BG BH : Key} {NA NB : Nat}
     (hA : packRows n G.graph.adjMatrix.data.toList = NA)

--- a/HexGraphIso/Kernel/IsoLit.lean
+++ b/HexGraphIso/Kernel/IsoLit.lean
@@ -13,19 +13,19 @@ public section
 
 /-!
 The positive route's kernel checker. `graph_iso` proves `Isomorphic G H`
-by tying each side to a literal, one sequential kernel evaluation per
-graph, and validating the transporter entirely on those literals.
-`Kernel.checkIso` walks row-chunked literal lists with bare-`Nat`-match
-accessors, so the kernel pays a short list walk per probe instead of a
-flat `Array` index into the adjacency matrix, whose walk length grows
-with the flat index.
+by reducing each side to a list literal, one kernel evaluation per
+graph, then validating the transporter entirely on those literals.
+`Kernel.checkIso` reads row-chunked literal lists through bare `Nat`
+matches, so the kernel walks one short row per probe instead of
+indexing the flat adjacency matrix, whose spine walk grows with the
+flat index.
 -/
 
 namespace Hex.GraphIso
 
 variable {n k : Nat}
 
-/-- Literal list access priced for kernel reduction: one bare match
+/-- Indexed list access built for cheap kernel reduction: one bare match
 per step, no bounds proofs, no `Array` wrapper. -/
 @[expose] def atD {α : Type} : List α → Nat → α → α
   | [], _, d => d
@@ -93,8 +93,8 @@ namespace Kernel
 
 /-- Validate a forward transporter on literal data: `flatA`/`flatB`
 are the flat adjacency lists, `cellsA`/`cellsB` the colour values,
-and `pl` the transporter images, all tied back to the graphs by the
-hypotheses of `Kernel.isIso_of_checkIso`. -/
+and `pl` the transporter images, each identified with the graph it
+comes from by a hypothesis of `Kernel.isIso_of_checkIso`. -/
 @[expose] def checkIso (n : Nat) (flatA flatB : List Bool)
     (cellsA cellsB pl : List Nat) : Bool :=
   let rowsA := chunkRows n n flatA
@@ -107,10 +107,10 @@ hypotheses of `Kernel.isIso_of_checkIso`. -/
     (List.range n).all fun j =>
       atD rB (atD pl j 0) false == atD rA j false
 
-/-- Tying equalities plus a literal transporter check prove that the
-permutation transports: the kernel evaluates each graph once —
-sequentially, into its literal — and the rest of the replay runs on
-literals. -/
+/-- Equalities identifying the graph data with the literals, plus a
+literal transporter check, prove that the permutation transports. The
+kernel evaluates each graph once, into its literal, and the rest of the
+check runs on literals. -/
 theorem isIso_of_checkIso {G H : Colored n k} {p : Perm n}
     {LA LB : List Bool} {CA CB PL : List Nat}
     (hA : G.graph.adjMatrix.data.toList = LA)
@@ -148,8 +148,8 @@ theorem isIso_of_checkIso {G H : Colored n k} {p : Perm n}
     rw [hPL i, hPL j, hflat, hflat] at h
     exact h
 
-/-- Tying equalities plus a literal transporter check prove
-isomorphism. -/
+/-- Equalities identifying the graph data with the literals, plus a
+literal transporter check, prove isomorphism. -/
 theorem isomorphic_of_checkIso {G H : Colored n k} {p : Perm n}
     {LA LB : List Bool} {CA CB PL : List Nat}
     (hA : G.graph.adjMatrix.data.toList = LA)

--- a/HexGraphIso/Kernel/Packed.lean
+++ b/HexGraphIso/Kernel/Packed.lean
@@ -13,8 +13,8 @@ public import HexGraphIso.Kernel.IsoLit
 public section
 
 /-!
-Kernel-priced primitives for the certificate replay, and the packed
-rows the replay reads.
+Primitives written for cheap kernel reduction, used by the certificate
+replay, and the packed rows the replay reads.
 
 The kernel has no support for `Array` and reduces `List` access by
 walking the spine, so every indexed read of the replay's labelling
@@ -22,25 +22,25 @@ and partition state costs the index. It does have GMP-accelerated
 `Nat` arithmetic and bit operations, each one reduction step whatever
 the operand size. This file packs a list of small naturals into one
 `Nat` of fixed-width fields, so that a read is a shift and a mask and
-a write is a handful of arithmetic steps, and states the
-correspondence `Rep` between a packed number and the list it encodes
-that the replay clones in `HexGraphIso.Kernel.CheckKey` thread through
-their equalities.
+a write is a handful of arithmetic steps. It also states `Rep`, the
+correspondence between a packed number and the list it encodes, which
+the packed definitions in `HexGraphIso.Kernel.CheckKey` carry through
+their equalities with the list ones.
 
 Every definition here that the kernel evaluates is spelled with the
 raw `Nat.add`, `Nat.beq`, `Nat.land`, ... functions the kernel
 accelerates and with `cond` on their `Bool` results, so no typeclass
 instance or `Decidable` wrapper stands between the term and the
-accelerated step; the `if`/`==`/`&&&` spellings unfold to these by
+accelerated step. The `if`/`==`/`&&&` spellings unfold to these by
 `rfl`, which is how the proofs connect the two. The same treatment
 gives `popCountK` and `lowBitK`, byte-table forms of the per-bit
-recursions that the kernel otherwise pays one step per bit for.
+recursions the kernel otherwise pays one step per bit for.
 
-`Kernel.packRows` reads the tied flat adjacency literal into one
-packed number with field width `n`, row `v` in bits
-`[n * v, n * (v + 1))`; `flatRows` and `rowsOfFlat` are the list and
-packed-set readings of the same rows that the soundness proofs go
-through.
+`Kernel.packRows` reads the flat adjacency literal into one packed
+number with field width `n`, row `v` in bits
+`[n * v, n * (v + 1))`. `flatRows` and `rowsOfFlat` are the list and
+packed-set readings of the same rows, and the soundness proofs go
+through them.
 -/
 namespace Hex.GraphIso.Nauty
 
@@ -115,12 +115,12 @@ theorem cond_beq_true {α : Type} (a : Bool) (x y : α) :
 
 /-! # The loop driver
 
-Structural recursion on a `Nat` fuel unfolds through `Nat.brecOn` at
-about four times the cost of a bare `Nat.rec` step, and `List.range`
-costs the kernel some twenty microseconds per element it builds.
-`iterUp` is the ascending counted loop as one `Nat.rec` step per
-iteration; the range-driven folds and maps of the replay go through
-it and its two derived forms. -/
+Structural recursion on a `Nat` fuel unfolds through `Nat.brecOn`,
+which costs several reduction steps per iteration, and a loop written
+over `List.range` makes the kernel build that list first. `iterUp` is
+the ascending counted loop as one `Nat.rec` step per iteration. The
+range-driven folds and maps of the replay go through it and its two
+derived forms, `mapRange` and `allRange`. -/
 
 /-- The compiled form of `iterUp`. -/
 def iterUpImpl {α : Type} (k : Nat) (f : Nat → α → α) (a : α) : α :=
@@ -245,11 +245,11 @@ theorem cleanupK_eq (l : Nat) : cleanupK l = cleanup l := rfl
 
 /-! # Byte-table `popCount` and `lowBit`
 
-The per-bit recursions cost the kernel about forty reduction steps
-per bit (each iteration a `Nat` decision, a modulus, a division, an
-addition, all through their instances). One byte per iteration, the
-byte's answer read from a 256-entry table packed four bits per entry
-into one literal, is one shift and one mask per byte. -/
+The per-bit recursions cost the kernel a fixed number of `Nat`
+operations per bit: a decision, a modulus, a division and an addition,
+each through its instance. Taking one byte per iteration and reading
+the byte's answer from a 256-entry table packed four bits per entry
+into one literal costs one shift and one mask per byte. -/
 
 /-- `popCount` of every byte, four bits per entry. -/
 @[expose] def popCountTable : Nat :=
@@ -682,7 +682,7 @@ theorem flatRows_small (nn : Nat) (flat : List Bool) :
 /-! # Rows packed from the flat literal
 
 `flatRows` rebuilds each row by probing its segment position by
-position, a spine walk per bit; `rowOfSegK` reads the segment once. -/
+position, a spine walk per bit. `rowOfSegK` reads the segment once. -/
 
 /-- The bit set of a row segment whose head sits at position `j`. -/
 @[expose] def rowOfSegK : List Bool → Nat → Nat

--- a/HexGraphIso/Kernel/RootCode.lean
+++ b/HexGraphIso/Kernel/RootCode.lean
@@ -16,11 +16,11 @@ The root separator: the head code of the specification key, computed
 by a single refinement of the initial partition and no tree search.
 Isomorphic graphs have equal specification keys, so a difference in
 that one code refutes isomorphism at the cost of one refinement per
-graph, far below a certificate replay.
+graph, far below the cost of a certificate replay.
 
 `Kernel.rootCode` runs the refinement over the packed state of
-`HexGraphIso.Kernel.CheckKey` on the rows tied as one packed number;
-`Kernel.rootCode_eq` identifies it with the head of
+`HexGraphIso.Kernel.CheckKey`, on the adjacency rows packed as one
+number. `Kernel.rootCode_eq` identifies it with the head of
 `Nauty.canonSpecKey` through the list and `Array` layers, and
 `Kernel.not_isomorphic_of_rootCode` is the theorem the tactic applies.
 -/
@@ -66,7 +66,7 @@ private theorem rootCodeL_eq (n : Nat) (g : Array (VSet n)) (lab0 : Array Nat)
 namespace Kernel
 
 /-- The specification key's head code of a coloured graph whose
-adjacency rows are tied as the one packed number `rows`: a single
+adjacency rows are packed as the one number `rows`: a single
 refinement of the initial partition. -/
 @[expose] def rootCode (G : Colored n k) (rows : Nat) : Nat :=
   (refineP (initCtx n rows) 1 (initLabP G) (initPtnP G)
@@ -92,7 +92,7 @@ theorem rootCode_eq (G : Colored n k) (hn : 2 ≤ n) :
   rw [rootCode_eq_L G _ hn, canonSpecKey, ← rowsOfFlat_eq_rowsOf G,
     ← toNat_rowsOfFlat, rootCodeL_eq, rootCodeA_eq _ _ _ _ hn]
 
-/-- The compiled-side root-code test: whether the root route fires on
+/-- The compiled-side root-code test: whether the root route separates
 this pair. Evaluated at elaboration time over the `Array` rows, so the
 route decision costs one refinement per graph and no kernel work. -/
 def rootSeparates (G H : Colored n k) : Bool :=
@@ -100,13 +100,13 @@ def rootSeparates (G H : Colored n k) : Bool :=
   !Nat.beq (rootCodeA n (rowsOf G) (initialPartition G).1 (initialPartition G).2)
     (rootCodeA n (rowsOf H) (initialPartition H).1 (initialPartition H).2)
 
-/-- The root codes of two coloured graphs disagree: the negative
-route's cheapest kernel obligation, one refinement per graph. -/
+/-- The root codes of two coloured graphs disagree: the cheapest
+kernel check of the negative route, one refinement per graph. -/
 @[expose] def rootDiff (G H : Colored n k) (NA NB : Nat) : Bool :=
   decide (2 ≤ n) && !Nat.beq (rootCode G NA) (rootCode H NB)
 
-/-- Tying equalities plus a root-code disagreement prove
-non-isomorphism. -/
+/-- Equalities identifying each graph's packed rows, plus a root-code
+disagreement, prove non-isomorphism. -/
 theorem not_isomorphic_of_rootCode {G H : Colored n k} {NA NB : Nat}
     (hA : packRows n G.graph.adjMatrix.data.toList = NA)
     (hB : packRows n H.graph.adjMatrix.data.toList = NB)

--- a/HexGraphIso/ModuleBoundaryTests.lean
+++ b/HexGraphIso/ModuleBoundaryTests.lean
@@ -17,16 +17,21 @@ public meta import Lean
 public section
 
 /-!
-Module-boundary kernel regression ladder for the certificate replay
-closure, in the mould of `HexBasic.ModuleBoundaryTests`: every
-obligation here is closed by `kdecide`, which assigns the raw
-`of_decide_eq_true` shape so that ONLY the module-finalization kernel
-evaluates it — the exact obligation the `graph_iso` certificate route
-emits. These stages caught two exposure gaps: `mash`/`cleanup` and
-`codeSentinel` missing `@[expose]` here, and core `Array.map`
-delegating to the unexposed `Array.mapM` (worked around by
-`Hex.Array.map'`; upstream fix pending in the lean4 exposure series).
-The tests must stay in their own module: the defect class is a
+Module-boundary kernel tests for the certificate replay, in the mould of
+`HexBasic.ModuleBoundaryTests`. Every goal here is closed by `kdecide`,
+which assigns the raw `of_decide_eq_true` shape so that only the
+module-finalization kernel evaluates it, the same shape the `graph_iso`
+certificate route emits. Together the examples check that every
+declaration the certificate route's kernel goal reaches is evaluable
+from another module: the refinement steps, the certificate checker, the
+packed bit-set operations, and the array and list helpers underneath
+them.
+
+`Hex.Array.map'` appears below in place of core `Array.map`, which
+delegates to an unexposed `Array.mapM` and so does not reduce across a
+module boundary.
+
+The tests must stay in their own module. The defect they catch is a
 callee's body being unavailable across a module boundary, so a
 same-module test proves nothing.
 -/
@@ -37,7 +42,7 @@ meta section
 open Lean Meta Elab Tactic
 
 /-- Close a decidable goal with `of_decide_eq_true (id (Eq.refl true))`,
-assigned raw so that ONLY the declaration kernel evaluates it. -/
+assigned raw so that only the declaration kernel evaluates it. -/
 elab "kdecide" : tactic => do
   let g ← getMainGoal
   let p ← g.getType
@@ -108,7 +113,7 @@ example : (refine { g := rowsOf probeGraph } 1
     (initActive 10 (initialPartition probeGraph).2)
     (initialPartition probeGraph).2.length).longcode = 128 := by kdecide
 
--- residual-suspect isolation
+-- Individual list, array and bit-set helpers the checker calls.
 example : ([1,2,3].zipIdx 0 = [(1,0),(2,1),(3,2)]) := by kdecide
 example : (keyCmp probeKey probeKey = Ordering.eq) := by kdecide
 set_option maxRecDepth 1000000 in
@@ -125,8 +130,8 @@ example : checkNode { g := rowsP } 100 probeKey.rows
     (validGammas rowsP probeCert) 1 1
     lab0 (initPtn 10 12 [9]) (initActive 10 [9]) 1 probeCert
     probeKey.codes = none := by kdecide
--- core `Array.map` itself still stalls here (unexposed impl loop; see
--- the upstream draft); the house `Hex.Array.map'` reduces:
+-- Core `Array.map` does not reduce here, because it delegates to the
+-- unexposed `Array.mapM`. `Hex.Array.map'` reduces:
 example : (Hex.Array.map' (fun w => w + 1) lab0).toList =
     [1,2,3,4,5,6,7,8,9,10] := by kdecide
 example : (Hex.Array.map' (fun w => w + 1) #[1, 2]) = #[2, 3] := by kdecide
@@ -159,10 +164,10 @@ example : checkNode { g := rowsP } 100 probeKey.rows
 set_option maxRecDepth 1000000 in
 example : checkKey probeGraph probeCert probeKey = true := by kdecide
 
-/-! # The obligations the tactic emits
+/-! # The goals the tactic emits
 
-Both negative routes replay against the rows tied as one packed number,
-so these stages pin the kernel closure of `Kernel.packRows`, the packed
+Both negative routes replay against the adjacency rows packed into one
+natural number, so these examples exercise `Kernel.packRows`, the packed
 replay (`pget`/`pset`, the byte-table `popCount`, the raw bit-set
 operations) and the root refinement end to end. -/
 
@@ -179,7 +184,7 @@ example : Hex.GraphIso.Kernel.rootDiff probeGraph probeGraph
 
 /-! # Packed sets across limb boundaries
 
-`VSet 127` holds three 63-bit limbs; these probes put members in each
+`VSet 127` holds three 63-bit limbs. These examples put members in each
 limb and on both sides of the limb boundary at vertices `62` and `63`. -/
 
 private def bigA : VSet 127 := VSet.ofNat (2 ^ 126 + 2 ^ 63 + 2 ^ 62 + 1)

--- a/HexGraphIso/Nauty/Cert/CanonForm.lean
+++ b/HexGraphIso/Nauty/Cert/CanonForm.lean
@@ -13,11 +13,13 @@ public import HexGraphIso.Nauty.Search.Search
 public section
 
 /-!
-The `CanonResult`-level certificate wrapper: a checked canonical key
-together with the labelling that achieves it, packaged as the
-relabelled canonical form. `checkCanon` validates the certificate
-replay, the labelling's rows against the claimed key, and builds the
-form; its soundness ties the form to `canonSpecKey`.
+The `CanonResult`-level certificate: a checked canonical key together
+with the labelling that achieves it, packaged as the relabelled
+canonical form. `checkCanon` replays the certificate, checks the
+labelling's leaf rows against the claimed key, and builds the form.
+Its soundness theorem states that the claimed key is `canonSpecKey`
+and that the form is a relabelling of the input, hence isomorphic
+to it.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -54,8 +56,9 @@ rows must be the key's rows. Returns the canonical form and label. -/
     else
       none
 
-/-- A successful `checkCanon` pins the spec key, exhibits the form as
-a relabelling, and keeps the form in the isomorphism class. -/
+/-- A successful `checkCanon` identifies the claimed key with the
+spec key, exhibits the form as a relabelling, and shows the form
+isomorphic to the input. -/
 theorem checkCanon_sound {G : Colored n k} {cert : CertNode} {B : Key n}
     {lab : Array Nat} {res : CanonResult n k}
     (h : checkCanon G cert B lab = some res) :
@@ -83,9 +86,9 @@ theorem checkCanon_sound {G : Colored n k} {cert : CertNode} {B : Key n}
 /-- Produce a checked `CanonResult`: run the untrusted key search and
 validate its candidate together with the transcribed search's
 canonical labelling in ONE trusted `checkCanon` replay (which contains
-the `checkKey` certificate replay — validating through `certifyKey?`
+the `checkKey` certificate replay: validating through `certifyKey?`
 first would replay the certificate twice). The transcription supplies
-nauty's exact label tie-breaking; every ingredient stays untrusted
+nauty's exact label tie-breaking. Every ingredient stays untrusted
 until the single replay accepts. -/
 @[expose] def certifyCanon? (G : Colored n k) :
     Option (CanonResult n k) :=
@@ -155,9 +158,9 @@ theorem not_isomorphic_of_certs {G H : Colored n k}
     (checkCanon_sound hH).1 (checkDiff_sound hd)
 
 /-- Two replayed key certificates with differing keys prove
-non-isomorphism: the Boolean form of `not_isomorphic_of_certs`, whose
-kernel obligation is two `checkKey` replays and one key comparison,
-with no achieving labelling required. -/
+non-isomorphism: the Boolean form of `not_isomorphic_of_certs`. The
+kernel computes two `checkKey` replays and one key comparison, with
+no achieving labelling required. -/
 theorem not_isomorphic_of_checkKeys {G H : Colored n k}
     {certG certH : CertNode} {BG BH : Key n}
     (hG : checkKey G certG BG = true)
@@ -339,8 +342,8 @@ theorem rowsOf_relabel_eq_leafRows {G : Colored n k} {l : Label n}
 
 /-! # Determinism facts for checked forms -/
 
-/-- Everything a successful `checkCanon` establishes, with the label's
-entries pinned to the claimed array. -/
+/-- Everything a successful `checkCanon` establishes, with the
+label's entries equal to those of the claimed array. -/
 theorem checkCanon_inv {G : Colored n k} {cert : CertNode} {B : Key n}
     {lab : Array Nat} {res : CanonResult n k}
     (h : checkCanon G cert B lab = some res) :

--- a/HexGraphIso/Nauty/Cert/Cert.lean
+++ b/HexGraphIso/Nauty/Cert/Cert.lean
@@ -445,12 +445,12 @@ fails, otherwise `some achieved` where `achieved` records whether this
 subtree attains the claimed best. Success certifies that every leaf
 key of the subtree is `≤` the claimed suffix.
 
-One structural recursion (fuel-first, the child sweep an inline fold
+One structural recursion (fuel-first, the child fold written inline
 with `none` absorbing, the per-node `refine`/`breakout` results bound
-once with `let` for shared reduction), so certificate obligations
-reduce in any module's kernel. The `checkChildren` spelling of the
-child sweep below is the proof-layer view; `checkNode_children_eq`
-connects them. -/
+once with `let` for shared reduction), so goals about certificates
+reduce in any module's kernel. `checkChildren` below spells the same
+child fold as a separate recursion, and `checkNode_children_eq`
+relates the two. -/
 @[expose] def checkNode (ctx : Ctx n) (tcLevel : Nat)
     (brows : List (VSet n)) (vgens : List (Array Nat)) :
     Nat → Nat → Array Nat → Array Nat → VSet n → Nat → CertNode →
@@ -524,7 +524,7 @@ connects them. -/
               none
   termination_by structural fuel => fuel
 
-/-- The child sweep of `checkNode` as its own recursion over the child
+/-- The child fold of `checkNode` as its own recursion over the child
 list, from offset `o` on: the spelling the soundness induction
 consumes. -/
 @[expose] def checkChildren (ctx : Ctx n) (tcLevel : Nat)

--- a/HexGraphIso/Nauty/Cert/CertAutom.lean
+++ b/HexGraphIso/Nauty/Cert/CertAutom.lean
@@ -25,16 +25,17 @@ respects that node's ordered partition and every coarser ancestor
 partition, so a single global store plus a per-node cell-respect
 filter (`respectsMasks`) makes deep discoveries reusable higher up. The
 per-node orbit walk (`witness?`) composes filtered generators by
-breadth-first search inside the target cell; this under-approximates
-the true partition stabilizer (products of individually non-respecting
-generators may respect the partition) and is a heuristic, not a group
-computation.
+breadth-first search inside the target cell. This under-approximates
+the true partition stabilizer, because products of individually
+non-respecting generators may respect the partition. It is a
+heuristic, not a group computation.
 
 Skipping invariant: a child offset is pruned only against a strictly
 earlier offset, so every pruned subtree's key equals the key of an
 earlier offset that was either explored or pruned against a yet
-earlier one; the chain strictly decreases and terminates at an
-explored representative already folded into the running maximum.
+earlier one. The chain of offsets strictly decreases, so it
+terminates at an explored representative already folded into the
+running maximum.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -104,7 +105,7 @@ preferring generators that merge orbits. -/
     return st
   if st.gens.any (fun p => p.1 == γ) then
     return st
-  -- untrusted fast filter (nauty's edge-wise test); the trusted
+  -- untrusted fast filter (nauty's edge-wise test). The trusted
   -- checkAutom runs only when a record is emitted
   unless γ.size == n &&
       ((List.range n).all fun v => γ[v]! < n) &&
@@ -160,7 +161,7 @@ trusted automorphism check, the earlier-offset requirement, and the
 replay's cell-transport check.  Rechecking the witness here makes
 certificate-store validity local to the producer: a malformed cached
 generator or composition can only turn this prune into an ordinary
-descent, rather than poison the whole candidate certificate. -/
+descent, rather than invalidate the whole candidate certificate. -/
 @[expose] def childCellsOk (ctx : Ctx n) (rsLab rsPtn : Array Nat) (level tc : Nat)
     (o o' : Nat) (γ : Array Nat) : Bool :=
   checkAutom ctx.g γ && decide (o' < o) &&
@@ -271,13 +272,14 @@ revalidates everything. -/
               ([], st, none)
             (.node children.reverse, st')
 
-/-- Trace-driven candidate production, per the SPEC: the transcribed
-search runs once with tracing on, and the certificate pass translates
-its trace — the harvested generators, the achieving labelling, and
-its recorded code chain (checker-valid, because spec and search share
-one code coordinate system) — into a certificate against that key.
-No second search runs; the node budget bounds the traced walk. Purely
-a candidate producer — nothing here is trusted. -/
+/-- Trace-driven candidate production: the transcribed search runs
+once with tracing on, and the certificate pass translates its trace
+into a certificate against the traced key. The trace supplies the
+harvested generators, the achieving labelling, and the recorded code
+chain, which the checker accepts because the specification and the
+search share one code coordinate system. No second search runs. The
+node budget bounds the traced walk. This produces a candidate only.
+Nothing here is trusted. -/
 @[expose] def produceCand (G : Colored n k) (budget : Option Nat) :
     Option (CertNode × Key n) :=
   let ctx : Ctx n := { g := rowsOf G }

--- a/HexGraphIso/Nauty/Cert/CertReplay.lean
+++ b/HexGraphIso/Nauty/Cert/CertReplay.lean
@@ -13,7 +13,7 @@ import all HexGraphIso.Nauty.Cert.Cert
 public section
 
 /-!
-The conditional replay spine: the certificate emitted by the
+The conditional replay theorem: the certificate emitted by the
 trace-driven producer replays through the trusted checker. The
 theorem is conditional on the two facts the producer cannot certify
 about itself: domination (the claimed key bounds this subtree's spec
@@ -24,17 +24,17 @@ a rejection verdict (`some false`) forces the subtree strictly below
 the claim, so at the root a dominated-and-achieved key replays to
 `some true`, which is `checkKey`.
 
-The domination hypothesis is semantic and walk-independent: it is
-instantiated at the root by the layer-three theorem that the traced
-key is `canonSpecKey`. Store validity is instantiated by the traced
-generator-validity results. The final assembly is
+The domination hypothesis is semantic and does not depend on the
+walk. At the root it is supplied by `canonSpecKey_eq_tracedKey`,
+which states that the traced key is `canonSpecKey`. Store validity is
+supplied by the traced generator-validity results. The final assembly is
 `produceCand_checkKey` at the end of this file, whose shape matches
 the hypothesis of `certifyCanon?_isSome_of_checkKey`.
 -/
 
 namespace Hex.GraphIso.Nauty
 
-/-! # Budget plumbing
+/-! # Budget lemmas
 
 With no node budget, charging is free and the walk never exhausts.
 These mirror the private lemmas of `CertTotal`. -/
@@ -450,7 +450,7 @@ private theorem certifyNodeAutom_ne_autom (ctx : Ctx n) (tcLevel : Nat) :
           · dsimp only
             exact fun h => nomatch h
 
-/-- The child-sweep equation for a non-`.autom` head. -/
+/-- The child-fold equation for a non-`.autom` head. -/
 private theorem checkChildren_cons_of_ne_autom {ctx : Ctx n}
     (tcLevel : Nat) (brows : List (VSet n)) (vgens : List (Array Nat))
     (fuel level : Nat) (rsLab rsPtn : Array Nat) (tc numcells : Nat)
@@ -476,7 +476,7 @@ private theorem checkChildren_cons_of_ne_autom {ctx : Ctx n}
   · exact absurd rfl (hne o2 γ2)
   · rw [checkChildren] <;> first | rfl | (intro o' γ h; exact nomatch h)
 
-/-! # The replay sweep
+/-! # The induction over the child fold
 
 The checker accepts the children a dominated walk emits. The fold
 body is abstract: `hstep` characterizes one step of the walk's child
@@ -939,7 +939,7 @@ theorem certifyNode_replays {ctx : Ctx n}
         injection hcw with h1 h2
         subst h1
         rw [AutomsOk] at hgs
-        -- run the sweep
+        -- apply the child-fold induction
         rw [List.range_eq_range'] at hfold
         obtain ⟨kidsNew, hkF, hkL, hccl⟩ := sweep_replays hgsz hv
           tcLevel brows fuel level
@@ -1162,10 +1162,9 @@ theorem produceCand_checkKey {G : Colored n k} {cert : CertNode}
     rw [hcert] at hcheck
     exact ha ▸ hcheck
 
-/-- The two remaining layer-three clauses close `certifyCanon?`
-totality: domination (the traced key is the spec key) and store
-validity (every produced record's generator is a checked
-automorphism). -/
+/-- Two hypotheses suffice for `certifyCanon?` totality: domination
+(the traced key is the spec key) and store validity (every produced
+record's generator is a checked automorphism). -/
 theorem certifyCanon?_isSome_of_dominated (G : Colored n k)
     (hdom : canonSpecKey G = tracedKey G)
     (hval : ∀ cert B, produceCand G none = some (cert, B) →

--- a/HexGraphIso/Nauty/Cert/CertTotal.lean
+++ b/HexGraphIso/Nauty/Cert/CertTotal.lean
@@ -16,13 +16,12 @@ public section
 
 /-!
 Totality of the trace-driven candidate producer, and the reduction of
-`certifyCanon?` totality to the certificate replay: with no node
-budget the producer never exhausts, its key is read off the traced
-run, and every conjunct of `checkCanon` except the `checkKey` replay
-is discharged by the landed transcription-side results. What remains
-of `(certifyCanon? G).isSome` after this file is exactly the layer-
-three obligation: the replay accepts the produced certificate against
-the traced key.
+`certifyCanon?` totality to the certificate replay. With no node
+budget the producer never exhausts, and its key is read off the
+traced run. The transcription-side results discharge every conjunct
+of `checkCanon` except the `checkKey` replay. What remains to prove
+for `(certifyCanon? G).isSome` is that the replay accepts the
+produced certificate against the traced key.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -222,10 +221,9 @@ private theorem label_ofArray?_isSome {lab : Array Nat}
 
 /-- The reduction of `certifyCanon?` totality to the certificate
 replay: if the produced certificate replays against the traced key,
-every other conjunct of the single trusted validation is discharged
-by the landed transcription-side results, so the certified
-canonicalization succeeds. The hypothesis is exactly the layer-three
-obligation of the verified search refinement programme. -/
+the transcription-side results discharge every other conjunct of the
+single trusted validation, so the certified canonicalization
+succeeds. -/
 theorem certifyCanon?_isSome_of_checkKey (G : Colored n k)
     (h : ∀ cert B, produceCand G none = some (cert, B) →
       checkKey G cert B = true) :

--- a/HexGraphIso/Nauty/Cert/Translator.lean
+++ b/HexGraphIso/Nauty/Cert/Translator.lean
@@ -13,29 +13,28 @@ public import HexGraphIso.Nauty.Cert.CanonForm
 public section
 
 /-!
-Layers one and two of the verified search refinement
-(SPEC § Verified search refinement): properties of the trace-driven
-certificate translator.
+Properties of the trace-driven certificate translator.
 
-Layer one is total production: `produceCand G none` always returns a
-candidate, because an absent budget cannot exhaust — `charge` is the
-identity, and no other producer step touches the budget fields.
+`produceCand G none` always returns a candidate. With an absent node
+budget `charge` is the identity, and no other producer step touches
+the budget fields, so nothing in the walk can exhaust it.
 
-Layer two's foundation is automorphism closure: `checkAutom` is
-closed under the producer's witness composition, so every witness
-composed from individually-valid generators is itself valid.
+`checkAutom_of_isautom` states that the admission filter's `isautom`
+implies the replay's `checkAutom` for a permutation of a symmetric,
+loopless, per-row-bounded row array. `rowsOf_symm`, `rowsOf_loopless`
+and `rowsOf_bounded` discharge those row hypotheses for `rowsOf G`.
 
-The programme is complete: `certifyCanon?_isSome` is proved in
-`Correct/Certify.lean`. It did not take the route this file's
-statements anticipated, and the section following the closure toolkit
-records where each layer-two obligation actually landed.
+`checkAutom` is closed under the producer's witness composition and
+under inversion, and it holds of the identity array. Every witness
+composed from individually valid generators is therefore itself
+valid.
 -/
 
 namespace Hex.GraphIso.Nauty
 
 variable {n : Nat}
 
-/-! # Layer one: total production under an absent budget -/
+/-! # Total production under an absent budget -/
 
 theorem charge_of_budget_none {st : AutState}
     (h : st.budget = none) : st.charge = st := by
@@ -110,8 +109,8 @@ theorem certifyNodeAutom_budget (ctx : Ctx n) (tcLevel : Nat) :
             (certifyNodeAutom_budget ctx tcLevel fuel
               _ _ _ _ _ _ _ hs.1).2.trans hs.2⟩
 
-/-- Layer one: the trace-driven producer is total under an absent
-budget — nothing in the walk can exhaust it. -/
+/-- The trace-driven producer always returns a candidate under an
+absent budget: nothing in the walk can exhaust it. -/
 theorem produceCand_none_isSome {k : Nat} (G : Colored n k) :
     (produceCand G none).isSome := by
   have hfold := foldl_preserves
@@ -144,10 +143,10 @@ theorem produceCand_none_isSome {k : Nat} (G : Colored n k) :
   rw [hex]
   rfl
 
-/-! # Graph facts for `rowsOf`: dischargers for the row-set hypotheses
+/-! # Graph facts for `rowsOf`
 
-`checkAutom_of_isautom` below is stated graph-agnostically over a row
-array with symmetry, looplessness, and per-row bounds; these lemmas
+`checkAutom_of_isautom` below is stated over an arbitrary row array
+with symmetry, looplessness, and per-row bounds. The lemmas here
 discharge those hypotheses for `rowsOf G`. -/
 
 theorem rowsOf_symm {k : Nat} (G : Colored n k) :
@@ -164,7 +163,7 @@ theorem rowsOf_loopless {k : Nat} (G : Colored n k) :
   rw [getElem!_rowsOf G hi, mem_rowOf_lt G hi hi,
     G.graph.adj_self ⟨i, hi⟩]
 
-/-! # Layer two, foundation: `checkAutom` closure under composition -/
+/-! # `checkAutom` closure under composition -/
 
 theorem composePerm_getElem! (f π : Array Nat) {nn v : Nat}
     (hv : v < nn) : (composePerm f π nn)[v]! = f[π[v]!]! := by
@@ -350,53 +349,49 @@ theorem checkAutom_range {g : Array (VSet n)} :
     rw [hget v hvn, this, image_id _]
 
 /-!
-# Where the layer-two obligations landed
+# Where these results are used
 
-`certifyCanon?_isSome` is proved (`Correct/Certify.lean`), by a
-route that uses some of what this file states and replaces the rest.
+`checkAutom_of_isautom` below converts the admission filter's
+`isautom` into the replay's `checkAutom`. It consumes `isautom_iff`,
+the `rowsOf` lemmas above and the `PopCount` comparison lemmas.
+It is applied in `Invariant/Store`, where `scatter_isPerm` supplies
+its permutation hypothesis: both admission sites in `processnode`
+push a scatter of one discrete leaf labelling over another, which is
+a permutation by construction.
 
-* `checkAutom_of_isautom`, the counting bridge below, is live. It
-  consumes `isautom_iff`, the `rowsOf` dischargers above and the
-  `PopCount` comparison toolkit, and it is applied in
-  `Invariant/Store`, where `scatter_isPerm` supplies its permutation
-  hypothesis: both admission sites in `processnode` push a scatter of
-  one discrete leaf labelling over another, which is a permutation by
-  construction. The general obligation an earlier reading of layer
-  two posed here, over every `γ` in `(runColoredTraced G).autos` and
-  every `composeOnto` the certify walk harvests, turned out not to be
-  needed by anything.
-* The validated-store invariant (`GensOk.admit`, `GensOk.init`,
-  `GensOk.foldl_admit`) and witness validity (`witness?_checkAutom`)
-  state store validity as an invariant of the search-side generator
-  store. The landed proof does not use them: `CertStore.lean` proves
-  `certifyNodeAutom_automsOk` structurally over the emitted
-  certificate, because the producer checks each witness immediately
-  before emitting an automorphism prune, so
-  `certifyCanon?_isSome_of_keyEq` carries no store hypothesis.
-* The replay spine is `certifyNode_replays` and
-  `certifyCanon?_isSome_of_dominated` (`CertReplay.lean`), and its
-  domination hypothesis is discharged by `canonSpecKey_eq_tracedKey`,
-  which is layer three. Domination is not removable: `certifyNodeAutom`
-  emits `.codePrune` on the `.gt` comparison, which the replay
-  rejects, and a `.leaf` whose key exceeds the claimed suffix fails
-  `keyCmp`, so an unconditional spine would have been unsound.
-
-The closure toolkit above is the part of this file with consumers
-outside it: `checkAutom_compose` and `checkAutom_range` are used by
+`checkAutom_compose` and `checkAutom_range` above are used by
 `Invariant/Autos` and `Invariant/Orbits`.
+
+`GensOk.admit`, `GensOk.init`, `GensOk.foldl_admit` and
+`witness?_checkAutom` state validity of the search-side generator
+store: every stored generator pair passes `checkAutom`, as does every
+witness `witness?` composes from such a store. Nothing outside this
+file uses them. `CertStore.lean` instead proves
+`certifyNodeAutom_automsOk` structurally over the emitted
+certificate, because the producer checks each witness immediately
+before emitting an automorphism prune, which is why
+`certifyCanon?_isSome_of_keyEq` carries no hypothesis about the
+generator store.
+
+`certifyNode_replays` and `certifyCanon?_isSome_of_dominated`
+(`CertReplay.lean`) replay the produced certificate under a
+domination hypothesis, which `canonSpecKey_eq_tracedKey` discharges.
+The hypothesis is not removable: `certifyNodeAutom` emits a
+`.codePrune` on a `.gt` comparison, which the replay rejects, and a
+`.leaf` whose key exceeds the claimed suffix fails `keyCmp`.
 
 ## The guarded-scan `forIn` technique
 
 `isautom` is a nested `forIn` over `[0, n)` with an early
-`return false`, a loop shape with no other reasoning precedent in the
-tree. The reusable technique is a "guarded scan" whose state is
-`Option Bool × Unit`: it yields `(none, ())` while every element
-passes and is done with `(some false, ())` on the first failure, so
-the result flag is `none` exactly when every element passes
-(`forIn_scan_fst_cases`, `forIn_scan_fst_eq_none`), with
-`forIn_range_eq` and `id_run_scan` reducing the `[0, n)` range and the
-outer `Id` do-block. `isautom_iff` below is what it buys, and the
-counting bridge consumes that.
+`return false`. The reasoning technique for that loop shape is a
+"guarded scan" whose state is `Option Bool × Unit`: it yields
+`(none, ())` while every element passes and is done with
+`(some false, ())` on the first failure, so the result flag is `none`
+exactly when every element passes (`forIn_scan_fst_cases`,
+`forIn_scan_fst_eq_none`), with `forIn_range_eq` and `id_run_scan`
+reducing the `[0, n)` range and the outer `Id` do-block. The
+specification this yields is `isautom_iff` below, which
+`checkAutom_of_isautom` consumes.
 
 ### Guarded-scan technique
 
@@ -475,10 +470,10 @@ private theorem id_run_scan (F : Id (Option Bool × Unit)) :
 
 /-! ### The `isautom` specification -/
 
-/-- The outer loop body of `isautom`, spelled with the named core
-matcher so it is syntactically identical to the `do`-desugaring
-(restating it with `match` syntax would mint a fresh matcher the
-unifier rejects). -/
+/-- The outer loop body of `isautom`, spelled with the generated
+matcher `Break.runK.match_1` so it is syntactically identical to the
+`do`-desugaring (restating it with `match` syntax would generate a
+fresh matcher the unifier rejects). -/
 private def isautomOuter (ctx : Ctx n) (γ : Array Nat) (i : Nat)
     (__s : Option Bool × Unit) : Id (ForInStep (Option Bool × Unit)) :=
   have row := ctx.g[i]!
@@ -612,15 +607,15 @@ theorem isautom_iff (ctx : Ctx n) (γ : Array Nat) :
     rw [hnone]
 
 /-!
-**The residual gap to `certifyCanon?` totality is closed.** Beyond
-layers one and two it needed the rows equality (definitional from
+`certifyCanon?_isSome` in `Correct/Certify.lean` is the statement
+that certified canonicalization always succeeds. Besides the results
+above it rests on the rows equality (definitional from
 `produceCand`'s key), `labelColorSorted` of the transcription's
-output labelling, and layer three, the maximality of the traced key.
-Layer three is `canonSpecKey_eq_tracedKey` and the assembly is
-`certifyCanon?_isSome`, both in `Correct/Certify.lean`.
+output labelling, and the maximality of the traced key,
+`canonSpecKey_eq_tracedKey`.
 -/
 
-/-! # Layer two, part b: `checkAutom` from the admission filter
+/-! # `checkAutom` from the admission filter
 
 `AutState.admit` verifies candidates with `isautom` (upper-triangle
 edge preservation) rather than the replay's `checkAutom` (per-row
@@ -663,13 +658,12 @@ private theorem map_eq_of_le_of_sum_le {f g : Nat → Nat} :
     · exact map_eq_of_le_of_sum_le l
         (fun y hy => hle y (List.mem_cons_of_mem a hy)) (by omega) x hx'
 
-/-- Layer two, part b, the counting bridge: for a permutation of
-`[0, n)`, the admission filter's `isautom` implies the replay's
-`checkAutom`, over any symmetric, loopless, per-row-bounded row
-array. The row hypotheses are discharged for `rowsOf G` by
-`rowsOf_symm`, `rowsOf_loopless`, and `rowsOf_bounded`; the
-permutation hypothesis is supplied at the use site in
-`Invariant/Store` by `scatter_isPerm`. -/
+/-- The counting argument: for a permutation of `[0, n)`, the
+admission filter's `isautom` implies the replay's `checkAutom`, over
+any symmetric, loopless, per-row-bounded row array. `rowsOf_symm`,
+`rowsOf_loopless` and `rowsOf_bounded` discharge the row hypotheses
+for `rowsOf G`. `scatter_isPerm` supplies the permutation hypothesis
+at the use site in `Invariant/Store`. -/
 theorem checkAutom_of_isautom {ctx : Ctx n} {γ : Array Nat}
     (hsz : γ.size = n)
     (hperm : (((List.range n).map fun v => γ[v]!).isPerm
@@ -762,18 +756,18 @@ theorem checkAutom_of_isautom {ctx : Ctx n} {γ : Array Nat}
     simp only [beq_iff_eq]
     exact (hrow v (List.mem_range.mp hv)).symm
 
-/-! # Layer two, part b: the validated-store invariant
+/-! # The validated-store invariant
 
 Every generator pair the producer stores passes `checkAutom`: the
-stored generator via the admission filter's `isautom` plus the
-counting bridge, the stored inverse via `checkAutom_invPerm`. The
-permutation side of each candidate enters as a hypothesis on the
+stored generator via the admission filter's `isautom` plus
+`checkAutom_of_isautom`, the stored inverse via `checkAutom_invPerm`.
+The permutation side of each candidate enters as a hypothesis on the
 admitted candidate.
 
-The landed totality proof does not go through this invariant.
-`CertStore.lean` establishes store validity structurally over the
-emitted certificate instead; what follows states the search-side
-invariant. -/
+This states validity of the search-side generator store.
+`CertStore.lean` establishes validity of the emitted certificate's
+records structurally instead, and that is what
+`certifyCanon?_isSome_of_keyEq` uses. -/
 
 /-- The store invariant: every stored generator pair passes
 `checkAutom` in both components. -/
@@ -783,7 +777,7 @@ def GensOk (ctx : Ctx n) (st : AutState) : Prop :=
 
 /-- Admission preserves the store invariant: the filter re-verifies
 size, bounds, and `isautom`, so with the candidate's permutation
-side (hypothesis `hγ`) the counting bridge validates the stored
+side (hypothesis `hγ`) `checkAutom_of_isautom` validates the stored
 pair. -/
 theorem GensOk.admit {ctx : Ctx n} {st : AutState} {γ : Array Nat}
     (hsymm : ∀ i j, i < n → j < n →
@@ -837,10 +831,9 @@ theorem GensOk.init (ctx : Ctx n) (nn : Nat) (budget : Option Nat) :
   intro p hp
   simp [AutState.init] at hp
 
-/-- Layer two, part b, the validated-store invariant: an admission
-fold over candidates that are permutations whenever they pass the
-admission filter (hypothesis `hautos`) stores only
-`checkAutom`-valid generator pairs. -/
+/-- An admission fold over candidates that are permutations
+whenever they pass the admission filter (hypothesis `hautos`) stores
+only `checkAutom`-valid generator pairs. -/
 theorem GensOk.foldl_admit {ctx : Ctx n} {st : AutState}
     (hsymm : ∀ i j, i < n → j < n →
       (ctx.g[i]!).mem j = (ctx.g[j]!).mem i)
@@ -855,13 +848,13 @@ theorem GensOk.foldl_admit {ctx : Ctx n} {st : AutState}
     (fun _ γ hγ hs => GensOk.admit hsymm hloop (hautos γ hγ) hs)
     st hst
 
-/-! # Layer two, part b: witness validity
+/-! # Witness validity
 
 `witness?` composes filtered generators breadth-first from the
-identity; over a store of `checkAutom`-valid pairs every composed
-witness is `checkAutom`-valid, by a queue invariant over the closure
-toolkit (`checkAutom_range`, `checkAutom_compose`). The loop body is
-restated with the named core matchers (`witness?.match_*`), the same
+identity. Over a store of `checkAutom`-valid pairs every composed
+witness is `checkAutom`-valid, by a queue invariant that uses
+`checkAutom_range` and `checkAutom_compose`. The loop body is
+restated with the generated matchers (`witness?.match_*`), the same
 technique as `isautomOuter` above. -/
 
 /-- The state a `ForInStep` carries, whichever constructor. -/
@@ -887,7 +880,7 @@ private theorem forIn_id_inv {α β : Type} {P : β → Prop}
       exact forIn_id_inv as
         (fun a' ha' => h a' (List.mem_cons_of_mem a ha')) b' hstep
 
-/-- The outer loop body of `witness?`, spelled with the named core
+/-- The outer loop body of `witness?`, spelled with the generated
 matchers so it is definitionally identical to the `do`-desugaring. -/
 private def witnessOuter (rsLab : Array Nat) (tc o : Nat)
     (usable : Array (Array Nat × Array Nat)) (_x : Nat)
@@ -1029,10 +1022,10 @@ private theorem witnessOuter_inv {ctx : Ctx n} {rsLab : Array Nat}
         · exact hqs2 q hmem
         · exact checkAutom_compose hf' hπ
 
-/-- Layer two, part b, witness validity: over a store of
-`checkAutom`-valid generator pairs, every witness `witness?` returns
-passes `checkAutom` — the breadth-first queue holds only the identity
-and `checkAutom`-closed compositions. -/
+/-- Over a store of `checkAutom`-valid generator pairs, every
+witness `witness?` returns passes `checkAutom`. The breadth-first
+queue holds only the identity and `checkAutom`-closed
+compositions. -/
 theorem witness?_checkAutom {ctx : Ctx n} {rsLab : Array Nat}
     {tc o : Nat} {usable : Array (Array Nat × Array Nat)}
     {o' : Nat} {π : Array Nat}

--- a/HexGraphIso/Nauty/Invariant/Autos.lean
+++ b/HexGraphIso/Nauty/Invariant/Autos.lean
@@ -14,8 +14,8 @@ import all HexGraphIso.Nauty.Search.Search
 public section
 
 /-!
-The autos-store ledger (SPEC § Verified search refinement, the
-target-cell pruning clause of the domination obligation).
+The `(fix, mcr)` ledger of the autos workspace, and the target-cell
+pruning it justifies.
 
 `shortprune` and `longprune` filter the sibling iteration through the
 `(fix, mcr)` pairs of the bounded autos workspace. This file gives the
@@ -34,7 +34,7 @@ shape the maximality induction consumes.
   The induction maintains `AutosOk` anchored at the root partition
   (where it is unconditional) and moves single pairs down the path
   with `pairOk_descend` exactly when the pair's `fix` covers the
-  vertex being individualized — for the pairs a filter actually
+  vertex being individualized. For the pairs a filter actually
   applies, `fix` contains every base vertex, so the descent is always
   available where it is needed.
 * **Filter soundness.** `pruned_carried` is the well-founded descent:
@@ -274,7 +274,7 @@ theorem pairOk_descend {ctx : Ctx n}
 
 /-! # Filter soundness: the well-founded descent -/
 
-/-- The descent core, abstract in the surviving set `R`: whenever a
+/-- The descent, stated for an arbitrary surviving set `R`: whenever a
 dropped vertex is strictly carried down by some ledger realizer, every
 cell vertex is carried by a composite realizer onto a survivor. -/
 theorem pruned_carried {g : Array (VSet n)} {ptn lab : Array Nat} {level tc len : Nat}
@@ -465,9 +465,10 @@ theorem longprune_carried {g : Array (VSet n)} {ptn lab : Array Nat}
   exact ⟨p.1, p.2, haut p hpmem htest, hmcr,
     fun w _ hw => mem_of_subset htest hw⟩
 
-/-- `shortprune` soundness: with the ledger reading of the most recent
-pair and its fix test (the `needshortprune` protocol's obligation),
-every vertex of the target cell is carried onto a survivor. -/
+/-- `shortprune` soundness: given the ledger reading of the most recent
+pair and its fix test (which is what the `needshortprune` protocol
+requires), every vertex of the target cell is carried onto a
+survivor. -/
 theorem shortprune_carried {g : Array (VSet n)} {ptn lab : Array Nat}
     {level tc len : Nat} {st : SearchSt n}
     (hok : LabOk lab n) (hs : lab.size = n) (hsp : ptn.size = n)

--- a/HexGraphIso/Nauty/Invariant/Closure.lean
+++ b/HexGraphIso/Nauty/Invariant/Closure.lean
@@ -13,24 +13,23 @@ import all HexGraphIso.Nauty.Invariant.Orbits
 public section
 
 /-!
-The orbit closure is complete (SPEC § Verified search refinement).
+Completeness of the orbit closure.
 
 A loop's fold runs over the children it visited, while a node's key
 is the maximum over the whole subtree. The two agree once every child
-is dominated by the maximum over the visited ones. Supplying that
-domination for the children `firstChildLoop` drops is the loop step's
-real content.
+is dominated by the maximum over the visited ones. The loop step
+therefore has to supply that domination for the children
+`firstChildLoop` drops.
 
 The justification of a dropped child is `childKey_of_orbPruned`, whose
 hypothesis is the model's `orbPruned`, phrased through the executable
 forward closure `orbitClose` at fuel `nn`. The transcription's test is
 a single pointer read, and `orbConn_of_ptr` turns that into
-`WordConn gens v orbits[v]!`. Between the two sits a gap `Invariant/Orbits`
-deliberately left open: it proved the closure *sound*, which is all
-store validity needed, and recorded that completeness "is not needed
-for soundness, only if B2 wants to show the model prunes at least as
-much as the transcription". The domination step is exactly that
-direction, so this file closes the gap.
+`WordConn gens v orbits[v]!`. `Invariant/Orbits` proves `orbitClose`
+sound, which is what store validity needs. This module proves it
+complete: every `WordConn`-connected vertex is in the closure. That is
+the direction the domination argument needs, since it says the model
+prunes at least as much as the transcription does.
 
 The word a `WordConn` supplies can be longer than `nn`, so fuel `nn`
 is not justified by running the word. It is justified by saturation:

--- a/HexGraphIso/Nauty/Invariant/Codes.lean
+++ b/HexGraphIso/Nauty/Invariant/Codes.lean
@@ -17,8 +17,9 @@ Code-comparison faithfulness: the transcription's lazily threaded
 level-code comparison (`compCanon` / `eqlevCanon` / `canoncode`)
 implements lexicographic comparison of the current path's refinement
 codes against the incumbent leaf's code list. This is the code-side
-counterpart of `Invariant/Leaves`, and the per-event clause suite the
-domination induction threads through the search quartet.
+counterpart of `Invariant/Leaves`. It supplies one clause per search
+event, and the domination induction threads those clauses through the
+four search functions.
 
 The discipline being captured, with `cs` the codes of the current
 path (one per level, `1`-indexed) and `bs` the incumbent's codes
@@ -28,8 +29,8 @@ path (one per level, `1`-indexed) and `bs` the incumbent's codes
   through the whole path, and `eqlevCanon` records the path length;
 - `compCanon = -1` means the codes diverged downward at some level
   `j`, `eqlevCanon` is frozen at `j - 1`, and no comparison deeper
-  than `j` is ever consulted — lexicographically the whole subtree
-  is smaller;
+  than `j` is ever consulted, because lexicographically the whole
+  subtree is smaller;
 - `compCanon = 1` means the codes diverged upward at `j`; from `j`
   on, `othernode` overwrites `canoncode` with the path's own codes,
   so that when the path reaches a leaf and is installed the stored
@@ -41,7 +42,7 @@ contents; the events are `otherNodePrep` (one comparison step),
 one and the reset form used after a leaf whose `compCanon` was
 repurposed for the row comparison), `firstterminal` (the seed), and
 the pure incumbent installation (`install_codeInv`, the code-`3`
-core). `codeInv_keyCmp_lt`/`gt` are the payoff: a frozen comparison
+arm). `codeInv_keyCmp_lt`/`gt` are the payoff: a frozen comparison
 decides the key order of every leaf below the node against the
 incumbent, whatever the deeper codes and rows are.
 -/
@@ -830,10 +831,11 @@ theorem firstterminal_codeInv {nn : Nat} {cs : List Nat}
   · intro h
     cases h
 
-/-- Installing the current path as the new incumbent (the code-`3`
-core): after a non-downward comparison, the store already holds the
-path's codes, so recording the path as incumbent with the sentinel
-stamped re-seeds the invariant at full agreement. -/
+/-- Installing the current path as the new incumbent (the pure part
+of the code-`3` arm): after a non-downward comparison, the store
+already holds the path's codes, so recording the path as incumbent
+with the sentinel stamped re-seeds the invariant at full
+agreement. -/
 theorem install_codeInv {nn : Nat} {cs bs : List Nat}
     {canoncode : Array Nat} {canonlevel : Nat}
     {eqlevCanon compCanon : Int}
@@ -888,7 +890,7 @@ an off-path leaf a candidate automorphism (`processnode` code `1`),
 so the domination induction needs the same faithfulness clause: the
 recorded depth really is a code-prefix agreement with the first
 leaf's codes. Unlike the incumbent thread there is no overwrite
-window — `firstcode` is written only on the first path — and no
+window (`firstcode` is written only on the first path) and no
 trichotomy, only an agreement depth that steps forward on a match at
 the next level (`otherNodePrep`), is clamped by `recover` and the
 target-cell demotion in `othernode`, and is seeded at the first leaf
@@ -980,11 +982,11 @@ theorem firstCodeInv_len_of_sentinel {nn : Nat} {cs fs : List Nat}
   exact Nat.lt_irrefl _
     (hc ▸ hinv.flt _ (List.getElem_mem (by omega)))
 
-/-- The sentinel hypothesis above is load-bearing rather than a proof
-convenience. At a live gate whose path is strictly shorter than the
-first path, the current leaf's key strictly exceeds the first leaf's,
-because the sentinel outranks every real code, so the code-`1` skip
-would discard a candidate standing above the incumbent. -/
+/-- The sentinel hypothesis above cannot be dropped. Where the
+first-path comparison is still live and the path is strictly shorter
+than the first path, the current leaf's key strictly exceeds the first
+leaf's, because the sentinel outranks every real code, so the code-`1`
+skip would discard a candidate above the incumbent. -/
 theorem firstCodeInv_listCmp_gt_of_lt {nn : Nat} {cs fs : List Nat}
     {firstcode : Array Nat}
     (hinv : FirstCodeInv nn cs fs firstcode cs.length)
@@ -1002,9 +1004,10 @@ theorem firstCodeInv_listCmp_gt_of_lt {nn : Nat} {cs fs : List Nat}
       getElem!_pos fs cs.length (by omega)]
     exact hinv.flt _ (List.getElem_mem _)
 
-/-- The code-`1` leaf case in the form the induction applies: at a
-live gate, with the first-path store showing the sentinel just above
-the current level, the two code paths are equal outright. -/
+/-- The code-`1` leaf case in the form the induction applies: where
+the first-path comparison is still live and the first-path store shows
+the sentinel just above the current level, the two code paths are
+equal outright. -/
 theorem firstCodeInv_eq_of_live {nn : Nat} {cs fs : List Nat}
     {firstcode : Array Nat}
     (hinv : FirstCodeInv nn cs fs firstcode cs.length)

--- a/HexGraphIso/Nauty/Invariant/Coverage.lean
+++ b/HexGraphIso/Nauty/Invariant/Coverage.lean
@@ -11,7 +11,8 @@ public import HexGraphIso.Nauty.Cert.Cert
 public section
 
 /-!
-Transitive coverage for a mutable child sweep.
+Transitive coverage for a child loop whose target set changes as it
+runs.
 
 The nauty loops shrink their target set while they run.  A child removed
 by an orbit or stored-automorphism filter need not repeat an already
@@ -26,7 +27,7 @@ namespace Hex.GraphIso.Nauty
 /-- Every member of `all` is either covered already or has the same key as
 a no-larger member of `live`.  The decreasing rank lets successive
 automorphism filters compose even when a new carrier lands outside the
-already-filtered set. -/
+set the previous filter left. -/
 @[expose] def ChildCover (key : Nat → Key n) (rank : Nat → Nat)
     (all done live : Nat → Prop) : Prop :=
   ∀ x, all x → done x ∨
@@ -39,7 +40,7 @@ theorem ChildCover.init (key : Nat → Key n) (rank : Nat → Nat)
   intro x hx
   exact Or.inr ⟨x, hx, rfl, Nat.le_refl _⟩
 
-/-- One sweep step composes coverage transitively. -/
+/-- One filtering step composes coverage transitively. -/
 theorem ChildCover.step {key : Nat → Key n} {rank : Nat → Nat}
     {all done live done' live' : Nat → Prop}
     (h : ChildCover key rank all done live)
@@ -73,9 +74,9 @@ theorem ChildCover.filter {key : Nat → Key n} {rank : Nat → Nat}
     ChildCover key rank all done live' :=
   h.step (fun x hx => Or.inr (hs x hx)) (fun _ hx => hx)
 
-/-- Resolving one filtered survivor may revisit the old coverage relation.
-Strict rank descent at every newly removed live vertex makes this process
-well founded. -/
+/-- Resolving one filtered survivor may appeal to the coverage relation
+of the previous live set. Strict rank descent at every newly removed
+live vertex makes that recursion well founded. -/
 theorem ChildCover.resolve {key : Nat → Key n} {rank : Nat → Nat}
     {all done live live' : Nat → Prop}
     (h : ChildCover key rank all done live)
@@ -98,7 +99,7 @@ theorem ChildCover.resolve {key : Nat → Key n} {rank : Nat → Nat}
   termination_by x => rank x
 
 /-- A descending filter preserves ranked coverage even when a carrier
-lands outside the old live set. -/
+lands outside the live set it started from. -/
 theorem ChildCover.filterDesc {key : Nat → Key n} {rank : Nat → Nat}
     {all done live live' : Nat → Prop}
     (h : ChildCover key rank all done live)
@@ -136,11 +137,11 @@ theorem ChildCover.bound {key : Nat → Key n} {rank : Nat → Nat}
   intro x hx
   exact hle x (h.finish hempty x hx)
 
-/-- Coverage transfers a common upper bound when both absorbed children
-and the surviving live representatives lie below it.  This is the form
-used by a frozen comparison unwind: the existing ledger handles the
-visited prefix, while the frozen code verdict handles the abandoned
-suffix. -/
+/-- Coverage transfers a common upper bound when both the absorbed
+children and the surviving live representatives lie below it.  This is
+the form a frozen comparison unwind uses: the ledger already covers the
+visited prefix, and the frozen code verdict covers the siblings the
+unwind skips. -/
 theorem ChildCover.boundLive {key : Nat → Key n} {rank : Nat → Nat}
     {all done live : Nat → Prop} {b : Key n}
     (h : ChildCover key rank all done live)

--- a/HexGraphIso/Nauty/Invariant/Domination.lean
+++ b/HexGraphIso/Nauty/Invariant/Domination.lean
@@ -23,13 +23,13 @@ public section
 The domination layer: the key-level reading of the search state's
 incumbent, and the per-arm key verdicts of the leaf event. Together
 with the comparison machines of `Invariant/Codes` and the row clause
-of `Invariant/Leaves`, these are the dischargers the maximality induction
-applies at each `processnode` arm to conclude that the traced key
-dominates every visited leaf — the `canonSpecKey G = tracedKey G`
+of `Invariant/Leaves`, these are what the maximality induction applies
+at each `processnode` arm to conclude that the traced key dominates
+every visited leaf, which is the `canonSpecKey G = tracedKey G`
 equality the replay spine consumes.
 
 The incumbent's key is `⟨bs ++ [codeSentinel], leafRows ctx canonlab⟩`
-for the ghost code list `bs` tracked by `CodeCmpInv`; a leaf of the
+for the ghost code list `bs` tracked by `CodeCmpInv`. A leaf of the
 current path has key `⟨cs ++ [codeSentinel], leafRows ctx lab⟩`. The
 verdict lemmas translate the imperative comparison state into
 `keyCmp` on those keys:
@@ -39,92 +39,85 @@ verdict lemmas translate the imperative comparison state into
   `codeInv_keyCmp_gt` at `ext := [codeSentinel]`).
 - `compCanon = 0` with the path shorter than the incumbent: the leaf
   ends in the sentinel where the incumbent still has a real code, so
-  the leaf compares above (`tied_short_keyCmp_gt`) — the short-leaf
-  install (`level < canonlevel → code 3`) is correct.
+  the leaf compares above (`tied_short_keyCmp_gt`). That is why the
+  short-leaf install (`level < canonlevel → code 3`) is correct.
 - `compCanon = 0` at the incumbent's depth: the code lists are equal
   outright and the rows decide (`tied_full_keyCmp`), which is the
   `testcanlab` outcome by `leafEvent_faithful`.
 
-The event layer is complete: `processnode_leaf` (the off-first-path
-leaf), `processnode_leafFirst` (the first-path-agreeing leaf failing
-the admission gate, via the gate-failure reduction
-`processnode_gateFail_eq`), `processnode_auto` with `auto_keyMax`
-(the gate-passing leaf: comparison state untouched, the sentinel guard
-supplies exact path depth, and the mandatory `isautom` scan validates the
-admitted scatter), `recover_machines` with the
-`recover_frames`/`otherNodePrep_frames` threading, and the
+The leaf event is covered arm by arm: `processnode_leaf` (the
+off-first-path leaf), `processnode_leafFirst` (the first-path-agreeing
+leaf failing the admission test, through the reduction
+`processnode_gateFail_eq`), `processnode_auto` with `auto_keyMax` (the
+leaf passing the admission test: the comparison state is untouched,
+the sentinel guard supplies exact path depth, and the mandatory
+`isautom` scan validates the admitted scatter), `recover_machines`
+with the `recover_frames`/`otherNodePrep_frames` threading, and the
 `firstterminal_*` seeds for all four threads.
 
-The induction's statement layer is now also in place: the `DomOk`
-record (see its section comment for the two design decisions —
-incumbent-maximality is a conclusion shape in the `searchNode_eq`
-style, and unwinding-correctness is a loop obligation, not a stored
-clause), the path-prefix key algebra (`prefixKey` with its
-`keyMax`/`keysMax` distribution laws), the two `specNode` arm
-isolations (`specNode_discrete`, `specNode_internal` with
-`specChild`), and the leaf-guard agreement
-(`discreteAt_iff_bcount`, aligning the imperative `numcells == n`
-dispatch with the specification's `discreteAt` through
-`SearchOk.count`).
+The statement layer of the induction is the `DomOk` record (its
+section comment gives the two decisions its shape encodes), the
+path-prefix key algebra (`prefixKey` with its `keyMax`/`keysMax`
+distribution laws), the two `specNode` arm isolations
+(`specNode_discrete`, and `specNode_internal` with `specChild`), and
+the leaf-guard agreement `discreteAt_iff_bcount`, which aligns the
+imperative `numcells == n` dispatch with the specification's
+`discreteAt` through `SearchOk.count`.
 
-The return-protocol layer is now proven, and it fixes the
-induction's architecture per unwind mode:
+A dominated sibling is absorbed in a different place in each of the
+two unwind modes.
 
-- **Frozen unwinds absorb locally.** After a code-4 leaf with the
+- A frozen unwind absorbs locally. After a code-4 leaf with the
   machine frozen downward, `pruneReturn`'s `eqlevCanon` and
   `allsamelevel - 1` forms never return below the recorded
-  divergence, so every abandoned loop's truncated path still
-  contains it: `frozen_take_keyLe` dominates each abandoned
-  sibling's whole subtree, loop by loop, on the way up. In this
-  mode every quartet theorem still concludes the full `keyMax`
-  equation.
-- **Generator returns absorb wholesale at the gca loop.** After a
-  code-1/code-2 admission, intermediate loops conclude nothing
-  locally; the quartet theorems hand up the payload (the admitted
+  divergence, so the truncated path of every loop left behind still
+  contains that divergence: `frozen_take_keyLe` dominates each such
+  sibling's whole subtree, loop by loop, on the way up. In this mode
+  every quartet theorem concludes the full `keyMax` equation.
+- A generator return absorbs wholesale at the gca loop. After a
+  code-1 or code-2 admission, the intermediate loops conclude nothing
+  locally. The quartet theorems hand up the payload: the admitted
   scatter, its carry between the guiding sibling's and the current
-  child's individualized vertices, its cell stabilization at the
-  gca node), and the loop at the returned gca level identifies the
-  whole current child subtree with the guiding sibling's via
-  `childKey_of_carried`, whose key its own fold already
-  absorbed. The conclusion shape is therefore a disjunction: normal
-  exit or frozen unwind with the full equation, generator unwind
-  with the payload.
-- The in-loop orbit skips (`st.orbits[tv]! == tv` failing)
-  discharge by `orbConn_of_ptr` + `wordConn_symm` +
-  `cellStab_of_scatter` + `childKey_of_carried` at the loop's own
-  node.
+  child's individualized vertices, and its cell stabilization at the
+  gca node. The loop at the returned gca level identifies the whole
+  current child subtree with the guiding sibling's via
+  `childKey_of_carried`, whose key its own fold has already absorbed.
+  The conclusion is therefore a disjunction: normal exit or frozen
+  unwind with the full equation, generator unwind with the payload.
+- The in-loop orbit skips (`st.orbits[tv]! == tv` failing) follow from
+  `orbConn_of_ptr`, `wordConn_symm`, `cellStab_of_scatter` and
+  `childKey_of_carried` at the loop's own node.
 
-The three obligations this file once listed as external are all
-supplied now. The cheapautom subtree theorem is
-`descPath_leafRows_all` and its `leafRows_eq_of_descPaths` corollary;
-store-validity arm 2 is `genTraceOk_processnode` and
-`processnode_checkAutom`; the `(fix, mcr)` ledger is `Invariant/Autos`,
-whose `longprune_carried`/`shortprune_carried` meet
-`childKey_of_carried`'s hypotheses exactly. `DomOk` therefore carries
-both ledgers (`genTraceOk`, `autosOk`), both ride the internal steps
-by frame (`otherNodePrep_store`, `recover_store`,
-`firstterminal_store`, transported by `genTraceOk_of_eq` and
-`autosOk_of_eq`), and the admission event preserves store validity
-under the record outright. The only remaining row premise is the
-code-2 tie, which is local and proven by
-`rows_eq_of_testcanlab_tie`. Code 1 does not require a descent
-geometry invariant: `processnode` checks the first-path sentinel at
-`level + 1` and scans the scatter with `isautom` before admission.
-`firstCodeInv_eq_of_live` therefore supplies equal path codes, while
-`processnode_checkAutom` validates the generator directly.
+Three supporting facts come from the rest of this layer. The
+cheapautom subtree fact is `descPath_leafRows_all` with its
+`leafRows_eq_of_descPaths` corollary. Store validity across the leaf
+event is `genTraceOk_processnode` and `processnode_checkAutom`. The
+`(fix, mcr)` ledger is `Invariant/Autos`, whose `longprune_carried`
+and `shortprune_carried` meet `childKey_of_carried`'s hypotheses
+exactly. `DomOk` carries both ledgers (`genTraceOk`, `autosOk`), both
+ride the internal steps by frame (`otherNodePrep_store`,
+`recover_store`, `firstterminal_store`, transported by
+`genTraceOk_of_eq` and `autosOk_of_eq`), and the admission event
+preserves store validity under the record. The one row premise the
+event needs is the code-2 tie, which is local and proved by
+`rows_eq_of_testcanlab_tie`. Code 1 needs no descent geometry
+invariant: `processnode` checks the first-path sentinel at
+`level + 1` and scans the scatter with `isautom` before admission, so
+`firstCodeInv_eq_of_live` supplies equal path codes and
+`processnode_checkAutom` validates the generator.
 
-The mutual quartet induction follows the
+The mutual induction over the four search functions follows the
 `canonlab_cellsReach` skeleton (whose composite helpers
-`recover_out`/`processnode_searchOk`/`canonlab_or_of` are public)
-and threads `DomOk`, discharges leaf arms by `processnode_leaf`/
-`processnode_leafFirst`/`processnode_auto` + `auto_keyMax` through
-`specNode_discrete`/`prefixKey_leafKey`, internal arms by
-`specNode_internal` (the `keysMax` fold literally matching the
-loop), machines by `otherNodePrep_codeInv`/`recover_machines` and
-the frames, dispatch by `discreteAt_iff_bcount`, and unwinds by
-the mode analysis above. At the root, `specNode_achieved` closes
-the achieved direction and the induction the domination direction,
-giving `canonSpecKey G = tracedKey G`.
+`recover_out`/`processnode_searchOk`/`canonlab_or_of` are public) and
+threads `DomOk`. It discharges leaf arms by `processnode_leaf`,
+`processnode_leafFirst` and `processnode_auto` + `auto_keyMax`
+through `specNode_discrete`/`prefixKey_leafKey`, internal arms by
+`specNode_internal` (whose `keysMax` fold matches the loop
+literally), machines by `otherNodePrep_codeInv`/`recover_machines`
+and the frames, dispatch by `discreteAt_iff_bcount`, and unwinds by
+the two modes above. At the root, `specNode_achieved` gives the
+achieved direction and the induction the domination direction, so
+`canonSpecKey G = tracedKey G`.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -683,11 +676,11 @@ theorem processnode_rowTie {ctx : Ctx n} {level numcells : Nat}
 /-- The full leaf event off the first path: at a discrete node,
 `processnode` leaves the incumbent at the key maximum of the entry
 incumbent and the current leaf, re-establishes the store invariant,
-and hands back a comparison machine for the unwind — intact when the
-comparison stayed frozen or re-seeded by an install, or in the
-reset form when a row rejection repurposed `compCanon`
-(`recover_codeInv_reset` consumes it). The return level is one of
-the four unwind forms. -/
+and hands back a comparison machine for the unwind. That machine is
+intact when the comparison stayed frozen or was re-seeded by an
+install, and in the reset form when a row rejection repurposed
+`compCanon` (`recover_codeInv_reset` consumes it). The return level is
+one of the four unwind forms. -/
 theorem processnode_leaf {nn : Nat} {ctx : Ctx n} {cs bs : List Nat}
     {numcells : Nat} {st : SearchSt n}
     (hcinv : CodeCmpInv nn cs bs st.canoncode st.canonlevel
@@ -877,10 +870,10 @@ theorem processnode_leaf {nn : Nat} {ctx : Ctx n} {cs bs : List Nat}
 /-! # The unwind carries both machines -/
 
 /-- One `recover` step after a node event: the comparison machine
-survives the unwind in whichever mode the event left it — live with
-`compCanon ≤ 0`, or the reset mode a row rejection leaves behind —
-and the first-path machine is clamped. The induction applies this at
-every return to a child loop. -/
+survives the unwind in whichever mode the event left it (live with
+`compCanon ≤ 0`, or the reset mode a row rejection leaves behind), and
+the first-path machine is clamped. The induction applies this at every
+return to a child loop. -/
 theorem recover_machines {nn inf : Nat} {cs bs fs : List Nat}
     {st : SearchSt n} {lvl : Nat}
     (hc : (st.compCanon ≤ 0 ∧
@@ -902,7 +895,7 @@ theorem recover_machines {nn inf : Nat} {cs bs fs : List Nat}
   · exact recover_codeInv hinv hle hlvl
   · exact recover_codeInv_reset hinv hlvl
 
-/-! # The first-path-agreeing leaf: the code-`1` gate -/
+/-! # The first-path-agreeing leaf: the code-`1` admission test -/
 
 /-- nauty's `workperm` at a first-path-agreeing leaf: the scatter of
 the current leaf's labelling over the first leaf's. -/
@@ -994,7 +987,7 @@ private theorem pushAuto_maxlevel (st : SearchSt n) (p : VSet n × VSet n) :
   rw [pushAuto]; split <;> rfl
 
 /-- The code-`1` arm: a first-path-agreeing leaf passing the
-admission gate records a generator and unwinds to `gcaFirst` with
+admission test records a generator and unwinds to `gcaFirst` with
 the whole comparison state untouched. -/
 theorem processnode_auto {ctx : Ctx n} {level numcells : Nat}
     {st : SearchSt n}
@@ -1383,10 +1376,10 @@ theorem processnode_rowTie_autos {ctx : Ctx n} {level numcells : Nat}
   all_goals by_cases hcap : st.autos.size = st.wsCap
   all_goals simp [hm, hcap, pushAuto, id_run_eq]
 
-/-- A first-path-agreeing leaf failing the admission gate behaves,
+/-- A first-path-agreeing leaf failing the admission test behaves,
 in the return level and the whole comparison state, exactly as the
-same state entered off the first path: the gate's only effect is the
-skipped generator. -/
+same state entered off the first path. The only effect of the test is
+the skipped generator. -/
 theorem processnode_gateFail_eq {ctx : Ctx n} {level numcells : Nat}
     {st : SearchSt n}
     (heq : (st.eqlevFirst == level) = true)
@@ -1447,7 +1440,7 @@ theorem processnode_gateFail_eq {ctx : Ctx n} {level numcells : Nat}
        | exact Or.inr (Or.inr rfl)
        | omega)
 
-/-- Failing the first-path admission gate has the same autos-ledger
+/-- Failing the first-path admission test has the same autos-ledger
 effect as entering the ordinary off-path comparison arm. -/
 theorem processnode_gateFail_autos {ctx : Ctx n} {level numcells : Nat}
     {st : SearchSt n}
@@ -1522,8 +1515,8 @@ theorem processnode_gateFail_autos {ctx : Ctx n} {level numcells : Nat}
     | exact congrArg (fun p => st.autos.set! (st.wsCap - 1) p) hfm
 
 /-- The leaf event at a first-path-agreeing leaf that fails the
-admission gate: identical to `processnode_leaf`, by the gate-failure
-reduction. -/
+admission test: identical to `processnode_leaf`, by the reduction
+`processnode_gateFail_eq`. -/
 theorem processnode_leafFirst {nn : Nat} {ctx : Ctx n}
     {cs bs : List Nat} {numcells : Nat} {st : SearchSt n}
     (hcinv : CodeCmpInv nn cs bs st.canoncode st.canonlevel
@@ -2084,28 +2077,28 @@ theorem discreteAt_iff_bcount {ptn : Array Nat} {level nn : Nat}
 /-! # The `DomOk` record
 
 The per-node entry invariant of the maximality induction, at a node
-about to refine at `level = cs.length + 1`. Two deliberate design
-decisions, so the next sitting does not re-litigate them:
+about to refine at `level = cs.length + 1`. Two facts about its
+shape:
 
-- **Incumbent-maximality is a conclusion shape, not a record
-  clause.** Following `searchNode_eq`'s `incMax` contract, each
-  quartet theorem concludes
+- **Incumbent-maximality is a conclusion, not a record clause.**
+  Following `searchNode_eq`'s `incMax` contract, each quartet theorem
+  concludes
   `incKey ctx bs' out.canonlab =
     keyMax (incKey ctx bs st.canonlab) (prefixKey cs (specNode …))`
-  rather than storing a fold over visited leaves in the record; the
-  `keysMax` algebra composes the per-child equations across the
-  sweep, and pruned children contribute through the verdict lemmas
+  rather than storing a fold over visited leaves in the record. The
+  `keysMax` algebra composes the per-child equations across the child
+  loop, and pruned children contribute through the verdict lemmas
   (`frozen_lt_keyCmp`, `auto_keyMax`, `childKey_of_orbPruned`).
 
-- **Unwinding-correctness is a loop obligation, not a record
-  clause.** The orbit consultation in `firstChildLoop` is justified
+- **Unwinding-correctness is proved at the loop, not stored in the
+  record.** The orbit consultation in `firstChildLoop` is justified
   by the `stab` clause held at the loop's own node: a loop that
-  continues (return level ≥ its level) received only generators
-  whose carrier leaves lie inside its subtree, so
+  continues (return level at least its own level) received only
+  generators whose carrier leaves lie inside its subtree, so
   `cellStab_of_scatter` re-establishes `stab` for the newly admitted
-  generators; an early unwind exits the loop and discharges nothing.
-  The gca return levels enter through `processnode_leaf`'s return
-  disjunction, not through a stored clause. -/
+  generators. An early unwind exits the loop and proves nothing
+  there. The gca return levels enter through `processnode_leaf`'s
+  return disjunction, not through a stored clause. -/
 
 variable {n k : Nat}
 
@@ -2155,18 +2148,18 @@ theorem autosOk_of_eq {g : Array (VSet n)} {rptn rlab : Array Nat}
     AutosOk g rptn rlab 1 st'.autos := by
   rw [h]; exact hok
 
-/-! # The leaf event's row obligations
+/-! # The row equalities the leaf event needs
 
-`processnode_checkAutom` and `genTraceOk_processnode` leave two row
-equalities to the induction. The row-tie one is local: a `testcanlab`
-tie against the updated store is exactly equality of the two leaf-row
-lists, by the store invariant the node already carries. The first-path
-one is the cheapautom descent and is discharged at the use site from
-the run's `gcaFirst`/`firsttc` bookkeeping. -/
+`processnode_checkAutom` and `genTraceOk_processnode` each leave a row
+equality for the induction to supply. The row-tie one is local: a
+`testcanlab` tie against the updated store is exactly equality of the
+two leaf-row lists, by the store invariant the node already carries.
+The first-path one is the cheapautom descent, proved at the use site
+from the run's `gcaFirst`/`firsttc` bookkeeping. -/
 
 /-- A `testcanlab` tie against the updated store says the leaf's rows
-are the incumbent's: this is the `harm3` obligation of
-`genTraceOk_processnode`, discharged from `DomOk.canongInv`. -/
+are the incumbent's: this is the `harm3` hypothesis of
+`genTraceOk_processnode`, supplied from `DomOk.canongInv`. -/
 theorem rows_eq_of_testcanlab_tie {ctx : Ctx n} {st : SearchSt n}
     (hinv : CanongInv ctx st.canong st.canonlab st.samerows)
     (h : (testcanlab ctx
@@ -2185,9 +2178,9 @@ theorem rows_eq_of_testcanlab_tie {ctx : Ctx n} {st : SearchSt n}
 
 /-! # Labelling facts of a reached state
 
-The row obligations and the scatter exits are stated over `LabOk`
-and `LabInj`; a reached labelling supplies both, so the induction
-never carries them separately from `SearchOk`. -/
+The row equalities and the scatter exits are stated over `LabOk` and
+`LabInj`. A reached labelling supplies both, so the induction never
+carries them separately from `SearchOk`. -/
 
 /-- A reached labelling lands in the vertex range. -/
 theorem labOk_of_reach {G : Colored n k} {lab : Array Nat}
@@ -2212,24 +2205,25 @@ theorem labInj_of_reach {G : Colored n k} {lab : Array Nat}
 
 /-! # The admission event under the node invariant
 
-Packaging the remaining row obligation with the labelling facts of a
-reached state: at a node carrying `DomOk`, `processnode` preserves store
-validity outright. The two
-`reached` hypotheses are what the induction knows from having passed
-`firstterminal`, where both the first leaf and the incumbent are
-installed from a reached labelling. -/
+The remaining row equality packaged with the labelling facts of a
+reached state: at a node carrying `DomOk`, `processnode` preserves
+store validity outright. The two `reached` hypotheses are what the
+induction knows from having passed `firstterminal`, where both the
+first leaf and the incumbent are installed from a reached
+labelling. -/
 
 /-! # Absorption of dominated sibling suffixes
 
-An early unwind abandons the remaining siblings of every loop
-strictly between the return level and the leaf. When the leaf event
-left the comparison machine frozen downward, the recorded divergence
-sits at level `eqlevCanon + 1`, and the `pruneReturn` forms that
-fire in that mode (`eqlevCanon` itself, or `allsamelevel - 1` above
-it) never return below the divergence; every abandoned loop's path
-prefix therefore still contains the divergence, so the whole subtree
-of every abandoned sibling compares below the incumbent and the key
-maximum absorbs the suffix locally, loop by loop. -/
+An early unwind leaves the remaining siblings of every loop strictly
+between the return level and the leaf unvisited. Suppose the leaf
+event left the comparison machine frozen downward. The recorded
+divergence sits at level `eqlevCanon + 1`, and the `pruneReturn`
+forms that fire in that mode (`eqlevCanon` itself, or
+`allsamelevel - 1` above it) never return below the divergence. The
+path prefix of every skipped loop therefore still contains the
+divergence, so the whole subtree of every skipped sibling compares
+below the incumbent, and the key maximum absorbs the suffix locally,
+loop by loop. -/
 
 private theorem getElem!_take'' {l : List Nat} {m i : Nat}
     (him : i < m) (hil : i < l.length) : (l.take m)[i]! = l[i]! := by
@@ -2337,10 +2331,10 @@ explored child subtree is absorbed at once: the admitted scatter is a
 checked automorphism that stabilizes the loop's cells and carries the
 guiding sibling's individualized vertex onto the current child's, so
 the two children's subtree keys are equal, and the guiding sibling's
-key is already folded into the incumbent. The abandoned intermediate
-loops below need no local justification in this mode; the return
-level being the gca is exactly what lets their whole enclosing child
-subtree be absorbed here. -/
+key is already folded into the incumbent. The intermediate loops
+below need no local justification in this mode. The return level being
+the gca is exactly what lets their whole enclosing child subtree be
+absorbed here. -/
 
 /-- A checked automorphism stabilizing the refined node's cells and
 carrying one target-cell vertex onto another identifies the two

--- a/HexGraphIso/Nauty/Invariant/Incumbent.lean
+++ b/HexGraphIso/Nauty/Invariant/Incumbent.lean
@@ -59,9 +59,9 @@ degenerate reading therefore *outranks every reachable leaf key*, and
 that the final incumbent is the degenerate one, which is false as soon
 as the search installs anything.
 
-`CanonSpec` already carries the fix: `incMax : Option (Key n) → Key n →
-Key n` with `none` as the bottom.  The semantic induction threads that
-option explicitly.  It can
+`CanonSpec` is stated with an option for exactly this reason:
+`incMax : Option (Key n) → Key n → Key n`, with `none` as the bottom.
+The semantic induction threads that option explicitly. The option can
 be read back from the imperative state only outside the temporary
 upward-comparison window, where `canoncode` contains path codes rather
 than the installed incumbent's codes. -/
@@ -182,9 +182,9 @@ target position being a *singleton cell* from the individualization
 onwards. Both steps of that transport are proved below, over one
 operation each: `refine` fixes a singleton cell's position, and a
 `breakout` elsewhere misses it, because two maximal runs are equal or
-disjoint. What is not proved here is the run-level statement that
-chains them, since the descent is the mutual recursion itself; see the
-note after `breakout_misses_singleton`. -/
+disjoint. The run-level statement that composes them is not proved
+here, because the descent is the mutual recursion itself. See the note
+after `breakout_misses_singleton`. -/
 
 /-- Individualizing offset `o` puts that offset's vertex at the target
 position. -/
@@ -248,9 +248,9 @@ theorem breakout_misses_singleton {lab ptn : Array Nat}
   · rw [ite_eq_left h]
   · rw [ite_eq_right (by omega), ite_eq_right (by omega), ite_eq_right (by omega)]
 
-/-! What remains for the position facts is a run-level frame: that one
-call of a quartet function preserves `lab[q]` at every position that is
-a singleton cell on entry. Its proof is an induction over the same
+/-! The position facts also need a run-level frame: one call of a
+quartet function preserves `lab[q]` at every position that is a
+singleton cell on entry. Its proof is an induction over the same
 mutual recursion as the absorption equation, discharging `refine` by
 `refine_fixes_singleton`, each deeper `breakout` by
 `singleton_outside_cell` and `breakout_misses_singleton`, and the
@@ -262,16 +262,15 @@ recursion. -/
 
 /-! # The root assembly
 
-The corrected statement reaches the programme's target. The root call
-of `firstPathNode` starts from a state with `canonlevel = 0`, so its
-incoming incumbent is `none` and `incMax` discards it; what comes out
-is therefore the node key of the root, which is `canonSpec` by
-definition, and the state's own incumbent reading is `tracedKey` by
-definition. `certifyCanon?_isSome_of_dominated` then closes.
+The root call of `firstPathNode` starts from a state with
+`canonlevel = 0`, so its incoming incumbent is `none` and `incMax`
+discards it. What comes out is therefore the node key of the root,
+which is `canonSpec` by definition, and the state's own incumbent
+reading is `tracedKey` by definition.
+`certifyCanon?_isSome_of_dominated` then gives the conclusion.
 
-The quartet's root instance is the hypothesis here, and it is the only
-thing these theorems assume: the induction that supplies it is the
-remaining work. -/
+The root instance of the quartet's absorption equation is a hypothesis
+of these theorems, and it is the only thing they assume. -/
 
 /-- The root state `runTraced` starts from. -/
 @[expose] def rootSt (n : Nat) (lab0 : Array Nat)
@@ -336,7 +335,7 @@ end Hex.GraphIso.Nauty
 
 
 /-!
-The node steps of the quartet (SPEC § Verified search refinement).
+The node steps of the quartet.
 
 A node's own work, either side of its child loop, never touches the
 incumbent: it refines, records its refinement code and target cell,

--- a/HexGraphIso/Nauty/Invariant/Leaves.lean
+++ b/HexGraphIso/Nauty/Invariant/Leaves.lean
@@ -26,7 +26,7 @@ the specification's `leafRows`:
   `testcanlab` returns the trichotomy of the lexicographic `VSet.rowCmp`
   comparison of `leafRows ctx lab` against the stored rows, and its
   second component is a leading-agreement count;
-- `leafEvent_faithful`: the packaged per-leaf clause — the comparison
+- `leafEvent_faithful`: the packaged per-leaf clause. The comparison
   outcome is `listCmp VSet.rowCmp (leafRows ctx lab) (leafRows ctx
   canonlab)`, and the out-state store satisfies the invariant both at
   `n` against the incumbent and at the returned prefix length against
@@ -36,9 +36,9 @@ the specification's `leafRows`:
 - `keyCmp_codes_eq`: on equal code lists the key comparison is the
   row comparison, connecting the trichotomy to `keyCmp` on leaf keys.
 
-`CanongInv` is stated as an explicit hypothesis; its propagation
-across the non-leaf events of the search is the simulation
-induction's obligation.
+`CanongInv` is stated as an explicit hypothesis. The simulation
+induction proves that it propagates across the non-leaf events of the
+search.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -428,7 +428,7 @@ leaf, `processnode` updates the store and compares. Under the store
 invariant, the comparison outcome is the model row comparison of the
 two leaf keys, and the updated store satisfies the invariant both at
 `n` against the incumbent and at the returned prefix length against
-the fresh leaf — re-establishing `CanongInv` whichever way the leaf
+the fresh leaf, so `CanongInv` holds again whichever way the leaf
 resolves. -/
 theorem leafEvent_faithful {ctx : Ctx n} {canong : Array (VSet n)} {canonlab lab : Array Nat}
     {samerows : Nat}

--- a/HexGraphIso/Nauty/Invariant/Orbits.lean
+++ b/HexGraphIso/Nauty/Invariant/Orbits.lean
@@ -378,7 +378,7 @@ theorem childKey_of_orbPruned {ctx : Ctx n}
         segN_cons, segN_zero, hheadO',
         getElem!_map_of_lt σ.toFun _ (by rw [hbsz]; omega), hheadO,
         hσvO]
-    · -- the remainder cells the.erase two vertices and transport
+    · -- the remainder cells erase two vertices and transport
       rw [show tc + (L + 1) - (tc + 1) = L by omega, htailO',
         segN_map_of_le _ _ _ _ (by rw [hbsz]; omega), htailO]
       have hCstab := hstabSeg tc (L + 1) hic hrange
@@ -485,8 +485,8 @@ other touch points.
 Symmetry of `WordConn` is where the group theory lives: the chase
 loops inside `orbjoin` link roots found from both ends of a
 generator edge, so the pointer being justified can point against the
-direction of the discovered word. Forward words still suffice —
-a bounded injective array has finite order pointwise
+direction of the discovered word. Forward words still suffice,
+because a bounded injective array has finite order pointwise
 (`exists_applyWord_replicate_self`, by pigeonhole on the trajectory),
 so the inverse of a generator is one of its forward powers
 (`wordConn_symm`). No inverse arrays are ever materialized, matching

--- a/HexGraphIso/Nauty/Invariant/Reach.lean
+++ b/HexGraphIso/Nauty/Invariant/Reach.lean
@@ -16,7 +16,7 @@ The quartet induction: every state the transcribed search
 (`firstPathNode`/`firstChildLoop`/`otherNode`/`otherChildLoop`)
 reaches keeps its labelling cell-content-reachable from the initial
 labelling (`CellsReach`), its initial boundaries intact, and its
-`numcells` accurate — so the search's `canonlab` output is reached
+`numcells` accurate. The search's `canonlab` output is therefore reached
 (`canonlab_cellsReach`), which discharges the transcription-side
 residuals of `certifyCanon?_isSome`
 (`labelColorSorted_canonlab`, `canonlab_perm_range`).
@@ -1870,8 +1870,8 @@ theorem canonlab_size {k : Nat} (G : Colored n k) :
 
 /-- The transcribed search's canonical labelling is reached: it
 fills every cell of the initial partition with that cell's own
-vertices. The B2 simulation clause of the verified search refinement
-programme, discharging the transcription-side residuals of
+vertices. This is the simulation clause the rest of the correctness
+argument shares, and it supplies the transcription-side residuals of
 `certifyCanon?_isSome`. -/
 theorem canonlab_cellsReach {k : Nat} (G : Colored n k) :
     CellsReach G (runColored G).canonlab := by

--- a/HexGraphIso/Nauty/Invariant/Refine.lean
+++ b/HexGraphIso/Nauty/Invariant/Refine.lean
@@ -18,26 +18,26 @@ the clause's induction consumes.
 -/
 
 /-!
-Transcription labelling invariants for the verified search refinement
-programme: label well-formedness and the `labelColorSorted` residual
-of `certifyCanon?_isSome`.
+Labelling invariants of the transcribed search: label
+well-formedness and the `labelColorSorted` residual of
+`certifyCanon?_isSome`.
 
 The single simulation-relation clause on the imperative search state
 is that the labelling stays cell-content-reachable from the initial
 labelling relative to the initial partition: `CellsReach G lab` below.
 `breakout` individualizes a vertex to the front of its cell and
 `refine` splits cells into finer cells, and both are permutations
-within the initial colour classes, so every leaf the search reaches
-— in particular `canonlab` — satisfies it. From that one clause the
+within the initial colour classes, so every leaf the search reaches,
+`canonlab` in particular, satisfies it. From that one clause the
 two transcription-side residuals follow immediately through the
 existing achievement lemmas: `achieved_perm_range` turns it into
 permutation-ness (`canonlab` is a bijection of `Fin n`) and
 `achieved_position_colors` turns it into `labelColorSorted`.
 
-These lemmas prove those two reductions in full; the quartet
-induction establishing the clause for the transcribed `canonlab`
-lives in `Invariant/Reach` (`canonlab_cellsReach`), the shared B2
-simulation clause of the layer-three programme.
+These lemmas prove those two reductions in full. The quartet
+induction that establishes the clause for the transcribed `canonlab`
+is `canonlab_cellsReach` in `Invariant/Reach`, and the rest of the
+correctness argument shares that clause.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -105,12 +105,12 @@ theorem labelColorSorted_of_cellsReach {G : Colored n k}
 
 /-! # Operation-level preservation lemmas
 
-The two labelling-mutating search operations — `refine` and
-`breakout` — permute labels only within cells of the current partition,
-which refines the initial partition, so both preserve `CellsReach`.
-These are the reusable substrate the quartet induction assembles: each
-takes the threaded fact that the initial cell boundaries persist in the
-current partition (`hcoarse`) and preserves the clause. -/
+The two labelling-mutating search operations, `refine` and `breakout`,
+permute labels only within cells of the current partition, which
+refines the initial partition, so both preserve `CellsReach`. The
+quartet induction composes these two lemmas: each takes the threaded
+fact that the initial cell boundaries persist in the current partition
+(`hcoarse`) and preserves the clause. -/
 
 /-- `refine` preserves `CellsReach`: it reorders labels within cells of
 its own (finer) partition, and the initial boundaries persist, so
@@ -1048,8 +1048,9 @@ theorem bcount_initPtn {n k : Nat} (G : Colored n k) :
 /-! # The quartet invariants
 
 The per-node invariant (`SearchOk`) and per-call effect (`SearchOut`)
-of the transcribed search, with their composition toolkit. The
-quartet induction itself consumes these downstream. -/
+of the transcribed search, with the lemmas that compose them.
+`Invariant/Reach` and `Invariant/Domination` use these in the
+induction over the four search functions. -/
 
 variable {n k : Nat}
 

--- a/HexGraphIso/Nauty/Invariant/Stabilize.lean
+++ b/HexGraphIso/Nauty/Invariant/Stabilize.lean
@@ -12,9 +12,9 @@ public import HexGraphIso.Nauty.Invariant.Refine
 public section
 
 /-!
-The stabilization invariant of the verified search refinement: the
-generators the search admits fix the cells of their admitting nodes
-setwise, and cell stabilization survives descent.
+The stabilization invariant of the search: the generators it admits
+fix the cells of their admitting nodes setwise, and cell
+stabilization survives descent.
 
 `childKey_of_orbPruned` consumes `CellStab` at the node performing an
 orbit prune. This file supplies it from the run facts the simulation
@@ -23,8 +23,8 @@ induction carries, in three layers:
 * **Reach transfer.** `cellsPerm` from an ancestor node's state is the
   node-relative generalization of `CellsReach`, and the two
   labelling-mutating operations preserve it (`refine_reachAt`,
-  `breakout_reachAt`); the root-relative lemmas in
-  `Invariant/Refine` are the instance at the initial partition.
+  `breakout_reachAt`). The root-relative lemmas in `Invariant/Refine`
+  are the instance at the initial partition.
 * **Scatter stabilization.** A generator is admitted as a scatter
   carrying one leaf labelling onto another. Both labellings are
   reachable from any common ancestor, and a scatter joining two

--- a/HexGraphIso/Nauty/Invariant/Store.lean
+++ b/HexGraphIso/Nauty/Invariant/Store.lean
@@ -20,8 +20,8 @@ the domination induction threads.
 -/
 
 /-!
-Store validity for the admitted automorphisms (SPEC § Verified search
-refinement, the replay hypothesis's store-validity clause).
+Store validity for the admitted automorphisms, which is what the
+replay hypothesis needs of `genTrace`.
 
 The traced run's `genTrace` feeds the certificate producer: every
 `.autom` record carries one of its entries, and the replay's
@@ -45,9 +45,9 @@ every row.
 The code-1 arm's other guard, `gcaFirst ≥ noncheaplevel` with no
 `isautom` scan, admits on the strength of `cheapautom`: an equitable
 partition whose nontrivial cells are small enough forces every leaf
-below to realize an automorphism. That argument needs a theory of
-equitable partitions the development does not yet have; the theorems
-here are stated so that arm can slot in beside them once proven.
+below to realize an automorphism. `SmallCell/Transitive` proves that
+arm (`checkAutom_scatter_of_descPaths`), from the two same-target
+descents below the greatest common ancestor.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -235,9 +235,9 @@ theorem checkAutom_scatter_of_leafRows_eq {ctx : Ctx n}
 
 `processnode` is the only search step that grows `genTrace`. The
 lemmas below characterize the grown entry: the scatter loops become
-folds, and the event lemma ties each push to its admission guard, in
-the shape the run-level threading consumes together with the
-per-admission theorems above.
+folds, and the event lemma records which guard admitted each push.
+The run-level induction consumes them together with the per-admission
+theorems above.
 -/
 
 private theorem id_run_eq {α : Type} (x : Id α) : x.run = x := rfl

--- a/HexGraphIso/Nauty/Model/Autom.lean
+++ b/HexGraphIso/Nauty/Model/Autom.lean
@@ -11,30 +11,31 @@ public import HexGraphIso.Nauty.Model.Node
 public section
 
 /-!
-The automorphism-pruned step of the abstract evaluator ladder.
-`searchNodeA` extends the code-pruned branch-and-bound of `searchNode`
-with the generator skip the transcription performs and the certificate
-replays as `.autom` records: a child position is dropped when a stored
-generator carries its labelling, cell by cell, onto an earlier
-sibling's. For a store of checked automorphisms (`checkAutom`), the
-skipped subtree's key equals the earlier sibling's by `specNode_autom`,
-so the prune is lossless. `searchNodeA_eq` shows the doubly-pruned
-recursion still computes `incMax inc (specNode ...)`, and
-`searchCanonA_key` packages the root call as a verified pruned
-evaluator of `canonSpecKey`. The store is a per-call parameter used at
-every node of the subtree; growth of the store mid-sweep is `Model/Store`.
+The second of three verified pruned evaluators of the declarative
+canonical key. `searchNodeA` extends the code-pruned branch-and-bound
+of `searchNode` with the generator prune: a child position is dropped
+when a stored generator maps that child's labelling, cell by cell, to
+an earlier sibling's. This is the skip the transcribed search performs
+and the certificate replays as `.autom` records. For a store of
+checked automorphisms (`checkAutom`), the skipped subtree's key equals
+the earlier sibling's by `specNode_autom`, so the prune is lossless.
+`searchNodeA_eq` shows the doubly-pruned recursion still computes
+`incMax inc (specNode ...)`, and `searchCanonA_key` presents the root
+call as a verified pruned evaluator of `canonSpecKey`. The store here
+is a single parameter, fixed for the whole call. `searchNodeG` is the
+version whose store grows as generators are found.
+
 Nothing on the theorem path for `canonSpecKey = tracedKey` uses these
-declarations. They are kept as a source of lemmas about pruning in the
-abstract.
+declarations. They are kept as a source of lemmas about pruning.
 -/
 
 namespace Hex.GraphIso.Nauty
 
 variable {n k : Nat}
 
-/-- Pairwise generator skip for child `o` of a sweep: some stored
-generator carries this child's labelling to an earlier sibling's,
-cell by cell — the executable mirror of the `.autom` replay
+/-- Pairwise generator skip for child `o` at a node: some stored
+generator maps this child's labelling, cell by cell, to an earlier
+sibling's. This is the executable form of the `.autom` replay
 condition. -/
 @[expose] def autPruned (nn : Nat) (gens : List (Array Nat))
     (rsLab rsPtn : Array Nat) (level tc o : Nat) : Bool :=
@@ -75,8 +76,9 @@ child sweep skipping generator-pruned positions. -/
 
 /-- Branch-and-bound with both prunes: the incumbent's code prunes a
 subtree exactly as in `searchNode`, and stored generators prune
-sibling positions inside each sweep. Untrusted as an evaluator; the
-theorem `searchNodeA_eq` verifies it against `specNode`. -/
+sibling positions among the children of a node. It is not trusted as
+an evaluator. The theorem `searchNodeA_eq` verifies it against
+`specNode`. -/
 @[expose] def searchNodeA (ctx : Ctx n) (tcLevel : Nat)
     (gens : List (Array Nat)) :
     Nat → Nat → Array Nat → Array Nat → VSet n → Nat → Option (Key n) → Key n

--- a/HexGraphIso/Nauty/Model/Node.lean
+++ b/HexGraphIso/Nauty/Model/Node.lean
@@ -11,17 +11,19 @@ public import HexGraphIso.Nauty.Cert.Cert
 public section
 
 /-!
-The code-pruned step of the abstract evaluator ladder. `searchNode`
-threads an incumbent best key and skips any subtree whose refinement
-code falls below the incumbent's code at its depth, exactly as the
-transcription prunes on `code < canoncode[level]`. `searchNode_eq`
-proves the pruned recursion computes the pairwise maximum of the
-incumbent and the unpruned subtree key with no side conditions, so
-`searchCanon_eq` and `searchCanon_key` present the root call as a
-verified pruned evaluator of `canonSpec` and of `canonSpecKey`.
+The first of three verified pruned evaluators of the declarative
+canonical key, each adding one of the transcribed search's prunes.
+This one adds the code prune. `searchNode` threads an incumbent best
+key and skips any subtree whose refinement code falls below the
+incumbent's code at its depth, exactly as the transcribed search
+prunes on `code < canoncode[level]`. `searchNode_eq` proves the pruned
+recursion computes the pairwise maximum of the incumbent and the
+unpruned subtree key, with no side conditions, so `searchCanon_eq` and
+`searchCanon_key` present the root call as a verified pruned evaluator
+of `canonSpec` and of `canonSpecKey`.
+
 Nothing on the theorem path for `canonSpecKey = tracedKey` uses these
-declarations. They are kept as a source of lemmas about pruning in the
-abstract.
+declarations. They are kept as a source of lemmas about pruning.
 -/
 
 namespace Hex.GraphIso.Nauty

--- a/HexGraphIso/Nauty/Model/Store.lean
+++ b/HexGraphIso/Nauty/Model/Store.lean
@@ -14,20 +14,21 @@ public import HexGraphIso.Nauty.Spec.SpecIso
 public section
 
 /-!
-The growing-store step of the abstract evaluator ladder. Where
-`searchNodeA` prunes against a fixed generator store, `searchNodeG`
-threads the store through the recursion, so a generator admitted at a
-leaf prunes later siblings of every sweep on the path back up,
-including later siblings of the sweep that discovered it, as the
-transcription's store does. Admission is abstract: an oracle `adm`
-proposes generators from each discrete leaf's labelling and the
-incumbent, and every theorem holds for any oracle whose proposals pass
-`checkAutom`. `searchNodeG_eq` shows the recursion still computes
-`incMax inc (specNode ...)` and that store validity is an invariant,
-and `searchCanonG_key` packages the root call as a verified evaluator
-of `canonSpecKey`. Nothing on the theorem path for
-`canonSpecKey = tracedKey` uses these declarations. They are kept as a
-source of lemmas about pruning in the abstract.
+The third of three verified pruned evaluators of the declarative
+canonical key. Where `searchNodeA` prunes against a fixed generator
+store, `searchNodeG` threads the store through the recursion, so a
+generator admitted at a leaf prunes later siblings at every node on
+the path back up, including later siblings of the node that discovered
+it. That is what the transcribed search's store does. Admission is
+left open: an oracle `adm` proposes generators from each discrete
+leaf's labelling and the incumbent, and every theorem holds for any
+oracle whose proposals pass `checkAutom`. `searchNodeG_eq` shows the
+recursion still computes `incMax inc (specNode ...)` and that store
+validity is an invariant, and `searchCanonG_key` presents the root
+call as a verified evaluator of `canonSpecKey`.
+
+Nothing on the theorem path for `canonSpecKey = tracedKey` uses these
+declarations. They are kept as a source of lemmas about pruning.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -52,9 +53,9 @@ theorem validStore_append {ctx : Ctx n} {S T : List (Array Nat)}
 mutual
 
 /-- The child sweep with a growing store: each unpruned child is
-searched with the store as it stands, and the store it returns —
-possibly grown at leaves below — is what later siblings are pruned
-against. -/
+searched with the store as it stands, and the store that child
+returns, possibly grown at leaves below it, is what later siblings are
+pruned against. -/
 @[expose] def sweepG (ctx : Ctx n) (tcLevel : Nat)
     (adm : Array Nat → Option (Key n) → List (Array Nat))
     (fuel level : Nat) (rsLab rsPtn : Array Nat)
@@ -71,9 +72,9 @@ against. -/
       sweepG ctx tcLevel adm fuel level rsLab rsPtn tc numcells os r
   termination_by os _ => (fuel, 1, os.length)
 
-/-- One node step at a refined state: at a discrete leaf the oracle's
-proposals join the store; at a live node the first child absorbs the
-incumbent and the sweep threads the store across the rest. -/
+/-- One node step at a refined state. At a discrete leaf the oracle's
+proposals join the store. At a live node the first child absorbs the
+incumbent and `sweepG` threads the store across the rest. -/
 @[expose] def stepG (ctx : Ctx n) (tcLevel : Nat)
     (adm : Array Nat → Option (Key n) → List (Array Nat))
     (fuel level : Nat) (rs : RefineSt n) (tail0 : Option (Key n))

--- a/HexGraphIso/Nauty/Search/Bits.lean
+++ b/HexGraphIso/Nauty/Search/Bits.lean
@@ -17,20 +17,22 @@ public section
 /-!
 Vertex-set primitives for the nauty-compatible search.
 
-The word layer under the packed vertex sets of `VSet`: the least set
-bit (`lowBit`, nauty's `FIRSTBITNZ`), the population count
-(`popCount`, nauty's `POPCOUNT`), and the byte-chunked walk that lists
-the set bits of a word, each with a per-bit specification the kernel can
-replay, a byte-table implementation the compiled code runs, and the
-`csimp` equality between them. A word here is a natural number; the
-implementations are only ever applied to 63-bit limbs, where every
-operation is a scalar one.
+The word-level operations beneath the packed vertex sets of `VSet`:
+the least set bit (`lowBit`, nauty's `FIRSTBITNZ`), the population
+count (`popCount`, nauty's `POPCOUNT`), and the byte-chunked walk that
+lists the set bits of a word (`toListGo`, which uses `toListByte` on
+each byte). Each comes with a per-bit specification the kernel can
+replay, a byte-table implementation the compiled code runs
+(`lowBitFast` and `popCountFast`, whose loops are `lowBitGo` and
+`popCountGo`), and the `csimp` equality between them. A word here is a
+natural number. The implementations are only ever applied to 63-bit
+limbs, where every operation is a scalar one.
 -/
 
 namespace Hex.GraphIso.Nauty
 
-/-- The index of the least set bit. Returns `0` for the empty set; callers
-guard on nonemptiness. Structurally recursive on an always-sufficient
+/-- The index of the least set bit, or `0` for the empty set (callers
+guard on nonemptiness). Structurally recursive on an always-sufficient
 fuel so the kernel can replay it. -/
 @[expose] def lowBit (s : Nat) : Nat :=
   go (s + 1) s
@@ -286,8 +288,8 @@ decreasing_by omega
   toListByteGo b base cnt 0 acc
 
 /-- The byte-chunked `toList` walk: one big-number shift per byte,
-early exit once the remainder is empty. Accumulates reversed; one
-final reverse restores ascending order. -/
+with an early exit once the remainder is empty. It accumulates in
+reverse, and one final reverse restores ascending order. -/
 @[expose] def toListGo (base cnt s : Nat) (acc : List Nat) : List Nat :=
   if cnt = 0 ∨ s = 0 then acc
   else toListGo (base + 8) (cnt - 8) (s >>> 8)
@@ -375,8 +377,8 @@ theorem toListGo_eq (base cnt s : Nat) (acc : List Nat) :
 
 /-! # Word-level lemmas
 
-Bit facts about a single word that the packed vertex-set layer
-(`VSet`) builds its membership lemmas from. -/
+Bit facts about a single word, from which the packed vertex sets of
+`VSet` build their membership lemmas. -/
 
 /-- The number of set bits below `n`. -/
 @[expose] def bitCount (n s : Nat) : Nat :=
@@ -527,8 +529,8 @@ theorem testBit_ne_at_lowBit_xor {a b : Nat} (hab : a ≠ b) :
 
 The kernel-facing replay (`HexGraphIso.Kernel.CheckKey`) keeps every
 vertex set as one `Nat`, because the kernel's GMP-backed `Nat`
-arithmetic is its cheapest reduction path. These are that layer's set
-operations. `VSet.toNat` relates each to its packed runtime
+arithmetic is its cheapest reduction path. These are the set
+operations it uses. `VSet.toNat` relates each to its packed runtime
 counterpart. Insertion and deletion are guarded by the vertex bound
 exactly as the packed operations are, so the correspondences are
 unconditional. -/

--- a/HexGraphIso/Nauty/Search/Refine.lean
+++ b/HexGraphIso/Nauty/Search/Refine.lean
@@ -15,21 +15,31 @@ public import HexGraphIso.Nauty.Search.VSet
 public section
 
 /-!
-Partition-level routines of the nauty-compatible search, transcribed from
-the pinned nauty 2.9.3 sources (`naugraph.c`, `nautil.c`); those files are
-the normative reference for every behavioural detail here, including the
-splitter processing order, the refinement-code arithmetic, the two-pointer
-cell partition, the stable counting redistribution, and the target-cell
-rules.
+Partition-level routines of the nauty-compatible search, transcribed
+from the pinned nauty 2.9.3 sources (`naugraph.c`, `nautil.c`). Those
+files are the normative reference for every behavioural detail here,
+including the splitter processing order, the refinement-code
+arithmetic, the two-pointer cell partition, the stable counting
+redistribution, and the target-cell rules.
 
-The partition nest is nauty's `(lab, ptn)` pair: `lab` lists the vertices,
-and position `i` ends a cell of the partition at level `l` exactly when
-`ptn[i] ≤ l`. `NAUTY_INFINITY` is modelled by any value exceeding every
-level in use; only comparisons with levels are observable.
+The partition nest is nauty's `(lab, ptn)` pair: `lab` lists the
+vertices, and position `i` ends a cell of the partition at level `l`
+exactly when `ptn[i] ≤ l`. `NAUTY_INFINITY` is modelled by any value
+exceeding every level in use. Only comparisons with levels are
+observable.
 
-Deviations that provably preserve every observable result are noted where
-they occur (bucket-window initialization and the stable counting sort in
-`refineStep`, both local scratch in nauty).
+`refine` drives one splitting pass per active cell: `refineLoop`
+repeats `refineStep` until the active set is empty or every cell is a
+singleton, and `refineStep` dispatches to `refineTrivial` for a
+singleton splitter and `refineNontrivial` otherwise. `targetcell`
+chooses the cell to individualize. Down to depth `tcLevel` it uses
+`bestcell`, which counts, in `bestcellRows` and `bestcellRow`, how many
+other nonsingleton cells each nonsingleton cell is nontrivially joined
+to.
+
+Deviations that provably preserve every observable result are noted
+where they occur (bucket-window initialization and the stable counting
+sort in `refineStep`, both local scratch in nauty).
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -76,7 +86,13 @@ where
       else
         []
 
-/-- Working state of one `refine` call on `n` vertices. -/
+/-- Working state of one `refine` call on `n` vertices. `lab` and
+`ptn` are the partition nest and `active` the positions of the cells
+still to be used as splitters, all three nauty's arrays of those names.
+`numcells` counts the cells. `hint` is the position `pickSplit` tries
+first on the next iteration. `maxpos` is the position of the largest
+fragment of the last nontrivial split, which is the one left out of the
+active set. `longcode` is the accumulated refinement code. -/
 structure RefineSt (n : Nat) where
   lab : Array Nat
   ptn : Array Nat
@@ -333,12 +349,13 @@ Touches no labelling data. -/
 
 `nontrivialCellFast` computes the same `RefineSt` as `nontrivialCell`
 through one counts pass, a multiplicity bucket array, a bucket-driven
-window scan, and a stable single-pass placement — O(cell + window)
-with no intermediate lists, where the specification's `multOf`-driven
-scan and `segmentOf` redistribution are O(cell x window) with list
-construction throughout. The equality `nontrivialCell_eq_fast` below
-is `@[csimp]`, so every compiled call site runs the counting sort;
-the specification spellings above stay the proof surface. -/
+window scan, and a stable single-pass placement. That costs
+O(cell + window) and builds no intermediate lists, where the
+specification's `multOf`-driven scan and `segmentOf` redistribution
+cost O(cell x window) and build lists throughout. The equality
+`nontrivialCell_eq_fast` below is `@[csimp]`, so every compiled call
+site runs the counting sort. The definitions above are the ones the
+proofs are stated against. -/
 
 /-- The counts pass: per-member neighbour counts into the splitter
 set, the members themselves, and the count extrema, in one walk. -/
@@ -493,14 +510,14 @@ theorem ntcScan_eq_windowScan (level cell1 cell2 bmin : Nat)
         ntcScan_eq_windowScan level cell1 cell2 bmin bucket counts
           fuel (j + 1) c1 maxcell st hrest]
 
-/-! # The counting-sort activation
+/-! # The counting sort computes the specification
 
 The bucket-array counting sort `nontrivialCellFast` equals the
-specification `nontrivialCell`; the proof lives here, upstream of the
-`refine` drivers, so the concluding `@[csimp]` rewrites their compiled
-call sites. The segment write-back lemmas sit first: they are stated
-against `writeSegment` alone, and `CellPermLoop`'s `segN` lemmas
-consume them downstream. -/
+specification `nontrivialCell`. The proof sits upstream of the `refine`
+drivers, so the concluding `@[csimp]` rewrites their compiled call
+sites. The segment write-back lemmas come first: they are stated
+against `writeSegment` alone, and `CellPermLoop`'s `segN` lemmas use
+them downstream. -/
 
 theorem writeSegment_outside :
     ∀ (seg : List Nat) (lab : Array Nat) (lo q : Nat),
@@ -924,7 +941,7 @@ private theorem grpAt_getElem! {β : Type} [Inhabited β] (w : Nat)
       simp only [Nat.add_zero]
       rw [hrec]; congr 1; omega
 
-/-! # Bridging `baseOff`/`placed` to list `countP` forms -/
+/-! # `baseOff` and `placed` as list `countP` forms -/
 
 /-- Counting a predicate over a prefix of positions equals counting it
 over the prefix list. -/
@@ -1041,9 +1058,9 @@ private theorem grouped_getElem! {β : Type} [Inhabited β] (cs : List Nat)
 /-- The placement crux: the element `segmentOf` produces at
 `baseOff v + placed o v` (the counting-sort target slot for the
 `o`-th member, whose count value offset is `v`) is exactly the member
-`lab[cell1 + o]` the stable walk writes there. This is piece (a) of the
-`nontrivialCell = nontrivialCellFast` activation: it identifies the
-scatter destination with the specification's grouped output. -/
+`lab[cell1 + o]` the stable walk writes there. This is the first half
+of `nontrivialCell = nontrivialCellFast`: it identifies the scatter
+destination with the specification's grouped output. -/
 private theorem segmentOf_getElem!_placement (lab counts : Array Nat)
     (cell1 bmin W o : Nat)
     (hcv : countValues counts.toList = (List.range W).map (bmin + ·))
@@ -1139,10 +1156,10 @@ theorem ntcPass_concrete_members (ctx : Ctx n) (lab : Array Nat)
 /-! # The placement against `writeSegment ∘ segmentOf`
 
 `ntcPlace` walks the members in cell order, writing each at its
-group's running position. Its stability equals the specification's
-`writeSegment ∘ segmentOf` under the base-position invariant: after a
-length-`o` prefix, group `v`'s cursor sits at `base v` plus the number
-of already-placed value-`v` members. -/
+group's running position. It produces the same array as the
+specification's `writeSegment ∘ segmentOf`, under the base-position
+invariant: after a length-`o` prefix, group `v`'s cursor sits at
+`base v` plus the number of already-placed value-`v` members. -/
 
 /-- The absolute destination of the `o`-th member under the base
 positions `base`: its group base plus the number of already-placed
@@ -1153,8 +1170,8 @@ private def dest (counts : Array Nat) (bmin : Nat) (base : Nat → Nat)
 
 /-- The scatter characterization: when the cursor array holds each
 group's base plus its placed count, `ntcPlace` writes member `o` at
-`dest o` for each `o` in the walked window, in order — a fold of
-independent `set!`s. -/
+`dest o` for each `o` in the walked window, in order. The result is a
+fold of independent `set!`s. -/
 private theorem ntcPlace_eq_fold (counts members : Array Nat) (bmin : Nat)
     (base : Nat → Nat) :
     ∀ (fuel o0 : Nat) (lab starts : Array Nat),
@@ -1353,7 +1370,7 @@ private theorem destOff_inj (counts : Array Nat) (bmin : Nat)
       (placed_lt_mult counts bmin o' (counts[o']! - bmin) ho' (by simp))
 
 /-- A `Nodup` list of naturals, all below `N`, of length `N`, contains
-every `k < N` — the pigeonhole surjectivity. -/
+every `k < N`, by pigeonhole. -/
 private theorem nodup_range_full (N : Nat) (l : List Nat) (hnd : l.Nodup)
     (hlen : l.length = N) (hlt : ∀ x ∈ l, x < N) :
     ∀ k, k < N → k ∈ l := by
@@ -1874,8 +1891,8 @@ where
     (workset : VSet n) (v2 : Nat) : List Nat → Array Nat → Array Nat
   | [], bucket => bucket
   | v1 :: rest, bucket =>
-    -- nauty tests `workset & gp ≠ 0` and `workset & ~gp ≠ 0`; the second
-    -- says `workset` is not contained in the row.
+    -- nauty tests `workset & gp ≠ 0` and `workset & ~gp ≠ 0`. The second
+    -- of those says `workset` is not contained in the row.
     if ¬ workset.interIsEmpty ctx.g[lab[startArr[v1]!]!]! ∧
         ¬ workset.subset ctx.g[lab[startArr[v1]!]!]! then
       bestcellRow ctx lab startArr workset v2 rest
@@ -1901,9 +1918,9 @@ where
     else
       argmaxLoop bucket rest v1 v2
 
-/-- nauty's `bestcell`: the first cell nontrivially joined to the greatest
-number of other nonsingleton cells, as a `lab` position; `n` when every
-cell is a singleton. -/
+/-- nauty's `bestcell`: the first cell nontrivially joined to the
+greatest number of other nonsingleton cells, as a `lab` position. The
+result is `n` when every cell is a singleton. -/
 @[expose] def bestcell (ctx : Ctx n) (lab ptn : Array Nat) (level : Nat) : Nat :=
   let starts := ((cells ptn level n).filter fun (c1, c2) => c1 ≠ c2).map (·.1)
   let nnt := starts.length
@@ -1915,7 +1932,10 @@ cell is a singleton. -/
       (List.range' 1 (nnt - 1)) (Array.replicate nnt 0)
     startArr[argmaxLoop bucket (List.range' 1 (nnt - 1)) 0 bucket[0]!]!
 
-/-- nauty's `targetcell` for the pinned undirected configuration. -/
+/-- nauty's `targetcell` for the pinned undirected configuration: keep
+the hinted position when it still starts a nonsingleton cell of the
+partition at `level`, otherwise take `bestcell` while
+`level ≤ tcLevel` and the first nonsingleton cell deeper than that. -/
 @[expose] def targetcell (ctx : Ctx n) (lab ptn : Array Nat) (level tcLevel : Nat)
     (hint : Int) : Nat :=
   if hint ≥ 0 ∧ ptn[hint.toNat]! > level ∧

--- a/HexGraphIso/Nauty/Search/Search.lean
+++ b/HexGraphIso/Nauty/Search/Search.lean
@@ -16,20 +16,40 @@ public import HexGraphIso.Limits
 public section
 
 /-!
-The nauty-compatible canonical search, transcribed from `nauty.c` of the
-pinned nauty 2.9.3 release with the pinned dense options: `getcanon = 1`,
-undirected, caller partition, `tc_level = 100`, no vertex invariant, no
-Schreier machinery, and no user callbacks. `nauty.c` is normative for
-every detail: the first-path bookkeeping, the level-code and canonical
-comparisons, the five-way leaf classification, automorphism recording with
-its 500-entry workspace overwrite rule, orbit and short/long pruning, and
-the return-level unwinding protocol.
+The canonical search of nauty 2.9.3 dense basic mode, transcribed from
+`nauty.c` with the pinned dense options: `getcanon = 1`, undirected,
+caller partition, `tc_level = 100`, no vertex invariant, no Schreier
+machinery, and no user callbacks. `nauty.c` is normative for every
+detail: the first-path bookkeeping, the level-code and canonical
+comparisons, the five-way leaf classification, automorphism recording
+with its 500-entry workspace overwrite rule, orbit and short/long
+pruning, and the return-level unwinding protocol.
 
-This module is the executable production stage. Its agreement with the
-external nauty binary is established by conformance testing, and its
-agreement with the proven reference implementation on the isomorphism
-verdict is checked there as well; the certificate layer replays its output
-before anything is trusted in a proof.
+The search tree is walked by four mutually recursive functions.
+`firstPathNode` is nauty's `firstpathnode` and `firstChildLoop` is its
+loop over the target cell: together they descend the leftmost path and
+install its leaf as both the first leaf and the initial best-so-far
+leaf. `otherNode` is nauty's `othernode` and `otherChildLoop` is its
+loop over the target cell: together they visit every node off that
+path. Each of the four returns the level the search is to unwind to,
+and each takes a fuel argument in place of the unbounded C recursion.
+
+One `SearchSt` record carries what nauty keeps in file-scope variables
+for the duration of a `nauty()` call: the partition `(lab, ptn)` with
+its active cells and the individualized vertices, the first leaf and
+the best-so-far leaf with their labellings, adjacency rows and
+refinement codes, the level counters saying how far the current node
+still agrees with each of those two leaves, the orbit array, the
+bounded workspace of automorphism `(fix, mcr)` pairs that
+`shortprune` and `longprune` read, and the counters nauty returns in
+its `statsblk`. `runTraced` builds the initial state, calls
+`firstPathNode` at level 1, and reads the canonical labelling and rows
+out of the final state.
+
+Conformance testing establishes agreement with the external nauty
+binary, and agreement with the proven reference implementation on the
+isomorphism verdict. `HexGraphIso.Kernel.CheckKey` replays this
+module's output before a proof depends on it.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -37,16 +57,58 @@ namespace Hex.GraphIso.Nauty
 /-- The sentinel code above every real refinement code: nauty's `077777`. -/
 @[expose] def codeSentinel : Nat := 0o77777
 
-/-- Search state: nauty's globals for one `nauty()` invocation on `n`
-vertices. -/
+/-- Search state: what nauty keeps in file-scope variables for the
+duration of one `nauty()` call on `n` vertices. Every field is named
+for the nauty global or `statsblk` member it mirrors, except `wsCap`
+and `genTrace`.
+
+`lab` and `ptn` are the partition nest: position `i` ends a cell at
+level `l` exactly when `ptn[i] ≤ l`. `active` holds the positions of
+the cells still to be used as splitters by `refine`. `fixedpts` holds
+the vertices individualized on the path from the root to this node.
+
+`firstlab` and `canonlab` are the labellings of the first leaf and of
+the best-so-far leaf. `firstcode` and `canoncode` hold the refinement
+code of their ancestor at each level, terminated by `codeSentinel`.
+`firsttc` holds the target-cell position chosen at each level of the
+first path, or `-1` where there is none. `canong` holds the adjacency
+rows of the best-so-far leaf, correct in its first `samerows` rows,
+and `canonlevel` is that leaf's level.
+
+`eqlevFirst` (`eqlev_first`) and `eqlevCanon` (`eqlev_canon`) are the
+deepest levels to which this node's codes agree with the first leaf's
+and with the best-so-far leaf's. `compCanon` (`comp_canon`) is `-1`,
+`0` or `1` as this node's code at level `eqlevCanon + 1` is less than,
+equal to, or greater than the best-so-far leaf's. `gcaFirst`
+(`gca_first`) and `gcaCanon` (`gca_canon`) are the levels of the
+greatest common ancestors of this node with those two leaves, and
+`cosetindex` and `stabvertex` are the vertices individualized there.
+
+`orbits` sends each vertex to the least vertex of its orbit under the
+automorphisms found so far. `noncheaplevel` is one past the level of
+the deepest ancestor for which `cheapautom` is false. `allsamelevel`
+is the level of the least ancestor of the first leaf all of whose
+descendant leaves are known to be equivalent. `needshortprune` records
+that the parent's target cell is to be pruned by `shortprune` on
+return.
+
+`numnodes`, `numorbits`, `numgenerators`, `numbadleaves`, `maxlevel`,
+`tctotal` and `canupdates` are the members of nauty's `statsblk`: the
+nodes visited, the orbits, the generators reported, the leaves that
+were neither an automorphism nor an improvement, the greatest depth
+reached, the total size of the target cells chosen, and the number of
+times the best-so-far leaf was replaced. -/
 structure SearchSt (n : Nat) where
   lab : Array Nat
   ptn : Array Nat
   active : VSet n
   orbits : Array Nat
   fixedpts : VSet n := .empty
-  /-- Stored `(fix, mcr)` pairs of discovered automorphisms; nauty's
-  workspace, whose last slot is overwritten once `wsCap` pairs exist. -/
+  /-- nauty's automorphism workspace: stored `(fix, mcr)` pairs of
+  discovered automorphisms, read by `shortprune` and `longprune`. Once
+  `wsCap` pairs are present the last slot is overwritten instead of a
+  new one being added. `wsCap` is 500, the number of pairs that fit in
+  the `2 * 500 * m` setwords `densenauty` supplies. -/
   autos : Array (VSet n × VSet n) := #[]
   wsCap : Nat := 500
   firstcode : Array Nat
@@ -74,10 +136,9 @@ structure SearchSt (n : Nat) where
   numgenerators : Nat := 0
   numbadleaves : Nat := 0
   maxlevel : Nat := 1
-  /-- Every accepted automorphism is also kept in full (`genTrace`,
-  discovery order) for the trace-driven certificate producer, in
-  addition to the bounded `(fix, mcr)` workspace pairs; the
-  production `run` discards it. -/
+  /-- No nauty counterpart: every accepted automorphism kept in full,
+  in discovery order, for the certificate producer, alongside the
+  bounded `(fix, mcr)` pairs of `autos`. `run` discards it. -/
   genTrace : Array (Array Nat) := #[]
 deriving Inhabited
 
@@ -233,7 +294,7 @@ def longprune (tcell fixedpts : VSet n)
 
 /-- nauty's `shortprune`: intersect the target cell with the `mcr` set of
 the most recently stored automorphism. The store is never empty when this
-is called; an empty store leaves the cell unchanged. -/
+is called. An empty store leaves the cell unchanged. -/
 def shortprune (tcell : VSet n) (st : SearchSt n) : VSet n :=
   match st.autos.back? with
   | some (_, mcr) => tcell.inter mcr
@@ -328,8 +389,7 @@ termination_by (fuel, 1, cfuel)
 
 /-- The comparison bookkeeping of nauty's `othernode` between the
 refinement and the target-cell choice: the first-path level-code
-comparison and the best-so-far level-code comparison, exactly as the
-corresponding `othernode` lines perform them. -/
+comparison and the best-so-far level-code comparison. -/
 def otherNodePrep (level : Nat) (code : Nat) (st : SearchSt n) :
     SearchSt n := Id.run do
   let mut st := st
@@ -395,7 +455,10 @@ level to return to. -/
     | none => return (Int.ofNat level - 1, st)
 termination_by (fuel, 0, 0)
 
-/-- The child loop of `othernode`. -/
+/-- The child loop of `othernode`: individualize each surviving
+target-cell vertex in ascending order, applying `shortprune` after any
+child that asks for it and `longprune` after the first. Returns
+`some rtn` for an early unwind. -/
 @[expose] def otherChildLoop (ctx : Ctx n) (inf tcLevel : Nat) (fuel cfuel : Nat)
     (level numcells tc tv1 : Nat) (tv? : Option Nat) (tcell0 : VSet n)
     (st0 : SearchSt n) : Option Int × SearchSt n :=
@@ -427,8 +490,15 @@ termination_by (fuel, 1, cfuel)
 
 end
 
-/-- The result of a canonical search on `n` vertices: nauty's `canonlab`
-and the rows of `canong`, with the observable statistics. -/
+/-- The result of a canonical search on `n` vertices: the canonical
+labelling `canonlab` and the adjacency rows `canong` under it, together
+with the statistics nauty reports in its `statsblk`. Those are the
+nodes visited (`numnodes`), the orbits and generators of the
+automorphism group (`numorbits`, `numgenerators`), the leaves that were
+neither an automorphism nor an improvement (`numbadleaves`), the
+greatest depth reached (`maxlevel`), the total size of the target cells
+chosen (`tctotal`), and the number of times the best-so-far leaf was
+replaced (`canupdates`). -/
 structure RunResult (n : Nat) where
   canonlab : Array Nat
   canong : Array (VSet n)
@@ -451,13 +521,12 @@ end. -/
   (cellEnds.foldl (fun (p : VSet n × Nat) e => (p.1.insert p.2, e + 1))
     (.empty, 0)).1
 
-/-- A traced run: the transcribed search result together with every
-accepted automorphism, in discovery order, and the best path's
-refinement codes — the trace the certificate translator consumes.
-The search's `canoncode` chain and the certificate checker use the
-same code coordinates (each child call is seeded with the parent's
-recomputed cell count), so the codes are read off the final state
-directly. -/
+/-- A traced run: the search result, every accepted automorphism in
+discovery order, and the best path's refinement codes. This is the
+trace the certificate producer reads. The search's `canoncode` array
+and the certificate checker use the same code coordinates (each child
+call is seeded with the parent's recomputed cell count), so the codes
+are read off the final state directly. -/
 structure TraceRun (n : Nat) where
   result : RunResult n
   autos : Array (Array Nat)
@@ -467,7 +536,7 @@ structure TraceRun (n : Nat) where
 
 /-- Run the pinned dense-nauty canonical search on `n` vertices with
 adjacency rows `g` and the initial ordered partition `(lab0, cellEnds)`,
-returning the trace alongside the result; `cellEnds` lists, in order,
+returning the trace alongside the result. `cellEnds` lists, in order,
 the last position of each colour cell. -/
 def runTraced (n : Nat) (g : Array (VSet n)) (lab0 : Array Nat)
     (cellEnds : List Nat) : TraceRun n := Id.run do

--- a/HexGraphIso/Nauty/Search/VSet/Basic.lean
+++ b/HexGraphIso/Nauty/Search/VSet/Basic.lean
@@ -24,15 +24,15 @@ word operations. This module is the same shape on Lean's small natural
 numbers: a `VSet n` is an array of `⌈n/63⌉` limbs, each below `2^63`
 so that it is an unboxed scalar at runtime, with vertex `v` at bit
 `v % 63` of limb `v / 63`. Bits at or above `n` are always clear.
-Every operation is a loop over the limbs; the binary operations
+Every operation is a loop over the limbs. The binary operations
 allocate their result array, and `insert` and `erase` update in place
-when the set is uniquely referenced. Vertex `0` sits at the least significant bit, so the
-least vertex of a set is the lowest set bit of its first nonzero limb,
-and `rowCmp` reads the least differing vertex from the lowest set bit
-of the first differing limb of the symmetric difference. (nauty puts
-vertex `0` at the most significant bit so that unsigned word comparison
-is the row order; only the direction inside a word differs, and the
-observable order is the same.)
+when the set is uniquely referenced. Vertex `0` sits at the least
+significant bit, so the least vertex of a set is the lowest set bit of
+its first nonzero limb, and `rowCmp` reads the least differing vertex
+from the lowest set bit of the first differing limb of the symmetric
+difference. (nauty puts vertex `0` at the most significant bit so that
+unsigned word comparison is the row order. Only the direction inside a
+word differs, and the observable order is the same.)
 
 The interface is membership-based: `mem` is the specification lens,
 `ext` identifies sets with the same members, and every operation has a
@@ -106,7 +106,7 @@ theorem limbs_ext {s t : VSet n} (h : s.limbs = t.limbs) : s = t := by
   cases h
   rfl
 
-/-- Equality compares the limb arrays; `Hex.instDecidableEqArray` keeps
+/-- Equality compares the limb arrays. `Hex.instDecidableEqArray` keeps
 the comparison kernel-reducible across the module boundary. -/
 instance : DecidableEq (VSet n) := fun s t =>
   if h : s.limbs = t.limbs then isTrue (limbs_ext h)
@@ -132,7 +132,7 @@ theorem ext_iff {s t : VSet n} : s = t ↔ ∀ v, s.mem v = t.mem v :=
 
 /-- A limb array is well formed for `n` vertices when it has `limbCount n`
 limbs, every limb is a 63-bit word, and no bit at or above `n` is set.
-The runtime never checks this; each operation preserves it by proof. -/
+The runtime never checks this. Each operation preserves it by proof. -/
 structure Wf (n : Nat) (limbs : Array Nat) : Prop where
   size_eq : limbs.size = limbCount n
   bounded : ∀ i : Nat, limbs[i]! < 2 ^ 63
@@ -323,8 +323,8 @@ theorem mem_erase (s : VSet n) (v w : Nat) :
 /-! # Limbwise binary operations -/
 
 /-- The limbwise combination of two packed sets. `Hex.Array.zipWith'`
-reduces in the kernel where core `Array.zipWith` stalls, and compiles to
-the core loop. -/
+reduces in the kernel where Lean's own `Array.zipWith` stalls, and
+compiles to the same loop. -/
 @[expose] def zipLimbs (op : Nat → Nat → Nat) (s t : VSet n) : Array Nat :=
   Hex.Array.zipWith' op s.limbs t.limbs
 
@@ -717,8 +717,8 @@ theorem subset_iff_inter {s t : VSet n} : s.subset t = true ↔ s.inter t = s :=
     let x := s.limbs[i]!
     if x != 0 then some (63 * i + lowBit x) else firstFrom s fuel (i + 1)
 
-/-- The least member; `0` for the empty set (callers guard on
-nonemptiness). nauty's `FIRSTBITNZ` over the words. -/
+/-- The least member, or `0` for the empty set (callers guard on
+nonemptiness). This is nauty's `FIRSTBITNZ` over the words. -/
 @[expose] def minElem (s : VSet n) : Nat :=
   (firstFrom s s.limbs.size 0).getD 0
 
@@ -1040,8 +1040,8 @@ where
       if a == b then go fuel (i + 1)
       else if a.testBit (lowBit (a ^^^ b)) then .gt else .lt
 
-/-- The outcome of the limb scan from `i` with `fuel` limbs: equal
-prefixes give `.eq`; otherwise the first differing limb decides by its
+/-- The outcome of the limb scan from `i` with `fuel` limbs. Equal
+prefixes give `.eq`. Otherwise the first differing limb decides, by its
 least differing bit. -/
 theorem rowCmp_go_eq_of {s t : VSet n} :
     ∀ (fuel i : Nat), (∀ k, k < fuel → s.limbs[i + k]! = t.limbs[i + k]!) →

--- a/HexGraphIso/Nauty/Search/VSet/Nat.lean
+++ b/HexGraphIso/Nauty/Search/VSet/Nat.lean
@@ -82,7 +82,7 @@ theorem toNat_inj {s t : VSet n} (h : s.toNat = t.toNat) : s = t :=
 `toNat` reads the packed limbs as one bitset, the representation the
 kernel-facing replay (`HexGraphIso.Kernel.CheckKey`) computes with.
 Each packed operation corresponds to its `Nat` counterpart in
-`HexGraphIso.Nauty.Search.Bits`; `ofNat` reads a bitset back. -/
+`HexGraphIso.Nauty.Search.Bits`. `ofNat` reads a bitset back. -/
 
 theorem toNat_empty : (empty : VSet n).toNat = 0 :=
   Nat.eq_of_testBit_eq fun v => by rw [testBit_toNat, mem_empty, Nat.zero_testBit]

--- a/HexGraphIso/Nauty/Spec/Achieved.lean
+++ b/HexGraphIso/Nauty/Spec/Achieved.lean
@@ -11,16 +11,15 @@ public import HexGraphIso.Nauty.Spec.SpecCanon
 public section
 
 /-!
-The achieved leaf: the spec key's rows are the leaf rows of a
-labelling reachable from the initial state, which fills each cell of
-every ancestor partition with the same vertices. This is the content
-of `specCanon_iso`: the total canonical form is isomorphic to its
-input.
+The achieved leaf: the rows of `canonSpecKey` are the leaf rows of a
+labelling reachable from the initial state, one that fills each cell of
+every ancestor partition with the same vertices. That is the content of
+`specCanon_iso`: the canonical form is isomorphic to its input.
 
-The engine is multiset preservation: every labelling write in `refine`
-and `breakout` reorders one region confined to a cell of the current
-partition, and partitions only gain boundaries, so contents of the
-original cells never change.
+The proof rests on multiset preservation. Every labelling write in
+`refine` and `breakout` reorders one region confined to a cell of the
+current partition, and partitions only gain boundaries, so the contents
+of the original cells never change.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -700,7 +699,7 @@ theorem bcount_pos_of_boundary {ptn : Array Nat} {level nn q : Nat}
 
 /-! # The achieved leaf -/
 
-/-- The spec key's rows are the leaf rows of a labelling that fills
+/-- The key of a node has the leaf rows of a labelling that fills
 every cell of this node's partition with the same vertices. -/
 theorem specNode_achieved {ctx : Ctx n}
     (tcLevel : Nat) :
@@ -826,7 +825,7 @@ theorem specNode_achieved {ctx : Ctx n}
         (refine ctx level lab ptn active numcells).lab[p.1 + o]!).2.2
         ((refine ctx level lab ptn active numcells).numcells + 1) hchildOk (by omega) hbcChild
       refine ⟨llab, hlsz, ?_, ?_⟩
-      · -- chain the three reorder stages
+      · -- chain the three reorderings
         have htv : (refine ctx level lab ptn active numcells).lab[p.1 + o]! ∈
             segN (refine ctx level lab ptn active numcells).lab p.1 (p.2 + 1 - p.1) := by
           rw [segN]

--- a/HexGraphIso/Nauty/Spec/CanonSpec.lean
+++ b/HexGraphIso/Nauty/Spec/CanonSpec.lean
@@ -17,28 +17,30 @@ The nauty-semantic canonical form as a total specification: the maximal
 leaf key of the unpruned individualization-refinement tree.
 
 A leaf key is the chain of refinement codes ending with the sentinel,
-followed by the leaf's `g^lab` adjacency rows; keys compare
-lexicographically, codes numerically and rows in nauty's row order.
-The production search's canonical leaf realizes this maximum:
+followed by the leaf's `g^lab` adjacency rows. Keys compare
+lexicographically, codes numerically and rows in nauty's row order. The
+canonical leaf of the production search is the leaf of greatest key.
+The specification states three ingredients differently from the
+transcribed search, without changing which leaf is greatest.
 
-- a node whose chain is dominated (`compCanon < 0`) can never supply the
+- A node whose chain is dominated (`compCanon < 0`) can never supply the
   canonical leaf, and those are exactly the nodes where nauty's
-  history-dependent `firsttc` hint applies, so the specification's
-  target-cell rule is hint-free; its nontrivial-join test reads the
-  cell's neighbour-count multiset (`joinTest`), which agrees with
-  nauty's first-vertex test on every equitable partition while being
-  invariant under renamings and within-cell reordering — the
+  history-dependent `firsttc` hint applies. The specification's
+  target-cell rule is therefore hint-free. Its nontrivial-join test
+  reads the cell's neighbour-count multiset (`joinTest`), which agrees
+  with nauty's first-vertex test on every equitable partition and is
+  invariant under renamings and under reordering within a cell. The
   certificate checker verifies agreement with the recorded target cell
-  on each replayed node;
-- the sentinel exceeds every real (cleaned) refinement code, which
+  on each replayed node.
+- The sentinel exceeds every real (cleaned) refinement code, which
   reproduces nauty's preference for shallower leaves on equal prefixes
-  (`level < canonlevel` forcing `compCanon = 1`);
-- children may be enumerated in any order under a maximum; the
+  (`level < canonlevel` forcing `compCanon = 1`).
+- Children may be enumerated in any order under a maximum. The
   specification enumerates the target cell by position, which makes
   renaming-equivariance pointwise.
 
 The branch guard is structural discreteness of the partition rather than
-nauty's `numcells` counter; the two agree on every reachable state, and
+nauty's `numcells` counter. The two agree on every reachable state, and
 the certificate checker replays concrete refinements where discreteness
 is directly decidable.
 -/
@@ -66,7 +68,8 @@ deriving Inhabited
     | .lt => .lt
     | .gt => .gt
 
-/-- Key n order: level codes first, then rows in nauty's row order. -/
+/-- The order on keys: level codes first, then rows in nauty's row
+order. -/
 @[expose] def keyCmp (k1 k2 : Key n) : Ordering :=
   match listCmp compare k1.codes k2.codes with
   | .eq => listCmp VSet.rowCmp k1.rows k2.rows
@@ -1291,7 +1294,7 @@ theorem specNode_perm {ctx : Ctx n} (tcLevel : Nat) :
               exact this
             rw [htL, htR]
             exact hTperm.erase v
-          · -- untouched old cells transfer through the parent
+          · -- cells other than the target transfer from the parent
             intro x len hx hd
             have hLs : segN (breakout.go v ((refine ctx level lab ptn
                 active numcells).lab.size + 1)
@@ -1533,7 +1536,7 @@ trips the guard the partition is discrete (the guard-exit hypothesis of
 only the active set and the code accumulator. The runs agree on `lab`,
 `ptn`, `hint` and `maxpos`, their cell counts differ by exactly `δ`,
 and their active sets agree whenever the exit partition is not
-discrete; only `longcode` and `numcells` carry the seed. -/
+discrete. Only `longcode` and `numcells` carry the seed. -/
 
 /-- Refine states equal up to a `numcells` shift of `δ` and the
 `longcode` accumulator. -/
@@ -1869,9 +1872,9 @@ theorem refineLoop_seed {ctx : Ctx n} {level δ : Nat} :
 /-- Seed-independence of `refine`: two runs whose `numcells` seeds
 differ by `δ` produce the same `lab`, `ptn`, `hint` and `maxpos`, cell
 counts differing by exactly `δ`, and the same active set whenever the
-exit partition is not discrete; only `longcode` and `numcells` carry
+exit partition is not discrete. Only `longcode` and `numcells` carry
 the seed. The hypothesis rules out a guard exit on a non-discrete
-partition; it holds whenever the larger seed is at most the true cell
+partition. It holds whenever the larger seed is at most the true cell
 count of `(ptn, level)`, in particular for the counts the search
 maintains. -/
 theorem refine_seed {ctx : Ctx n} {level : Nat} {lab ptn : Array Nat}

--- a/HexGraphIso/Nauty/Spec/CellPerm.lean
+++ b/HexGraphIso/Nauty/Spec/CellPerm.lean
@@ -14,18 +14,19 @@ public section
 /-!
 Refinement as a function of cell contents.
 
-nauty's canonical form is well defined on a coloured graph because the
-refinement machinery depends on an ordered partition only through the
-multiset of vertices in each cell: two labellings whose cells hold the
-same vertices in any order refine to the same positions and codes with
-cell-wise permuted labellings. This file builds that invariance, cell
-processor by cell processor, mirroring `Nauty.Equivariance`.
+nauty's canonical form is well defined on a coloured graph because
+refinement depends on an ordered partition only through the multiset of
+vertices in each cell: two labellings whose cells hold the same vertices
+in any order refine to the same positions and the same codes, with
+cell-wise permuted labellings. This file proves that invariance one
+splitting function at a time, in the same order as
+`Nauty.Spec.Equivariance`.
 
 `segN lab lo len` reads the labelling segment of `len` positions from
-`lo` as a list; cell contents are compared with `List.Perm`. The crux
-is `splitCellLoop_spec`: the two-pointer partition's final pointers are
-determined by the adjacency count of the cell's multiset, and its two
-output segments are permutations of the adjacency filters.
+`lo` as a list, and cell contents are compared with `List.Perm`. The
+main step is `splitCellLoop_spec`: the two-pointer partition's final
+pointers are determined by the adjacency count of the cell's multiset,
+and its two output segments are permutations of the adjacency filters.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -109,7 +110,7 @@ theorem splitCellLoop_spec {gRow : VSet n} :
         c1 (c2 - 1) h1
         (by rw [Array.size_set!, Array.size_set!]; omega)
         (by omega) (by omega)
-      -- the original segment is the swapped one plus its old head
+      -- the starting segment is the swapped one plus its former head
       have hS2 : (segN lab c1.toNat (k + 1)).Perm
           (lab[c1.toNat]! ::
             segN ((lab.set! c1.toNat lab[c2.toNat]!).set! c2.toNat
@@ -347,7 +348,7 @@ theorem cellsPerm_set! {ptn : Array Nat} {level : Nat}
   rcases Nat.lt_or_ge c a with hca | hca
   · -- the block lies right of the written boundary
     rcases Decidable.em (a = c + 1) with heq | hne
-    · -- right half: show the block ends exactly at the old cell end
+    · -- right half: show the block ends exactly at the original cell end
       have hebound : a + len - 1 = A + lenA - 1 := by
         rcases Nat.lt_trichotomy (a + len - 1) (A + lenA - 1) with
           hlt | heq | hgt
@@ -365,7 +366,7 @@ theorem cellsPerm_set! {ptn : Array Nat} {level : Nat}
       have hleneq : len = A + lenA - (c + 1) := by omega
       rw [heq, hleneq]
       exact hR
-    · -- disjoint block right of the old cell
+    · -- disjoint block right of the original cell
       have haright : A + lenA ≤ a := by
         rcases Nat.lt_or_ge a (A + lenA) with hlt | hge
         · exfalso
@@ -511,7 +512,7 @@ theorem isCell_disjoint_or_eq {ptn : Array Nat} {level a len a' len' : Nat}
   rcases Nat.lt_or_ge (a + len - 1) a' with hlt' | hge'
   · exact Or.inr (Or.inl (by omega))
   right; right
-  -- the runs overlap; first the starts agree
+  -- the runs overlap, so first the starts agree
   have hstarts : a = a' := by
     rcases Nat.lt_trichotomy a a' with hlt | heq | hgt
     · exfalso
@@ -610,7 +611,7 @@ theorem trivialCell_perm {level cell1 cell2 : Nat} {gRow : VSet n} {st st' : Ref
     rw [hp1', hp2', trivialSplit_setLab _ _ _ _ _ st', h.eq_setLab,
       trivialSplit_setLab _ _ _ _ _ st]
   rw [e1, e2]
-  -- disjoint old cells are untouched by both runs
+  -- cells disjoint from the split are untouched by both runs
   have houtP : ∀ a len, IsCell st.ptn level a len →
       a + len ≤ cell1 ∨ cell1 + (cell2 + 1 - cell1) ≤ a →
       (segN (splitCellLoop gRow (cell2 - cell1 + 2) st.lab

--- a/HexGraphIso/Nauty/Spec/CellPermLoop.lean
+++ b/HexGraphIso/Nauty/Spec/CellPermLoop.lean
@@ -14,7 +14,7 @@ public section
 Refinement as a function of cell contents, part two: the
 nontrivial-splitter window scan, the pass and loop assembly, and
 level transfer. Builds on the cell primitives and the trivial
-splitter of `Nauty.CellPerm`.
+splitter of `Nauty.Spec.CellPerm`.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -609,7 +609,7 @@ theorem nontrivialCell_perm {ctx : Ctx n} {level cell1 cell2 : Nat} {workset : V
       rw [hSEGlen']
       have := h.labSize
       omega)
-  -- the two written labellings are cell-equivalent for the old partition
+  -- the two written labellings are cell-equivalent for the input partition
   have hLout : ∀ a len, IsCell st.ptn level a len →
       a + len ≤ cell1 ∨ cell2 + 1 ≤ a →
       (segN (writeSegment st.lab cell1

--- a/HexGraphIso/Nauty/Spec/Equivariance.lean
+++ b/HexGraphIso/Nauty/Spec/Equivariance.lean
@@ -11,15 +11,23 @@ public import HexGraphIso.Nauty.Search.Refine
 public section
 
 /-!
-Equivariance of the ported nauty refinement.
+How the refinement transforms under a relabelling of the vertices.
 
 A `Renaming` of the vertices carries the graph rows to their images and
-the labelling to its composition, and leaves every position-level datum —
-`ptn`, `active`, cell boundaries, counts, and refinement codes —
+the labelling to its composition. Every position-level datum (`ptn`,
+`active`, cell boundaries, counts, and refinement codes) is left
 literally unchanged. This file proves that invariant through each
-explicit recursion of `Nauty.Refine`, culminating in `refine_map`: the
-whole refinement commutes with a renaming. This is stage 1 of the
-certificate plan in the library README.
+explicit recursion of `Nauty.Search.Refine`, culminating in
+`refine_map`: the whole refinement commutes with a renaming.
+
+The later sections carry the same statement through the remaining
+constructions the specification is built from: target-cell selection
+(`bestcell_map`, `targetcell_map`, `maketargetcell_map`),
+individualization (`breakout_map`), and the leaf adjacency rows
+(`leafRows_map`). On the renamed graph with the transported labelling,
+each of these produces the transported result, so a relabelling of the
+input vertices leaves the search tree and the keys at its leaves
+unchanged.
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -1006,7 +1014,7 @@ theorem refineLoop_map (σ : Renaming n) {ctx ctx' : Ctx n}
 /-- nauty's `refine` commutes with a vertex renaming: on the renamed
 graph with the transported labelling it produces the transported state,
 with identical partition, active set, cell structure, and refinement
-code. This is the core of stage 1 of the certificate plan. -/
+code. -/
 theorem refine_map (σ : Renaming n) {ctx ctx' : Ctx n}
     (hg : RowsMap σ ctx.g ctx'.g)
     (level : Nat) (lab ptn : Array Nat) (active : VSet n) (numcells : Nat)

--- a/HexGraphIso/Nauty/Spec/SpecCanon.lean
+++ b/HexGraphIso/Nauty/Spec/SpecCanon.lean
@@ -11,10 +11,11 @@ public import HexGraphIso.Nauty.Cert.CanonForm
 public section
 
 /-!
-The nauty-semantic canonical form as a total function of the spec key:
-adjacency is read off the key's rows, and the colouring lists each
-colour class contiguously in colour order. Checked certificate results
-coincide with this form, which anchors the stage-4 public switch.
+The nauty-semantic canonical form as a total function of the canonical
+key: adjacency is read off the key's rows, and the colouring lists each
+colour class contiguously in colour order. Every result the certificate
+checker accepts is equal to this form (`checkCanon_form`), and
+isomorphic coloured graphs have the same form (`specCanon_invariant`).
 -/
 
 namespace Hex.GraphIso.Nauty
@@ -167,7 +168,10 @@ are symmetric and loopless, this is the identity. -/
           exact hidx)]
         exact hval }
 
-/-- The total nauty-semantic canonical form. -/
+/-- The nauty-semantic canonical form of a coloured graph: the coloured
+graph determined by the rows of `canonSpecKey G`, with the colour
+classes laid out contiguously in colour order. It is defined for every
+input, with no certificate needed. -/
 @[expose] def specCanon (G : Colored n k) : Colored n k :=
   formOfKey G (canonSpecKey G).rows
 
@@ -269,7 +273,7 @@ theorem checkCanon_form_eq_formOfKey {G : Colored n k}
     rw [hkv, hkv] at h1
     exact Fin.eq_of_val_eq h1
 
-/-- A checked canonical form is the total spec form. -/
+/-- A checked canonical form is `specCanon` of the input. -/
 theorem checkCanon_form {G : Colored n k} {cert : CertNode} {B : Key n}
     {lab : Array Nat} {res : CanonResult n k}
     (h : checkCanon G cert B lab = some res) :
@@ -277,7 +281,8 @@ theorem checkCanon_form {G : Colored n k} {cert : CertNode} {B : Key n}
   rw [checkCanon_form_eq_formOfKey h, specCanon,
     (checkCanon_sound h).1]
 
-/-- The spec form is an isomorphism invariant. -/
+/-- `specCanon` is an isomorphism invariant: isomorphic coloured graphs
+have the same canonical form. -/
 theorem specCanon_invariant {G H : Colored n k}
     (hiso : Isomorphic G H) : specCanon G = specCanon H := by
   rw [specCanon, specCanon, canonSpecKey_eq_of_isomorphic hiso]

--- a/HexGraphIso/Ops.lean
+++ b/HexGraphIso/Ops.lean
@@ -128,8 +128,8 @@ permutation convention). -/
   (findIso G H).isSome
 
 /-- Soundness of the search: any permutation it returns really is an
-isomorphism. This is the theorem to reach for after a successful
-`findIso`; it says nothing about the `none` case, for which see
+isomorphism. This is the theorem to use after a successful `findIso`.
+It says nothing about the `none` case, for which see
 `findIso_isSome_iff`. -/
 theorem findIso_sound {G H : Colored n k} {p : Perm n}
     (h : findIso G H = some p) : IsIso G H p := by

--- a/HexGraphIso/Perm.lean
+++ b/HexGraphIso/Perm.lean
@@ -311,7 +311,7 @@ complete. -/
 
 /-- A canonical-labelling result array in nauty's `canonlab` convention:
 `l[i]` is the old vertex placed at new position `i`. The underlying data is
-the same duplicate-free complete vertex array as `Perm`; the wrapper marks
+the same duplicate-free complete vertex array as `Perm`. The wrapper marks
 the direction. -/
 structure Label (n : Nat) where
   /-- The underlying bijection sending each new position to the old vertex

--- a/HexGraphIso/Tactic.lean
+++ b/HexGraphIso/Tactic.lean
@@ -82,10 +82,9 @@ namespace Tactic
 open Lean Elab Lean.Elab.Tactic Meta
 
 /-- `set_option trace.graph_iso true` reports the route each call closes
-through — `relabel`, `witness`, `root` or `certs` — and, for the
-certificate route, the record counts the kernel replays; the
-kernel-cost harness (`scripts/bench/graphiso_kernel_cost.py`) reads
-these lines. -/
+through (`relabel`, `witness`, `root` or `certs`) and, for the
+certificate route, the number of records the kernel replays. The script
+`scripts/bench/graphiso_kernel_cost.py` reads these lines. -/
 meta initialize registerTraceClass `graph_iso
 
 /-- The logical limits of one `graph_iso` call. -/
@@ -194,8 +193,8 @@ meta def permExpr (n : Nat) (p : Array Nat) : MetaM Expr := do
 /-- Build `of_decide_eq_true (Eq.refl true) : p` without reducing
 `decide p` in the elaborator: the kernel performs the one decisive
 evaluation when it checks the ascribed `Eq.refl`. `mkDecideProof`
-would evaluate twice — once at elaboration, once at kernel check —
-which doubles the cost of every replay obligation. -/
+evaluates twice, once at elaboration and once at kernel checking, which
+doubles the cost of every replay. -/
 meta def kernelDecideProof (p : Expr) : MetaM Expr := do
   let inst ← synthInstance (← mkAppM ``Decidable #[p])
   let decideApp := mkApp2 (mkConst ``Decidable.decide) p inst
@@ -217,26 +216,28 @@ meta def boolListLit (bs : List Bool) : MetaM Expr :=
     mkConst (if bb then ``Bool.true else ``Bool.false))
 
 /-- The expression `e.graph.adjMatrix.data.toList` for a coloured
-graph expression `e`: the tying side of a flat-literal equality. -/
+graph expression `e`: the left-hand side of the flat-literal
+equality. -/
 meta def matrixListSide (e : Expr) : MetaM Expr := do
   mkAppM ``Vector.toList #[← mkAppM ``Matrix.data
     #[← mkAppM ``Graph.adjMatrix #[← mkAppM ``Colored.graph #[e]]]]
 
 /-- The expression `Kernel.packRows n e.graph.adjMatrix.data.toList`:
-the tying side of the packed-rows equality the negative routes
+the left-hand side of the packed-rows equality the negative routes
 replay. -/
 meta def matrixPackedSide (n : Nat) (e : Expr) : MetaM Expr := do
   mkAppM ``Kernel.packRows #[mkNatLit n, ← matrixListSide e]
 
 /-- The packed rows of a runtime graph, row `v` at bits
-`[n * v, n * (v + 1))`: the literal side of the packed-rows equality. -/
+`[n * v, n * (v + 1))`: the right-hand side of the packed-rows
+equality. -/
 meta def rawPackedRows (r : Raw) : Nat :=
   (List.range r.n).foldr (fun v acc => r.rows[v]!.toNat + (acc <<< r.n)) 0
 
 /-- One side of a negative goal: the graph expression, its runtime
-image, the packed-rows literal, and the tie of the graph's adjacency to
-that literal. Both negative routes replay against these, so each side
-is evaluated and tied once per call. -/
+image, the packed-rows literal, and the proof that the graph's
+adjacency packs to that literal. Both negative routes replay against
+these, so each side is evaluated once per call. -/
 meta structure Side where
   /-- The coloured graph expression. -/
   expr : Expr
@@ -247,8 +248,8 @@ meta structure Side where
   /-- The packed-rows literal. -/
   lit : Expr
 
-/-- Evaluate a coloured graph expression and tie it to its packed-rows
-literal, one sequential kernel evaluation of the graph's adjacency. -/
+/-- Evaluate a coloured graph expression and prove its packed rows equal
+to a literal, in one kernel evaluation of the graph's adjacency. -/
 meta def mkSide (e : Expr) : MetaM Side := do
   let r ← evalColored e
   let lit := mkNatLit (rawPackedRows r)
@@ -271,7 +272,8 @@ meta def keyExpr (K : Kernel.Key) : Expr :=
   mkApp2 (mkConst ``Kernel.Key.mk) (toExpr K.codes) (toExpr K.rows)
 
 /-- Match `Isomorphic G H` (returning `(false, n, k, G, H)`) or
-`¬ Isomorphic G H` (returning `true` first); `none` for other goals. -/
+`¬ Isomorphic G H` (returning `true` first). Other goals give
+`none`. -/
 meta def matchGoal? (target : Expr) : MetaM (Option (Bool × Expr × Expr × Expr × Expr)) := do
   let t ← whnfR target
   match_expr t with
@@ -284,8 +286,8 @@ meta def matchGoal? (target : Expr) : MetaM (Option (Bool × Expr × Expr × Exp
   | _ => return none
 
 /-- Match the uncoloured `Graph.Isomorphic G H` (returning
-`(false, n, G, H)`) or its negation (returning `true` first); `none`
-for other goals. -/
+`(false, n, G, H)`) or its negation (returning `true` first). Other
+goals give `none`. -/
 meta def matchUncoloredGoal? (target : Expr) :
     MetaM (Option (Bool × Expr × Expr × Expr)) := do
   let t ← whnfR target
@@ -326,10 +328,10 @@ private meta def countAutom : Nauty.CertNode → Nat
   | .autom _ _ => 1
   | .node cs => cs.foldl (fun a c => a + countAutom c) 0
 
-/-- The root-separator leg of the negative path: when the root
-refinement codes already differ — the typical case for irregular pairs
-— the kernel obligation is a single refinement per graph, so the leg
-always runs. -/
+/-- The root-separator leg of the negative path. When the two root
+refinement codes already differ (the typical case for irregular pairs)
+the kernel evaluates one refinement per graph, so this leg is tried
+first on every negative goal. -/
 meta def proveNotIsoRoot? (G H : Side) : MetaM (Option Expr) := do
   unless (← evalBoolCore (← mkAppM ``Kernel.rootSeparates #[G.expr, H.expr])) do
     return none
@@ -339,18 +341,18 @@ meta def proveNotIsoRoot? (G H : Side) : MetaM (Option Expr) := do
   trace[graph_iso] "route=root n={G.raw.n}"
   return some (← mkAppM ``Kernel.not_isomorphic_of_rootCode #[G.tie, H.tie, hs])
 
-/-- The certificate leg of the negative path: budgeted certificate
-production on both sides compiled, the key comparison compiled, and the
-kernel replaying only two Boolean `Kernel.checkKey` certificates plus
-`checkDiffL`. Returns the limit that ran out when the route is
-unavailable; throws when the keys agree, because the goal is then
-unprovable. -/
+/-- The certificate leg of the negative path. Compiled code produces one
+budgeted certificate per side and compares the two canonical keys. The
+kernel then replays two Boolean `Kernel.checkKey` calls and one
+`checkDiffL` call. When a limit runs out the result names that limit.
+When the two keys agree this throws, because the goal is then not
+provable. -/
 meta def proveNotIsoCerts (cfg : Config) (G H : Side) :
     MetaM (Except MessageData Expr) := do
-  -- deliberately the VALIDATED bounded producer: the ~10ms compiled
-  -- validation guarantees every emitted kernel obligation replays
-  -- successfully — a bad candidate must fall back here, not surface as
-  -- a kernel rejection at module finalization
+  -- The validating bounded producer: its compiled validation pass
+  -- guarantees that every certificate it emits replays successfully, so
+  -- a candidate that fails is rejected here rather than by the kernel at
+  -- module finalization.
   let bounded (e : Expr) :
       MetaM (Option (Nauty.CertNode × Kernel.Key)) := do
     evalCertCore (← mkAppM ``Kernel.certifyKey?
@@ -392,11 +394,10 @@ meta def proveNotIsoCerts (cfg : Config) (G H : Side) :
 
 /-- Produce a proof of `¬ Isomorphic G H` for closed executable coloured
 graphs: the root separator first, then certificate replay. The
-certificate obligations replay only because their whole closure is
-exposed to the module-finalization kernel; the regression ladder in
-`HexGraphIso.ModuleBoundaryTests` pins that closure. Shared by the core
-negative branch and downstream extensions (the Mathlib layer calls it
-on the encodings). -/
+certificates replay only because every declaration they reach is
+exposed across module boundaries, which `HexGraphIso.ModuleBoundaryTests`
+checks. Both the `Colored` negative branch and downstream extensions use
+this: `HexGraphIsoMathlib` calls it on the encoded graphs. -/
 meta def proveNotIso (cfg : Config) (GE HE : Expr) : MetaM Expr := do
   let G ← mkSide GE
   let H ← mkSide HE
@@ -409,11 +410,11 @@ meta def proveNotIso (cfg : Config) (GE HE : Expr) : MetaM Expr := do
       throwError "graph_iso: every negative route is exhausted: the root \
           refinement codes agree, and {reason}"
 
-/-- The witness leg of the positive path: tie each side's adjacency,
-colouring and the transporter to literals, and check the transporter on
-those literals. Returns the permutation expression and the proof of
-`IsIso G H p`, which the core branch wraps as `Isomorphic` and
-downstream extensions decode. -/
+/-- The witness leg of the positive path: prove each side's adjacency,
+its colouring and the transporter equal to literals, then check the
+transporter on those literals. Returns the permutation expression and
+the proof of `IsIso G H p`. The `Colored` branch wraps that proof as
+`Isomorphic`, and downstream extensions decode it. -/
 meta def proveIsIso (cfg : Config) (n : Nat) (GE HE : Expr) (a b : Raw)
     (p : Array Nat) (nodes : Nat) : MetaM (Expr × Expr) := do
   if checkCost n > cfg.maxKernelSteps then
@@ -553,7 +554,7 @@ meta def proveGraphIso (cfg : Config) (target : Expr)
 every vertex alike, hand the pair to `proveGraphIso`, and transport the
 conclusion back through `Graph.isomorphic_singleColor_iff`. Both
 directions of that equivalence are proof terms, so the uncoloured route
-costs the kernel nothing beyond the coloured obligation and the one
+costs the kernel nothing beyond the coloured goal's replay and the one
 `0 < n` decision. -/
 meta def proveGraphIsoUncolored (cfg : Config) (target : Expr)
     (parsed : Bool × Expr × Expr × Expr) : MetaM Expr := do

--- a/HexGraphIso/TacticTests.lean
+++ b/HexGraphIso/TacticTests.lean
@@ -14,10 +14,10 @@ public meta import HexGraphIso.Random
 public meta import HexGraphIso.TestGraphs
 
 /-!
-Regression tests for the Mathlib-free `graph_iso` tactic: positive and
-negative goals, coloured and uncoloured goals, the limit syntax, and
-the promised diagnostics. The kernel replays every closing proof; every failure case
-asserts its message and leaves the goal unchanged.
+Tests for the Mathlib-free `graph_iso` tactic: positive and negative
+goals, coloured and uncoloured goals, the limit syntax, and the
+diagnostic messages. The kernel replays every closing proof. Each
+failure case asserts its message and leaves the goal unchanged.
 -/
 
 namespace Hex.GraphIso.TacticTests
@@ -42,8 +42,8 @@ example : Isomorphic p3 p3' := by
   graph_iso (maxSearchNodes := 200000) (maxKernelSteps := 10000000)
 example : Isomorphic p3 p3' := by
   graph_iso (maxKernelSteps := 10000000) (maxCertRecords := 200000)
--- a zero certificate budget must still close the goal; this pair is
--- irregular, so the root separator takes it before the certificate leg
+-- A zero certificate budget must still close the goal. This pair is
+-- irregular, so the root separator closes it before the certificate leg.
 example : ¬ Isomorphic p3 k3 := by graph_iso (maxCertRecords := 0)
 
 /-- error: graph_iso: the graphs are not isomorphic; the positive goal is not provable -/
@@ -83,7 +83,7 @@ def kneser52G : Graph 10 :=
      (3, 4), (3, 5), (3, 7), (4, 9), (5, 8), (6, 7)]
 
 /-- The pentagonal prism: also cubic on ten vertices, so degree
-refinement alone cannot separate it from the Petersen graph; the
+refinement alone cannot separate it from the Petersen graph. The
 negative goal replays the two canonical-key certificates in the
 kernel. -/
 def prism5G : Graph 10 :=
@@ -105,7 +105,7 @@ example : ¬ Isomorphic petersen prism5 := by graph_iso
 
 /-!
 This pair is cubic, so the root refinement codes agree and only the
-certificate leg is left; withdrawing its record budget leaves every
+certificate leg is left. Withdrawing its record budget leaves every
 negative route exhausted, and the message names the limit that ran out.
 -/
 

--- a/HexGraphIso/TestGraphs.lean
+++ b/HexGraphIso/TestGraphs.lean
@@ -17,7 +17,8 @@ regression tests and the fresh-module probes: the graph of the first
 SplitMix64 corpus seed, its image under the recorded Fisher-Yates
 relabelling, and the graph of the second seed. The masks and the
 relabelling are kept literal so a kernel replay does not evaluate the
-`UInt64` stream; the `#guard`s tie them back to the generators.
+`UInt64` stream. The `#guard`s check the literals against the
+generators.
 -/
 
 namespace Hex.GraphIso.TestGraphs

--- a/HexGraphIso/Uncolored.lean
+++ b/HexGraphIso/Uncolored.lean
@@ -21,8 +21,8 @@ at the call nor unwraps one from the conclusion.
 `Graph.singleColor` is the one-cell view, and
 `Graph.isomorphic_singleColor_iff` identifies the two notions of
 isomorphism through it. Every theorem here is transported along that
-equivalence rather than reproved, so the uncoloured surface makes
-exactly the promises the coloured one does, completeness and canonical
+equivalence rather than reproved, so the uncoloured operations state
+exactly what the coloured ones state, completeness and canonical
 invariance included.
 -/
 

--- a/HexGraphIsoMathlib/Basic.lean
+++ b/HexGraphIsoMathlib/Basic.lean
@@ -16,17 +16,16 @@ public section
 Mathlib-facing coloured graphs.
 
 `SimpleGraph.Coloring` expresses proper colouring, where adjacent
-vertices must have different colours; that is not nauty's input. The
+vertices must have different colours. That is not nauty's input. The
 object here is an arbitrary ordered vertex partition: a `SimpleGraph`
 together with an onto colour map into `Fin k`. An isomorphism preserves
 each ordered colour index and may not permute the cells.
 
-The structure requires every colour to occur. A caller with a
-non-surjective map can either restrict `k` and renumber the used colours
-explicitly, or use the checked helper `Colored.ofColor?`, which returns
-`none` together with nothing rather than silently compressing or
-reordering colours — compression would change the canonical labelling
-convention.
+The structure requires every colour to occur. A caller whose colour map
+is not onto can restrict `k` and renumber the used colours explicitly,
+or call `Colored.ofColor?`, which returns `none` instead of compressing
+or reordering the colours. Compressing them would change the ordered
+colouring, and with it the canonical labelling.
 -/
 
 namespace Hex.GraphIso.Mathlib
@@ -36,7 +35,9 @@ universe u v
 variable {V : Type u} {W : Type v} {k : Nat}
 
 /-- A finite simple graph with an ordered vertex colouring by `Fin k` in
-which every colour is used. -/
+which every colour is used. This is the Mathlib-side counterpart of
+`Hex.GraphIso.Colored`: the colouring need not be proper, and an
+isomorphism has to preserve each colour index. -/
 structure Colored (V : Type u) (k : Nat) [Fintype V] where
   /-- The underlying Mathlib graph. -/
   graph : SimpleGraph V
@@ -78,7 +79,8 @@ def Colored.ofColor? [DecidableEq (Fin k)] (graph : SimpleGraph V)
   else
     none
 
-/-- The unused colour witnessing a failed `Colored.ofColor?`. -/
+/-- `Colored.ofColor?` returns `none` exactly when some colour of
+`Fin k` is taken by no vertex. -/
 theorem Colored.ofColor?_eq_none_iff [DecidableEq (Fin k)] [DecidableEq V]
     {graph : SimpleGraph V} {color : V → Fin k} :
     Colored.ofColor? graph color = none ↔ ∃ c : Fin k, ∀ v, color v ≠ c := by

--- a/HexGraphIsoMathlib/Encode.lean
+++ b/HexGraphIsoMathlib/Encode.lean
@@ -17,17 +17,18 @@ theorems.
 For `e : V ≃ Fin n`, the executable graph has an edge between `e v` and
 `e w` exactly when the Mathlib graph has an edge between `v` and `w`,
 and the executable colour of `e v` is the original colour of `v`. The
-two directions of `encode_iso_iff` explicitly conjugate the executable
-permutation by the chosen equivalences; no enumeration is treated as
-canonical, and a different choice changes neither the isomorphism
-verdict nor `colored_iso_iff_canon_eq`.
+two directions of `encode_iso_iff` conjugate the executable permutation
+by the chosen equivalences. No enumeration is treated as canonical:
+both `encode_iso_iff` and `colored_iso_iff_canon_eq` hold for every
+choice of `e`.
 -/
 
 namespace Hex.GraphIso
 
 variable {n : Nat}
 
-/-- The equivalence of `Fin n` performed by a forward permutation. -/
+/-- The equivalence of `Fin n` given by a forward permutation: `p.get`
+one way, `p.inv.get` the other. -/
 @[expose] def Perm.toEquiv (p : Perm n) : Fin n ≃ Fin n where
   toFun := p.get
   invFun := p.inv.get
@@ -37,7 +38,8 @@ variable {n : Nat}
 @[simp] theorem Perm.toEquiv_apply (p : Perm n) (i : Fin n) :
     p.toEquiv i = p.get i := rfl
 
-/-- The forward permutation performing an equivalence of `Fin n`. -/
+/-- The forward permutation with the same action as an equivalence of
+`Fin n`. -/
 @[expose] def Perm.ofEquiv (e : Fin n ≃ Fin n) : Perm n :=
   Perm.ofFn e (fun _ _ h => e.injective h)
     (fun i => ⟨e.symm i, e.apply_symm_apply i⟩)
@@ -115,8 +117,8 @@ omit [Fintype V] [Fintype W] in
 variable {G : Colored V k} {H : Colored W k}
   [DecidableRel G.graph.Adj] [DecidableRel H.graph.Adj]
 
-/-- A checked executable transporter decodes to a colour-preserving
-Mathlib isomorphism. -/
+/-- Decode a checked executable transporter into a colour-preserving
+isomorphism of the Mathlib graphs. -/
 def isoOfIsIso (eV : V ≃ Fin n) (eW : W ≃ Fin n) {p : Hex.GraphIso.Perm n}
     (h : IsIso (encode eV G) (encode eW H) p) : Colored.Iso G H where
   graphIso :=
@@ -160,8 +162,10 @@ theorem encode_iso_iff (eV : V ≃ Fin n) (eW : W ≃ Fin n) :
     rcases h.elim with ⟨p, hp⟩
     exact Colored.Isomorphic.intro (isoOfIsIso eV eW hp)
 
-/-- The principal Mathlib-facing biconditional: two coloured graphs are
-isomorphic exactly when their encodings have equal canonical forms. -/
+/-- Two coloured Mathlib graphs are isomorphic exactly when their
+encodings have equal canonical forms. The right-hand side is a decidable
+equality of executable values, so this reduces a Mathlib isomorphism
+question to running the canonical labelling. -/
 theorem colored_iso_iff_canon_eq (eV : V ≃ Fin n) (eW : W ≃ Fin n) :
     G.Isomorphic H ↔
       canon (encode eV G) = canon (encode eW H) :=
@@ -169,29 +173,28 @@ theorem colored_iso_iff_canon_eq (eV : V ≃ Fin n) (eW : W ≃ Fin n) :
 
 /-! # Automorphisms -/
 
-/-- The automorphism generators the pinned search discovers, decoded as
-colour-preserving self-isomorphisms of the Mathlib graph. Each entry is
-an automorphism by `Hex.GraphIso.autos_isIso`, decoded by
-`isoOfIsIso`; whether the list generates the whole automorphism group
-is not proved, so this is a source of automorphisms rather than a
+/-- The automorphism generators found by `Hex.GraphIso.Aut.gens` on the
+encoding, decoded as colour-preserving self-isomorphisms of the Mathlib
+graph. Each entry is an automorphism, by `Hex.GraphIso.Aut.gens_isIso`
+and `isoOfIsIso`. That the list generates the whole automorphism group
+is not proved, so this is a supply of automorphisms and not a
 presentation of the group. -/
 def autos (e : V ≃ Fin n) (G : Colored V k) [DecidableRel G.graph.Adj] :
     List (Colored.Iso G G) :=
   (Aut.gens (encode e G)).attach.map fun p =>
     isoOfIsIso e e (Aut.gens_isIso p.property)
 
-/-- The orbit-stabilizer product the pinned search computes, which is
-the order of the colour-preserving automorphism group when the recorded
-orbits are the true ones. Conformance pins it against nauty's
-`grpsize`; no theorem states it, because that would need the generators
-to generate the whole group, and without that it is only a lower
-bound. -/
+/-- The orbit-stabilizer product computed by `Hex.GraphIso.Aut.order` on
+the encoding. It is the order of the colour-preserving automorphism
+group when the discovered generators generate that group. No theorem
+states this, and without completeness of the generators the value is
+only a lower bound. Conformance compares it with nauty's `grpsize`. -/
 def autOrder (e : V ≃ Fin n) (G : Colored V k) [DecidableRel G.graph.Adj] :
     Nat :=
   Aut.order (encode e G)
 
-/-- The number of vertex orbits the pinned search reports, under the
-same caveat as `autOrder`. -/
+/-- The number of vertex orbits reported by `Hex.GraphIso.Aut.numOrbits`
+on the encoding, under the same caveat as `autOrder`. -/
 def autNumOrbits (e : V ≃ Fin n) (G : Colored V k)
     [DecidableRel G.graph.Adj] : Nat :=
   Aut.numOrbits (encode e G)

--- a/HexGraphIsoMathlib/Tactic.lean
+++ b/HexGraphIsoMathlib/Tactic.lean
@@ -17,8 +17,8 @@ public section
 /-!
 # The `graph_iso` extension for `SimpleGraph` goals
 
-Importing this library extends the existing `graph_iso` syntax — no
-second tactic name — to closed ground `SimpleGraph` goals:
+Importing this library extends the existing `graph_iso` syntax (there is
+no second tactic name) to closed ground `SimpleGraph` goals:
 
 ```
 example : G ≃g H := by graph_iso
@@ -31,14 +31,15 @@ example : IsEmpty (Colored.Iso CG CH) := by graph_iso
 example : ¬ Colored.Isomorphic CG CH := by graph_iso
 ```
 
-The reifier encodes both graphs along `Fintype.equivFin` and reuses the
-Mathlib-free machinery: positive goals take the core witness route and
-decode its `IsIso` proof; negative goals go through the shared negative
-engine, which tries the root separator and then certificate replay, and
-decode through the `not_encode_iso` theorems; unequal cardinalities
-close immediately through `Fintype.card_congr` obstructions, and empty
-vertex types through the explicit empty isomorphism. The same three
-logical limits are accepted and are not reinterpreted.
+Both graphs are encoded along `listEquiv`, the enumeration of the vertex
+type by a literal element list, and the Mathlib-free machinery does the
+work. A positive goal takes the witness route and decodes its `IsIso`
+proof. A negative goal takes the negative path of the Mathlib-free
+tactic, which tries the root separator and then certificate replay, and
+decodes through the `not_encode_iso` theorems. Unequal cardinalities
+close through the `Fintype.card_congr` obstructions, and empty vertex
+types through the explicit empty isomorphism. The three logical limits
+of `graph_iso` mean the same thing here as on executable goals.
 -/
 
 namespace HexGraphIsoMathlib.Tactic
@@ -52,14 +53,19 @@ private meta unsafe def evalNatUnsafe (e : Expr) : MetaM Nat :=
 @[implemented_by evalNatUnsafe]
 private meta opaque evalNatCore (e : Expr) : MetaM Nat
 
-/-- The supported goal shapes. Each carries the two graph expressions;
-`colored` marks `Colored` goals, `negative` refuting shapes, `wrap`
-whether a positive `Nonempty`/`Isomorphic` wrapper is required. -/
+/-- A supported goal, as read off the target. -/
 meta structure Shape where
+  /-- The left-hand graph. -/
   G : Expr
+  /-- The right-hand graph. -/
   H : Expr
+  /-- Whether the goal is about `Colored` graphs rather than bare
+  `SimpleGraph`s. -/
   colored : Bool
+  /-- Whether the goal refutes isomorphism. -/
   negative : Bool
+  /-- Whether a positive goal asks for the `Nonempty`/`Isomorphic`
+  wrapper around the isomorphism. -/
   wrap : Bool
   /-- For negatives: build `¬ ·` (`true`) or `IsEmpty ·` (`false`). -/
   useNot : Bool := false
@@ -94,6 +100,8 @@ meta def matchColoredIsomorphic? (t : Expr) : MetaM (Option (Expr × Expr)) := d
       return some (args[args.size - 2]!, args[args.size - 1]!)
   return none
 
+/-- The shape of the goal, or `none` when the target is not one of the
+supported shapes. -/
 meta def parseGoal? (target : Expr) : MetaM (Option Shape) := do
   let t ← whnfR target
   match_expr t with
@@ -152,12 +160,23 @@ meta def vertexType (colored : Bool) (g : Expr) : MetaM Expr := do
 
 /-- Elaboration data for one side of the goal. -/
 meta structure Side where
+  /-- The vertex type. -/
   V : Expr
+  /-- The `Fintype V` instance. -/
   instV : Expr
+  /-- The term `Fintype.card V`. -/
   cardTerm : Expr
+  /-- The value of `Fintype.card V`. -/
   card : Nat
+  /-- The enumeration `V ≃ Fin (Fintype.card V)`, a `listEquiv`
+  application on a literal element list. -/
   equiv : Expr
 
+/-- Collect the elaboration data for one side: its vertex type, the
+`Fintype` instance, the cardinality, and the enumeration equivalence
+built from the reduced `Finset.univ.val`. A vertex type with no
+`Fintype` or `DecidableEq` instance, or one whose enumeration does not
+reduce to a literal list, is reported here. -/
 meta def mkSide (colored : Bool) (g : Expr) : MetaM Side := do
   let V ← vertexType colored g
   let instV ← try
@@ -232,6 +251,8 @@ meta def encodeSide (colored : Bool) (g : Expr) (side : Side) :
           \n{ex.toMessageData}"
     return (enc, some hpos)
 
+/-- The proof term for a parsed goal. When the goal does not hold, or a
+logical limit runs out, this fails with a message saying which. -/
 meta def proveShape (cfg : Hex.GraphIso.Tactic.Config) (target : Expr)
     (shape : Shape) : MetaM Expr := do
   let sG ← mkSide shape.colored shape.G

--- a/HexGraphIsoMathlib/TacticSupport.lean
+++ b/HexGraphIsoMathlib/TacticSupport.lean
@@ -12,11 +12,11 @@ public section
 
 /-!
 Object-language support for the `graph_iso` extension to `SimpleGraph`
-goals: the one-cell colouring of an uncoloured graph, the checked
-kernel-facing entry points for each supported goal shape, and the
-empty-graph and cardinality special cases. The tactic emits applications
-of these theorems on literal data; every decisive check is performed by
-the kernel through the shared core routes of `HexGraphIso.Tactic`.
+goals: the one-cell colouring of an uncoloured graph, the entry points
+for each supported goal shape, and the empty-graph and cardinality
+special cases. The tactic emits applications of these theorems to
+literal data. The decisive check is always performed by the kernel, on
+the same routes the Mathlib-free `HexGraphIso.Tactic` uses.
 -/
 
 namespace Hex.GraphIso.Mathlib
@@ -25,11 +25,11 @@ universe u v
 
 variable {V : Type u} {W : Type v} [Fintype V] [Fintype W] {k n : Nat}
 
-/-- The enumeration equivalence induced by a literal duplicate-free
-complete element list: vertex `v` maps to its list position. Both
-directions are structural list operations, so ground instances
-kernel-reduce; the tactic obtains the list by reducing
-`Finset.univ.val` and certifies the three side conditions by `decide`. -/
+/-- The enumeration equivalence induced by a duplicate-free list of all
+the vertices: `v` maps to its position in the list. Both directions are
+structural list operations, so a ground instance reduces in the kernel.
+The tactic obtains the list by reducing `Finset.univ.val`, and proves
+the three side conditions by `decide`. -/
 @[expose] def listEquiv [DecidableEq V] (l : List V)
     (hlen : l.length = Fintype.card V) (hnodup : l.Nodup)
     (hcompl : ∀ v : V, v ∈ l) : V ≃ Fin (Fintype.card V) where
@@ -38,8 +38,9 @@ kernel-reduce; the tactic obtains the list by reducing
   left_inv v := List.getElem_idxOf (List.idxOf_lt_length_of_mem (hcompl v))
   right_inv _i := Fin.ext (hnodup.idxOf_getElem _ _)
 
-/-- The one-cell colouring of an uncoloured graph over a nonempty vertex
-type; the executable encoding of `G ≃g H` goals. -/
+/-- The colouring of an uncoloured graph over a nonempty vertex type
+that gives every vertex colour `0`. A `G ≃g H` goal is encoded through
+this colouring, since a one-cell colouring constrains nothing. -/
 @[expose] def onecell (G : SimpleGraph V) (h : 0 < Fintype.card V) :
     Colored V 1 where
   graph := G
@@ -66,7 +67,8 @@ theorem onecell_isomorphic_iff {G : SimpleGraph V} {H : SimpleGraph W}
 
 /-! # Positive entry points -/
 
-/-- A kernel-checked transporter yields a coloured isomorphism. -/
+/-- The coloured isomorphism a kernel-checked transporter of the
+encodings yields. -/
 def coloredIsoOfIsIso (eV : V ≃ Fin n) (eW : W ≃ Fin n)
     {G : Colored V k} {H : Colored W k}
     [DecidableRel G.graph.Adj] [DecidableRel H.graph.Adj]
@@ -74,7 +76,8 @@ def coloredIsoOfIsIso (eV : V ≃ Fin n) (eW : W ≃ Fin n)
     Colored.Iso G H :=
   isoOfIsIso eV eW h
 
-/-- A kernel-checked transporter yields a graph isomorphism. -/
+/-- The graph isomorphism a kernel-checked transporter of the
+one-cell encodings yields. -/
 def graphIsoOfIsIso (eV : V ≃ Fin n) (eW : W ≃ Fin n)
     {G : SimpleGraph V} {H : SimpleGraph W}
     [DecidableRel G.Adj] [DecidableRel H.Adj]
@@ -101,9 +104,10 @@ def coloredIsoOfCardZero (G : Colored V k) (H : Colored W k)
 
 /-! # Negative entry points -/
 
-/-- Non-isomorphism of the encodings refutes coloured isomorphism:
-the route-agnostic form, taking whatever negative proof the tactic's
-shared engine produced. -/
+/-- Non-isomorphism of the encodings refutes coloured isomorphism. The
+hypothesis is stated about `Hex.GraphIso.Isomorphic`, so it accepts a
+negative proof from either the root-separator route or the
+certificate-replay route. -/
 theorem not_isomorphic_of_not_encode_iso (eV : V ≃ Fin n) (eW : W ≃ Fin n)
     {G : Colored V k} {H : Colored W k}
     [DecidableRel G.graph.Adj] [DecidableRel H.graph.Adj]

--- a/HexGraphIsoMathlib/TacticTests.lean
+++ b/HexGraphIsoMathlib/TacticTests.lean
@@ -14,9 +14,9 @@ public meta import Mathlib.Data.Fintype.Powerset
 /-!
 Regression tests for the `graph_iso` extension to `SimpleGraph` goals:
 every supported goal shape, distinct vertex types of equal cardinality,
-immediate unequal-cardinality negatives, ordered colours preserved and
-violated, empty-graph goal shapes, transparent composed constructors,
-and the promised diagnostics on unsupported inputs and exhausted limits.
+unequal-cardinality negatives, ordered colours preserved and violated,
+empty-graph goal shapes, graphs built through `SimpleGraph.fromRel`, and
+the diagnostics on unprovable goals and exhausted limits.
 -/
 
 namespace HexGraphIsoMathlib.TacticTests
@@ -25,8 +25,11 @@ open Hex.GraphIso.Mathlib SimpleGraph
 
 /-! # Cycles and paths on `Fin 5` through transparent constructors -/
 
+/-- The five-cycle, joined by the successor relation. -/
 def c5a : SimpleGraph (Fin 5) := SimpleGraph.fromRel fun i j => j = i + 1
+/-- The five-cycle again, joined by adding two: isomorphic to `c5a`. -/
 def c5b : SimpleGraph (Fin 5) := SimpleGraph.fromRel fun i j => j = i + 2
+/-- The path on five vertices, which is not isomorphic to `c5a`. -/
 def p5 : SimpleGraph (Fin 5) := SimpleGraph.fromRel fun i j => j.val = i.val + 1
 
 instance : DecidableRel c5a.Adj := fun _ _ =>
@@ -98,6 +101,7 @@ example : ¬ Nonempty (c5a ≃g petersenDrawing) := by graph_iso
 
 /-! # Empty-graph goal shapes -/
 
+/-- The graph on no vertices. -/
 def emptyG : SimpleGraph (Fin 0) := ⊥
 instance : DecidableRel emptyG.Adj := fun v _ => v.elim0
 
@@ -112,16 +116,19 @@ Two edge-marked and one nonedge-marked two-colourings of the six-cycle:
 `graph_iso` proves the edge-marked pair isomorphic and refutes the
 nonedge-marked colouring against either. -/
 
+/-- The six-cycle. -/
 def c6 : SimpleGraph (Fin 6) :=
   SimpleGraph.fromRel fun i j => j = i + 1
 
 instance : DecidableRel c6.Adj := fun _ _ =>
   decidable_of_iff _ (SimpleGraph.fromRel_adj ..).symm
 
+/-- The six-cycle with the two-colouring `f`. -/
 def mark (f : Fin 6 → Fin 2)
     (h : Function.Surjective f) : Colored (Fin 6) 2 :=
   { graph := c6, color := f, onto := h }
 
+/-- The six-cycle with the endpoints of one edge marked colour `0`. -/
 def edgeMarkA : Colored (Fin 6) 2 :=
   mark (fun i => if i.val ≤ 1 then 0 else 1)
     (fun c => by
@@ -129,6 +136,8 @@ def edgeMarkA : Colored (Fin 6) 2 :=
       | 0 => exact ⟨0, by decide⟩
       | 1 => exact ⟨3, by decide⟩)
 
+/-- The six-cycle with the endpoints of a different edge marked
+colour `0`. -/
 def edgeMarkB : Colored (Fin 6) 2 :=
   mark (fun i => if 3 ≤ i.val ∧ i.val ≤ 4 then 0 else 1)
     (fun c => by
@@ -136,6 +145,7 @@ def edgeMarkB : Colored (Fin 6) 2 :=
       | 0 => exact ⟨3, by decide⟩
       | 1 => exact ⟨0, by decide⟩)
 
+/-- The six-cycle with two non-adjacent vertices marked colour `0`. -/
 def nonedgeMark : Colored (Fin 6) 2 :=
   mark (fun i => if i.val = 0 ∨ i.val = 3 then 0 else 1)
     (fun c => by

--- a/bench/HexGraphIso/Bench.lean
+++ b/bench/HexGraphIso/Bench.lean
@@ -11,10 +11,10 @@ import LeanBench
 /-!
 Benchmark registrations for `hex-graph-iso`.
 
-This first slice measures the polynomially modelled building blocks and
-the exponentially modelled declarative canonical key on deterministic
-family inputs; input construction is hoisted into `prep` so each model
-tracks the timed operation.
+The scientific registrations measure the polynomially modelled building
+blocks and the exponentially modelled declarative canonical key on
+deterministic family inputs. Input construction happens in `prep`, so
+each declared model describes the timed operation alone.
 
 Scientific registrations:
 
@@ -36,28 +36,27 @@ backed by it, the certificate pipeline, and the pinned nauty
 comparator register as fixed benchmarks on committed circulant sizes:
 
 * `runHexCanon{8,12,16}` versus `runNautyCanon{8,12,16}`: the public
-  `canon` (the transcription surface; before the API flip this
-  series measured the certificate-checked pipeline — series break
-  noted) against the pinned nauty 2.9.3 comparator (in-process FFI
+  `canon` against the pinned nauty 2.9.3 comparator (in-process FFI
   against the vendored source, via `Hex.BenchOracle.Nauty`), joined
-  on the canonical upper-triangle bits.
+  on the canonical upper-triangle bits. Under these names `canon`
+  measured the certificate-checked pipeline before it became the
+  transcribed search, so the recorded series is not comparable across
+  that change.
 * `runIsIso12`, `runFindIso12`: the public isomorphism decisions.
 * `runCertify12`, `runCertReplay12`: unbounded certificate generation
   and the generation-plus-replay pipeline (`Nauty.certifyKey?` and
-  `Nauty.certifyCanon?`), the certificate route the `graph_iso`
-  tactic replays; the limit-gated public wrappers are covered by
-  conformance.
+  `Nauty.certifyCanon?`), which is the certificate route the
+  `graph_iso` tactic replays. The public wrappers that enforce the
+  record limits are covered by conformance instead.
 * `runCanonAgree16`: the agreement check joining the two comparator
-  columns — `verify` fails if the public canonical bits ever diverge
+  columns. `verify` fails if the public canonical bits ever diverge
   from pinned nauty's.
 * `runAutGens{12,16}`, `runAutOrbits{12,16}`: the automorphism
-  generator list and the vertex orbits, the cheap projections of the
-  automorphism surface, one traversal each.
-* `runAutOrder{12,16}`: the whole `autos` surface including the
-  orbit-stabilizer chain for the group order, which runs one further
-  traversal per base point; the gap against `runAutGens` is the price
-  of the order.
-* `runAutSound16`: the agreement check on the automorphism surface.
+  generator list and the vertex orbits, one traversal each.
+* `runAutOrder{12,16}`: all of `autos`, including the orbit-stabilizer
+  chain for the group order, which runs one further traversal per base
+  point. The gap against `runAutGens` is what the order costs.
+* `runAutSound16`: the agreement check on `autos`.
   `verify` fails if any returned generator is not accepted by
   `checkIso` against the graph itself, or if the orbit array is not
   constant on the orbits it records. The comparison against pinned
@@ -72,11 +71,12 @@ open Hex.GraphIso
 
 /-- Flattened benchmark input: a deterministic coloured circulant. -/
 structure GraphInput where
+  /-- The number of vertices. -/
   n : Nat
   deriving Repr, BEq, Hashable
 
-/-- The benchmark family: the circulant on `{1, 2}` offsets with the
-one-cell colouring, plus a fallback for `n = 0`. -/
+/-- The input of one benchmark point: the circulant on `{1, 2}` offsets
+at `n` vertices, with the one-cell colouring. -/
 def prepGraph (n : Nat) : GraphInput :=
   { n := n }
 
@@ -200,11 +200,17 @@ private def runNautyCanonAt (m : Nat) (_ : Unit) : IO String := do
     return result.tri
   | none => return ""
 
+/-- The public `canon` on the 8-vertex circulant. -/
 def runHexCanon8 : Unit → IO String := runHexCanonAt 8
+/-- Pinned nauty on the 8-vertex circulant. -/
 def runNautyCanon8 : Unit → IO String := runNautyCanonAt 8
+/-- The public `canon` on the 12-vertex circulant. -/
 def runHexCanon12 : Unit → IO String := runHexCanonAt 12
+/-- Pinned nauty on the 12-vertex circulant. -/
 def runNautyCanon12 : Unit → IO String := runNautyCanonAt 12
+/-- The public `canon` on the 16-vertex circulant. -/
 def runHexCanon16 : Unit → IO String := runHexCanonAt 16
+/-- Pinned nauty on the 16-vertex circulant. -/
 def runNautyCanon16 : Unit → IO String := runNautyCanonAt 16
 
 /-- The unpruned specification key at the largest feasible size, as a
@@ -215,21 +221,25 @@ def runSpecKey6 : Unit → IO Nat := fun _ =>
     return (Nauty.canonSpecKey G).codes.foldl (· + ·) 0
   | none => return 0
 
+/-- The `isIso` decision on the 12-vertex circulant against itself. -/
 def runIsIso12 : Unit → IO Bool := fun _ =>
   match graphOf { n := 12 } with
   | some ⟨_, G⟩ => return isIso G G
   | none => return false
 
+/-- The `findIso` search on the 12-vertex circulant against itself. -/
 def runFindIso12 : Unit → IO Bool := fun _ =>
   match graphOf { n := 12 } with
   | some ⟨_, G⟩ => return (findIso G G).isSome
   | none => return false
 
+/-- Unbounded certificate generation on the 12-vertex circulant. -/
 def runCertify12 : Unit → IO Bool := fun _ =>
   match graphOf { n := 12 } with
   | some ⟨_, G⟩ => return (Nauty.certifyKey? G).isSome
   | none => return false
 
+/-- Certificate generation and replay on the 12-vertex circulant. -/
 def runCertReplay12 : Unit → IO String := fun _ =>
   match graphOf { n := 12 } with
   | some ⟨_, G⟩ =>
@@ -253,14 +263,20 @@ private def runAutOrderAt (m : Nat) (_ : Unit) : IO Nat :=
   | some ⟨_, G⟩ => return (autos G).order
   | none => return 0
 
+/-- The automorphism generators of the 12-vertex circulant. -/
 def runAutGens12 : Unit → IO Nat := runAutGensAt 12
+/-- The automorphism generators of the 16-vertex circulant. -/
 def runAutGens16 : Unit → IO Nat := runAutGensAt 16
+/-- The vertex orbits of the 12-vertex circulant. -/
 def runAutOrbits12 : Unit → IO Nat := runAutOrbitsAt 12
+/-- The vertex orbits of the 16-vertex circulant. -/
 def runAutOrbits16 : Unit → IO Nat := runAutOrbitsAt 16
+/-- The automorphism group order of the 12-vertex circulant. -/
 def runAutOrder12 : Unit → IO Nat := runAutOrderAt 12
+/-- The automorphism group order of the 16-vertex circulant. -/
 def runAutOrder16 : Unit → IO Nat := runAutOrderAt 16
 
-/-- The automorphism-surface agreement check: `verify` fails if a
+/-- The agreement check on `autos` at `n = 16`: `verify` fails if a
 returned generator is not an automorphism, or if the orbit array is
 not constant on the orbits it records. -/
 def runAutSound16 : Unit → IO Nat := fun _ => do

--- a/bench/HexGraphIso/Cactus.lean
+++ b/bench/HexGraphIso/Cactus.lean
@@ -20,9 +20,9 @@ Emits one JSON line per instance:
 ```
 
 Timing is the minimum of several repetitions after one warmup call.
-The driver is for local and scheduled sweeps
-(`scripts/plots/hexgraphiso-cactus.py` renders the plots); it is not
-part of merge CI.
+The driver runs in local and scheduled sweeps, not in merge CI.
+`scripts/plots/hexgraphiso-cactus.py` renders the plots from its
+output.
 
 The `engine` mode times the two canonical searches against each other
 on the same materialized instances, emitting
@@ -88,8 +88,8 @@ private def timeMinNs (act : Unit → IO Nat) : IO Nat := do
     let t1 ← IO.monoNanosNow
     if best == 0 || t1 - t0 < best then
       best := t1 - t0
-  -- scaling self-check: a doubled batch must cost about double, or the
-  -- measurement is an artifact (hoisting, memoization) — warn loudly
+  -- scaling self-check: a doubled batch must cost about double. If it
+  -- does not, the measurement is an artifact (hoisting, memoization).
   if effReps > 1 && best > 20000 then
     let t0 ← IO.monoNanosNow
     blackBox (← act ())
@@ -101,9 +101,10 @@ private def timeMinNs (act : Unit → IO Nat) : IO Nat := do
         (1x best {best}ns, 2x batch {two}ns) — measurement suspect"
   return best
 
-/-- The second canonical search the `engine` mode times against the
-literal port. It is `Nauty.runColored` until the structured search
-exists; substituting that search is this definition. -/
+/-- The search the `engine` mode times against the literal port. It
+calls `Nauty.runColored`, so as it stands both columns time the same
+search. Point this definition at another search to compare that one
+instead. -/
 private def engine {n k : Nat} (G : Colored n k) : Nauty.RunResult n :=
   Nauty.runColored G
 
@@ -190,9 +191,9 @@ private def instances : List Inst := Id.run do
 
 /-! # Pair problems
 
-Isomorphism decisions for the proof-obligation cactus: each problem is
-a pair with a known polarity. The `exprA`/`exprB` fields are the Lean
-source of the two sides, consumed by the tactic harness in
+Isomorphism decisions for the cactus over `graph_iso` proofs: each
+problem is a pair with a known polarity. The `exprA`/`exprB` fields
+are the Lean source of the two sides, consumed by the tactic harness in
 `scripts/plots/hexgraphiso-cactus.py` to generate `graph_iso` proof
 files, so the compiled and tactic tiers run the same problems.
 Polarity is revalidated at runtime before timing. -/
@@ -261,9 +262,9 @@ private def pairInstances : List PairInst := Id.run do
       (Families.kneser 7 2) (Families.johnson 7 2) h
       "Graph.singleColor (Families.kneser 7 2)"
       "Graph.singleColor (Families.johnson 7 2)" :: out
-  -- irregular negatives (added as a documented series break): distinct
-  -- degree multisets at matched size, so the root refinement separates
-  -- them and the tiered negative route's cheapest tier is exercised
+  -- irregular negatives, distinct degree multisets at matched size: the
+  -- root refinement separates them, so the cheapest tier of the negative
+  -- route runs. Sweeps without them are over a smaller corpus.
   if h : 0 < 3 * 4 then
     out := negPair "irregular" "neg-grid3x4-vs-circulant12"
       (Families.grid 3 4) (Families.circulant 12 [1, 2]) h
@@ -284,7 +285,7 @@ private def pairInstances : List PairInst := Id.run do
       (Families.grid 4 6) (Families.copies 2 (Families.grid 3 4)) h
       "Graph.singleColor (Families.grid 4 6)"
       "Graph.singleColor (Families.copies 2 (Families.grid 3 4))" :: out
-  -- larger positives (corpus extension, series break 2)
+  -- larger positives: sweeps without them are over a smaller corpus
   for n in [64, 128] do
     if h : 0 < n then
       out := posPair "circulant-12" s!"pos-circulant{n}"
@@ -300,8 +301,8 @@ private def pairInstances : List PairInst := Id.run do
   if h : 0 < (61 : Nat) then
     out := posPair "paley" "pos-paley61" (Families.paley 61) h
       "Graph.singleColor (Families.paley 61)" :: out
-  -- strongly regular negative: same parameters (25, 12, 5, 6), never
-  -- isomorphic — vertex partitions stay uniform until deep in the search
+  -- strongly regular negative: the same parameters (25, 12, 5, 6) and
+  -- not isomorphic, so the partitions stay uniform deep into the search
   if h : 0 < (25 : Nat) then
     out := negPair "srg" "neg-paley25-vs-latin5"
       (Families.paley 25) (Families.latinSquare 5) h

--- a/bench/HexGraphIso/Profile.lean
+++ b/bench/HexGraphIso/Profile.lean
@@ -20,14 +20,16 @@ replay), `ccanon` (one `checkCanon`), `canon` (the public
 canonicalization), `stats` (work counters, no timing). No argument
 runs every stage.
 
-Methodology notes (hard-won):
-- Never measure with `lake env lean` `#eval`: the interpreter is
-  25-30× slower than compiled code, uniformly.
+Methodology:
+- Never measure with `lake env lean` `#eval`. The interpreter is more
+  than an order of magnitude slower than compiled code, so interpreted
+  times say nothing about the compiled pipeline.
 - Loop bodies take data-dependent inputs (two relabelled variants
-  indexed by the running accumulator) so the compiler cannot hoist the
-  pure call; per-iteration times must replicate across iteration
-  counts (checked by the `--check` flag of the cactus sweep, and by
-  running a stage at two counts here).
+  indexed by the running accumulator) so that the compiler cannot hoist
+  the pure call out of the loop. A per-iteration time is only
+  meaningful if it repeats across iteration counts: check it with the
+  `--check` flag of the cactus sweep, or by running a stage at two
+  counts here.
 -/
 
 open Hex.GraphIso Hex.GraphIso.Nauty
@@ -47,9 +49,10 @@ private def mkInst {n : Nat} (name : String) (G : Hex.Graph n) (h : 0 < n) :
   let g0 := G.singleColor h
   { name, g0, g1 := g0.relabel (rot n h) }
 
-/-- The second canonical search the `erun` stage times against `run`.
-It is `runColored` until the structured search exists; substituting
-that search is this definition. -/
+/-- The search the `erun` stage times against `run`. It calls
+`runColored`, so as it stands the two stages time the same search.
+Point this definition at another search to profile that one beside the
+transcribed port. -/
 private def engine {n k : Nat} (G : Colored n k) : RunResult n :=
   runColored G
 

--- a/bench/HexGraphIso/ProofProbe/Cfi.lean
+++ b/bench/HexGraphIso/ProofProbe/Cfi.lean
@@ -6,10 +6,10 @@ Authors: Kim Morrison
 
 import HexGraphIso.ProofProbe.Support
 
-/-! The scheduled negative CFI pair (SPEC release case 4): the
-Cai-Fürer-Immerman construction over `K4`, untwisted against twisted,
-at `n = 40`, under separately recorded larger limits. Scheduled-only:
-this module is not part of the merge-CI probe build.
+/-! The negative CFI pair: the Cai-Fürer-Immerman construction over
+`K4`, untwisted against twisted, at `n = 40`, under larger limits than
+the other probes need. This module runs on the scheduled profile only,
+not in the merge-CI probe build.
 -/
 
 set_option maxRecDepth 4000000

--- a/bench/HexGraphIso/ProofProbe/Coloured10Neg.lean
+++ b/bench/HexGraphIso/ProofProbe/Coloured10Neg.lean
@@ -6,8 +6,8 @@ Authors: Kim Morrison
 
 import HexGraphIso.ProofProbe.Support
 
-/-! The negative ordered-colour pair at `n = 10` (SPEC release case 3,
-negative half): an adjacent marked pair against a non-adjacent one.
+/-! The negative ordered-colour pair at `n = 10`: an adjacent marked
+pair against a non-adjacent one.
 -/
 
 set_option maxRecDepth 100000

--- a/bench/HexGraphIso/ProofProbe/Coloured10Pos.lean
+++ b/bench/HexGraphIso/ProofProbe/Coloured10Pos.lean
@@ -6,9 +6,8 @@ Authors: Kim Morrison
 
 import HexGraphIso.ProofProbe.Support
 
-/-! The positive ordered-colour pair at `n = 10` (SPEC release case 3,
-positive half): the Petersen graph with two different adjacent pairs
-marked with colour zero. -/
+/-! The positive ordered-colour pair at `n = 10`: the Petersen graph
+with two different adjacent pairs marked with colour zero. -/
 
 open Hex.GraphIso Hex.GraphIso.ProofProbe in
 example : Isomorphic edgeMarkA edgeMarkB := by graph_iso

--- a/bench/HexGraphIso/ProofProbe/Negative12.lean
+++ b/bench/HexGraphIso/ProofProbe/Negative12.lean
@@ -6,8 +6,7 @@ Authors: Kim Morrison
 
 import HexGraphIso.ProofProbe.Support
 
-/-! The negative pair from the two recorded `G(12, 1/2)` seeds (SPEC
-release case 2). -/
+/-! The negative pair from the two recorded `G(12, 1/2)` seeds. -/
 
 set_option maxRecDepth 400000
 

--- a/bench/HexGraphIso/ProofProbe/Positive12.lean
+++ b/bench/HexGraphIso/ProofProbe/Positive12.lean
@@ -7,7 +7,7 @@ Authors: Kim Morrison
 import HexGraphIso.ProofProbe.Support
 
 /-! The positive random `n = 12` pair related by the recorded
-relabelling (SPEC release case 1). -/
+relabelling. -/
 
 open Hex.GraphIso Hex.GraphIso.ProofProbe in
 example : Isomorphic g12 g12relabelled := by graph_iso

--- a/bench/HexGraphIso/ProofProbe/Support.lean
+++ b/bench/HexGraphIso/ProofProbe/Support.lean
@@ -8,12 +8,11 @@ import HexGraphIso
 import HexGraphIso.TestGraphs
 
 /-!
-Shared inputs for the `graph_iso` fresh-module probes
-(SPEC/hex-graph-iso § Benchmarks, "the tactic has fresh-module
-probes"). Each probe case imports this module and nothing else beyond
-it, so a fresh build of one probe measures reification, compiled
-search, literal elaboration, and kernel replay for exactly one goal
-against the `Baseline` module's matched import cost.
+Shared inputs for the `graph_iso` fresh-module probes. Each probe case
+imports this module and nothing else beyond it, so a fresh build of one
+probe measures reification, compiled search, literal elaboration and
+kernel replay for exactly one goal, against the `Baseline` module's
+matched import cost.
 
 The random instances are the recorded corpus pair of
 `HexGraphIso.TestGraphs`, shared with the `graph_iso` regression
@@ -31,8 +30,8 @@ even-parity subsets of its three edge ports) and an `a`/`b` port pair
 per incident base edge; ports join middle vertices containing them,
 `a`–`a` and `b`–`b` across each base edge, and the twist crosses
 exactly one base edge. The two graphs agree on every refinement
-invariant and differ globally, the classical hard negative for
-individualization-refinement.
+invariant and are not isomorphic. This is the classical hard negative
+instance for individualization-refinement.
 -/
 
 namespace Hex.GraphIso.ProofProbe
@@ -44,6 +43,8 @@ tests -/
 
 export Hex.GraphIso.TestGraphs (g12 g12relabelled g12b)
 
+/-- The Petersen graph on `Fin 10`, one-cell coloured: an outer
+pentagon, an inner pentagram, and the five spokes. -/
 def petersen : Colored 10 1 :=
   { graph := Graph.ofEdges
       [(0, 1), (1, 2), (2, 3), (3, 4), (0, 4),
@@ -51,12 +52,19 @@ def petersen : Colored 10 1 :=
        (0, 5), (1, 6), (2, 7), (3, 8), (4, 9)]
     coloring := Coloring.trivial 10 }
 
+/-- The two-colouring of `Fin 10` giving vertices `a` and `b` colour
+`0` and every other vertex colour `1`. -/
 def markPair (a b : Fin 10) : Coloring 10 2 :=
   (Coloring.ofVector? (Hex.Vector.ofFn' fun i =>
     if i = a ∨ i = b then 0 else 1)).getD (Coloring.mod 10 2)
 
+/-- The Petersen graph with one adjacent pair marked colour `0`. -/
 def edgeMarkA : Colored 10 2 := ⟨petersen.graph, markPair 0 1⟩
+/-- The Petersen graph with a different adjacent pair marked colour
+`0`, isomorphic to `edgeMarkA` as a coloured graph. -/
 def edgeMarkB : Colored 10 2 := ⟨petersen.graph, markPair 2 3⟩
+/-- The Petersen graph with a non-adjacent pair marked colour `0`,
+which no colour-preserving isomorphism carries to `edgeMarkA`. -/
 def nonedgeMark : Colored 10 2 := ⟨petersen.graph, markPair 0 2⟩
 
 /-! # The CFI pair over `K4`
@@ -113,6 +121,8 @@ def cfiAdjCore (twist : Bool) (x y : Nat) : Bool := Id.run do
   if twist && lo == 0 && hi == 1 then return !sameKind
   return sameKind
 
+/-- The CFI graph over `K4` on 40 vertices, one-cell coloured, twisted
+or untwisted. -/
 def cfi (twist : Bool) : Colored 40 1 :=
   { graph := Graph.ofAdj
       (fun i j => if i == j then false else

--- a/conformance/HexGraphIso/Cases.lean
+++ b/conformance/HexGraphIso/Cases.lean
@@ -21,13 +21,13 @@ fixture corpus, `eachAutos` its automorphism-record part and
 driver runs the same cases in the same sequence.
 
 `Runner` is the search a record is read off. `canonAnswer` reads the
-label and canonical upper-triangle bits off the public `canonicalize`
-and the node and generator counts off `Nauty.runColored`;
+label and canonical upper-triangle bits off the public `canonicalize`,
+and the node and generator counts off `Nauty.runColored`.
 `engineAnswer` reads all of them off `engine`, the second search the
-drivers compare against.
-`engine` is `Nauty.runColoredTraced` until the structured search exists,
-so the twin compares the literal port with itself and the emitters'
-`--engine` mode emits the same records as their default mode.
+drivers compare against. As it stands `engine` calls
+`Nauty.runColoredTraced`, so the twin compares the literal port with
+itself and the emitters' `--engine` mode emits the same records as
+their default mode.
 -/
 
 namespace Hex.GraphIsoCases
@@ -41,10 +41,15 @@ private def lib : String := "HexGraphIso"
 /-- One corpus case: a coloured graph as the emitted record describes
 it. Colours are one per vertex, edges are unordered pairs. -/
 structure Case where
+  /-- The case identifier carried by the emitted record. -/
   name : String
+  /-- The number of vertices. -/
   n : Nat
+  /-- The number of colours. -/
   k : Nat
+  /-- The colour of each vertex. -/
   colors : Array Nat
+  /-- The edges, as unordered vertex pairs. -/
   edges : List (Nat × Nat)
 
 /-- The vertex pairs `(i, j)`, `i < j`, in lexicographic order. -/
@@ -86,10 +91,10 @@ private def triRows {n : Nat} (rows : Array (VSet n)) : String :=
 
 /-! # Searches -/
 
-/-- The second search the twin runner and the `--engine` emitter modes
-measure against the literal port. It is `Nauty.runColoredTraced` until
-the structured search exists; substituting that search is this
-definition. -/
+/-- The search the twin runner and the `--engine` emitter modes measure
+against the literal port. It calls `Nauty.runColoredTraced`, so as it
+stands both sides run the same search. Point this definition at another
+search to compare that one instead. -/
 def engine {n k : Nat} (G : Colored n k) : TraceRun n :=
   runColoredTraced G
 
@@ -97,9 +102,13 @@ def engine {n k : Nat} (G : Colored n k) : TraceRun n :=
 the canonical upper-triangle adjacency bits, the visited-node count and
 the number of accepted generators. -/
 structure Answer where
+  /-- The canonical label, as the image of each vertex. -/
   label : List Nat
+  /-- The canonical upper-triangle adjacency bits. -/
   tri : String
+  /-- The number of search-tree nodes visited. -/
   numnodes : Nat
+  /-- The number of accepted automorphism generators. -/
   numgens : Nat
 
 /-- A search a fixture record is read off; `none` when the search
@@ -440,8 +449,8 @@ def eachCampaign (act : Case → IO Unit) : IO Unit := do
   act (graphCase "campaign/multipartite" (Families.completeMultipartite [3, 4, 5]))
   act (graphCase "campaign/copies5c5" (Families.copies 5 (Families.cycle 5)))
   act (graphCase "campaign/circulant17" (Families.circulant 17 [1, 2, 4, 8]))
-  -- large hard instances matching the extended cactus corpus (series
-  -- break 2): the campaign is where nauty cross-checks these sizes
+  -- large hard instances matching the extended cactus corpus: the
+  -- campaign is where nauty cross-checks these sizes
   act (graphCase "campaign/paley61" (Families.paley 61))
   act (graphCase "campaign/paley113" (Families.paley 113))
   act (graphCase "campaign/hypercube7" (Families.hypercube 7))

--- a/conformance/HexGraphIso/Conformance.lean
+++ b/conformance/HexGraphIso/Conformance.lean
@@ -185,9 +185,9 @@ private def specFormAgrees {n k : Nat} (G : Colored n k) : Bool :=
 #guard specFormAgrees path4
 #guard specFormAgrees (Graph.singleColor (Families.cycle 6))
 
--- the public canonical form now carries nauty's canonical rows: the
--- certificate-checked `canon` and the transcribed search agree on the
--- adjacency rows of the canonical representative
+-- the public canonical form carries nauty's canonical rows: `canon`
+-- and the transcribed search agree on the adjacency rows of the
+-- canonical representative
 private def canonRowsAgree {n k : Nat} (G : Colored n k) : Bool :=
   Nauty.rowsOf (canon G) == (Nauty.runColored G).canong
 
@@ -244,8 +244,8 @@ where go : List Nauty.CertNode → Bool
   | c :: cs => hasAutom c || go cs
 
 -- pruning is live on a symmetric example: the validated certificate
--- carries `.autom` records and stays near nauty's visited-node count
--- (18 records at the time of pinning; the bound is deliberately loose)
+-- carries `.autom` records and stays near nauty's visited-node count.
+-- The bound of 36 is loose: the Petersen certificate has 18 records.
 #guard
   match Nauty.certifyKey? petersen with
   | some (cert, _) => hasAutom cert && cert.size ≤ 36

--- a/conformance/HexGraphIso/EmitCampaign.lean
+++ b/conformance/HexGraphIso/EmitCampaign.lean
@@ -21,7 +21,7 @@ lake exe hexgraphiso_emit_campaign | python3 scripts/oracle/graphiso_nauty.py
 Records carry the public `canonicalize` answer (label and canonical
 upper-triangle bits) with the node count from the transcribed search,
 as in `HexGraphIso.EmitFixtures`, so the campaign pins the public
-surface against real nauty. Only failures are retained as replay
+operations against real nauty. Only failures are retained as replay
 records (the oracle reports the failing case identifier).
 
 `--engine` emits the same cases with the label, canonical bits and node

--- a/conformance/HexGraphIso/EmitFixtures.lean
+++ b/conformance/HexGraphIso/EmitFixtures.lean
@@ -28,8 +28,8 @@ production pipeline behind `canon` and `label`), with the coloured
 graph built through the public checked constructors.
 The search-node count comes from the transcribed search
 (`Nauty.runColored`). The oracle recomputes all of them with the pinned
-external nauty, so the campaign pins the public surface, not only the
-transcription.
+external nauty, so the fixture pins the public operations, not only the
+transcribed search.
 
 `--engine` emits the same cases with the label, canonical bits and node
 count read off `Cases.engine` instead, so the oracle pins that search

--- a/scripts/bench/graphiso_kernel_cost.py
+++ b/scripts/bench/graphiso_kernel_cost.py
@@ -24,8 +24,8 @@ before and after a change is one number.
 
 ``--floor`` additionally times the shared floor of every negative
 route: the kernel evaluation of each graph's adjacency into its packed
-rows (the tie ``Kernel.packRows n G.graph.adjMatrix.data.toList = N`` the
-tactic emits), as one ``of_decide_eq_true`` obligation per side.
+rows (the equation ``Kernel.packRows n G.graph.adjMatrix.data.toList =
+N`` the tactic emits), as one ``of_decide_eq_true`` proof per side.
 
 Usage:
 

--- a/scripts/bench/graphiso_pernode_fit.py
+++ b/scripts/bench/graphiso_pernode_fit.py
@@ -15,7 +15,7 @@ and for nauty by least squares, and prints the exponents with the ratio
 ``--check MARGIN`` exits non-zero when, on any family with at least
 ``--min-sizes`` sizes, the hex exponent exceeds nauty's by more than
 ``MARGIN``: the required check that keeps the per-node factor from
-growing with ``n`` again. Families with fewer sizes are reported but not
+growing with ``n``. Families with fewer sizes are reported but not
 checked, and the check fails if no family qualifies. It is a growth
 check, not a constant-factor check: a slowdown that is uniform in ``n``
 is the per-library bench's business.

--- a/scripts/plots/hexgraphiso-before-after.py
+++ b/scripts/plots/hexgraphiso-before-after.py
@@ -28,9 +28,9 @@ import json
 import math
 from pathlib import Path
 
-# ``checked_ns`` is the certificate replay the public surface ran before
-# the two tiers collapsed; sweeps recorded since omit it, and a tier
-# absent from either sweep is left out of the comparison.
+# ``checked_ns`` is the certificate replay, recorded while it was a
+# separate tier from ``fast_ns``. Sweeps taken after the two became one
+# omit it, and a tier absent from either sweep is left out here.
 TIERS = [
     ("nauty_ns", "nauty 2.9.3 (C)"),
     ("fast_ns", "hex canonicalize"),

--- a/scripts/plots/hexgraphiso-cactus-animation.py
+++ b/scripts/plots/hexgraphiso-cactus-animation.py
@@ -21,9 +21,9 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 RESULTS = ROOT / "reports" / "bench-results"
 
-# ``checked_ns`` is the certificate replay the public surface ran before
-# the two tiers collapsed; sweeps recorded since omit it, and the frame
-# then omits the series.
+# ``checked_ns`` is the certificate replay, recorded while it was a
+# separate tier from ``fast_ns``. Sweeps taken after the two became one
+# omit it, and the frame then draws no such series.
 TIERS = [
     ("nauty_ns", "nauty 2.9.3 (C)", "#555555"),
     ("fast_ns", "hex canonicalize", "#1f77b4"),


### PR DESCRIPTION
This PR rewrites the module, section and declaration docstrings of `HexGraphIso/` outside `Nauty/Correct/`, `Nauty/SmallCell/` and `Nauty/Equitable/`, together with `HexGraphIsoMathlib/`, `bench/HexGraphIso/`, `conformance/HexGraphIso/` and the graph-iso benchmark and plot helpers, so that each one states what its declarations are and what its theorems say. The chronology goes: the abandoned induction plan narrated by `Nauty/Invariant/Domination.lean`, the record in `Nauty/Cert/Translator.lean` of where each part of an earlier decomposition ended up, the deliberately-left-open gap described by `Nauty/Invariant/Closure.lean`, the staged-corpus and staged-plan framing in `Families.lean` and `Nauty/Spec/Equivariance.lean`, the exposure gaps `ModuleBoundaryTests.lean` recounted catching, and the citations of a SPEC section named "Verified search refinement", which does not exist. The measurement narratives around `Kernel/Packed.lean`'s counted loop and byte tables and around `bench/HexGraphIso/Profile.lean`'s methodology are replaced by the design facts they were evidence for, the benchmark corpus comments say which earlier series a set of instances is not comparable with instead of announcing that a break was added, and `Nauty/Search/Search.lean` describes the four mutually recursive functions of the port and names, field by field, the nauty global each `SearchSt` field mirrors. Two citations are corrected on the way through: `HexGraphIsoMathlib` builds its encoding from `Finset.univ.val` rather than along `Fintype.equivFin`, and its automorphism list cites `Hex.GraphIso.Aut.gens_isIso`. Every change is inside a comment, which `scripts/bench/check_graphiso_sweep_freshness.py` confirms by exempting all 46 fingerprinted paths without a new sweep.

`scripts/plots/hexgraphiso-cactus.py` is left untouched, and the previously undocumented declarations inside the fingerprinted tree stay undocumented, because the sweep's comment-only exemption applies to `.lean` paths and accepts a rewritten comment but not an added one; https://github.com/kim-em/hex-dev/issues/10038#issuecomment-5555140527 records the reproduction and lists the declarations.

Stacked on #10052.

Closes #10038

🤖 Prepared with Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
