### PR TITLE
docs(number-field): check the quickstart's printed root with guard_msgs

### DIFF
--- a/HexNumberField/README.md
+++ b/HexNumberField/README.md
@@ -41,8 +41,9 @@ def sqrt3 : AlgebraicNumber :=
 #guard (sqrt2 + sqrt3).p = #p[1, 0, -10, 0, 1]
 #guard (sqrt2 + sqrt3)⁻¹ == sqrt3 - sqrt2
 
+/-- info: root of X^4 - 10*X^2 + 1 near 3.146264369941 -/
+#guard_msgs in
 #eval sqrt2 + sqrt3
--- root of X^4 - 10*X^2 + 1 near 3.146264369941
 ```
 
 # Functionality


### PR DESCRIPTION
This PR turns the `#eval` in the hex-number-field README quickstart into a `#guard_msgs` block, so the printed `root of X^4 - 10*X^2 + 1 near 3.146264369941` is checked rather than asserted in a comment. The snippet elaborates through Lake with the guard passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
