### PR TITLE
feat(release): publish the aggregate's docs workflow from this monorepo

### DIFF
--- a/PLAN/Releases.md
+++ b/PLAN/Releases.md
@@ -185,11 +185,11 @@ mirrors' CI workflows are managed centrally in
 
 "Nothing else" is computed, not listed. `allowed_paths` in `sync_released.py`
 derives what each mirror may contain from its manifest entry — the managed
-paths, the managed `.github/workflows/ci.yml`, and the skeleton the sync does
-not author — and `prune_unmanaged` deletes the rest of the clone before
-anything is copied in, so a library admitted to the manifest inherits the
-policy without a cleanup list of its own. Nothing else under `.github/`
-survives, so a mirror cannot accumulate a second workflow beside its build-only
+paths, the workflows `released-ci.yml` declares for it, and the skeleton the
+sync does not author — and `prune_unmanaged` deletes the rest of the clone
+before anything is copied in, so a library admitted to the manifest inherits
+the policy without a cleanup list of its own. Nothing else under `.github/`
+survives, so a mirror cannot accumulate a workflow beside its build-only
 one, and a mirror carries neither a `reports/` tree nor `.claude/` notes beyond
 the figures its entry names. The `pins_only` aggregate is exempt, since its
 umbrella module, lakefile and documentation tree live only in the released
@@ -206,7 +206,8 @@ Five pieces, under `scripts/release/` and `.github/workflows/`:
 
 - `released.yml` — a per-repo manifest: which paths to copy, which mirror-local
   paths to keep, and which upstream repos to pin, in dependency order.
-- `released-ci.yml` — the complete per-repository mirror workflows. Each is one
+- `released-ci.yml` — the complete per-repository mirror workflows. Each entry
+  under `workflows:` is one
   ubuntu job that builds the published library and its regression target;
   repository-specific build commands remain explicit while cache setup and
   policy are uniform. The explicit cache covers the library build plus

--- a/scripts/release/BOOTSTRAP.md
+++ b/scripts/release/BOOTSTRAP.md
@@ -26,8 +26,11 @@ for and which is therefore deleted by name from every entry.
 
 The skeleton the sweep keeps is `lakefile.toml` or `lakefile.lean`,
 `lake-manifest.json`, `lean-toolchain`, `LICENSE`, `.gitignore`, `AGENTS.md`
-and `README.md`. Under `.github/` only the managed `workflows/ci.yml` survives,
-so a mirror cannot accumulate a second workflow beside its build-only one. A
+and `README.md`. Under `.github/` only the workflows `released-ci.yml` declares
+for that repository survive: every mirror has `workflows/ci.yml`, and an entry
+under `extra_workflows:` adds one more by name, so a mirror cannot accumulate a
+workflow nobody here publishes. The `pins_only` aggregate is the only
+repository with an extra, its `docs` renderer. A
 mirror carries no `reports/` tree and no `.claude/` notes: bench results,
 performance write-ups and agent orientation belong to the whole graph and stay
 here. The one exception is a figure a manifest entry names in its `figures:`

--- a/scripts/release/released-ci.yml
+++ b/scripts/release/released-ci.yml
@@ -2567,3 +2567,60 @@ workflows:
                 .lake/build
                 .lake/packages/Hex*/.lake/build
               key: lake-build-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}-${{ github.run_id }}-${{ github.run_attempt }}
