### PR TITLE
doc(rcf): fold the worked examples into the introduction

### DIFF
--- a/HexManual/Chapters/HexRCF.lean
+++ b/HexManual/Chapters/HexRCF.lean
@@ -51,23 +51,15 @@ statement without a named witness, and the witness in the cubic above is
 irrational. `rcf` needs neither hints nor a witness, and on this fragment it
 always answers.
 
-Import `HexRCF` and write `rcf` at the goal:
+Import `HexRCF` and write `rcf` at the goal. Here it proves that the Chebyshev
+polynomial `T₅` is bounded by one on `(−1, 1]` and attains the bound, that a
+cubic has a root in a dyadic interval and none outside it, and that a quartic
+is nonnegative with equality at exactly one point. Each is one call:
 
 ```lean
 example : ∀ x : ℝ, x ^ 2 + 1 > 0 := by
   rcf
-```
 
-# Three facts a mathematician might want
-%%%
-tag := "hex-rcf-examples"
-%%%
-
-The Chebyshev polynomial `T₅` is bounded by one on `(−1, 1]` and attains the
-bound; a cubic has a root in a dyadic interval and none outside it; a quartic
-is nonnegative with equality at exactly one point. Each is one call:
-
-```lean
 example : ∀ x : ℝ, x ∈ Set.Ioc (-1 : ℝ) 1 →
     -1 ≤ 16 * x ^ 5 - 20 * x ^ 3 + 5 * x ∧
       16 * x ^ 5 - 20 * x ^ 3 + 5 * x ≤ 1 := by


### PR DESCRIPTION
This PR removes the "Three facts a mathematician might want" section from the `HexRCF` chapter and moves its examples into the introduction, so the chapter's opening runs straight from what `rcf` decides to what it proves without a heading in between. The examples and the surrounding prose are unchanged apart from the sentence that now introduces them.

🤖 Prepared with Claude Code