### PR TITLE
feat(number-field): print values as expressions that rebuild them

### DIFF
--- a/HexManual/Chapters/HexNumberField.lean
+++ b/HexManual/Chapters/HexNumberField.lean
@@ -200,9 +200,9 @@ def c : QAdjoin cbrt2.p cbrt2.x := cbrt2.toQAdjoin
 #guard c.toAlgebraicNumber cbrt2.rep cbrt2.rep_mk = cbrt2
 ```
 
-An element prints as its coordinate polynomial, and a rational polynomial
-denotes its reduction, so the printed form is again an expression for the
-element: `c⁵ = 2c²`.
+An element prints as its coordinate polynomial, here `c⁵ = 2c²`, and a
+rational polynomial denotes its reduction, so the printed form is again an
+expression for the element:
 
 ```lean (name := cbrt2Pow)
 #eval c ^ 5
@@ -211,7 +211,7 @@ element: `c⁵ = 2c²`.
 #p[0, 0, 2]
 ```
 ```lean
-#guard c ^ 5 = #p[0, 0, 2]
+#guard (c ^ 5).coeffs = #p[0, 0, 2]
 ```
 
 ```lean -show

--- a/HexManual/Chapters/HexNumberField.lean
+++ b/HexManual/Chapters/HexNumberField.lean
@@ -85,14 +85,16 @@ check is the classical fact that `√2 + √3` has minimal polynomial
 `X⁴ − 10X² + 1`, and the fourth is `1 / (√2 + √3) = √3 − √2`. Equality of
 canonical numbers is decidable. Without the Mathlib companion, compare with
 `==`, the executable test; with it, `=` is available too, because the
-companion proves that the test is correct. Printing a number shows that
-polynomial and twelve decimals of a certified approximation:
+companion proves that the test is correct. A number prints as the
+expression that rebuilds it, its minimal polynomial and its index among
+that polynomial's roots; here `√2 + √3` is the largest of the four real roots
+of the quartic:
 
 ```lean (name := sqrtSumEval)
 #eval sqrt2 + sqrt3
 ```
 ```leanOutput sqrtSumEval
-root of X^4 - 10*X^2 + 1 near 3.146264369941
+(ZPoly.algebraicRoots #p[1, 0, -10, 0, 1])[3]!
 ```
 
 The golden ratio is the positive root of `X² − X − 1`. Its defining identity,
@@ -198,13 +200,18 @@ def c : QAdjoin cbrt2.p cbrt2.x := cbrt2.toQAdjoin
 #guard c.toAlgebraicNumber cbrt2.rep cbrt2.rep_mk = cbrt2
 ```
 
-An element prints as its coordinates, a rational polynomial in the generator:
+An element prints as its coordinate polynomial, and a rational polynomial
+denotes its reduction, so the printed form is again an expression for the
+element: `c⁵ = 2c²`.
 
 ```lean (name := cbrt2Pow)
 #eval c ^ 5
 ```
 ```leanOutput cbrt2Pow
-2*x^2
+#p[0, 0, 2]
+```
+```lean
+#guard c ^ 5 = #p[0, 0, 2]
 ```
 
 ```lean -show