+
+# Workflows a released repository needs beyond its build-only `ci.yml`, keyed
+# the same way and published to `.github/workflows/<name>.yml`. Only the
+# `pins_only` aggregate has one: it is the repository whose Pages site carries
+# the API documentation for every published library, so its renderer belongs
+# under the same source-of-truth rule as everything else here.
+extra_workflows:
+  hex:
+    docs: |
+      name: docs
+      on:
+        push:
+          branches: [main]
+      # No `workflow_dispatch`: docgen-action gates its doc build, artifact upload,
+      # and Pages deploy on `github.event_name == 'push'`, so a manual dispatch would
+      # run the Lean build and then silently skip publishing. Re-render by pushing an
+      # empty commit to `main`.
+      concurrency:
+        group: ${{ github.workflow }}-${{ github.ref }}
+        cancel-in-progress: true
+      permissions:
+        contents: read
+        pages: write
+        id-token: write
+      jobs:
+        docs:
+          runs-on: ubuntu-latest
+          environment:
+            name: github-pages
+          steps:
+            # Mathlib's generated doc HTML is large; free space so the runner doesn't fill up.
+            - uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+              with:
+                tool-cache: false
+            - uses: actions/checkout@v4
+              with:
+                fetch-depth: 0 # doc-gen4 source links need full history
+            # Preserve the Mathlib-rebuild guard from ci.yml: fetch the olean cache and
+            # hard-fail if a cache miss would recompile Mathlib from source.
+            - uses: leanprover/lean-action@v1
+              with:
+                auto-config: false
+                build: false
+            - run: lake exe cache get
+            - name: Build the aggregate (fail if Mathlib rebuilds from source)
+              run: |
+                set -o pipefail
+                lake build 2>&1 | tee build.log
+                if grep -qE 'Building Mathlib\b' build.log; then
+                  echo "ERROR: Mathlib rebuilt from source (cache miss)"; exit 1; fi
+            # doc-gen4 renders declaration pages for the whole import cone (Mathlib
+            # included) in a docbuild/ sub-project that reuses ../.lake/packages, caches
+            # the generated HTML keyed on lake-manifest.json, and deploys to Pages.
+            - name: Build and deploy API documentation
+              uses: leanprover-community/docgen-action@10db47458f91456d87804787d3dfcd914b9a19e3
+              with:
+                build-page: false

--- a/scripts/release/sync_released.py
+++ b/scripts/release/sync_released.py
@@ -161,16 +161,72 @@ def released_ci_workflows(path: Path | None = None) -> dict[str, str]:
     return workflows
 
 
-def apply_ci_workflow(entry: dict, clone: Path) -> str:
-    """Publish the selected central workflow into a released clone."""
+def released_extra_workflows(path: Path | None = None) -> dict[str, dict[str, str]]:
+    """Load the workflows a repository gets beyond its build-only `ci.yml`.
+
+    Keyed by repository short name, then by workflow file stem, so `hex`'s
+    `docs` entry is published as `.github/workflows/docs.yml`. Absent from the
+    document means no repository has one, which is a legitimate state.
+    """
+    source = path or RELEASED_CI
+    document = yaml.safe_load(source.read_text(encoding="utf-8"))
+    extras = document.get("extra_workflows") if isinstance(document, dict) else None
+    if extras is None:
+        return {}
+    if not isinstance(extras, dict):
+        raise ValueError(f"{source}: extra_workflows must be a mapping")
+    for repo, workflows in extras.items():
+        if not isinstance(repo, str) or not isinstance(workflows, dict) or not workflows:
+            raise ValueError(
+                f"{source}: extra_workflows entries must map a name to a non-empty mapping")
+        for stem, workflow in workflows.items():
+            if not isinstance(stem, str) or not isinstance(workflow, str):
+                raise ValueError(
+                    f"{source}: extra workflow entries must map names to text")
+            if stem == "ci":
+                raise ValueError(
+                    f"{source}: {repo} declares ci as an extra workflow; ci.yml is"
+                    " published from the workflows mapping")
+            if not workflow.endswith("\n"):
+                raise ValueError(
+                    f"{source}: extra workflow {stem} for {repo} must end in a newline")
+    return extras
+
+
+def managed_workflow_paths(entry: dict) -> set[Path]:
+    """The `.github/workflows/` files one mirror is allowed to carry.
+
+    Every mirror has `ci.yml`; the manifest may declare further workflows for a
+    repository. This is the allowance, so it describes the destinations without
+    requiring the content to exist: a repository with no managed CI workflow is
+    an error when publishing, not when computing what may survive a sweep.
+    """
+    short = entry["repo"].split("/")[-1]
+    stems = ["ci", *released_extra_workflows().get(short, {})]
+    return {Path(".github") / "workflows" / f"{stem}.yml" for stem in stems}
+
+
+def managed_workflows(entry: dict) -> dict[Path, str]:
+    """The complete `.github/workflows/` content one mirror is published with."""
     short = entry["repo"].split("/")[-1]
     workflows = released_ci_workflows()
     if short not in workflows:
         raise RuntimeError(f"no managed CI workflow for {entry['repo']}")
