### PR TITLE
docs(number-field): compare with = where the companion is imported

### DIFF
--- a/HexManual/Chapters/HexNumberField.lean
+++ b/HexManual/Chapters/HexNumberField.lean
@@ -75,15 +75,18 @@ def sqrt3 : AlgebraicNumber :=
   (ZPoly.algebraicRoots #p[-3, 0, 1])[1]!
 
 #guard (ZPoly.algebraicRoots #p[-2, 0, 1]).size = 2
-#guard sqrt2 * sqrt2 == 2
+#guard sqrt2 * sqrt2 = 2
 #guard (sqrt2 + sqrt3).p = #p[1, 0, -10, 0, 1]
-#guard (sqrt2 + sqrt3)⁻¹ == sqrt3 - sqrt2
+#guard (sqrt2 + sqrt3)⁻¹ = sqrt3 - sqrt2
 ```
 
 The field `p` of a canonical number is its minimal polynomial, so the third
 check is the classical fact that `√2 + √3` has minimal polynomial
-`X⁴ − 10X² + 1`, and the fourth is `1 / (√2 + √3) = √3 − √2`. Printing a
-number shows that polynomial and twelve decimals of a certified approximation:
+`X⁴ − 10X² + 1`, and the fourth is `1 / (√2 + √3) = √3 − √2`. Equality of
+canonical numbers is decidable. Without the Mathlib companion, compare with
+`==`, the executable test; with it, `=` is available too, because the
+companion proves that the test is correct. Printing a number shows that
+polynomial and twelve decimals of a certified approximation:
 
 ```lean (name := sqrtSumEval)
 #eval sqrt2 + sqrt3
@@ -99,8 +102,8 @@ its reciprocal, and the tenth Lucas number all fall out of decidable equality:
 def φ : AlgebraicNumber :=
   (ZPoly.algebraicRoots #p[-1, -1, 1])[1]!
 
-#guard φ * φ == φ + 1
-#guard φ⁻¹ == φ - 1
+#guard φ * φ = φ + 1
+#guard φ⁻¹ = φ - 1
 -- φ¹⁰ + φ⁻¹⁰ is the Lucas number L₁₀ = 123, so φ¹⁰ is a
 -- root of X² − 123X + 1.
 #guard (φ ^ (10 : Nat)).p = #p[1, -123, 1]
@@ -130,7 +133,7 @@ def lazyProduct : AlgebraicRoot :=
 
 #guard lazyProduct.p = #p[-4, 0, 1]
 #guard lazyProduct.exact.p = #p[-2, 1]
-#guard lazyProduct.exact == 2
+#guard lazyProduct.exact = 2
 ```
 
 A chain of lazy operations therefore costs a chain of resultants and one
@@ -192,7 +195,7 @@ def c : QAdjoin cbrt2.p cbrt2.x := cbrt2.toQAdjoin
 
 #guard c ^ 3 = 2
 #guard c⁻¹ = c * c / 2
-#guard c.toAlgebraicNumber cbrt2.rep cbrt2.rep_mk == cbrt2
+#guard c.toAlgebraicNumber cbrt2.rep cbrt2.rep_mk = cbrt2
 ```
 
 An element prints as its coordinates, a rational polynomial in the generator:

--- a/HexManual/Chapters/HexNumberFieldTower.lean
+++ b/HexManual/Chapters/HexNumberFieldTower.lean
@@ -116,7 +116,7 @@ def gMinus : Poly T2 := #p[-1, (-2 : Rat) • r2, 1]
   let F := factor T2 quartic
   coeffs F.scalar = #[1, 0] &&
     F.factors.all (fun (_, m) => m = 1) &&
-    F.factors.map (fun (g, _) => g) == #[gMinus, gPlus]
+    F.factors.map (fun (g, _) => g) = #[gMinus, gPlus]
 ```
 
 At each level `K(α)/K` the method searches a fixed list of integer shifts for
@@ -185,12 +185,12 @@ def F : Flattening T23 := flatten T23
 
 #guard F.root.p = #p[1, 0, -10, 0, 1]
 #guard (F.toPrimitive s2).coeffs = #p[0, -9 / 2, 0, 1 / 2]
-#guard F.fromPrimitive (F.toPrimitive s3) == s3
+#guard F.fromPrimitive (F.toPrimitive s3) = s3
 -- (√2 + √3)^10 = 47525 + 19402√6 over the basis
 -- 1, √2, √3, √6.
 #guard coeffs ((s2 + s3) ^ 10) = #[47525, 0, 0, 19402]
 #guard (F.toPrimitive ((s2 + s3) ^ 10)).toAlgebraicNumber
-    F.root.rep F.root.rep_mk == (sqrt2 + sqrt3) ^ 10
+    F.root.rep F.root.rep_mk = (sqrt2 + sqrt3) ^ 10
 
 end HexNumberFieldTowerChapter
 ```

--- a/HexNumberField/README.md
+++ b/HexNumberField/README.md
@@ -36,9 +36,10 @@ def sqrt2 : AlgebraicNumber :=
 def sqrt3 : AlgebraicNumber :=
   (ZPoly.algebraicRoots #p[-3, 0, 1])[1]!
 
--- Arithmetic is exact and equality is decidable; `p` is the
--- minimal polynomial.
+-- Arithmetic is exact; `p` is the minimal polynomial.
 #guard (sqrt2 + sqrt3).p = #p[1, 0, -10, 0, 1]
+-- Equality is decidable. Without the Mathlib companion,
+-- compare with `==`; with it, `=` works too.
 #guard (sqrt2 + sqrt3)⁻¹ == sqrt3 - sqrt2
 
 /-- info: root of X^4 - 10*X^2 + 1 near 3.146264369941 -/


### PR DESCRIPTION
This PR writes equality checks in the number-field and tower chapters with `=` rather than `==`. Both chapters import the Mathlib companion, which supplies `DecidableEq AlgebraicNumber` from the proof that the executable test is correct, so `=` is available and reads as mathematics. The number-field chapter says when each spelling applies, and the README, which imports only the computational library, keeps `==` with the same explanation in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