--- a/HexManual/Chapters/HexNumberField.lean
+++ b/HexManual/Chapters/HexNumberField.lean
@@ -75,15 +75,18 @@ def sqrt3 : AlgebraicNumber :=
   (ZPoly.algebraicRoots #p[-3, 0, 1])[1]!
 
 #guard (ZPoly.algebraicRoots #p[-2, 0, 1]).size = 2
-#guard sqrt2 * sqrt2 == 2
+#guard sqrt2 * sqrt2 = 2
 #guard (sqrt2 + sqrt3).p = #p[1, 0, -10, 0, 1]
-#guard (sqrt2 + sqrt3)⁻¹ == sqrt3 - sqrt2
+#guard (sqrt2 + sqrt3)⁻¹ = sqrt3 - sqrt2
 ```
 
 The field `p` of a canonical number is its minimal polynomial, so the third
 check is the classical fact that `√2 + √3` has minimal polynomial
-`X⁴ − 10X² + 1`, and the fourth is `1 / (√2 + √3) = √3 − √2`. Printing a
-number shows that polynomial and twelve decimals of a certified approximation:
+`X⁴ − 10X² + 1`, and the fourth is `1 / (√2 + √3) = √3 − √2`. Equality of
+canonical numbers is decidable. Without the Mathlib companion, compare with
+`==`, the executable test; with it, `=` is available too, because the
+companion proves that the test is correct. Printing a number shows that
+polynomial and twelve decimals of a certified approximation:
 
 ```lean (name := sqrtSumEval)
 #eval sqrt2 + sqrt3
@@ -99,8 +102,8 @@ its reciprocal, and the tenth Lucas number all fall out of decidable equality:
 def φ : AlgebraicNumber :=
   (ZPoly.algebraicRoots #p[-1, -1, 1])[1]!
 
-#guard φ * φ == φ + 1
-#guard φ⁻¹ == φ - 1
+#guard φ * φ = φ + 1
+#guard φ⁻¹ = φ - 1
 -- φ¹⁰ + φ⁻¹⁰ is the Lucas number L₁₀ = 123, so φ¹⁰ is a
 -- root of X² − 123X + 1.
 #guard (φ ^ (10 : Nat)).p = #p[1, -123, 1]
@@ -130,7 +133,7 @@ def lazyProduct : AlgebraicRoot :=
 
 #guard lazyProduct.p = #p[-4, 0, 1]
 #guard lazyProduct.exact.p = #p[-2, 1]
-#guard lazyProduct.exact == 2
+#guard lazyProduct.exact = 2
 ```
 
 A chain of lazy operations therefore costs a chain of resultants and one
@@ -192,7 +195,7 @@ def c : QAdjoin cbrt2.p cbrt2.x := cbrt2.toQAdjoin
 
 #guard c ^ 3 = 2
 #guard c⁻¹ = c * c / 2
-#guard c.toAlgebraicNumber cbrt2.rep cbrt2.rep_mk == cbrt2
+#guard c.toAlgebraicNumber cbrt2.rep cbrt2.rep_mk = cbrt2
 ```
 
 An element prints as its coordinates, a rational polynomial in the generator:

--- a/HexManual/Chapters/HexNumberFieldTower.lean
+++ b/HexManual/Chapters/HexNumberFieldTower.lean
@@ -116,7 +116,7 @@ def gMinus : Poly T2 := #p[-1, (-2 : Rat) • r2, 1]
   let F := factor T2 quartic
   coeffs F.scalar = #[1, 0] &&
     F.factors.all (fun (_, m) => m = 1) &&
-    F.factors.map (fun (g, _) => g) == #[gMinus, gPlus]
+    F.factors.map (fun (g, _) => g) = #[gMinus, gPlus]
 ```
 
 At each level `K(α)/K` the method searches a fixed list of integer shifts for
@@ -185,12 +185,12 @@ def F : Flattening T23 := flatten T23
 
 #guard F.root.p = #p[1, 0, -10, 0, 1]
 #guard (F.toPrimitive s2).coeffs = #p[0, -9 / 2, 0, 1 / 2]
-#guard F.fromPrimitive (F.toPrimitive s3) == s3
+#guard F.fromPrimitive (F.toPrimitive s3) = s3
 -- (√2 + √3)^10 = 47525 + 19402√6 over the basis
 -- 1, √2, √3, √6.
 #guard coeffs ((s2 + s3) ^ 10) = #[47525, 0, 0, 19402]
 #guard (F.toPrimitive ((s2 + s3) ^ 10)).toAlgebraicNumber
-    F.root.rep F.root.rep_mk == (sqrt2 + sqrt3) ^ 10
+    F.root.rep F.root.rep_mk = (sqrt2 + sqrt3) ^ 10
 
 end HexNumberFieldTowerChapter
 ```

--- a/HexNumberField/IntegerRoots.lean
+++ b/HexNumberField/IntegerRoots.lean
@@ -141,66 +141,21 @@ end ZPoly
 
 namespace AlgebraicNumber
 
-namespace Display
-
-/-- `q` truncated toward zero to `digits` decimal places. A display helper
-for the `Repr` instance; it carries no contract. -/
-def decimal (q : Rat) (digits : Nat) : String :=
-  let scale := 10 ^ digits
-  let n := q.num.natAbs * scale / q.den
-  let whole := n / scale
-  let frac := n % scale
-  let fracDigits := toString frac
-  let padded := String.ofList (List.replicate (digits - fracDigits.length) '0') ++ fracDigits
-  (if q.num < 0 && n ≠ 0 then "-" else "") ++ s!"{whole}.{padded}"
-
-/-- A rational written as `n` or `n/d`. -/
-def rational (q : Rat) : String :=
-  if q.den = 1 then s!"{q.num}" else s!"{q.num}/{q.den}"
-
-/-- Rational coefficients written with descending powers of `var`. A display
-helper for the `Repr` instances; it carries no contract. -/
-def polynomialIn (var : String) (coeffs : Array Rat) : String :=
-  let terms := (List.range coeffs.size).reverse.filterMap fun i =>
-    let c := coeffs.getD i 0
-    if c = 0 then none
-    else
-      let magnitude := rational (if c < 0 then -c else c)
-      let body :=
-        if i = 0 then magnitude
-        else
-          (if magnitude = "1" then "" else s!"{magnitude}*") ++
-            (if i = 1 then var else s!"{var}^{i}")
-      some (decide (c < 0), body)
-  match terms with
-  | [] => "0"
-  | (negative, body) :: rest =>
-      rest.foldl (fun acc (neg, term) => acc ++ (if neg then " - " else " + ") ++ term)
-        ((if negative then "-" else "") ++ body)
-
-/-- `p` written with descending powers of `X`. -/
-def polynomial (p : ZPoly) : String :=
-  polynomialIn "X" (p.coeffs.map fun (c : Int) => (c : Rat))
-
-end Display
-
+/-- A canonical number prints as the expression that rebuilds it: its minimal
+polynomial and its index among that polynomial's roots in `algebraicRoots`
+order, real roots first in increasing order. Every canonical number is one
+of the roots of its own minimal polynomial, so the index is always found. -/
 instance : Repr AlgebraicNumber where
   reprPrec a _ :=
-    let ball := a.approx 64
-    let re := Display.decimal ball.re.toRat 12
-    let value :=
-      if a.isReal then re
-      else
-        let im := Display.decimal ball.im.toRat 12
-        re ++ (if im.startsWith "-" then " - " ++ im.drop 1 else " + " ++ im) ++ "i"
-    Std.Format.text s!"root of {Display.polynomial a.p} near {value}"
+    let index := ((ZPoly.algebraicRoots a.p).findIdx? (· == a)).getD 0
+    Std.Format.text s!"(ZPoly.algebraicRoots {repr a.p})[{index}]!"
 
 end AlgebraicNumber
 
-/-- A fixed-field element prints as its reduced coordinates, a rational
-polynomial in the generator `x`. -/
+/-- A fixed-field element prints as its reduced coordinate polynomial,
+`#p[a₀, a₁, ...]`, which rebuilds it through the coercion from
+`DensePoly Rat`. -/
 instance {p : ZPoly} {x : SimpleRoot p} : Repr (QAdjoin p x) where
-  reprPrec a _ :=
-    Std.Format.text (AlgebraicNumber.Display.polynomialIn "x" a.coeffs.coeffs)
+  reprPrec a prec := reprPrec a.coeffs prec
 
 end Hex

--- a/HexNumberField/QAdjoin.lean
+++ b/HexNumberField/QAdjoin.lean
@@ -114,6 +114,10 @@ instance : SMul Rat (QAdjoin p x) := ⟨smul⟩
 def ofRat (q : Rat) : QAdjoin p x :=
   q • (1 : QAdjoin p x)
 
+/-- A rational polynomial denotes its reduction, so `#p[0, 0, 2]` names the
+element `2x²` when the expected type is `QAdjoin p x`. -/
+instance : Coe (DensePoly Rat) (QAdjoin p x) := ⟨reduce p x⟩
+
 instance : NatCast (QAdjoin p x) := ⟨fun n => ofRat (n : Rat)⟩
 instance : IntCast (QAdjoin p x) := ⟨fun n => ofRat (n : Rat)⟩
 -- Mathlib's generic `OfNat` from `NatCast` has priority 100. Keep this

--- a/HexNumberField/README.md
+++ b/HexNumberField/README.md
@@ -36,9 +36,10 @@ def sqrt2 : AlgebraicNumber :=
 def sqrt3 : AlgebraicNumber :=
   (ZPoly.algebraicRoots #p[-3, 0, 1])[1]!
 
--- Arithmetic is exact and equality is decidable; `p` is the
--- minimal polynomial.
+-- Arithmetic is exact; `p` is the minimal polynomial.
 #guard (sqrt2 + sqrt3).p = #p[1, 0, -10, 0, 1]
+-- Equality is decidable. Without the Mathlib companion,
+-- compare with `==`; with it, `=` works too.
 #guard (sqrt2 + sqrt3)⁻¹ == sqrt3 - sqrt2
 
 /-- info: root of X^4 - 10*X^2 + 1 near 3.146264369941 -/

--- a/HexNumberField/README.md
+++ b/HexNumberField/README.md
@@ -42,7 +42,7 @@ def sqrt3 : AlgebraicNumber :=
 -- compare with `==`; with it, `=` works too.
 #guard (sqrt2 + sqrt3)⁻¹ == sqrt3 - sqrt2
 
-/-- info: root of X^4 - 10*X^2 + 1 near 3.146264369941 -/
+/-- info: (ZPoly.algebraicRoots #p[1, 0, -10, 0, 1])[3]! -/
 #guard_msgs in
 #eval sqrt2 + sqrt3
 ```

--- a/HexNumberField/SPEC/hex-number-field.md
+++ b/HexNumberField/SPEC/hex-number-field.md
@@ -203,8 +203,10 @@ instance (n : Nat) : OfNat (QAdjoin p x) (n + 2)
 
 so numerals such as `2 : QAdjoin p x` denote `(2 : Rat) • 1`, and the
 companion's field structure reuses these casts rather than defining its own.
-`instance : Repr (QAdjoin p x)` prints the reduced coordinates as a rational
-polynomial in the generator `x`, for example `2*x^2`. Inversion requires
+`instance : Coe (DensePoly Rat) (QAdjoin p x)` reduces a rational polynomial,
+so `#p[0, 0, 2]` denotes `2x²` at that type, and
+`instance : Repr (QAdjoin p x)` prints an element as exactly that reduced
+coordinate polynomial, so a printed value can be pasted back. Inversion requires
 `[ZPoly.CheckedIrreducible p]` and uses a monic-normalized polynomial extended
 gcd over `ℚ` to control rational coefficient growth. For the presentation a
 canonical number induces, that evidence is an instance:
@@ -494,11 +496,10 @@ applies it to the stored representative; the companion proves `isReal_iff`.
 
 `approx a prec` is `QAdjoin.approx` applied to `a.toQAdjoin` with the stored
 representative; its ball contains `a.toComplex` and has radius at most
-`2^(-prec)`. The `Repr` instance prints the minimal polynomial and the ball
-centre truncated to twelve decimal places (real part only when `isReal`); it
-is for display and carries no contract beyond `approx`. Its two helpers,
-`AlgebraicNumber.Display.decimal` and `AlgebraicNumber.Display.polynomial`,
-are public only because the instance is, and carry no contract either.
+`2^(-prec)`. The `Repr` instance prints the expression that rebuilds the
+number: `(ZPoly.algebraicRoots p)[i]!` with `p` its minimal polynomial and
+`i` its index in `algebraicRoots p`, which is `rootLe` order. It is for
+display and carries no contract beyond that of `algebraicRoots`.
 
 ## Common-field construction
 

--- a/HexPoly/Dense.lean
+++ b/HexPoly/Dense.lean
@@ -289,6 +289,11 @@ macro_rules
   | `(#p[$coeffs,*]) =>
       `(Hex.DensePoly.ofCoeffs #[$coeffs,*])
 
+/-- A polynomial prints as the literal that rebuilds it, `#p[a₀, a₁, ...]`. -/
+instance [Repr R] : Repr (DensePoly R) where
+  reprPrec p _ :=
+    "#p[" ++ Std.Format.joinSep (p.coeffs.toList.map repr) ", " ++ "]"
+
 /-- The zero polynomial. -/
 @[expose]
 def zero : DensePoly R :=

--- a/HexPoly/SPEC/hex-poly.md
+++ b/HexPoly/SPEC/hex-poly.md
@@ -15,7 +15,8 @@ The normalization invariant (no trailing zeros) ensures structural equality
 The polynomial literal `#p[a₀, a₁, ...]` abbreviates
 `DensePoly.ofCoeffs #[a₀, a₁, ...]`. Coefficients are listed in ascending
 degree order, and the expected polynomial type determines the coefficient
-type. As with `ofCoeffs`, trailing zero coefficients are removed.
+type. As with `ofCoeffs`, trailing zero coefficients are removed. A polynomial prints, through its `Repr` instance, as that same literal,
+so a printed value can be pasted back.
 
 - Index = degree, `coeffs[i]` is coefficient of `x^i`
 - Normalization invariant: no trailing zeros

--- a/conformance/HexNumberField/Conformance.lean
+++ b/conformance/HexNumberField/Conformance.lean
@@ -531,12 +531,12 @@ private def algebraicRepeated? : Option AlgebraicPoly := do
 
 -- `sqrt(2) + sqrt(3)` through the public entry point has the expected
 -- minimal polynomial, its inverse is `sqrt(3) - sqrt(2)`, and the display
--- names the polynomial and twelve decimals.
+-- is the expression that rebuilds the number.
 #guard
   let s2 := (ZPoly.algebraicRoots #p[-2, 0, 1])[1]!
   let s3 := (ZPoly.algebraicRoots #p[-3, 0, 1])[1]!
   (s2 + s3).p = #p[1, 0, -10, 0, 1] && (s2 + s3)⁻¹ == s3 - s2 &&
-    (repr s2).pretty == "root of X^2 - 2 near 1.414213562373" &&
-    (repr (s2 + s3)).pretty == "root of X^4 - 10*X^2 + 1 near 3.146264369941"
+    (repr s2).pretty == "(ZPoly.algebraicRoots #p[-2, 0, 1])[1]!" &&
+    (repr (s2 + s3)).pretty == "(ZPoly.algebraicRoots #p[1, 0, -10, 0, 1])[3]!"
 
 end Hex.NumberFieldConformance

--- a/scripts/bench/proof_only_runtime_exemptions/hexpoly-dense-lean-7fd4c4da-cc6fa11d.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexpoly-dense-lean-7fd4c4da-cc6fa11d.json
@@ -1,0 +1,6 @@
+{
+ "path": "HexPoly/Dense.lean",
+ "baseline_blob": "7fd4c4da15f387692247ac934f8ca653c09d69dc",
+ "current_blob": "cc6fa11d21e587dc2b8c7d6eec4d600c4b11158a",
+ "reason": "Adds a `Repr` instance printing a polynomial as its `#p[...]` literal. A display instance only; no executable definition on the factorization path changes."
+}


### PR DESCRIPTION
This PR replaces the display-only `Repr` instances with printed forms that round-trip. A polynomial prints as its literal `#p[a₀, a₁, ...]`. A canonical algebraic number prints as `(ZPoly.algebraicRoots p)[i]!`, its minimal polynomial and its index among that polynomial's roots in the library's root order, which reconstructs it exactly since every canonical number is a root of its own minimal polynomial. A fixed-field element prints as its reduced coordinate polynomial, and a new coercion from `DensePoly Rat` makes that literal denote the element again, so `#guard c ^ 5 = #p[0, 0, 2]` reads as written. The decimal display helpers are removed; `approx` remains the way to a certified numeric value. Both SPECs, the number-field chapter, its README quickstart and the conformance check are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