-    destination = clone / ".github" / "workflows" / "ci.yml"
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    destination.write_text(workflows[short], encoding="utf-8")
-    return "  scripts/release/released-ci.yml -> .github/workflows/ci.yml"
+    out = {Path(".github") / "workflows" / "ci.yml": workflows[short]}
+    for stem, workflow in released_extra_workflows().get(short, {}).items():
+        out[Path(".github") / "workflows" / f"{stem}.yml"] = workflow
+    return out
+
+
+def apply_ci_workflow(entry: dict, clone: Path) -> list[str]:
+    """Publish the central workflows into a released clone."""
+    notes: list[str] = []
+    for dest_rel, workflow in managed_workflows(entry).items():
+        destination = clone / dest_rel
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(workflow, encoding="utf-8")
+        notes.append(f"  scripts/release/released-ci.yml -> {dest_rel.as_posix()}")
+    return notes
 
 
 def managed_paths(entry: dict) -> list[tuple[Path, Path, bool]]:
@@ -240,9 +296,6 @@ SKELETON = (
     "lean-toolchain",
 )
 
-# The one path under `.github/` a mirror keeps, written by `apply_ci_workflow`
-# rather than by the managed-path copy.
-MANAGED_WORKFLOW = Path(".github") / "workflows" / "ci.yml"
 
 # Removed from every released repository, the `pins_only` aggregate included.
 # The aggregate is otherwise exempt from the sweep, because its umbrella module,
@@ -289,7 +342,7 @@ def allowed_paths(entry: dict) -> tuple[set[Path], set[Path]]:
     """
     subtrees = {Path(name) for name in SKELETON}
     subtrees.update(keep_paths(entry))
-    files = {MANAGED_WORKFLOW}
+    files = managed_workflow_paths(entry)
     for _src, dest_rel, is_dir in managed_paths(entry):
         (subtrees if is_dir else files).add(dest_rel)
     return subtrees, files
@@ -362,7 +415,7 @@ def apply_paths(entry: dict, clone: Path) -> list[str]:
         rendered = aggregate_readme.render(manifest, REPO_ROOT / template)
         (clone / "README.md").write_text(rendered, encoding="utf-8")
         notes.append(f"  {template} + released.yml -> README.md (generated)")
-    notes.append(apply_ci_workflow(entry, clone))
+    notes.extend(apply_ci_workflow(entry, clone))
     notes.extend(prune_unmanaged(entry, clone))
     if entry.get("pins_only"):
         return notes

--- a/scripts/release/test_sync_released.py
+++ b/scripts/release/test_sync_released.py
@@ -282,6 +282,68 @@ class SyncReleasedTests(unittest.TestCase):
                 {"repo": "leanprover/hex-example"}, self.repo / "clone"
             )
 
+    def test_extra_workflow_is_published_beside_ci(self) -> None:
+        """A declared extra workflow lands at `.github/workflows/<stem>.yml`."""
+        source = self.repo / "released-ci.yml"
+        source.write_text(
+            "workflows:\n  hex: |\n    name: CI\n"
+            "extra_workflows:\n  hex:\n    docs: |\n      name: docs\n",
+            encoding="utf-8")
+        clone = self.repo / "clone"
+        with patch.object(sync_released, "RELEASED_CI", source):
+            notes = sync_released.apply_ci_workflow(
+                {"repo": "leanprover/hex"}, clone)
+        self.assertEqual(
+            (clone / ".github" / "workflows" / "ci.yml").read_text(), "name: CI\n")
+        self.assertEqual(
+            (clone / ".github" / "workflows" / "docs.yml").read_text(), "name: docs\n")
+        self.assertIn(
+            "  scripts/release/released-ci.yml -> .github/workflows/docs.yml", notes)
+
+    def test_sweep_keeps_a_declared_extra_workflow(self) -> None:
+        """The allowance follows the manifest, so the sweep cannot orphan it."""
+        source = self.repo / "released-ci.yml"
+        source.write_text(
+            "workflows:\n  hex-bridge: |\n    name: CI\n"
+            "extra_workflows:\n  hex-bridge:\n    docs: |\n      name: docs\n",
+            encoding="utf-8")
+        clone = self._bridge_clone()
+        for stem in ("ci", "docs", "stray"):
+            (clone / ".github" / "workflows" / f"{stem}.yml").write_text(
+                "name: x\n", encoding="utf-8")
+        with tempfile.TemporaryDirectory() as source_directory:
+            with (
+                patch.object(sync_released, "REPO_ROOT", Path(source_directory)),
+                patch.object(sync_released, "RELEASED_CI", source),
+            ):
+                sync_released.prune_unmanaged(self._bridge_entry(), clone)
+        workflows = clone / ".github" / "workflows"
+        self.assertTrue((workflows / "ci.yml").exists())
+        self.assertTrue((workflows / "docs.yml").exists())
+        self.assertFalse((workflows / "stray.yml").exists())
+
+    def test_extra_workflows_reject_a_ci_stem(self) -> None:
+        """`ci.yml` has one source; declaring it twice would be ambiguous."""
+        source = self.repo / "released-ci.yml"
+        source.write_text(
+            "workflows:\n  hex: |\n    name: CI\n"
+            "extra_workflows:\n  hex:\n    ci: |\n      name: other\n",
+            encoding="utf-8")
+        with (
+            patch.object(sync_released, "RELEASED_CI", source),
+            self.assertRaisesRegex(ValueError, "ci as an extra workflow"),
+        ):
+            sync_released.released_extra_workflows(source)
+
+    def test_extra_workflows_require_a_trailing_newline(self) -> None:
+        source = self.repo / "released-ci.yml"
+        source.write_text(
+            "workflows:\n  hex: |\n    name: CI\n"
+            "extra_workflows:\n  hex:\n    docs: \"name: docs\"\n",
+            encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "must end in a newline"):
+            sync_released.released_extra_workflows(source)
+
     def test_pins_only_apply_overwrites_managed_ci(self) -> None:
         source = self.repo / "released-ci.yml"
         source.write_text(


### PR DESCRIPTION
This PR brings `leanprover/hex`'s `docs.yml` under the same source-of-truth rule as every other published artifact. It was the one workflow in the released set that lived only in the released repository, which both put it outside review here and made any change to it an uncoordinated commit that the sync's divergence guard would then refuse to sync past.

`released-ci.yml` grows an `extra_workflows:` mapping, keyed by repository and then by file stem, so `hex`'s `docs` entry publishes as `.github/workflows/docs.yml`. `allowed_paths` derives the `.github/workflows/` allowance from that mapping rather than from a single hardcoded `ci.yml`, so the sweep introduced in #10021 cannot orphan a declared workflow while a mirror still cannot accumulate one nobody here publishes. Declaring `ci` as an extra is rejected, since `ci.yml` already has exactly one source.

Nothing published changes: the dry run reports the aggregate byte-identical, `(no changes)`.

🤖 Prepared with Claude Code