### PR TITLE
refactor(real-roots): namespace the drivers and drop the width cap

### DIFF
--- a/Examples/Release5.lean
+++ b/Examples/Release5.lean
@@ -69,13 +69,13 @@ theorem complexInput_simple : HasOnlySimpleRoots complexInput := by
 
 /-- A none-free array of certified, pairwise-disjoint complex-root atoms. -/
 noncomputable def complexRoots :=
-  HexRootsMathlib.isolate! complexInput complexInput_simple complexInput_ne 32
+  HexRootsMathlib.isolate complexInput complexInput_simple complexInput_ne 32
 
 example : complexRoots.size = 3 := by
   rw [show complexRoots.size =
       (HexRootsMathlib.toPolyℂ complexInput).natDegree by
     simpa [complexRoots] using
-    HexRootsMathlib.isolate!_count complexInput complexInput_simple
+    HexRootsMathlib.isolate_count complexInput complexInput_simple
       complexInput_ne 32]
   exact complexInput_degree
 

--- a/HexIntervalAlgebraic/Experiment/PolynomialDispatch.lean
+++ b/HexIntervalAlgebraic/Experiment/PolynomialDispatch.lean
@@ -179,7 +179,7 @@ structure RealRegion where
 /-- The real backend is the actual Sturm isolator followed by cached exact
 bisection refinement of every emitted interval. -/
 def realBackend? (p : ZPoly) (target : Int) : Option (Array RealRegion) := do
-  let output ← isolateSturm? p
+  let output ← ZPoly.isolateSturm? p
   let chain := ZPoly.sturmChain p
   return output.isolations.map fun isolation =>
     let refined := isolation.refineToWithChain chain rfl target
@@ -188,7 +188,7 @@ def realBackend? (p : ZPoly) (target : Int) : Option (Array RealRegion) := do
 /-- Plain square projection of the proof-carrying complex backend. -/
 def complexBackend? (p : ZPoly) (target : Int) : Option (Array DyadicSquare) :=
   if simple : HasOnlySimpleRoots p then
-    (Hex.isolate p simple target .nk).map fun isolations =>
+    (Hex.isolate? p simple target .nk).map fun isolations =>
       isolations.map (fun isolation => isolation.square)
   else none
 

--- a/HexManual/Chapters/HexRealRoots.lean
+++ b/HexManual/Chapters/HexRealRoots.lean
@@ -49,10 +49,10 @@ squarefreeness is needed at the call site.
 tag := "hex-real-roots-core"
 %%%
 
-The computational package exposes {name}`Hex.isolate?`, which tries Descartes
+The computational package exposes {name}`Hex.ZPoly.isolate?`, which tries Descartes
 search before falling back to Sturm bisection. The
-{name}`Hex.isolateDescartes?` and {name}`Hex.isolateSturm?` variants select one
-engine explicitly; {name}`Hex.rootCount` and {name}`Hex.sturmCount` expose the
+{name}`Hex.ZPoly.isolateDescartes?` and {name}`Hex.ZPoly.isolateSturm?` variants select one
+engine explicitly; {name}`Hex.ZPoly.rootCount` and {name}`Hex.ZPoly.sturmCount` expose the
 exact counting operations. These functions run in native Lean and need no
 external oracle at runtime.
 
@@ -182,9 +182,8 @@ refines to that binary target. Widths above one therefore request `k = 0`,
 which still refines any wider natural interval to width at most one;
 refinement only narrows, so a coarse request cannot undo the isolator's
 separation. A non-dyadic request can produce a strictly narrower interval than
-requested. Targets finer than `2⁻⁴⁰⁹⁶` are rejected as pathological. Refining
-`x⁴ − 2` to width `2⁻²⁰` places the positive root in an interval of width
-exactly `2⁻²⁰`:
+requested. Refining `x⁴ − 2` to width `2⁻²⁰` places the positive root in an
+interval of width exactly `2⁻²⁰`:
 
 ```lean
 open Hex Polynomial

--- a/HexManual/Chapters/HexRoots.lean
+++ b/HexManual/Chapters/HexRoots.lean
@@ -49,14 +49,14 @@ region is the square's circumscribed disc. A component that a Pellet witness
 certifies to hold `k ≥ 2` roots with multiplicity, most naturally a repeated
 root, is reported instead as a {deftech}_cluster_. A nonzero polynomial with
 only simple roots isolates entirely into atoms; that is the case the
-user-facing {name}`Hex.isolate` entry point below handles.
+user-facing {name}`Hex.isolate?` entry point below handles.
 
-# The `isolate` entry point
+# The `isolate?` entry point
 %%%
 tag := "hex-roots-isolate"
 %%%
 
-For a nonzero polynomial with only simple roots, {name}`Hex.isolate` runs the
+For a nonzero polynomial with only simple roots, {name}`Hex.isolate?` runs the
 whole isolator and returns `some` array of atoms, one per distinct complex
 root. It is `Option`-valued for the degenerate inputs the precondition still
 admits: the zero polynomial, which has every point as a root, gives `none`,
@@ -65,7 +65,7 @@ and a nonzero constant gives `some #[]`. It takes the polynomial as a
 roots are simple, a target precision in bits, and a choice of which atom
 certificate to attempt:
 
-{docstring Hex.isolate}
+{docstring Hex.isolate?}
 
 The simple-root precondition is decidable, so discharging it is a matter of
 `by decide` in the common case, or a companion lemma for a named polynomial.
@@ -78,19 +78,19 @@ Proof-facing clients can avoid `Option` entirely. The companion's total
 wrapper requires the missing nonzero hypothesis and uses the driver
 completeness theorem to return the array directly:
 
-{docstring HexRootsMathlib.isolate!}
+{docstring HexRootsMathlib.isolate}
 
 Completeness selects the wrapper's value from a successful executable run, and
 its principal theorems expose that run equation, the exact root count, the
 complete root set, and the requested precision:
 
-{docstring HexRootsMathlib.isolate!_eq}
+{docstring HexRootsMathlib.isolate_eq}
 
-{docstring HexRootsMathlib.isolate!_count}
+{docstring HexRootsMathlib.isolate_count}
 
-{docstring HexRootsMathlib.isolate!_roots}
+{docstring HexRootsMathlib.isolate_roots}
 
-{docstring HexRootsMathlib.isolate!_prec}
+{docstring HexRootsMathlib.isolate_prec}
 
 The strategy argument, a {name}`Hex.AtomStrategy`, selects which certificate
 form the driver attempts, and in which order: `.nk` for the
@@ -138,7 +138,7 @@ both other roots have norm below one, which is the Pisot condition for `β`.
 
 {docstring HexRootsMathlib.Examples.pisot}
 
-The polynomial has only simple roots, so it meets {name}`Hex.isolate`'s precondition. The
+The polynomial has only simple roots, so it meets {name}`Hex.isolate?`'s precondition. The
 companion proves this once, from a Bézout identity for `p` and `p'`, and
 reusing that lemma discharges the precondition:
 
@@ -173,11 +173,11 @@ statement of what it found.
 tag := "hex-roots-soundness"
 %%%
 
-A successful {name}`Hex.isolate` run is not just a list of squares; the companion reads a
+A successful {name}`Hex.isolate?` run is not just a list of squares; the companion reads a
 complete root enumeration out of it. Each atom names a genuine complex root,
 distinct atoms name distinct roots, and together they exhaust the root set:
 
-{docstring HexRootsMathlib.isolate_sound}
+{docstring HexRootsMathlib.isolate?_sound}
 
 The root an atom names is a semantic value, not part of the executable data.
 The companion selects it from the atom's certificate:
@@ -246,24 +246,24 @@ Everything the driver computes is executable and Mathlib-free.
 input becomes a complex polynomial through {name}`HexRootsMathlib.toPolyℂ`,
 and the executable certificates become statements about its root set in
 `Polynomial ℂ`. The correspondence has two halves. Soundness is
-{name}`HexRootsMathlib.isolate_sound` from
+{name}`HexRootsMathlib.isolate?_sound` from
 {ref "hex-roots-soundness"}[the certificate section]: a successful run
 enumerates exactly the distinct complex roots, at the requested precision.
 Completeness is the converse guarantee, that on a nonzero polynomial with
 only simple roots the search cannot fail, for every strategy and every
 requested precision:
 
-{docstring HexRootsMathlib.isolate_isSome}
+{docstring HexRootsMathlib.isolate?_isSome}
 
-Completeness is what lets the total wrapper {name}`HexRootsMathlib.isolate!`
+Completeness is what lets the total wrapper {name}`HexRootsMathlib.isolate`
 from {ref "hex-roots-isolate"}[the entry-point section] drop the `Option`
 and return the atom array directly, with its run equation, root count,
-root set, and precision exposed by the `isolate!_*` theorems shown there.
+root set, and precision exposed by the `isolate_*` theorems shown there.
 One further guarantee is stated on the wrapper: distinct atoms have
 disjoint closed circumscribed discs, so the certified enclosures never
 overlap and each root is separated from every other by exact dyadic data.
 
-{docstring HexRootsMathlib.isolate!_disjoint}
+{docstring HexRootsMathlib.isolate_disjoint}
 
 Behind these statements the companion develops the analysis the
 certificates rely on: a ported Newton-Kantorovich contraction theorem, the
@@ -292,6 +292,6 @@ isolator, and is consumed through its Mathlib companion:
   Newton-Kantorovich theorem and develops the argument principle, Rouché's
   theorem, and the Mahler separation bound for polynomials on circles, then
   proves soundness and completeness of the isolator: every certificate names
-  the roots it claims, and {name}`Hex.isolate` never fails on a nonzero squarefree input.
+  the roots it claims, and {name}`Hex.isolate?` never fails on a nonzero squarefree input.
   The Mathlib dependency lives entirely in this companion; a {name}`Hex.ZPoly` input
   keeps the executable core Mathlib-free.

--- a/HexNumberField/Basic.lean
+++ b/HexNumberField/Basic.lean
@@ -86,7 +86,7 @@ def IsCanonical (p : ZPoly) (squarefree : HasOnlySimpleRoots p)
     (p ≠ ZPoly.X ∧
       ∃ (isolations : Array (DyadicRootIsolation p))
         (refined : Array (RefinedIsolation p)),
-        isolate p squarefree (separationDepth p : Int) = some isolations ∧
+        isolate? p squarefree (separationDepth p : Int) = some isolations ∧
           isolations.mapM DyadicRootIsolation.toRefined? = some refined ∧
           rep ∈ refined.toList)
 
@@ -97,7 +97,7 @@ def canonicalRep? (p : ZPoly) (squarefree : HasOnlySimpleRoots p)
     (rep : RefinedIsolation p) (hzero : p ≠ ZPoly.X) :
     Option {r : RefinedIsolation p //
       IsCanonical p squarefree r ∧ r.sameRoot rep = true} :=
-  match hisolate : isolate p squarefree (separationDepth p : Int) with
+  match hisolate : isolate? p squarefree (separationDepth p : Int) with
   | none => none
   | some isolations =>
       match hrefine : isolations.mapM DyadicRootIsolation.toRefined? with
@@ -193,7 +193,7 @@ private def zeroRaw : AlgebraicNumber :=
 -- Keep executable evidence that the ordinary isolator also meets its stated
 -- completeness bound on `X`; the explicit zero path makes totality independent
 -- of this bounded computation.
-#guard (isolate ZPoly.X zero_squarefree
+#guard (isolate? ZPoly.X zero_squarefree
   (separationDepth ZPoly.X : Int)).isSome
 
 /-- The canonical algebraic number zero, represented by the fixed explicit

--- a/HexNumberField/Convert.lean
+++ b/HexNumberField/Convert.lean
@@ -75,7 +75,7 @@ def exactFactor? (a : AlgebraicRoot) (q : ZPoly) : Option AlgebraicNumber :=
       if hdegree : 0 < q.natDegree then
         if hirred : ZPoly.isIrreducible q = true then
           if hsquarefree : HasOnlySimpleRoots q then do
-            let isolations ← isolate q hsquarefree (separationDepth q : Int)
+            let isolations ← isolate? q hsquarefree (separationDepth q : Int)
             let refined ← isolations.mapM DyadicRootIsolation.toRefined?
             let comparable ← refined.mapM fun r =>
               (r.refineTo? (mahlerPrec a.p : Int)).unattach
@@ -270,7 +270,7 @@ def toAlgebraicNumber? [ZPoly.CheckedIrreducible p]
       if hdegree : 0 < q.natDegree then
         if hirred : ZPoly.isIrreducible q = true then
           if hsquarefree : HasOnlySimpleRoots q then do
-            let isolations ← isolate q hsquarefree (separationDepth q : Int)
+            let isolations ← isolate? q hsquarefree (separationDepth q : Int)
             let refined ← isolations.mapM DyadicRootIsolation.toRefined?
             let requested : Int := mahlerPrec q
             let target := requested + (approxGuardBits rep.1.square a.coeffs : Int)

--- a/HexNumberField/IntegerRoots.lean
+++ b/HexNumberField/IntegerRoots.lean
@@ -115,7 +115,7 @@ def algebraicRoots? (p : ZPoly) : Option (Array AlgebraicNumber) :=
       if hpos : 0 < q.leadingCoeff then
         if hdeg : 0 < q.natDegree then
           if hsimple : HasOnlySimpleRoots q then do
-            let isolations ← isolate q hsimple (separationDepth q : Int)
+            let isolations ← isolate? q hsimple (separationDepth q : Int)
             let refined ← isolations.mapM DyadicRootIsolation.toRefined?
             let roots ← refined.mapM fun rep =>
               (AlgebraicRoot.ofRefined q hprim hpos hdeg hsimple rep).exact?

--- a/HexNumberField/Lazy.lean
+++ b/HexNumberField/Lazy.lean
@@ -184,7 +184,7 @@ def ofEliminant? (raw : ZPoly)
         if hsimple : HasOnlySimpleRoots p then do
           let prec : Int := separationDepth p
           let ball ← ballAt prec
-          let isolations ← isolate p hsimple prec
+          let isolations ← isolate? p hsimple prec
           let refined ← isolations.mapM DyadicRootIsolation.toRefined?
           match refined.toList.filter fun r => r.1.square.meetsBall ball with
           | [matching] =>

--- a/HexNumberField/Roots.lean
+++ b/HexNumberField/Roots.lean
@@ -174,7 +174,7 @@ def componentRoots? [ZPoly.CheckedIrreducible p]
     if hpos : 0 < eliminant.leadingCoeff then
       if hdegree : 0 < eliminant.natDegree then
         if hsimple : HasOnlySimpleRoots eliminant then do
-          let isolations ← isolate eliminant hsimple (separationDepth eliminant : Int)
+          let isolations ← isolate? eliminant hsimple (separationDepth eliminant : Int)
           let refined ← isolations.mapM DyadicRootIsolation.toRefined?
           let evaluationEliminant := evalEliminant f eliminant
           refined.foldlM

--- a/HexNumberFieldMathlib/Basic.lean
+++ b/HexNumberFieldMathlib/Basic.lean
@@ -267,7 +267,7 @@ private theorem RefinedIsolation.eq_of_canonical {p : ZPoly}
         · simp at htoJ
       have hij : i = j := by
         by_contra hij
-        apply HexRootsMathlib.isolate_roots_ne p squarefree₁
+        apply HexRootsMathlib.isolate?_roots_ne p squarefree₁
           (separationDepth p : Int) .nkThenPellet hisolate hi hj hij
         rw [← hrawI, ← hrawJ]
         change HexRootsMathlib.DyadicRootIsolation.root r.1 =

--- a/HexNumberFieldMathlib/ComponentRoots.lean
+++ b/HexNumberFieldMathlib/ComponentRoots.lean
@@ -189,7 +189,7 @@ theorem componentRoots?_sound [ZPoly.CheckedIrreducible p]
       next hdegree =>
         split at hrun
         next hsimple =>
-          cases hisolate : isolate (ZPoly.squareFreeCore (normEliminant f))
+          cases hisolate : isolate? (ZPoly.squareFreeCore (normEliminant f))
               hsimple (separationDepth
                 (ZPoly.squareFreeCore (normEliminant f)) : Int) with
           | none => simp [hisolate] at hrun
@@ -285,7 +285,7 @@ theorem componentRoots?_complete [ZPoly.CheckedIrreducible p]
       next hdegree =>
         split at hrun
         next hsimple =>
-          cases hisolate : isolate (ZPoly.squareFreeCore (normEliminant f))
+          cases hisolate : isolate? (ZPoly.squareFreeCore (normEliminant f))
               hsimple (separationDepth
                 (ZPoly.squareFreeCore (normEliminant f)) : Int) with
           | none => simp [hisolate] at hrun
@@ -302,7 +302,7 @@ theorem componentRoots?_complete [ZPoly.CheckedIrreducible p]
                   simp only [Option.bind_some] at hrun
                   rw [← Array.foldlM_toList] at hrun
                   obtain ⟨iso, hiso, hisoRoot⟩ :=
-                    HexRootsMathlib.isolate_root_mem_of_pos
+                    HexRootsMathlib.isolate?_root_mem_of_pos
                       (ZPoly.squareFreeCore (normEliminant f)) hsimple
                       (separationDepth
                         (ZPoly.squareFreeCore (normEliminant f)) : Int)

--- a/HexNumberFieldMathlib/Exact.lean
+++ b/HexNumberFieldMathlib/Exact.lean
@@ -44,23 +44,23 @@ theorem ofNormalized?_isSome
       intro hp
       rw [hp] at pos_degree
       simp at pos_degree
-    have hisolate := HexRootsMathlib.isolate_isSome p squarefree hpne
+    have hisolate := HexRootsMathlib.isolate?_isSome p squarefree hpne
       (separationDepth p : Int) .nkThenPellet
-    cases hrun : isolate p squarefree (separationDepth p : Int) with
+    cases hrun : isolate? p squarefree (separationDepth p : Int) with
     | none => simp [hrun] at hisolate
     | some isolations =>
         have hmapSome := HexRootsMathlib.array_mapM_isSome
           (xs := isolations) (f := DyadicRootIsolation.toRefined?)
           (fun iso hiso => by
             unfold DyadicRootIsolation.toRefined?
-            rw [dite_eq_left (HexRootsMathlib.isolate_refined p squarefree
+            rw [dite_eq_left (HexRootsMathlib.isolate?_refined p squarefree
               (separationDepth p : Int) .nkThenPellet hrun iso hiso)]
             rfl)
         cases hmap : isolations.mapM DyadicRootIsolation.toRefined? with
         | none => simp [hmap] at hmapSome
         | some refined =>
             obtain ⟨iso, hiso, hisoRoot⟩ :=
-              HexRootsMathlib.isolate_root_mem_of_pos p squarefree
+              HexRootsMathlib.isolate?_root_mem_of_pos p squarefree
                 (separationDepth p : Int) .nkThenPellet pos_degree hrun
                 (HexRootsMathlib.RefinedIsolation.isRoot rep)
             obtain ⟨i, hiList, hidx⟩ := List.getElem_of_mem hiso
@@ -176,16 +176,16 @@ theorem exactFactor?_isSome (a : AlgebraicRoot) (q : ZPoly)
     intro hq
     rw [hq] at hdegree
     simp at hdegree
-  have hisolate := HexRootsMathlib.isolate_isSome q hsimple hqne
+  have hisolate := HexRootsMathlib.isolate?_isSome q hsimple hqne
     (separationDepth q : Int) .nkThenPellet
-  cases hrun : isolate q hsimple (separationDepth q : Int) with
+  cases hrun : isolate? q hsimple (separationDepth q : Int) with
   | none => simp [hrun] at hisolate
   | some isolations =>
       have hmapSome := HexRootsMathlib.array_mapM_isSome
         (xs := isolations) (f := DyadicRootIsolation.toRefined?)
         (fun iso hiso => by
           unfold DyadicRootIsolation.toRefined?
-          rw [dite_eq_left (HexRootsMathlib.isolate_refined q hsimple
+          rw [dite_eq_left (HexRootsMathlib.isolate?_refined q hsimple
             (separationDepth q : Int) .nkThenPellet hrun iso hiso)]
           rfl)
       cases hmap : isolations.mapM DyadicRootIsolation.toRefined? with
@@ -208,7 +208,7 @@ theorem exactFactor?_isSome (a : AlgebraicRoot) (q : ZPoly)
           | none => simp [hrefine] at hrefineSome
           | some comparable =>
               obtain ⟨iso, hiso, hisoRoot⟩ :=
-                HexRootsMathlib.isolate_root_mem_of_pos q hsimple
+                HexRootsMathlib.isolate?_root_mem_of_pos q hsimple
                   (separationDepth q : Int) .nkThenPellet hdegree hrun hroot
               obtain ⟨i, hiList, hidx⟩ := List.getElem_of_mem hiso
               have hi : i < isolations.size := by simpa using hiList
@@ -1231,16 +1231,16 @@ theorem toAlgebraicNumber?_isSome [ZPoly.CheckedIrreducible p]
         intro hzero
         rw [hzero] at hdegree
         simp at hdegree
-      have hisolate := HexRootsMathlib.isolate_isSome q hsimple hqne
+      have hisolate := HexRootsMathlib.isolate?_isSome q hsimple hqne
         (separationDepth q : Int) .nkThenPellet
-      cases hrun : isolate q hsimple (separationDepth q : Int) with
+      cases hrun : isolate? q hsimple (separationDepth q : Int) with
       | none => simp [hrun] at hisolate
       | some isolations =>
           have hmapSome := HexRootsMathlib.array_mapM_isSome
             (xs := isolations) (f := DyadicRootIsolation.toRefined?)
             (fun iso hiso => by
               unfold DyadicRootIsolation.toRefined?
-              rw [dite_eq_left (HexRootsMathlib.isolate_refined q hsimple
+              rw [dite_eq_left (HexRootsMathlib.isolate?_refined q hsimple
                 (separationDepth q : Int) .nkThenPellet hrun iso hiso)]
               rfl)
           cases hmap : isolations.mapM DyadicRootIsolation.toRefined? with
@@ -1262,7 +1262,7 @@ theorem toAlgebraicNumber?_isSome [ZPoly.CheckedIrreducible p]
                   Polynomial.eval_map]
                 exact hrootRat
               obtain ⟨iso, hiso, hisoRoot⟩ :=
-                HexRootsMathlib.isolate_root_mem_of_pos q hsimple
+                HexRootsMathlib.isolate?_root_mem_of_pos q hsimple
                   (separationDepth q : Int) .nkThenPellet hdegree hrun hroot
               obtain ⟨i, hiList, hidx⟩ := List.getElem_of_mem hiso
               have hi : i < isolations.size := by simpa using hiList

--- a/HexNumberFieldMathlib/IntegerRoots.lean
+++ b/HexNumberFieldMathlib/IntegerRoots.lean
@@ -56,7 +56,7 @@ private theorem algebraicRoots?_eq_of_pos (p : ZPoly)
     (hdeg : 0 < (ZPoly.squareFreeCore p).natDegree)
     (hsimple : HasOnlySimpleRoots (ZPoly.squareFreeCore p)) :
     ZPoly.algebraicRoots? p =
-      (isolate (ZPoly.squareFreeCore p) hsimple
+      (isolate? (ZPoly.squareFreeCore p) hsimple
           (separationDepth (ZPoly.squareFreeCore p) : Int)).bind fun isolations =>
         (isolations.mapM DyadicRootIsolation.toRefined?).bind fun refined =>
           (refined.mapM fun rep =>
@@ -98,14 +98,14 @@ theorem algebraicRoots?_isSome (p : ZPoly) : (ZPoly.algebraicRoots? p).isSome :=
       simp [hp]
     have hcne : ZPoly.squareFreeCore p ≠ 0 := ZPoly.squareFreeCore_ne_zero p hpne
     rw [algebraicRoots?_eq_of_pos p h0 hprim hpos hdeg hsimple]
-    have hisolateSome := isolate_isSome (ZPoly.squareFreeCore p) hsimple hcne
+    have hisolateSome := isolate?_isSome (ZPoly.squareFreeCore p) hsimple hcne
       (separationDepth (ZPoly.squareFreeCore p) : Int) .nkThenPellet
     obtain ⟨isolations, hisolate⟩ := Option.isSome_iff_exists.mp hisolateSome
     rw [hisolate, Option.bind_some]
     have hmapSome := array_mapM_isSome (xs := isolations)
       (f := DyadicRootIsolation.toRefined?) (fun iso hiso => by
         unfold DyadicRootIsolation.toRefined?
-        rw [dite_eq_left (isolate_refined (ZPoly.squareFreeCore p) hsimple
+        rw [dite_eq_left (isolate?_refined (ZPoly.squareFreeCore p) hsimple
           (separationDepth (ZPoly.squareFreeCore p) : Int) .nkThenPellet hisolate
           iso hiso)]
         rfl)
@@ -168,14 +168,14 @@ theorem mem_algebraicRoots_iff (p : ZPoly) (hp : p ≠ 0) (z : ℂ) :
     have hcne : ZPoly.squareFreeCore p ≠ 0 := ZPoly.squareFreeCore_ne_zero p hp
     have heq := algebraicRoots?_eq p
     rw [algebraicRoots?_eq_of_pos p h0 hprim hpos hdeg hsimple] at heq
-    have hisolateSome := isolate_isSome (ZPoly.squareFreeCore p) hsimple hcne
+    have hisolateSome := isolate?_isSome (ZPoly.squareFreeCore p) hsimple hcne
       (separationDepth (ZPoly.squareFreeCore p) : Int) .nkThenPellet
     obtain ⟨isolations, hisolate⟩ := Option.isSome_iff_exists.mp hisolateSome
     rw [hisolate, Option.bind_some] at heq
     have hmapSome := array_mapM_isSome (xs := isolations)
       (f := DyadicRootIsolation.toRefined?) (fun iso hiso => by
         unfold DyadicRootIsolation.toRefined?
-        rw [dite_eq_left (isolate_refined (ZPoly.squareFreeCore p) hsimple
+        rw [dite_eq_left (isolate?_refined (ZPoly.squareFreeCore p) hsimple
           (separationDepth (ZPoly.squareFreeCore p) : Int) .nkThenPellet hisolate
           iso hiso)]
         rfl)
@@ -222,7 +222,7 @@ theorem mem_algebraicRoots_iff (p : ZPoly) (hp : p ≠ 0) (z : ℂ) :
     · intro hz
       have hcoreRoot : (toPolyℂ (ZPoly.squareFreeCore p)).IsRoot z :=
         HexPolyZMathlib.isRoot_squareFreeCore hp hz
-      obtain ⟨iso, hiso, hisoRoot⟩ := isolate_root_mem_of_pos (ZPoly.squareFreeCore p)
+      obtain ⟨iso, hiso, hisoRoot⟩ := isolate?_root_mem_of_pos (ZPoly.squareFreeCore p)
         hsimple (separationDepth (ZPoly.squareFreeCore p) : Int) .nkThenPellet hdeg
         hisolate hcoreRoot
       obtain ⟨i, hi, hidx⟩ := List.mem_iff_getElem.mp hiso
@@ -255,14 +255,14 @@ theorem algebraicRoots_nodup (p : ZPoly) :
     have hcne : ZPoly.squareFreeCore p ≠ 0 := ZPoly.squareFreeCore_ne_zero p hpne
     have heq := algebraicRoots?_eq p
     rw [algebraicRoots?_eq_of_pos p h0 hprim hpos hdeg hsimple] at heq
-    have hisolateSome := isolate_isSome (ZPoly.squareFreeCore p) hsimple hcne
+    have hisolateSome := isolate?_isSome (ZPoly.squareFreeCore p) hsimple hcne
       (separationDepth (ZPoly.squareFreeCore p) : Int) .nkThenPellet
     obtain ⟨isolations, hisolate⟩ := Option.isSome_iff_exists.mp hisolateSome
     rw [hisolate, Option.bind_some] at heq
     have hmapSome := array_mapM_isSome (xs := isolations)
       (f := DyadicRootIsolation.toRefined?) (fun iso hiso => by
         unfold DyadicRootIsolation.toRefined?
-        rw [dite_eq_left (isolate_refined (ZPoly.squareFreeCore p) hsimple
+        rw [dite_eq_left (isolate?_refined (ZPoly.squareFreeCore p) hsimple
           (separationDepth (ZPoly.squareFreeCore p) : Int) .nkThenPellet hisolate
           iso hiso)]
         rfl)
@@ -304,7 +304,7 @@ theorem algebraicRoots_nodup (p : ZPoly) :
     have hj : j.1 < roots.size := by simp
     by_contra hne
     have hne' : i.1 ≠ j.1 := fun h => hne (Fin.ext h)
-    have hroot := isolate_roots_ne (ZPoly.squareFreeCore p) hsimple
+    have hroot := isolate?_roots_ne (ZPoly.squareFreeCore p) hsimple
       (separationDepth (ZPoly.squareFreeCore p) : Int) .nkThenPellet hisolate
       (i := i.1) (j := j.1) (by omega) (by omega) hne'
     have hij' : roots[i.1].toComplex = roots[j.1].toComplex := by

--- a/HexNumberFieldMathlib/Lazy.lean
+++ b/HexNumberFieldMathlib/Lazy.lean
@@ -897,7 +897,7 @@ theorem AlgebraicRoot.ofEliminant?_sound
                     simpa [p] using
                       HexPolyZMathlib.isRoot_squareFreeCore hrawne hroot
                   obtain ⟨iso, hiso, hisoRoot⟩ :=
-                    HexRootsMathlib.isolate_root_mem_of_pos p hsimple
+                    HexRootsMathlib.isolate?_root_mem_of_pos p hsimple
                       (separationDepth p : Int) .nkThenPellet hdegree
                       hisolate hpRoot
                   obtain ⟨i, hiList, hidx⟩ := List.getElem_of_mem hiso
@@ -982,10 +982,10 @@ theorem AlgebraicRoot.ofEliminant?_isSome
   dsimp only
   rw [dite_eq_left hprim, dite_eq_left hpos, dite_eq_left hdegree, dite_eq_left hsimple]
   rw [hballAt]
-  have hisolateSome := HexRootsMathlib.isolate_isSome
+  have hisolateSome := HexRootsMathlib.isolate?_isSome
     (ZPoly.squareFreeCore raw) hsimple hpne
     (separationDepth (ZPoly.squareFreeCore raw) : Int) .nkThenPellet
-  cases hisolate : isolate (ZPoly.squareFreeCore raw) hsimple
+  cases hisolate : isolate? (ZPoly.squareFreeCore raw) hsimple
       (separationDepth (ZPoly.squareFreeCore raw) : Int) with
   | none => simp [hisolate] at hisolateSome
   | some isolations =>
@@ -994,7 +994,7 @@ theorem AlgebraicRoot.ofEliminant?_isSome
         (xs := isolations) (f := DyadicRootIsolation.toRefined?)
         (fun iso hiso => by
           unfold DyadicRootIsolation.toRefined?
-          rw [dite_eq_left (HexRootsMathlib.isolate_refined
+          rw [dite_eq_left (HexRootsMathlib.isolate?_refined
             (ZPoly.squareFreeCore raw) hsimple
             (separationDepth (ZPoly.squareFreeCore raw) : Int)
             .nkThenPellet hisolate iso hiso)]
@@ -1027,7 +1027,7 @@ theorem AlgebraicRoot.ofEliminant?_isSome
               · exact (congrArg Subtype.val (Option.some.inj htoJ)).symm
               · simp at htoJ
             intro hroots
-            apply HexRootsMathlib.isolate_roots_ne
+            apply HexRootsMathlib.isolate?_roots_ne
               (ZPoly.squareFreeCore raw) hsimple
               (separationDepth (ZPoly.squareFreeCore raw) : Int)
               .nkThenPellet hisolate
@@ -1036,7 +1036,7 @@ theorem AlgebraicRoot.ofEliminant?_isSome
               HexRootsMathlib.DyadicRootIsolation.root refined[j].1 at hroots
             simpa [hrawI, hrawJ] using hroots
           obtain ⟨iso, hiso, hisoRoot⟩ :=
-            HexRootsMathlib.isolate_root_mem_of_pos
+            HexRootsMathlib.isolate?_root_mem_of_pos
               (ZPoly.squareFreeCore raw) hsimple
               (separationDepth (ZPoly.squareFreeCore raw) : Int)
               .nkThenPellet hdegree hisolate hpRoot

--- a/HexNumberFieldMathlib/Roots.lean
+++ b/HexNumberFieldMathlib/Roots.lean
@@ -272,9 +272,9 @@ theorem componentRoots?_isSome [ZPoly.CheckedIrreducible p]
   unfold componentRoots?
   dsimp only
   rw [dite_eq_left hprim, dite_eq_left hpos, dite_eq_left hdegree, dite_eq_left hsimple]
-  have hisolateSome := HexRootsMathlib.isolate_isSome eliminant hsimple
+  have hisolateSome := HexRootsMathlib.isolate?_isSome eliminant hsimple
     heliminant (separationDepth eliminant : Int) .nkThenPellet
-  cases hisolate : isolate eliminant hsimple
+  cases hisolate : isolate? eliminant hsimple
       (separationDepth eliminant : Int) with
   | none => simp [hisolate] at hisolateSome
   | some isolations =>
@@ -283,7 +283,7 @@ theorem componentRoots?_isSome [ZPoly.CheckedIrreducible p]
         (xs := isolations) (f := DyadicRootIsolation.toRefined?)
         (fun iso hiso => by
           unfold DyadicRootIsolation.toRefined?
-          rw [dite_eq_left (HexRootsMathlib.isolate_refined eliminant hsimple
+          rw [dite_eq_left (HexRootsMathlib.isolate?_refined eliminant hsimple
             (separationDepth eliminant : Int) .nkThenPellet
             hisolate iso hiso)]
           rfl)

--- a/HexNumberFieldTower/Split.lean
+++ b/HexNumberFieldTower/Split.lean
@@ -235,7 +235,7 @@ def factorRoot? {T : NumberTower} (f : Poly T) : Option AlgebraicRoot := do
     if hpos : 0 < p.leadingCoeff then
       if hdegree : 0 < p.natDegree then
         if hsimple : HasOnlySimpleRoots p then do
-          let isolations ← isolate p hsimple (separationDepth p : Int)
+          let isolations ← isolate? p hsimple (separationDepth p : Int)
           let refined ← isolations.mapM DyadicRootIsolation.toRefined?
           let candidates := refined.toList.map fun rep : RefinedIsolation p =>
             ({ p

--- a/HexNumberFieldTowerMathlib/Split.lean
+++ b/HexNumberFieldTowerMathlib/Split.lean
@@ -260,7 +260,7 @@ theorem factorRoot?_sound (T : NumberTower) (f : Poly T)
       next hdegree =>
         split at h
         next hsimple =>
-          cases hisolate : isolate (factorEliminant f) hsimple
+          cases hisolate : isolate? (factorEliminant f) hsimple
               (separationDepth (factorEliminant f) : Int) with
           | none => simp [hisolate] at h
           | some isolations =>
@@ -368,10 +368,10 @@ theorem factorRoot?_isSome (T : NumberTower) (f : Poly T)
   unfold factorRoot?
   dsimp only
   rw [dite_eq_left hprim, dite_eq_left hpos, dite_eq_left hdegree, dite_eq_left hsimple]
-  have hisolateSome := HexRootsMathlib.isolate_isSome
+  have hisolateSome := HexRootsMathlib.isolate?_isSome
     (factorEliminant f) hsimple hcoreNe
     (separationDepth (factorEliminant f) : Int) .nkThenPellet
-  cases hisolate : isolate (factorEliminant f) hsimple
+  cases hisolate : isolate? (factorEliminant f) hsimple
       (separationDepth (factorEliminant f) : Int) with
   | none => simp [hisolate] at hisolateSome
   | some isolations =>
@@ -380,7 +380,7 @@ theorem factorRoot?_isSome (T : NumberTower) (f : Poly T)
         (xs := isolations) (f := DyadicRootIsolation.toRefined?)
         (fun iso hiso => by
           unfold DyadicRootIsolation.toRefined?
-          rw [dite_eq_left (HexRootsMathlib.isolate_refined
+          rw [dite_eq_left (HexRootsMathlib.isolate?_refined
             (factorEliminant f) hsimple
             (separationDepth (factorEliminant f) : Int)
             .nkThenPellet hisolate iso hiso)]
@@ -391,7 +391,7 @@ theorem factorRoot?_isSome (T : NumberTower) (f : Poly T)
       | some refined =>
           simp only [Option.bind_some]
           obtain ⟨iso, hiso, hisoRoot⟩ :=
-            HexRootsMathlib.isolate_root_mem_of_pos
+            HexRootsMathlib.isolate?_root_mem_of_pos
               (factorEliminant f) hsimple
               (separationDepth (factorEliminant f) : Int)
               .nkThenPellet hdegree hisolate hcoreRoot

--- a/HexRCF/DecisionCheck.lean
+++ b/HexRCF/DecisionCheck.lean
@@ -32,7 +32,7 @@ private def rawIsolations {p : ZPoly} (roots : Hex.RealRootIsolations p) :
 /-- Run executable isolation, validate the raw intervals against the carrier's
 literal replay, and refine touching intervals to strict separation. -/
 def buildIsolations? (carrier : CarrierCert) : Option IsolationCert :=
-  match Hex.isolate? carrier.carrier with
+  match Hex.ZPoly.isolate? carrier.carrier with
   | none => none
   | some roots =>
       let raw := rawIsolations roots

--- a/HexRCF/SPEC/hex-rcf.md
+++ b/HexRCF/SPEC/hex-rcf.md
@@ -192,7 +192,7 @@ proved equivalences.
    lemma for `Q = P*R` with `R ∣ Q'`. Since `Q` is the atom product,
    these are exactly the union of the atom root sets.
 
-   Run `Hex.isolate? P`; the compiled builder knows this succeeds from
+   Run `Hex.ZPoly.isolate? P`; the compiled builder knows this succeeds from
    the squarefreeness theorem. If there are no nonconstant atoms, do
    not construct a carrier: the decomposition is the single cell `ℝ`
    and the sign matrix is the already-folded constant formula.
@@ -414,7 +414,7 @@ constant, gives alternating flanks at every interior zero, and the
 positive derivative seed gives the root flank. Consequently the
 literal cast chain satisfies `Sturm.IsSturmChain`; in particular `f`
 is squarefree. Its interval count is the variation difference of
-this literal chain, not a call to `sturmCount f`, and its total count
+this literal chain, not a call to `ZPoly.sturmCount f`, and its total count
 is the corresponding `−∞/+∞` difference. The proof factors through
 `Sturm.sturm_half_open` and `Sturm.sturm_line`. Constants are handled
 separately because the interval-count theorem requires positive
@@ -488,7 +488,7 @@ The certificate contains:
 
 These are generalized isolation records: they must not be presented
 as the current `RealRootIsolation P` / `RealRootIsolations P` types,
-whose fields are definitionally tied to the executable `sturmCount P`
+whose fields are definitionally tied to the executable `ZPoly.sturmCount P`
 and `sturmChain P`. Their semantic theorems parallel
 `RealRootIsolation.exists_unique_root` and
 `RealRootIsolations.isolates`, but consume the literal replay counts,

--- a/HexRealRoots/Cert.lean
+++ b/HexRealRoots/Cert.lean
@@ -179,8 +179,8 @@ any interval is the sign-variation gap of the *literal* certified chain at the
 two endpoints — the shape the elaborator `decide`s per emitted root. -/
 theorem sturmCount_eq_of_cert {p : ZPoly} {chain : Array ZPoly}
     (h : SturmChainCert p chain) (I : DyadicInterval) :
-    sturmCount p I = (sturmVarAt chain I.lower : Int) - sturmVarAt chain I.upper := by
-  unfold sturmCount
+    ZPoly.sturmCount p I = (sturmVarAt chain I.lower : Int) - sturmVarAt chain I.upper := by
+  unfold ZPoly.sturmCount
   rw [← cert_imp_eq h]
 
 /-- **Root-count transport.** Under a valid certificate, the total root count of
@@ -188,8 +188,8 @@ theorem sturmCount_eq_of_cert {p : ZPoly} {chain : Array ZPoly}
 the elaborator `decide`s for the `complete` field. -/
 theorem rootCount_eq_of_cert {p : ZPoly} {chain : Array ZPoly}
     (h : SturmChainCert p chain) :
-    rootCount p = sturmVarNegInf chain - sturmVarPosInf chain := by
-  unfold rootCount
+    ZPoly.rootCount p = sturmVarNegInf chain - sturmVarPosInf chain := by
+  unfold ZPoly.rootCount
   rw [← cert_imp_eq h]
 
 end ZPoly

--- a/HexRealRoots/Isolate.lean
+++ b/HexRealRoots/Isolate.lean
@@ -25,17 +25,17 @@ public section
 /-!
 The top-level real-root isolation driver.
 
-`isolate?` runs the two engines over the same output type: the fast
+`ZPoly.isolate?` runs the two engines over the same output type: the fast
 Descartes search first, falling back to the provably terminating Sturm
 search on its `none`. Both emit `RealRootIsolations p` — pairwise-disjoint,
 ordered, Sturm-count-certified isolations, one per real root — so the driver
 is a one-liner that keeps whichever engine's certified output arrives first.
 
-The companion `HexRealRootsMathlib` proves `isolate? p ≠ none` for squarefree
+The companion `HexRealRootsMathlib` proves `ZPoly.isolate? p ≠ none` for squarefree
 `p` (`isolate?_isSome`), routed through the Sturm engine's completeness
 (`isolateSturm?_isSome`); the Descartes engine's own completeness waits on the
 unformalised two-circle theorem and no driver-level fact depends on it.
-Downstream libraries that need a total function (hex-rcf) combine `isolate?`
+Downstream libraries that need a total function (hex-rcf) combine `ZPoly.isolate?`
 with `isolate?_isSome`.
 -/
 namespace Hex
@@ -46,25 +46,25 @@ certified `RealRootIsolations p`, so the result carries a full Sturm-count
 witness regardless of which one found it. Returns `none` only when both
 engines decline (e.g. non-squarefree input); the companion proves this never
 happens for squarefree `p`. -/
-def isolate? (p : ZPoly) : Option (RealRootIsolations p) :=
-  isolateDescartes? p <|> isolateSturm? p
+def ZPoly.isolate? (p : ZPoly) : Option (RealRootIsolations p) :=
+  ZPoly.isolateDescartes? p <|> ZPoly.isolateSturm? p
 
 /-! Sanity checks (kept light; conformance lives in the shared sub-project).
-Polynomials are kept tiny so kernel reduction of `isolate?` is fast; the
+Polynomials are kept tiny so kernel reduction of `ZPoly.isolate?` is fast; the
 higher-degree fixtures live in the `#eval`-driven conformance suite. -/
 
 -- The zero polynomial and constants classify as `none`/isolations-of-a-root
--- exactly as the engines do: `isolate?` inherits each engine's contract.
-example : isolate? (DensePoly.ofCoeffs (#[] : Array Int)) = none := by decide
-example : (isolate? (DensePoly.ofCoeffs #[(7 : Int)])).isSome = true := by decide
+-- exactly as the engines do: `ZPoly.isolate?` inherits each engine's contract.
+example : ZPoly.isolate? (DensePoly.ofCoeffs (#[] : Array Int)) = none := by decide
+example : (ZPoly.isolate? (DensePoly.ofCoeffs #[(7 : Int)])).isSome = true := by decide
 
 -- The positive-degree fixtures route through the Descartes engine's rational
 -- squarefree decision, which the kernel does not reduce across the module
 -- boundary (it goes through `ceilSqrt`), so they are exercised by `#eval` in
 -- the conformance suite rather than `decide` here. Representative results:
---   `isolate? (x − 5)`        ⇒ `some`, 1 isolation
---   `isolate? (x² − 1)`       ⇒ `some`, 2 isolations
---   `isolate? (x² + 1)`       ⇒ `some`, 0 isolations
---   `isolate? ((x−1)²(x+1))`  ⇒ `none` (not squarefree; both engines decline)
+--   `ZPoly.isolate? (x − 5)`        ⇒ `some`, 1 isolation
+--   `ZPoly.isolate? (x² − 1)`       ⇒ `some`, 2 isolations
+--   `ZPoly.isolate? (x² + 1)`       ⇒ `some`, 0 isolations
+--   `ZPoly.isolate? ((x−1)²(x+1))`  ⇒ `none` (not squarefree; both engines decline)
 
 end Hex

--- a/HexRealRoots/IsolateDescartes.lean
+++ b/HexRealRoots/IsolateDescartes.lean
@@ -23,7 +23,7 @@ public section
 /-!
 The Descartes isolation engine.
 
-`isolateDescartes?` runs the same bisection search as `isolateSturm?`, but
+`ZPoly.isolateDescartes?` runs the same bisection search as `ZPoly.isolateSturm?`, but
 dispatches each sub-interval on the Descartes variation count
 `V := descartesVar (mobiusTransform p (a, b])` together with the exact test
 `p(b) = 0`:
@@ -47,7 +47,7 @@ the correctness.
 
 The per-node cost is one Möbius transform (`O(n²)` integer operations via
 Taylor shift) versus the Sturm engine's full chain evaluation, which is why
-this engine runs first in `isolate?`. The deferred companion theorem
+this engine runs first in `ZPoly.isolate?`. The deferred companion theorem
 `isolateDescartes?_isSome` (the Obreshkoff two-circle theorem;
 Krandick–Mehlhorn 2006) says none of the `none` outcomes happen for
 square-free input at this depth budget — in particular a non-real conjugate
@@ -75,7 +75,7 @@ Per node, with `V` the variation count and `bZero := (p(hi) = 0)`:
 - `V = 0`, `bZero`, or `V = 1`, `¬ bZero`: candidate — certify by the exact
   Sturm count `(sturmVarAt chain lo) − sturmVarAt chain hi`. If it is `1` emit
   the isolation (`subst hchain` turns the memoised-chain difference into
-  `sturmCount p (lo, hi] = 1` definitionally); otherwise return `none`, which
+  `ZPoly.sturmCount p (lo, hi] = 1` definitionally); otherwise return `none`, which
   aborts the engine;
 - `V = 1`, `bZero`, or `V ≥ 2`: bisect. Match `depth`: `0` returns `none` (the
   fuel discipline), `d + 1` recurses left then right at the dyadic midpoint.
@@ -122,11 +122,11 @@ private def descartesVisit (p : ZPoly) (chain : Array ZPoly)
 
 /-- The Descartes isolation engine.
 
-`isolateDescartes?` classifies its input exactly as `isolateSturm?` does:
+`ZPoly.isolateDescartes?` classifies its input exactly as `ZPoly.isolateSturm?` does:
 
 - `p = 0` (`degree? = none`): `none`.
 - `p` a nonzero constant (`degree? = some 0`): `some` with an empty isolation
-  array, matching `rootCount p = 0`. `assemble?` certifies completeness (the
+  array, matching `ZPoly.rootCount p = 0`. `assemble?` certifies completeness (the
   chain is empty, so `sturmVarNegInf − sturmVarPosInf = 0`).
 - `p` of positive degree that is not `SquareFreeRat`: `none`. Callers use
   `Hex.ZPoly.squareFreeCore` to obtain a square-free representative first.
@@ -138,13 +138,13 @@ The engine trusts Descartes' rule for nothing; it is a search heuristic
 wrapped in Sturm certificates. A `none` on square-free positive-degree input
 means a candidate's Sturm count was not `1`,
 an interval bisected past the depth budget, or the emitted total disagreed
-with `rootCount p`. The deferred companion theorem `isolateDescartes?_isSome`
+with `ZPoly.rootCount p`. The deferred companion theorem `isolateDescartes?_isSome`
 (the Obreshkoff two-circle theorem) says none of them happen for square-free
 input at this budget, so the driver's completeness — established through the
 Sturm engine — never waits on it. The per-node cost is one `O(n²)` Möbius
 transform against the Sturm engine's full chain evaluation, which is why this
-engine runs first in `isolate?`. -/
-def isolateDescartes? (p : ZPoly) : Option (RealRootIsolations p) :=
+engine runs first in `ZPoly.isolate?`. -/
+def ZPoly.isolateDescartes? (p : ZPoly) : Option (RealRootIsolations p) :=
   match p.degree? with
   | none => none
   | some 0 => assemble? p (ZPoly.sturmChain p) rfl #[]
@@ -164,29 +164,29 @@ The zero and nonzero-constant cases `decide` in the kernel: neither reaches
 the `SquareFreeRat` test or a Möbius transform. The positive-degree
 square-free cases do reach the `SquareFreeRat` rational gcd (well-founded
 recursion the kernel cannot reduce), so they are verified by `#eval` and their
-results recorded below. Each is cross-checked against `isolateSturm?`: the two
+results recorded below. Each is cross-checked against `ZPoly.isolateSturm?`: the two
 engines must agree on the isolation count (the intervals need not coincide). -/
 
 -- The zero polynomial is rejected (no `SquareFreeRat` test on this branch).
-example : isolateDescartes? (DensePoly.ofCoeffs (#[] : Array Int)) = none := by decide
+example : ZPoly.isolateDescartes? (DensePoly.ofCoeffs (#[] : Array Int)) = none := by decide
 
--- A nonzero constant isolates with zero roots (empty chain, `rootCount = 0`;
+-- A nonzero constant isolates with zero roots (empty chain, `ZPoly.rootCount = 0`;
 -- no `SquareFreeRat` test on this branch).
-example : (isolateDescartes? (DensePoly.ofCoeffs #[(7 : Int)])).isSome = true := by decide
+example : (ZPoly.isolateDescartes? (DensePoly.ofCoeffs #[(7 : Int)])).isSome = true := by decide
 
 -- Positive-degree square-free cases (verified by `#eval`, not `decide`, since
 -- `SquareFreeRat`'s rational gcd is well-founded and does not reduce in the
 -- kernel). Each line records the observed isolation count and confirms it
--- matches `isolateSturm?` on the same input:
---   `isolateDescartes? (x − 5)`      ⇒ `some`, 1 isolation   (Sturm: 1)
---   `isolateDescartes? (x² − 1)`     ⇒ `some`, 2 isolations  (Sturm: 2)
---   `isolateDescartes? (x² + 1)`     ⇒ `some`, 0 isolations  (Sturm: 0)
---   `isolateDescartes? (x³ − x)`     ⇒ `some`, 3 isolations, increasing (Sturm: 3)
---   `isolateDescartes? ((x−1)²(x+1))` ⇒ `none` (not square-free)  (Sturm: none)
---   `isolateDescartes? (2x² − 5x + 2)` ⇒ `some`, 2 isolations  (Sturm: 2)
+-- matches `ZPoly.isolateSturm?` on the same input:
+--   `ZPoly.isolateDescartes? (x − 5)`      ⇒ `some`, 1 isolation   (Sturm: 1)
+--   `ZPoly.isolateDescartes? (x² − 1)`     ⇒ `some`, 2 isolations  (Sturm: 2)
+--   `ZPoly.isolateDescartes? (x² + 1)`     ⇒ `some`, 0 isolations  (Sturm: 0)
+--   `ZPoly.isolateDescartes? (x³ − x)`     ⇒ `some`, 3 isolations, increasing (Sturm: 3)
+--   `ZPoly.isolateDescartes? ((x−1)²(x+1))` ⇒ `none` (not square-free)  (Sturm: none)
+--   `ZPoly.isolateDescartes? (2x² − 5x + 2)` ⇒ `some`, 2 isolations  (Sturm: 2)
 --       — roots `1/2` and `2`; bisection midpoints hit the root `2` exactly,
 --         exercising the `V = 0`-with-`p(b) = 0` candidate row.
---   `isolateDescartes? (x² − x)`     ⇒ `some`, 2 isolations  (Sturm: 2)
+--   `ZPoly.isolateDescartes? (x² − x)`     ⇒ `some`, 2 isolations  (Sturm: 2)
 --       — roots `0` and `1`, both dyadic; adjacent isolations may share an
 --         endpoint (still disjoint, half-open on the left).
 

--- a/HexRealRoots/IsolateSturm.lean
+++ b/HexRealRoots/IsolateSturm.lean
@@ -22,7 +22,7 @@ public section
 /-!
 The Sturm isolation engine.
 
-`isolateSturm?` bisects the initial interval `(−rootBound p, rootBound p]`,
+`ZPoly.isolateSturm?` bisects the initial interval `(−rootBound p, rootBound p]`,
 dispatching on the exact Sturm count of each sub-interval: count `0` is
 discarded, count `1` is emitted as a `RealRootIsolation` (the count is the
 witness), and count `≥ 2` bisects at the dyadic midpoint until the depth
@@ -34,7 +34,7 @@ is built once per polynomial, and every endpoint's `sturmVarAt` count is
 computed once and reused in both child intervals of a bisection. The witness
 of an emitted root re-evaluates the two endpoints against the memoised chain
 exactly once per emission (at most `deg p` times over a whole run), which is
-the honesty price of certifying each isolation's `sturmCount = 1` directly.
+the honesty price of certifying each isolation's `ZPoly.sturmCount = 1` directly.
 
 Everything is exact integer and dyadic arithmetic. The only rational
 computation is the `SquareFreeRat` input test, which classifies whether a
@@ -51,7 +51,7 @@ interval is `vlo − vhi`, so the dispatch reads off the two memoised counts:
 - `vlo = vhi` (count `0`): no root here, emit nothing;
 - `vlo = vhi + 1` (count `1`): emit the single isolation. The witness
   re-evaluates the two endpoints against `chain` once; `subst hchain` turns
-  the memoised-chain difference into `sturmCount p (lo, hi] = 1`
+  the memoised-chain difference into `ZPoly.sturmCount p (lo, hi] = 1`
   definitionally, so no chain construction is repeated per emission;
 - otherwise (count `≥ 2` on honest data, or negative on junk): if the depth
   budget is exhausted return `none`, else bisect
@@ -91,11 +91,11 @@ private def sturmVisit (p : ZPoly) (chain : Array ZPoly)
 
 /-- The Sturm isolation engine.
 
-`isolateSturm?` classifies its input explicitly:
+`ZPoly.isolateSturm?` classifies its input explicitly:
 
 - `p = 0` (`degree? = none`): `none`.
 - `p` a nonzero constant (`degree? = some 0`): `some` with an empty isolation
-  array, matching `rootCount p = 0`. `assemble?` certifies completeness (the
+  array, matching `ZPoly.rootCount p = 0`. `assemble?` certifies completeness (the
   chain is empty, so `sturmVarNegInf − sturmVarPosInf = 0`).
 - `p` of positive degree that is not `SquareFreeRat`: `none`. Callers use
   `Hex.ZPoly.squareFreeCore` to obtain a square-free representative first.
@@ -106,10 +106,10 @@ private def sturmVisit (p : ZPoly) (chain : Array ZPoly)
 
 A `none` from this engine on square-free positive-degree input has one precise
 meaning: an interval at separation depth still reported two or more roots, or
-the emitted total disagreed with `rootCount p`. The companion proves both
+the emitted total disagreed with `ZPoly.rootCount p`. The companion proves both
 impossible for square-free input (`isolateSturm?_isSome`), so on that input
 the engine is total in the sense that matters. -/
-def isolateSturm? (p : ZPoly) : Option (RealRootIsolations p) :=
+def ZPoly.isolateSturm? (p : ZPoly) : Option (RealRootIsolations p) :=
   match p.degree? with
   | none => none
   | some 0 => assemble? p (ZPoly.sturmChain p) rfl #[]
@@ -137,24 +137,24 @@ They are verified by `#eval` instead (the compiled interpreter reduces the
 well-founded gcd fine); the observed results are recorded in the comments. -/
 
 -- The zero polynomial is rejected (no `SquareFreeRat` test on this branch).
-example : isolateSturm? (DensePoly.ofCoeffs (#[] : Array Int)) = none := by decide
+example : ZPoly.isolateSturm? (DensePoly.ofCoeffs (#[] : Array Int)) = none := by decide
 
--- A nonzero constant isolates with zero roots (empty chain, `rootCount = 0`;
+-- A nonzero constant isolates with zero roots (empty chain, `ZPoly.rootCount = 0`;
 -- no `SquareFreeRat` test on this branch).
-example : (isolateSturm? (DensePoly.ofCoeffs #[(7 : Int)])).isSome = true := by decide
+example : (ZPoly.isolateSturm? (DensePoly.ofCoeffs #[(7 : Int)])).isSome = true := by decide
 
 -- Positive-degree square-free cases (verified by `#eval`, not `decide`, since
 -- `SquareFreeRat`'s rational gcd is well-founded and does not reduce in the
 -- kernel):
---   `isolateSturm? (x − 5)`  ⇒ `some` with 1 isolation `(−8, 8]` (which
+--   `ZPoly.isolateSturm? (x − 5)`  ⇒ `some` with 1 isolation `(−8, 8]` (which
 --                              contains the root `5`; the whole initial
 --                              interval already has Sturm count `1`).
---   `isolateSturm? (x² − 1)` ⇒ `some` with 2 isolations `(−4, 0]`, `(0, 4]`,
+--   `ZPoly.isolateSturm? (x² − 1)` ⇒ `some` with 2 isolations `(−4, 0]`, `(0, 4]`,
 --                              in increasing order (roots `−1`, `1`).
---   `isolateSturm? (x² + 1)` ⇒ `some` with 0 isolations (no real roots).
---   `isolateSturm? (x³ − x)` ⇒ `some` with 3 isolations `(−2, −1]`, `(−1, 0]`,
+--   `ZPoly.isolateSturm? (x² + 1)` ⇒ `some` with 0 isolations (no real roots).
+--   `ZPoly.isolateSturm? (x³ − x)` ⇒ `some` with 3 isolations `(−2, −1]`, `(−1, 0]`,
 --                              `(0, 4]` (roots `−1`, `0`, `1`).
 -- The non-square-free `(x − 1)²(x + 1) = x³ − x² − x + 1` is rejected:
---   `isolateSturm? (ofCoeffs #[1, -1, -1, 1]) = none`.
+--   `ZPoly.isolateSturm? (ofCoeffs #[1, -1, -1, 1]) = none`.
 
 end Hex

--- a/HexRealRoots/README.md
+++ b/HexRealRoots/README.md
@@ -26,19 +26,19 @@ open Hex
 
 def p : ZPoly := DensePoly.ofCoeffs #[-2, 0, 0, 0, 1]
 
-#eval (isolate? p).map (fun roots => roots.isolations.size)
+#eval (ZPoly.isolate? p).map (fun roots => roots.isolations.size)
 ```
 
 # Functionality
 
-- `Hex.isolate?` tries the Descartes search first and falls back to Sturm.
-- `Hex.isolateSturm?` runs direct Sturm bisection.
-- `Hex.isolateDescartes?` runs only the Descartes search, while still
+- `Hex.ZPoly.isolate?` tries the Descartes search first and falls back to Sturm.
+- `Hex.ZPoly.isolateSturm?` runs direct Sturm bisection.
+- `Hex.ZPoly.isolateDescartes?` runs only the Descartes search, while still
   certifying every emitted interval with Sturm.
-- `Hex.rootCount` computes the exact total real-root count.
-- `Hex.sturmCount` computes the exact count in one half-open interval.
+- `Hex.ZPoly.rootCount` computes the exact total real-root count.
+- `Hex.ZPoly.sturmCount` computes the exact count in one half-open interval.
 
-`isolate?` rejects the zero polynomial and, at the core level, expects a
+`ZPoly.isolate?` rejects the zero polynomial and, at the core level, expects a
 squarefree positive-degree input. Nonzero constants produce an empty result.
 The Mathlib bridge's `isolate_roots` elaborator automatically passes through
 the squarefree core, so end users normally do not manage repeated roots

--- a/HexRealRoots/Refine.lean
+++ b/HexRealRoots/Refine.lean
@@ -44,7 +44,7 @@ precomputed Sturm chain and a proof that its endpoint sign-variation gap is
 `1`, reusing the caller's already-built `chain` so the Sturm count is not
 recomputed. The `hchain : chain = ZPoly.sturmChain p` equality (passed as
 `rfl` when `chain` is let-bound to `ZPoly.sturmChain p`) identifies the gap
-`h` with `sturmCount p (lower, upper]` without rebuilding the chain — the
+`h` with `ZPoly.sturmCount p (lower, upper]` without rebuilding the chain — the
 same memoisation discipline as `assemble?`. -/
 private def ofHalf (chain : Array ZPoly) (hchain : chain = ZPoly.sturmChain p)
     (lower upper : Dyadic) (hlt : lower < upper)
@@ -60,7 +60,7 @@ midpoint `m` is `(lower + upper) / 2` computed exactly, so a genuine interval
 always splits into two nonempty halves. The left half `(lower, m]` is tried
 first — its Sturm count is `sturmVarAt chain lower − sturmVarAt chain m`,
 phrased directly on the let-bound `chain` so the chain is built once, never
-per `sturmCount`. If the left count is `1` it certifies; otherwise the right
+per `ZPoly.sturmCount`. If the left count is `1` it certifies; otherwise the right
 half `(m, upper]` is tried the same way. The half-open convention means a root
 exactly at `m` lands in the left half `(lower, m]` and its count is `1` there,
 so no endpoint comparison against `m` is ever needed.

--- a/HexRealRoots/ReplayTest.lean
+++ b/HexRealRoots/ReplayTest.lean
@@ -8,8 +8,8 @@ module
 
 -- PLAIN `public import` only: NO `import all`. This module is the regression
 -- lock for the `@[expose]` kernel-replay closure. Every `decide` below must
--- reduce in the kernel through the exposed bodies of `sturmChain`, `sturmCount`,
--- `rootCount`, `hasSquarefreeSturmChain`, `SturmChainCert`, and `orderedAdjacent`
+-- reduce in the kernel through the exposed bodies of `sturmChain`, `ZPoly.sturmCount`,
+-- `ZPoly.rootCount`, `hasSquarefreeSturmChain`, `SturmChainCert`, and `orderedAdjacent`
 -- alone. If a future edit drops an `@[expose]` (or reintroduces a `private` in
 -- the closure), one of these `decide`s stops reducing and this module fails —
 -- surfacing the regression that a downstream `module` consumer would hit.
@@ -30,14 +30,14 @@ namespace Hex.ReplayTest
 example : ZPoly.hasSquarefreeSturmChain (DensePoly.ofCoeffs #[(-1 : Int), 0, 1]) := by
   decide
 
-/-- A `sturmCount` value: `x² − 1` has one root in `(0, 2]` (the root at `1`).
+/-- A `ZPoly.sturmCount` value: `x² − 1` has one root in `(0, 2]` (the root at `1`).
 Reduces without `import all`, unlike the same check stated in `Var.lean`. -/
-example : sturmCount (DensePoly.ofCoeffs #[(-1 : Int), 0, 1])
+example : ZPoly.sturmCount (DensePoly.ofCoeffs #[(-1 : Int), 0, 1])
     (DyadicInterval.mk (Dyadic.ofInt 0) (Dyadic.ofInt 2) (by decide)) = 1 := by
   decide
 
-/-- A `rootCount` value: `x² − 1` has two real roots. -/
-example : rootCount (DensePoly.ofCoeffs #[(-1 : Int), 0, 1]) = 2 := by
+/-- A `ZPoly.rootCount` value: `x² − 1` has two real roots. -/
+example : ZPoly.rootCount (DensePoly.ofCoeffs #[(-1 : Int), 0, 1]) = 2 := by
   decide
 
 /-- A `SturmChainCert` instance: the literal chain `[x² − 1, x, 1]` is certified
@@ -51,7 +51,7 @@ example : SturmChainCert (DensePoly.ofCoeffs #[(-1 : Int), 0, 1])
 
 /-- An `orderedAdjacent` check on literal isolation data: the two isolations of
 `x² − 1`, `(−2, 0]` and `(0, 2]`, are adjacent-ordered (`0 ≤ 0`). The `count_one`
-witnesses also reduce through the exposed `sturmCount`. -/
+witnesses also reduce through the exposed `ZPoly.sturmCount`. -/
 example : orderedAdjacent (p := DensePoly.ofCoeffs #[(-1 : Int), 0, 1])
     #[⟨DyadicInterval.mk (Dyadic.ofInt (-2)) (Dyadic.ofInt 0) (by decide), by decide⟩,
       ⟨DyadicInterval.mk (Dyadic.ofInt 0) (Dyadic.ofInt 2) (by decide), by decide⟩] = true := by

--- a/HexRealRoots/SPEC/hex-real-roots.md
+++ b/HexRealRoots/SPEC/hex-real-roots.md
@@ -84,7 +84,7 @@ every input explicitly:
 - `p = 0`: `none`. (`SquareFreeRat 0` holds vacuously through the
   gcd size test, so the drivers check `p ≠ 0` separately.)
 - `p` a nonzero constant: `some` with an empty isolation array,
-  matching `rootCount p = 0`.
+  matching `ZPoly.rootCount p = 0`.
 - `p` of positive degree, not `SquareFreeRat`: `none`. Callers use
   `Hex.ZPoly.squareFreeCore` first.
 - `p` of positive degree and squarefree: complete isolation.
@@ -109,11 +109,11 @@ def sturmVarPosInf (chain : Array ZPoly) : Nat
     certified by the Sturm chain. An `Int` by definition. The
     companion proves it equals the root count (in particular, that it
     is nonnegative) for squarefree `p`. -/
-def sturmCount (p : ZPoly) (I : DyadicInterval) : Int :=
+def ZPoly.sturmCount (p : ZPoly) (I : DyadicInterval) : Int :=
   sturmVarAt (sturmChain p) I.lower − sturmVarAt (sturmChain p) I.upper
 
 /-- The total number of real roots of `p`. -/
-def rootCount (p : ZPoly) : Nat :=
+def ZPoly.rootCount (p : ZPoly) : Nat :=
   sturmVarNegInf (sturmChain p) − sturmVarPosInf (sturmChain p)
 ```
 
@@ -140,7 +140,7 @@ structure DyadicInterval where
     interval.upper]`. -/
 structure RealRootIsolation (p : ZPoly) where
   interval  : DyadicInterval
-  count_one : sturmCount p interval = 1
+  count_one : ZPoly.sturmCount p interval = 1
 
 /-- A complete isolation run: pairwise-disjoint isolations, in
     increasing order, one per real root of `p`. Both invariants are
@@ -151,7 +151,7 @@ structure RealRootIsolations (p : ZPoly) where
   ordered    : ∀ i j : Fin isolations.size, i < j →
                  isolations[i].interval.upper ≤
                    isolations[j].interval.lower
-  complete   : isolations.size = rootCount p
+  complete   : isolations.size = ZPoly.rootCount p
 
 end Hex
 ```
@@ -160,7 +160,7 @@ end Hex
 that touch at an endpoint are still disjoint as sets. `complete` is
 the completeness certificate: `count_one` puts exactly one root in
 each interval, the intervals are disjoint, and there are exactly
-`rootCount p` of them, so every real root is captured. The companion
+`ZPoly.rootCount p` of them, so every real root is captured. The companion
 turns these three decidable facts, under `SquareFreeRat p`, into the
 semantic statement. No theorem about either search engine is
 involved.
@@ -201,7 +201,7 @@ subdividing an interval the moment its count resolves.
 ## The Sturm engine
 
 ```lean
-def isolateSturm? (p : ZPoly) : Option (RealRootIsolations p)
+def ZPoly.isolateSturm? (p : ZPoly) : Option (RealRootIsolations p)
 ```
 
 Worklist bisection from `(−rootBound p, rootBound p]`. For each
@@ -217,7 +217,7 @@ increasing order and check `complete` (via `if h : _`). A failed
 check also returns `none`. A `none` from this engine has one precise
 meaning: an interval at separation depth still reported two or more
 roots, or the totals disagreed. The companion proves both impossible
-for squarefree input, so `isolateSturm?` is total in the sense that
+for squarefree input, so `ZPoly.isolateSturm?` is total in the sense that
 matters. The `Option` is the same fuel discipline as hex-roots'
 drivers.
 
@@ -234,7 +234,7 @@ def mobiusTransform (p : ZPoly) (I : DyadicInterval) : ZPoly
 /-- Sign variations of the coefficient list. -/
 def descartesVar (p : ZPoly) : Nat
 
-def isolateDescartes? (p : ZPoly) : Option (RealRootIsolations p)
+def ZPoly.isolateDescartes? (p : ZPoly) : Option (RealRootIsolations p)
 ```
 
 The search runs the same worklist, dispatching on
@@ -267,13 +267,13 @@ evaluation, which is why this engine runs first.
 ## The driver
 
 ```lean
-def isolate? (p : ZPoly) : Option (RealRootIsolations p) :=
-  isolateDescartes? p <|> isolateSturm? p
+def ZPoly.isolate? (p : ZPoly) : Option (RealRootIsolations p) :=
+  ZPoly.isolateDescartes? p <|> ZPoly.isolateSturm? p
 ```
 
-The companion proves `isolate? p ≠ none` for squarefree `p` (through
+The companion proves `ZPoly.isolate? p ≠ none` for squarefree `p` (through
 the Sturm engine). Downstream libraries that need a total function
-(hex-rcf) obtain one by combining `isolate?` with that theorem.
+(hex-rcf) obtain one by combining `ZPoly.isolate?` with that theorem.
 
 ## Termination
 
@@ -290,7 +290,7 @@ is required. What the depth budget *suffices for* differs:
   Obreshkoff two-circle theorem; Krandick-Mehlhorn 2006) shows that
   once an interval's width is below a constant multiple of `sep(p)`
   (the minimum distance between distinct complex roots), its
-  variation count is `0` or `1`, so `isolateDescartes? p ≠ none` for
+  variation count is `0` or `1`, so `ZPoly.isolateDescartes? p ≠ none` for
   squarefree `p` at this depth. The mechanism is the *λ-graded* sector
   bound (not a general count bound — the reading "variation count ≤
   number of roots in the two-circle region" is false): at most `λ`
@@ -351,7 +351,7 @@ The `isolate_roots` term elaborator (companion SPEC) replays Sturm
 certificates in the kernel. The replayed closure — thirteen
 definitions: `sturmChain`, `sturmChainAux`, `spem`, `spemAux`,
 `spemStep`, `signVar`, `sturmVarAt`, `sturmVarNegInf`,
-`sturmVarPosInf`, `sturmCount`, `rootCount`, `ZPoly.evalDyadic`,
+`sturmVarPosInf`, `ZPoly.sturmCount`, `ZPoly.rootCount`, `ZPoly.evalDyadic`,
 `dyadicSign` — carries `@[expose]` so downstream `module` consumers
 can `decide` against it without `import all`, and the three private
 helpers (`spemStep`, `spemAux`, `sturmChainAux`) become public (an
@@ -448,7 +448,7 @@ re-refine from a stored coarse representative. See
   evaluation, sign helper.
 - `HexRealRoots/Chain.lean`: `spem`, `sturmChain`.
 - `HexRealRoots/Var.lean`: `signVar`, `sturmVarAt`, the `±∞`
-  variants, `sturmCount`, `rootCount`, `RealRootIsolation`,
+  variants, `ZPoly.sturmCount`, `ZPoly.rootCount`, `RealRootIsolation`,
   `RealRootIsolations`.
 - `HexRealRoots/Prec.lean`: `sepPrec`, `isolationDepth`,
   `rootBound`.
@@ -456,7 +456,7 @@ re-refine from a stored coarse representative. See
   `descartesVar`.
 - `HexRealRoots/IsolateSturm.lean`: the Sturm engine.
 - `HexRealRoots/IsolateDescartes.lean`: the Descartes engine.
-- `HexRealRoots/Isolate.lean`: `isolate?`.
+- `HexRealRoots/Isolate.lean`: `ZPoly.isolate?`.
 - `HexRealRoots/Refine.lean`: `refine1`, `refineTo`.
 - `HexRealRoots/SimpleRealRoot.lean`: `RefinedRealIsolation`,
   `Overlaps`, `SimpleRealRoot`, `sameRoot`; the threading-pattern
@@ -495,16 +495,16 @@ python-flint (`fmpz_poly` real root API), FLINT/Arb.
 
 **Descartes-engine checks (retired).** While
 `isolateDescartes?_isSome` was open, the conformance suite asserted on
-every fixture that `isolateDescartes?` returns `some` and agrees with
-`isolate?`, standing in for the theorem. Now that
+every fixture that `ZPoly.isolateDescartes?` returns `some` and agrees with
+`ZPoly.isolate?`, standing in for the theorem. Now that
 `isolateDescartes?_isSome` is proven in the companion, those stand-ins
 are retired: the theorem carries the claim, and re-testing it per
 fixture is noise. The suite keeps only the ordinary input-contract
-checks — the `isolateDescartes? = none` rejection of the zero and
+checks — the `ZPoly.isolateDescartes? = none` rejection of the zero and
 non-squarefree inputs (which test the engine's classification of
 inadmissible input, not the termination theorem) — and the executable
 `mobiusTransform`/`descartesVar` transform tests. `EmitFixtures` emits
-from `isolate?` alone; the cross-engine agreement check it once carried
+from `ZPoly.isolate?` alone; the cross-engine agreement check it once carried
 is removed with the same change.
 
 ## Complexity contract
@@ -518,7 +518,7 @@ Write `n = deg p` and `h = log ‖p‖∞`.
   `O(n²)` dyadic operations per queried point, memoised per endpoint.
 - `mobiusTransform`: `O(n²)` integer operations per node.
 - `sepPrec p`, `rootBound p`: `O(n · h)` integer operations.
-- `isolate?`: the bisection tree has `O(n)` unresolved intervals per
+- `ZPoly.isolate?`: the bisection tree has `O(n)` unresolved intervals per
   level and depth at most `isolationDepth p = O(n·(h + log n))`, so
   `O(n² · (h + log n))` Möbius transforms in the worst case,
   dominated by Mignotte-style clustered inputs. Mignotte inputs

--- a/HexRealRoots/Var.lean
+++ b/HexRealRoots/Var.lean
@@ -27,13 +27,13 @@ the numeric heart of both root-counting engines — the Sturm counts here and
 the Descartes count in the Mobius layer both reduce to `signVar` of a list
 of exact signs.
 
-The Sturm counts turn `signVar` into a certificate: `sturmCount p (l, u]` is
+The Sturm counts turn `signVar` into a certificate: `ZPoly.sturmCount p (l, u]` is
 the sign-variation difference of `p`'s Sturm chain at the two dyadic
 endpoints, which counts the real roots in the half-open interval `(l, u]`
-exactly, and `rootCount p` is the same difference between `−∞` and `+∞`. A
+exactly, and `ZPoly.rootCount p` is the same difference between `−∞` and `+∞`. A
 `RealRootIsolation` bundles an interval with a `decide`-checkable proof that
 its Sturm count is `1`; a `RealRootIsolations` bundles an ordered,
-pairwise-disjoint array of them whose size matches `rootCount p`, which is
+pairwise-disjoint array of them whose size matches `ZPoly.rootCount p`, which is
 the completeness certificate the companion turns into the semantic
 statement. Everything here is exact integer or dyadic arithmetic: no floats,
 no error budget.
@@ -95,14 +95,14 @@ difference between the two endpoints. An `Int` by definition. The companion
 proves it equals the root count in the interval (in particular, that it is
 nonnegative) for squarefree `p`. -/
 @[expose]
-def sturmCount (p : ZPoly) (I : DyadicInterval) : Int :=
+def ZPoly.sturmCount (p : ZPoly) (I : DyadicInterval) : Int :=
   (sturmVarAt (ZPoly.sturmChain p) I.lower : Int) -
     sturmVarAt (ZPoly.sturmChain p) I.upper
 
 /-- The total number of real roots of `p`: the sign-variation difference of
 its Sturm chain between `−∞` and `+∞`. -/
 @[expose]
-def rootCount (p : ZPoly) : Nat :=
+def ZPoly.rootCount (p : ZPoly) : Nat :=
   sturmVarNegInf (ZPoly.sturmChain p) - sturmVarPosInf (ZPoly.sturmChain p)
 
 /-- Exactly one real root of `p` lies in the half-open interval
@@ -112,7 +112,7 @@ structure RealRootIsolation (p : ZPoly) where
   /-- The half-open interval `(lower, upper]` containing the root. -/
   interval  : DyadicInterval
   /-- The Sturm count certifies exactly one root in the interval. -/
-  count_one : sturmCount p interval = 1
+  count_one : ZPoly.sturmCount p interval = 1
 
 /-- A complete isolation run for `p`: pairwise-disjoint isolations, in
 increasing order, one per real root of `p`.
@@ -122,7 +122,7 @@ half-open intervals — the upper endpoint of each is at most the lower
 endpoint of the next. Because the intervals are half-open on the left,
 touching at a shared endpoint still leaves them disjoint as sets, so
 `ordered` gives pairwise disjointness for free. `complete` records that there
-are exactly `rootCount p` of them.
+are exactly `ZPoly.rootCount p` of them.
 
 Both invariants are decidable data, so for squarefree `p` the structure
 certifies itself no matter which engine produced it: `count_one` puts exactly
@@ -136,7 +136,7 @@ structure RealRootIsolations (p : ZPoly) where
   ordered    : ∀ i j : Fin isolations.size, i < j →
                  isolations[i].interval.upper ≤ isolations[j].interval.lower
   /-- There is exactly one isolation per real root of `p`. -/
-  complete   : isolations.size = rootCount p
+  complete   : isolations.size = ZPoly.rootCount p
 
 /-- Final-assembly helper shared by both isolation engines.
 
@@ -147,7 +147,7 @@ checked directly over `arr`; `complete` is checked against
 `sturmVarNegInf chain − sturmVarPosInf chain` on the caller's
 already-computed `chain`, and the `hchain : chain = sturmChain p` equality
 (passed as `rfl` by a caller whose `chain` is let-bound to `sturmChain p`)
-identifies that difference with `rootCount p` without recomputing the chain —
+identifies that difference with `ZPoly.rootCount p` without recomputing the chain —
 the memoisation discipline of computing the chain once per polynomial.
 
 A `none` here means the engine's output violated its own invariants; the
@@ -185,36 +185,36 @@ example : sturmVarAt (ZPoly.sturmChain (DensePoly.ofCoeffs #[(-1 : Int), 0, 1]))
 example : sturmVarAt (ZPoly.sturmChain (DensePoly.ofCoeffs #[(-1 : Int), 0, 1]))
     (Dyadic.ofInt 2) = 0 := by decide
 
--- `sturmCount (x² − 1)` on the half-open intervals. Roots are `±1`.
+-- `ZPoly.sturmCount (x² − 1)` on the half-open intervals. Roots are `±1`.
 -- `(−2, 2]`: varAt(−2) − varAt(2) = 2 − 0 = 2 (both roots).
-example : sturmCount (DensePoly.ofCoeffs #[(-1 : Int), 0, 1])
+example : ZPoly.sturmCount (DensePoly.ofCoeffs #[(-1 : Int), 0, 1])
     (DyadicInterval.mk (Dyadic.ofInt (-2)) (Dyadic.ofInt 2) (by decide)) = 2 := by decide
 -- `(0, 2]`: varAt(0) − varAt(2) = 1 − 0 = 1 (only the root at `1`).
-example : sturmCount (DensePoly.ofCoeffs #[(-1 : Int), 0, 1])
+example : ZPoly.sturmCount (DensePoly.ofCoeffs #[(-1 : Int), 0, 1])
     (DyadicInterval.mk (Dyadic.ofInt 0) (Dyadic.ofInt 2) (by decide)) = 1 := by decide
 -- `(−2, 0]`: varAt(−2) − varAt(0) = 2 − 1 = 1. The root at `−1` is captured;
 -- the included endpoint `0` is not a root. Half-open on the left counts
 -- `−1 ∈ (−2, 0]`.
-example : sturmCount (DensePoly.ofCoeffs #[(-1 : Int), 0, 1])
+example : ZPoly.sturmCount (DensePoly.ofCoeffs #[(-1 : Int), 0, 1])
     (DyadicInterval.mk (Dyadic.ofInt (-2)) (Dyadic.ofInt 0) (by decide)) = 1 := by decide
 -- `(1, 2]`: varAt(1) − varAt(2) = 0 − 0 = 0. The root at `1` sits on the
 -- excluded left endpoint, so it is not counted (half-open convention). At
 -- `1` the chain evals are `(0, 1, 1)` → signs `(0, +, +)` → 0 variations.
-example : sturmCount (DensePoly.ofCoeffs #[(-1 : Int), 0, 1])
+example : ZPoly.sturmCount (DensePoly.ofCoeffs #[(-1 : Int), 0, 1])
     (DyadicInterval.mk (Dyadic.ofInt 1) (Dyadic.ofInt 2) (by decide)) = 0 := by decide
 
--- `rootCount`: total real-root counts read off the leading coefficients and
+-- `ZPoly.rootCount`: total real-root counts read off the leading coefficients and
 -- degree parities, no evaluation.
 -- `x² − 1`: chain `[x²−1, x, 1]`, −∞ signs `(+, −, +)` → 2, +∞ `(+, +, +)` → 0.
-example : rootCount (DensePoly.ofCoeffs #[(-1 : Int), 0, 1]) = 2 := by decide
+example : ZPoly.rootCount (DensePoly.ofCoeffs #[(-1 : Int), 0, 1]) = 2 := by decide
 -- `x² + 1`: no real roots.
-example : rootCount (DensePoly.ofCoeffs #[(1 : Int), 0, 1]) = 0 := by decide
+example : ZPoly.rootCount (DensePoly.ofCoeffs #[(1 : Int), 0, 1]) = 0 := by decide
 -- `x³ − x`: roots `−1, 0, 1`; chain `[x³−x, 3x²−1, x, 1]`, −∞ `(−, +, −, +)` → 3.
-example : rootCount (DensePoly.ofCoeffs #[(0 : Int), -1, 0, 1]) = 3 := by decide
+example : ZPoly.rootCount (DensePoly.ofCoeffs #[(0 : Int), -1, 0, 1]) = 3 := by decide
 -- `x − 5`: one real root; chain `[x−5, 1]`, −∞ `(−, +)` → 1, +∞ `(+, +)` → 0.
-example : rootCount (DensePoly.ofCoeffs #[(-5 : Int), 1]) = 1 := by decide
+example : ZPoly.rootCount (DensePoly.ofCoeffs #[(-5 : Int), 1]) = 1 := by decide
 -- Constant `7`: empty chain, `0 − 0 = 0`.
-example : rootCount (DensePoly.ofCoeffs #[(7 : Int)]) = 0 := by decide
+example : ZPoly.rootCount (DensePoly.ofCoeffs #[(7 : Int)]) = 0 := by decide
 
 -- A concrete isolation of the single root of `x − 5` in `(4, 8]`.
 -- Chain `[x−5, 1]`; at `4` evals `(−1, 1)` → 1 variation, at `8` `(3, 1)` → 0,
@@ -222,7 +222,7 @@ example : rootCount (DensePoly.ofCoeffs #[(7 : Int)]) = 0 := by decide
 example : RealRootIsolation (DensePoly.ofCoeffs #[(-5 : Int), 1]) :=
   ⟨DyadicInterval.mk (Dyadic.ofInt 4) (Dyadic.ofInt 8) (by decide), by decide⟩
 
--- The whole isolation set for `x − 5` assembles: one isolation, `rootCount = 1`.
+-- The whole isolation set for `x − 5` assembles: one isolation, `ZPoly.rootCount = 1`.
 example :
     (assemble? (DensePoly.ofCoeffs #[(-5 : Int), 1])
       (ZPoly.sturmChain (DensePoly.ofCoeffs #[(-5 : Int), 1])) rfl

--- a/HexRealRootsMathlib.lean
+++ b/HexRealRootsMathlib.lean
@@ -40,8 +40,8 @@ over `Polynomial ℝ`, independently of the executable `HexRealRoots` types.
 
 The executable correspondence builds on these results:
 `ChainCorrespond` connects {name}`Hex.ZPoly.sturmChain`,
-{name}`Hex.sturmCount`, and
-{name}`Hex.rootCount` to the abstract development; `LiteralChain` proves the
+{name}`Hex.ZPoly.sturmCount`, and
+{name}`Hex.ZPoly.rootCount` to the abstract development; `LiteralChain` proves the
 corresponding theorem
 for a supplied positive-scaled recurrence, and `LiteralIsolations` states
 isolation semantics for its supplied counts; `Separation` supplies the Mahler

--- a/HexRealRootsMathlib/ChainCorrespond.lean
+++ b/HexRealRootsMathlib/ChainCorrespond.lean
@@ -27,7 +27,7 @@ public section
 # Correspondence between the executable Sturm machinery and the abstract theorem
 
 This module connects the executable real-root machinery in `HexRealRoots`
-(`Hex.ZPoly.sturmChain`, `Hex.sturmVarAt`, `Hex.sturmCount`, `Hex.rootCount`,
+(`Hex.ZPoly.sturmChain`, `Hex.sturmVarAt`, `Hex.ZPoly.sturmCount`, `Hex.ZPoly.rootCount`,
 `Hex.ZPoly.SquareFreeRat`) to the abstract `Polynomial ℝ` development in
 `HexRealRootsMathlib.SturmTheorem`.
 
@@ -1441,11 +1441,11 @@ theorem midpoint_lt_upper (I : Hex.DyadicInterval) : I.midpoint < I.upper := by
   linarith
 
 /-- **Sturm count correspondence.** For positive-degree, rationally squarefree
-`p`, the executable `Hex.sturmCount p I` equals the number of real roots of
+`p`, the executable `Hex.ZPoly.sturmCount p I` equals the number of real roots of
 `toPolyℝ p` in the half-open interval `(I.lower, I.upper]`. -/
 theorem sturmCount_eq_card_roots (p : Hex.ZPoly) (hp : 1 ≤ p.natDegree)
     (hsq : Hex.ZPoly.SquareFreeRat p) (I : Hex.DyadicInterval) :
-    Hex.sturmCount p I
+    Hex.ZPoly.sturmCount p I
       = ((toPolyℝ p).roots.filter
           (fun r => Dyadic.toReal I.lower < r ∧ r ≤ Dyadic.toReal I.upper)).card := by
   have hp0 : p ≠ 0 := by
@@ -1508,11 +1508,11 @@ theorem sturmVarNegInf_eq (chain : Array Hex.ZPoly) :
     exact sign_intCast_sign _
 
 /-- **Root count correspondence.** For positive-degree, rationally squarefree
-`p`, the executable `Hex.rootCount p` equals the total number of real roots
+`p`, the executable `Hex.ZPoly.rootCount p` equals the total number of real roots
 of `toPolyℝ p`. -/
 theorem rootCount_eq_card_roots (p : Hex.ZPoly) (hp : 1 ≤ p.natDegree)
     (hsq : Hex.ZPoly.SquareFreeRat p) :
-    Hex.rootCount p = ((toPolyℝ p).roots).card := by
+    Hex.ZPoly.rootCount p = ((toPolyℝ p).roots).card := by
   have hp0 : p ≠ 0 := by
     intro hh; rw [hh] at hp
     simp only [Hex.DensePoly.degree?_zero_getD] at hp

--- a/HexRealRootsMathlib/Drivers.lean
+++ b/HexRealRootsMathlib/Drivers.lean
@@ -13,7 +13,7 @@ public import HexRealRoots.Isolate
 public import HexRealRoots.Refine
 -- `import all` on the executable modules so the non-`@[expose]` bodies of the
 -- isolation engines (`sturmChain`, `sturmVarAt`, `sturmVisit`, `refine1`,
--- `isolateSturm?`, `isolate?`, and the dyadic evaluation helpers) unfold here.
+-- `ZPoly.isolateSturm?`, `ZPoly.isolate?`, and the dyadic evaluation helpers) unfold here.
 import all HexRealRootsMathlib.Separation
 import all HexRealRoots.Basic
 import all HexRealRoots.Chain
@@ -35,12 +35,12 @@ public section
   top-level driver) succeeds on nonzero squarefree input (positive degree is
   the real content; a nonzero constant certifies through the empty chain).
 
-## The `±rootBound` counts match `rootCount` with no chain-element gap
+## The `±rootBound` counts match `ZPoly.rootCount` with no chain-element gap
 
 The engine seeds `sturmVisit` with the memoised counts `sturmVarAt chain (−R)`
 and `sturmVarAt chain (+R)` at `R = rootBound p`, and `assemble?` later checks
 the emitted total against `sturmVarNegInf chain − sturmVarPosInf chain =
-rootCount p`. One might worry that a *chain element* (a remainder of `(p, p')`,
+ZPoly.rootCount p`. One might worry that a *chain element* (a remainder of `(p, p')`,
 not `p` itself) could have a real root beyond `rootBound p`, so that the
 endpoint variation counts at `±R` disagree with the `±∞` counts.
 
@@ -49,7 +49,7 @@ There is no such gap. `sturmCount_eq_card_roots` proves
 **`p`** in `(−R, R]` — a statement about `p`'s roots only, with the chain
 elements' own zeros already fully accounted for by Sturm's theorem. Since
 `rootBound_bounds_roots` places every real root of `p` inside `(−R, R]`, that
-count is `rootCount p` (via `rootCount_eq_card_roots`), regardless of where the
+count is `ZPoly.rootCount p` (via `rootCount_eq_card_roots`), regardless of where the
 chain elements vanish. So the telescoping total the engine checks always
 matches, and the check never spuriously fails.
 -/
@@ -81,8 +81,8 @@ counts over `(lo, mid]` and `(mid, hi]`: the half-open interval splits as a
 disjoint union, and the root-filter cardinalities add. -/
 private theorem sturmCount_split (hdeg : 1 ≤ p.natDegree)
     (hp : Hex.ZPoly.SquareFreeRat p) {lo mid hi : Dyadic} (h1 : lo < mid) (h2 : mid < hi) :
-    Hex.sturmCount p ⟨lo, hi, dlt_trans h1 h2⟩
-      = Hex.sturmCount p ⟨lo, mid, h1⟩ + Hex.sturmCount p ⟨mid, hi, h2⟩ := by
+    Hex.ZPoly.sturmCount p ⟨lo, hi, dlt_trans h1 h2⟩
+      = Hex.ZPoly.sturmCount p ⟨lo, mid, h1⟩ + Hex.ZPoly.sturmCount p ⟨mid, hi, h2⟩ := by
   rw [sturmCount_eq_card_roots p hdeg hp, sturmCount_eq_card_roots p hdeg hp,
     sturmCount_eq_card_roots p hdeg hp]
   dsimp only
@@ -119,7 +119,7 @@ private theorem sturmCount_split (hdeg : 1 ≤ p.natDegree)
 
 /-- A count-`0` interval contains no real root of `p`. -/
 private theorem no_root_of_count_zero (hdeg : 1 ≤ p.natDegree)
-    (hp : Hex.ZPoly.SquareFreeRat p) {J : Hex.DyadicInterval} (h : Hex.sturmCount p J = 0)
+    (hp : Hex.ZPoly.SquareFreeRat p) {J : Hex.DyadicInterval} (h : Hex.ZPoly.sturmCount p J = 0)
     (hP0 : toPolyℝ p ≠ 0) {r : ℝ} (hr : (toPolyℝ p).IsRoot r)
     (hlo : Dyadic.toReal J.lower < r) (hhi : r ≤ Dyadic.toReal J.upper) : False := by
   rw [sturmCount_eq_card_roots p hdeg hp] at h
@@ -160,11 +160,11 @@ theorem refine1_isolates_same (hp : Hex.ZPoly.SquareFreeRat p)
   have htlm : Dyadic.toReal lo < Dyadic.toReal m := toReal_lt_toReal_iff.mpr hlm
   have htmh : Dyadic.toReal m < Dyadic.toReal hi := toReal_lt_toReal_iff.mpr hmh
   -- The two half-counts sum to 1.
-  have hcount1 : Hex.sturmCount p ⟨lo, m, hlm⟩ + Hex.sturmCount p ⟨m, hi, hmh⟩ = 1 := by
+  have hcount1 : Hex.ZPoly.sturmCount p ⟨lo, m, hlm⟩ + Hex.ZPoly.sturmCount p ⟨m, hi, hmh⟩ = 1 := by
     rw [← sturmCount_split hdeg hp hlm hmh]; exact iso.count_one
-  have hCL0 : 0 ≤ Hex.sturmCount p ⟨lo, m, hlm⟩ := by
+  have hCL0 : 0 ≤ Hex.ZPoly.sturmCount p ⟨lo, m, hlm⟩ := by
     rw [sturmCount_eq_card_roots p hdeg hp]; exact Int.natCast_nonneg _
-  have hCR0 : 0 ≤ Hex.sturmCount p ⟨m, hi, hmh⟩ := by
+  have hCR0 : 0 ≤ Hex.ZPoly.sturmCount p ⟨m, hi, hmh⟩ := by
     rw [sturmCount_eq_card_roots p hdeg hp]; exact Int.natCast_nonneg _
   -- The refined width is half, independent of the branch.
   have hwidth_left : Dyadic.toReal (Hex.DyadicInterval.width ⟨lo, m, hlm⟩)
@@ -179,7 +179,7 @@ theorem refine1_isolates_same (hp : Hex.ZPoly.SquareFreeRat p)
     rw [toReal_sub]
     show _ = Dyadic.toReal (hi - lo) / 2
     rw [toReal_sub, toReal_midpoint]; ring
-  by_cases hCL : Hex.sturmCount p ⟨lo, m, hlm⟩ = 1
+  by_cases hCL : Hex.ZPoly.sturmCount p ⟨lo, m, hlm⟩ = 1
   · -- Left half certifies: refined interval is `(lo, m]`.
     have hCLraw : ((Hex.sturmVarAt (Hex.ZPoly.sturmChain p) iso.interval.lower : Int)
         - Hex.sturmVarAt (Hex.ZPoly.sturmChain p) iso.interval.midpoint) = 1 := hCL
@@ -188,7 +188,7 @@ theorem refine1_isolates_same (hp : Hex.ZPoly.SquareFreeRat p)
       unfold Hex.RealRootIsolation.refine1 Hex.RealRootIsolation.refine1With
       rw [dite_eq_left hlm, dite_eq_left hCLraw]
       rfl
-    have hCR : Hex.sturmCount p ⟨m, hi, hmh⟩ = 0 := by omega
+    have hCR : Hex.ZPoly.sturmCount p ⟨m, hi, hmh⟩ = 0 := by omega
     refine ⟨fun r hr => ?_, ?_⟩
     · rw [href]
       constructor
@@ -200,8 +200,8 @@ theorem refine1_isolates_same (hp : Hex.ZPoly.SquareFreeRat p)
         exact ⟨hrlo, le_trans hrhi (le_of_lt htmh)⟩
     · rw [href]; exact hwidth_left
   · -- Right half certifies: refined interval is `(m, hi]`.
-    have hCR : Hex.sturmCount p ⟨m, hi, hmh⟩ = 1 := by omega
-    have hCLz : Hex.sturmCount p ⟨lo, m, hlm⟩ = 0 := by omega
+    have hCR : Hex.ZPoly.sturmCount p ⟨m, hi, hmh⟩ = 1 := by omega
+    have hCLz : Hex.ZPoly.sturmCount p ⟨lo, m, hlm⟩ = 0 := by omega
     have hCLraw_neg : ¬((Hex.sturmVarAt (Hex.ZPoly.sturmChain p) iso.interval.lower : Int)
         - Hex.sturmVarAt (Hex.ZPoly.sturmChain p) iso.interval.midpoint) = 1 := hCL
     have hCRraw : ((Hex.sturmVarAt (Hex.ZPoly.sturmChain p) iso.interval.midpoint : Int)
@@ -222,7 +222,7 @@ theorem refine1_isolates_same (hp : Hex.ZPoly.SquareFreeRat p)
         exact ⟨lt_trans htlm hrlo, hrhi⟩
     · rw [href]; exact hwidth_right
 
-/-! # The initial interval carries all roots: `±rootBound` counts `rootCount` -/
+/-! # The initial interval carries all roots: `±rootBound` counts `ZPoly.rootCount` -/
 
 /-- `Dyadic.toReal` is negation-compatible. -/
 private theorem toReal_neg (x : Dyadic) : Dyadic.toReal (-x) = -Dyadic.toReal x := by
@@ -242,16 +242,16 @@ theorem neg_rootBound_lt_rootBound (p : Hex.ZPoly) :
   rw [← toReal_lt_toReal_iff, toReal_neg]
   have := rootBound_pos p; linarith
 
-/-- **The `±rootBound` variation gap equals `rootCount`.** The Sturm variation
+/-- **The `±rootBound` variation gap equals `ZPoly.rootCount`.** The Sturm variation
 difference between `-rootBound p` and `rootBound p` counts the real roots of `p`
-in `(-R, R]`, which is *every* real root (Cauchy bound), i.e. `rootCount p`. This
+in `(-R, R]`, which is *every* real root (Cauchy bound), i.e. `ZPoly.rootCount p`. This
 is a statement about `p`'s roots only — the chain elements' own (possibly larger)
 zeros never enter, so there is no `±R`-versus-`±∞` gap. -/
 theorem sturmVar_neg_pos_sub (hdeg : 1 ≤ p.natDegree)
     (hp : Hex.ZPoly.SquareFreeRat p) :
     (Hex.sturmVarAt (Hex.ZPoly.sturmChain p) (-(Hex.rootBound p)) : ℤ)
       - Hex.sturmVarAt (Hex.ZPoly.sturmChain p) (Hex.rootBound p)
-      = Hex.rootCount p := by
+      = Hex.ZPoly.rootCount p := by
   have hp0 : p ≠ 0 := by
     intro hh; rw [hh] at hdeg; simp only [Hex.DensePoly.degree?_zero_getD] at hdeg; omega
   have hP0 : toPolyℝ p ≠ 0 := fun h => hp0 (toPolyℝ_eq_zero_iff.mp h)
@@ -353,7 +353,7 @@ theorem sturmVarAt_le (hdeg : 1 ≤ p.natDegree)
     Hex.sturmVarAt (Hex.ZPoly.sturmChain p) b
       ≤ Hex.sturmVarAt (Hex.ZPoly.sturmChain p) a := by
   have h := sturmCount_eq_card_roots p hdeg hp ⟨a, b, hab⟩
-  have hid : Hex.sturmCount p ⟨a, b, hab⟩
+  have hid : Hex.ZPoly.sturmCount p ⟨a, b, hab⟩
       = (Hex.sturmVarAt (Hex.ZPoly.sturmChain p) a : ℤ)
         - Hex.sturmVarAt (Hex.ZPoly.sturmChain p) b := rfl
   rw [hid] at h
@@ -380,7 +380,7 @@ theorem sturmCount_le_one (hdeg : 1 ≤ p.natDegree)
     (hp : Hex.ZPoly.SquareFreeRat p) (J : Hex.DyadicInterval)
     (hw : Dyadic.toReal J.upper - Dyadic.toReal J.lower
       ≤ (2 : ℝ) ^ (-(Hex.sepPrec p : ℤ))) :
-    Hex.sturmCount p J ≤ 1 := by
+    Hex.ZPoly.sturmCount p J ≤ 1 := by
   have hp0 : p ≠ 0 := by
     intro hh; rw [hh] at hdeg; simp only [Hex.DensePoly.degree?_zero_getD] at hdeg; omega
   rw [sturmCount_eq_card_roots p hdeg hp J]
@@ -496,7 +496,7 @@ private theorem sturmVisit_spec (hdeg : 1 ≤ p.natDegree)
       · -- `count ≥ 2` at depth `0`: refuted by the separation bound.
         exfalso
         have hle := sturmVarAt_le hdeg hp hlt
-        have hcle : Hex.sturmCount p ⟨lo, hi, hlt⟩ ≤ 1 := sturmCount_le_one hdeg hp _ hw
+        have hcle : Hex.ZPoly.sturmCount p ⟨lo, hi, hlt⟩ ≤ 1 := sturmCount_le_one hdeg hp _ hw
         have hcle' : (Hex.sturmVarAt (Hex.ZPoly.sturmChain p) lo : ℤ)
             - Hex.sturmVarAt (Hex.ZPoly.sturmChain p) hi ≤ 1 := hcle
         omega
@@ -627,18 +627,18 @@ theorem assemble?_isSome {chain : Array Hex.ZPoly}
   rw [dite_eq_left hord, dite_eq_left hsize]
   rfl
 
-/-- `isolateSturm?` on positive-degree squarefree input is the top `sturmVisit`
+/-- `ZPoly.isolateSturm?` on positive-degree squarefree input is the top `sturmVisit`
 run handed to `assemble?`. -/
 private theorem isolateSturm?_eq {d : Nat} (hd : p.degree? = some (d + 1))
     (hp : Hex.ZPoly.SquareFreeRat p) :
-    Hex.isolateSturm? p =
+    Hex.ZPoly.isolateSturm? p =
       (match Hex.sturmVisit p (Hex.ZPoly.sturmChain p) rfl (Hex.isolationDepth p)
           (-(Hex.rootBound p)) (Hex.rootBound p)
           (Hex.sturmVarAt (Hex.ZPoly.sturmChain p) (-(Hex.rootBound p)))
           (Hex.sturmVarAt (Hex.ZPoly.sturmChain p) (Hex.rootBound p)) with
         | none => none
         | some arr => Hex.assemble? p (Hex.ZPoly.sturmChain p) rfl arr) := by
-  unfold Hex.isolateSturm?
+  unfold Hex.ZPoly.isolateSturm?
   simp only [hd]
   rw [ite_eq_left hp]
   rfl
@@ -647,10 +647,10 @@ private theorem isolateSturm?_eq {d : Nat} (hd : p.degree? = some (d + 1))
 
 /-- The positive-degree core of `isolateSturm?_isSome`: the worklist drains
 (`sturmVisit_spec`) and the emitted total matches
-`rootCount p = sturmVarNegInf − sturmVarPosInf` (the `±rootBound` gap counts
+`ZPoly.rootCount p = sturmVarNegInf − sturmVarPosInf` (the `±rootBound` gap counts
 every root, `sturmVar_neg_pos_sub`), so `assemble?` certifies. -/
 private theorem isolateSturm?_isSome_of_degree_pos (hdeg : 1 ≤ p.natDegree)
-    (hp : Hex.ZPoly.SquareFreeRat p) : (Hex.isolateSturm? p).isSome := by
+    (hp : Hex.ZPoly.SquareFreeRat p) : (Hex.ZPoly.isolateSturm? p).isSome := by
   obtain ⟨d, hd⟩ : ∃ d, p.degree? = some (d + 1) := by
     rw [Hex.DensePoly.natDegree_eq_degree?_getD] at hdeg
     rcases hh : p.degree? with _ | n
@@ -667,7 +667,7 @@ private theorem isolateSturm?_isSome_of_degree_pos (hdeg : 1 ≤ p.natDegree)
   have hInt := sturmVar_neg_pos_sub hdeg hp
   have hsize' : arr.size = Hex.sturmVarNegInf (Hex.ZPoly.sturmChain p)
       - Hex.sturmVarPosInf (Hex.ZPoly.sturmChain p) := by
-    have hrc : Hex.rootCount p = Hex.sturmVarNegInf (Hex.ZPoly.sturmChain p)
+    have hrc : Hex.ZPoly.rootCount p = Hex.sturmVarNegInf (Hex.ZPoly.sturmChain p)
         - Hex.sturmVarPosInf (Hex.ZPoly.sturmChain p) := rfl
     rw [hsize, ← hrc]; omega
   rw [isolateSturm?_eq hd hp, hvisit]
@@ -675,11 +675,11 @@ private theorem isolateSturm?_isSome_of_degree_pos (hdeg : 1 ≤ p.natDegree)
 
 /-- The Sturm engine on a nonzero constant: the driver's `some 0` branch hands
 `assemble?` the empty emission array, and the empty chain certifies
-`rootCount p = 0` (`sturmVarNegInf #[] − sturmVarPosInf #[] = 0`). -/
+`ZPoly.rootCount p = 0` (`sturmVarNegInf #[] − sturmVarPosInf #[] = 0`). -/
 private theorem isolateSturm?_isSome_of_degree_zero (hd : p.degree? = some 0) :
-    (Hex.isolateSturm? p).isSome := by
-  have heq : Hex.isolateSturm? p = Hex.assemble? p (Hex.ZPoly.sturmChain p) rfl #[] := by
-    unfold Hex.isolateSturm?
+    (Hex.ZPoly.isolateSturm? p).isSome := by
+  have heq : Hex.ZPoly.isolateSturm? p = Hex.assemble? p (Hex.ZPoly.sturmChain p) rfl #[] := by
+    unfold Hex.ZPoly.isolateSturm?
     rw [hd]
   have hchain0 : Hex.ZPoly.sturmChain p = #[] := by
     unfold Hex.ZPoly.sturmChain
@@ -697,9 +697,9 @@ is the real content (`isolateSturm?_isSome_of_degree_pos`); a nonzero constant
 certifies through the empty chain.
 
 The `p ≠ 0` hypothesis is necessary because `SquareFreeRat 0` is vacuous while
-`isolateSturm? 0 = none`. -/
+`ZPoly.isolateSturm? 0 = none`. -/
 theorem isolateSturm?_isSome (p : Hex.ZPoly) (hp0 : p ≠ 0)
-    (hp : Hex.ZPoly.SquareFreeRat p) : (Hex.isolateSturm? p).isSome := by
+    (hp : Hex.ZPoly.SquareFreeRat p) : (Hex.ZPoly.isolateSturm? p).isSome := by
   rcases hd : p.degree? with _ | n
   · exact absurd hd (degree?_ne_none hp0)
   · rcases n with _ | n
@@ -708,13 +708,13 @@ theorem isolateSturm?_isSome (p : Hex.ZPoly) (hp0 : p ≠ 0)
         (by simp [Hex.DensePoly.natDegree_eq_degree?_getD, hd]) hp
 
 /-- **The top-level driver succeeds on nonzero squarefree input.** A one-liner
-over `isolateSturm?_isSome`: `isolate?` keeps whichever engine's certified
+over `isolateSturm?_isSome`: `ZPoly.isolate?` keeps whichever engine's certified
 output arrives first, and the Sturm engine always has one. -/
 theorem isolate?_isSome (p : Hex.ZPoly) (hp0 : p ≠ 0)
-    (hp : Hex.ZPoly.SquareFreeRat p) : (Hex.isolate? p).isSome := by
+    (hp : Hex.ZPoly.SquareFreeRat p) : (Hex.ZPoly.isolate? p).isSome := by
   have hs := isolateSturm?_isSome p hp0 hp
-  unfold Hex.isolate?
-  cases hD : Hex.isolateDescartes? p with
+  unfold Hex.ZPoly.isolate?
+  cases hD : Hex.ZPoly.isolateDescartes? p with
   | some a => rfl
   | none => rw [hD] at *; simpa using hs
 

--- a/HexRealRootsMathlib/IsolateRoots.lean
+++ b/HexRealRootsMathlib/IsolateRoots.lean
@@ -189,7 +189,7 @@ onto the literal chain, where the emitted `decide` confirms the gap is `1`. -/
 theorem RealRootIsolation.count_one_of_cert {p : Hex.ZPoly} {chain : Array Hex.ZPoly}
     (hcert : Hex.SturmChainCert p chain) (I : Hex.DyadicInterval)
     (h : (Hex.sturmVarAt chain I.lower : Int) - Hex.sturmVarAt chain I.upper = 1) :
-    Hex.sturmCount p I = 1 :=
+    Hex.ZPoly.sturmCount p I = 1 :=
   (Hex.ZPoly.sturmCount_eq_of_cert hcert I).trans h
 
 /-- **The replay constructor `IsolatedRealRoots.ofCert`.** The production

--- a/HexRealRootsMathlib/IsolateRootsElab.lean
+++ b/HexRealRootsMathlib/IsolateRootsElab.lean
@@ -210,8 +210,8 @@ structure IsoData where
 constant Sturm tail), optionally refining every root to width `2 ^ (-widthK)`
 through the cached-chain `refineToWithChain`. -/
 meta def runBackend (f : Hex.ZPoly) (widthK : Option Int) : MetaM IsoData := do
-  let some out := Hex.isolate? f
-    | throwError "isolate_roots: internal error: the backend isolate? returned none on \
+  let some out := Hex.ZPoly.isolate? f
+    | throwError "isolate_roots: internal error: the backend ZPoly.isolate? returned none on \
         square-free input (please report this as a bug)"
   let chain := Hex.ZPoly.sturmChain f
   let isos := out.isolations
@@ -307,19 +307,18 @@ meta def emitOfCert (d : IsoData) : MetaM (TSyntax `term) := do
 
 /-- Convert a positive rational width `q` to the bit target `k = max 0 ⌈log₂ q⁻¹⌉`
 in exact integer arithmetic: the least `k ≥ 0` with `2 ^ (-k) ≤ q`. Widths above
-`1` give `k = 0` (they never coarsen the natural intervals). Targets finer than
-`2 ^ (-4096)` are rejected as pathological. -/
+`1` give `k = 0` (they never coarsen the natural intervals). -/
 meta def widthTarget (q : Rat) : MetaM Int := do
   let inv := q⁻¹
-  let mut k : Nat := 0
-  let mut pw : Rat := 1
-  while pw < inv do
-    if k ≥ 4096 then
-      throwError "isolate_roots: pathological width (finer than 2^-4096); the isolation \
-        would be astronomically large. Refine the result manually if you truly need this."
-    k := k + 1
-    pw := pw * 2
-  return Int.ofNat k
+  let n := inv.num.toNat
+  let d := inv.den
+  if n ≤ d then return 0
+  -- Writing `a = ⌊log₂ n⌋` and `b = ⌊log₂ d⌋`, the quotient `n / d` lies
+  -- strictly between `2 ^ (a - b - 1)` and `2 ^ (a - b + 1)`, so the least `k`
+  -- with `2 ^ k * d ≥ n` is `a - b` or one more. Both are read off the bit
+  -- lengths; `n > d` makes the `Nat` subtraction the real difference.
+  let k := Nat.log2 n - Nat.log2 d
+  return Int.ofNat (if d <<< k < n then k + 1 else k)
 
 /-! # The square-free-radical divisibility certificate -/
 

--- a/HexRealRootsMathlib/IsolateRootsElabTests.lean
+++ b/HexRealRootsMathlib/IsolateRootsElabTests.lean
@@ -130,10 +130,6 @@ info: isolate_roots: the width must be a closed rational (no free variables or m
 #guard_msgs in
 #check_failure (isolate_roots (width := 0) (X ^ 2 - 2 : Polynomial ℤ))
 
-/-- info: isolate_roots: pathological width (finer than 2^-4096); the isolation would be astronomically large. Refine the result manually if you truly need this. -/
-#guard_msgs in
-#check_failure (isolate_roots (width := 2 ^ (-5000 : ℤ)) (X ^ 2 - 2 : Polynomial ℤ))
-
 end Errors
 
 end HexRealRootsMathlib.ElabTests

--- a/HexRealRootsMathlib/IsolateRootsTests.lean
+++ b/HexRealRootsMathlib/IsolateRootsTests.lean
@@ -61,7 +61,7 @@ def x4m2 : ZPoly := DensePoly.ofCoeffs #[(-2 : Int), 0, 0, 0, 1]
 theorem sqfree_x4m2 : ZPoly.SquareFreeRat x4m2 :=
   squareFreeRat_of_hasSquarefreeSturmChain _ (by decide)
 
-/-- The complete run of `x⁴ − 2`: the two isolate? intervals `(-4, 0]`, `(0, 4]`. -/
+/-- The complete run of `x⁴ − 2`: the two ZPoly.isolate? intervals `(-4, 0]`, `(0, 4]`. -/
 def runX4m2 : RealRootIsolations x4m2 where
   isolations :=
     #[⟨⟨Dyadic.ofInt (-4), Dyadic.ofInt 0, by decide⟩, by decide⟩,

--- a/HexRealRootsMathlib/Isolations.lean
+++ b/HexRealRootsMathlib/Isolations.lean
@@ -10,7 +10,7 @@ public import Mathlib
 public import HexRealRootsMathlib.ChainCorrespond
 public import HexRealRoots.Var
 -- `import all` on the executable modules so the non-`@[expose]` bodies of
--- `sturmChain`, `sturmCount`, `sturmVarAt`, and `signVar` unfold here (the
+-- `sturmChain`, `ZPoly.sturmCount`, `sturmVarAt`, and `signVar` unfold here (the
 -- degree-positivity derivation reads the empty chain of a degree-`≤ 0` input).
 import all HexRealRootsMathlib.Separation
 import all HexRealRoots.Basic
@@ -72,7 +72,7 @@ theorem degree_pos_of_count_one (iso : Hex.RealRootIsolation p) :
   by_contra h
   have hz : p.natDegree = 0 := by omega
   have hc := iso.count_one
-  unfold Hex.sturmCount at hc
+  unfold Hex.ZPoly.sturmCount at hc
   rw [sturmChain_eq_nil_of_degree_nonpos hz] at hc
   simp only [Hex.sturmVarAt, List.map_nil, Hex.signVar, List.filter_nil,
     Hex.signVar.go, Nat.cast_zero, sub_zero] at hc
@@ -120,7 +120,7 @@ theorem RealRootIsolation.exists_unique_root (hp : Hex.ZPoly.SquareFreeRat p)
   exact hyM
 
 /-- The positive-degree core of `RealRootIsolations.isolates`: the injective
-root map from isolations hits `rootCount p` distinct roots, which is all of
+root map from isolations hits `ZPoly.rootCount p` distinct roots, which is all of
 them. -/
 private theorem isolates_of_degree_pos (hdeg : 1 ≤ p.natDegree)
     (hp : Hex.ZPoly.SquareFreeRat p) (out : Hex.RealRootIsolations p) :

--- a/HexRealRootsMathlib/LiteralIsolations.lean
+++ b/HexRealRootsMathlib/LiteralIsolations.lean
@@ -14,7 +14,7 @@ public section
 # Isolation semantics for literal root counts
 
 This module separates real-root isolation semantics from the executable
-`Hex.sturmCount` and `Hex.rootCount` functions. A `LiteralIsolation` stores an
+`Hex.ZPoly.sturmCount` and `Hex.ZPoly.rootCount` functions. A `LiteralIsolation` stores an
 interval whose supplied count is one; a `LiteralIsolations` stores an ordered
 array of those intervals whose size is a supplied total count. Semantic
 exactness of the two supplied counts is an explicit hypothesis of the

--- a/HexRealRootsMathlib/SPEC/hex-real-roots-mathlib.md
+++ b/HexRealRootsMathlib/SPEC/hex-real-roots-mathlib.md
@@ -4,7 +4,7 @@ Mathlib companion for [hex-real-roots](https://github.com/leanprover/hex-real-ro
 **soundness** of the certified isolations (a `RealRootIsolation`
 witness implies a unique real root in its half-open interval, and a
 `RealRootIsolations` value captures every real root exactly once) and
-**completeness** of the driver (`isolate? p ≠ none` for squarefree
+**completeness** of the driver (`ZPoly.isolate? p ≠ none` for squarefree
 `p`, through the Sturm engine). One theorem is deferred: that the
 Descartes engine alone never falls back. It is stated here, its
 prerequisite is named, and nothing else depends on it.
@@ -94,7 +94,7 @@ def sturmVar (chain : List (Polynomial ℝ)) (x : ℝ) : ℕ
 Steps 1-3 are the standard local lemmas; the theorem is a telescoping
 sum over the finitely many zeros of the chain elements in `(a, b]`.
 The half-open convention in step 3 is the one design-sensitive point,
-and it is what makes the executable `sturmCount` match hex-real-roots'
+and it is what makes the executable `ZPoly.sturmCount` match hex-real-roots'
 half-open intervals with no endpoint hypotheses.
 
 ## Chain correspondence
@@ -164,7 +164,7 @@ The finite-point bridge `sturmVarAt_eq` and the infinity bridges
 `sturmVarNegInf_eq` / `sturmVarPosInf_eq` are public for an arbitrary
 literal `Array ZPoly`. Together with `Sturm.sturm_half_open` and
 `Sturm.sturm_line`, they turn literal executable variation reads into
-root counts without calling `sturmCount` or `rootCount`. The
+root counts without calling `ZPoly.sturmCount` or `ZPoly.rootCount`. The
 `ZReplay.count_eq_card_roots` and `ZReplay.total_eq_card_roots` corollaries
 perform the list-to-array alignment and compose replay, squarefreeness, and
 counting in the form consumed by a checker.
@@ -175,7 +175,7 @@ upper]`, while an ordered complete array captures every root exactly
 once. These statements consume `Squarefree (toPolyℝ f)` and `f ≠ 0`,
 not the executable `SquareFreeRat f` predicate, and do not reuse the
 current `RealRootIsolation` fields that are definitionally tied to
-`sturmCount`. The existing executable isolation theorem remains separate for
+`ZPoly.sturmCount`. The existing executable isolation theorem remains separate for
 API compatibility: the generic statement intentionally mirrors its finite
 cardinality argument rather than coupling the literal layer back to the
 executable structures it is meant to abstract over.
@@ -185,11 +185,11 @@ executable structures it is meant to abstract over.
 ```lean
 theorem sturmCount_eq_card_roots (p : ZPoly) (hp : SquareFreeRat p)
     (I : DyadicInterval) :
-    Hex.sturmCount p I =
+    Hex.ZPoly.sturmCount p I =
       ((toPolyℝ p).roots.filter (fun r => I.lower < r ∧ r ≤ I.upper)).card
 
 theorem rootCount_eq_card_roots (p : ZPoly) (hp : SquareFreeRat p) :
-    Hex.rootCount p = (toPolyℝ p).roots.card
+    Hex.ZPoly.rootCount p = (toPolyℝ p).roots.card
 ```
 
 ## Isolation semantics
@@ -216,7 +216,7 @@ theorem RealRootIsolations.isolates
 ```
 
 The second follows from the first plus `ordered` (disjointness) and
-`complete` (counting): the isolations hold `rootCount p` distinct
+`complete` (counting): the isolations hold `ZPoly.rootCount p` distinct
 roots among them, and that is all the roots there are. Both are also
 exported in the `Hex` namespace, so dot notation resolves on the
 executable structures (`iso.exists_unique_root`).
@@ -360,7 +360,7 @@ constructor lands. The elaborator emits the replay shape. Two constraints shape 
 The executable closure the kernel replays — thirteen definitions:
 `sturmChain`, `sturmChainAux`, `spem`, `spemAux`, `spemStep`,
 `signVar`, `sturmVarAt`, `sturmVarNegInf`, `sturmVarPosInf`,
-`sturmCount`, `rootCount`, `ZPoly.evalDyadic`, `dyadicSign` — is
+`ZPoly.sturmCount`, `ZPoly.rootCount`, `ZPoly.evalDyadic`, `dyadicSign` — is
 `@[expose]`d in hex-real-roots for this purpose, with the three
 private helpers (`spemStep`, `spemAux`, `sturmChainAux`)
 de-privatized (an exposed public definition may not reference a
@@ -404,8 +404,9 @@ non-closed width, backend failure, and internal certificate mismatch
 elaboration): degree ≤ 10 at natural widths, and degree ≤ 6 refined
 to `2^(-20)`, cost seconds (deeper refined-width combinations are
 unmeasured); per-field certificates remain acceptable only below
-degree ~6. The
-elaborator caps refinement with a diagnostic for pathological widths.
+degree ~6. The bit target is read off the requested width's bit
+lengths, so a very fine width costs what isolating to it costs and
+nothing extra.
 
 **Phase-4 proof evidence.** `isolate_roots` is an elaboration/proof surface,
 not a LeanBench executable. Build-only modules below
@@ -480,10 +481,10 @@ and cited from each. Neither companion should carry a private copy.
     hence narrower than any gap between real roots, hence has Sturm
     count 0 or 1, so the worklist drains and the totals match. -/
 theorem isolateSturm?_isSome (p : ZPoly) (hp : SquareFreeRat p) :
-    (Hex.isolateSturm? p).isSome
+    (Hex.ZPoly.isolateSturm? p).isSome
 
 theorem isolate?_isSome (p : ZPoly) (hp : SquareFreeRat p) :
-    (Hex.isolate? p).isSome
+    (Hex.ZPoly.isolate? p).isSome
 ```
 
 Note this argument needs only the real-pair instances of
@@ -528,7 +529,7 @@ theorem sameRoot_iff (hp) (i₁ i₂) :
 
 ```lean
 theorem isolateDescartes?_isSome (p : ZPoly) (hp0 : p ≠ 0)
-    (hp : SquareFreeRat p) : (Hex.isolateDescartes? p).isSome
+    (hp : SquareFreeRat p) : (Hex.ZPoly.isolateDescartes? p).isSome
 ```
 
 Proven in `TwoCircle.lean`; with it the companion is fully
@@ -576,7 +577,7 @@ Status and boundaries:
   theorems, and hex-rcf's decision procedure were complete without it;
   its value is to retire the Sturm fallback path from the trusted
   runtime story. The executable conformance stand-ins for this
-  theorem (`isolateDescartes?` succeeds and agrees with `isolate?` per
+  theorem (`ZPoly.isolateDescartes?` succeeds and agrees with `ZPoly.isolate?` per
   fixture) are retired in the same change now that the theorem carries
   the claim.
 - Like the Sturm slice, the sector/region/parity development is stated

--- a/HexRealRootsMathlib/TwoCircle.lean
+++ b/HexRealRootsMathlib/TwoCircle.lean
@@ -14,7 +14,7 @@ public import HexRealRootsMathlib.TwoCircleSector
 public import HexRealRootsMathlib.Drivers
 public import HexRealRoots.IsolateDescartes
 -- `import all` on the executable modules so the non-`@[expose]` bodies of
--- `descartesVisit`, `isolateDescartes?`, `mobiusTransform`, `descartesVar`,
+-- `descartesVisit`, `ZPoly.isolateDescartes?`, `mobiusTransform`, `descartesVar`,
 -- `sturmVarAt`, `sturmChain`, `evalDyadic`, `dyadicSign`, `rootBound`,
 -- `sepPrec`, `isolationDepth`, and `assemble?` unfold here.
 import all HexRealRootsMathlib.Separation
@@ -561,10 +561,10 @@ private theorem descartesVisit_spec (hdeg : 1 ≤ p.natDegree)
 /-! # Driver completeness -/
 
 /-- The positive-degree core: the worklist drains (`descartesVisit_spec`) and the
-emitted total matches `rootCount p = sturmVarNegInf − sturmVarPosInf` (the
+emitted total matches `ZPoly.rootCount p = sturmVarNegInf − sturmVarPosInf` (the
 `±rootBound` gap counts every root), so `assemble?` certifies. -/
 private theorem isolateDescartes?_isSome_of_degree_pos (hdeg : 1 ≤ p.natDegree)
-    (hp : Hex.ZPoly.SquareFreeRat p) : (Hex.isolateDescartes? p).isSome := by
+    (hp : Hex.ZPoly.SquareFreeRat p) : (Hex.ZPoly.isolateDescartes? p).isSome := by
   obtain ⟨d, hd⟩ : ∃ d, p.degree? = some (d + 1) := by
     rw [Hex.DensePoly.natDegree_eq_degree?_getD] at hdeg
     rcases hh : p.degree? with _ | n
@@ -579,16 +579,16 @@ private theorem isolateDescartes?_isSome_of_degree_pos (hdeg : 1 ≤ p.natDegree
   have hInt := sturmVar_neg_pos_sub hdeg hp
   have hsize' : arr.size = Hex.sturmVarNegInf (Hex.ZPoly.sturmChain p)
       - Hex.sturmVarPosInf (Hex.ZPoly.sturmChain p) := by
-    have hrc : Hex.rootCount p = Hex.sturmVarNegInf (Hex.ZPoly.sturmChain p)
+    have hrc : Hex.ZPoly.rootCount p = Hex.sturmVarNegInf (Hex.ZPoly.sturmChain p)
         - Hex.sturmVarPosInf (Hex.ZPoly.sturmChain p) := rfl
     rw [hsize, ← hrc]; omega
-  -- `isolateDescartes?` on positive-degree square-free `p` is the top run + `assemble?`.
-  have heq : Hex.isolateDescartes? p
+  -- `ZPoly.isolateDescartes?` on positive-degree square-free `p` is the top run + `assemble?`.
+  have heq : Hex.ZPoly.isolateDescartes? p
       = (match Hex.descartesVisit p (Hex.ZPoly.sturmChain p) rfl (Hex.isolationDepth p)
             (-(Hex.rootBound p)) (Hex.rootBound p) with
           | none => none
           | some arr => Hex.assemble? p (Hex.ZPoly.sturmChain p) rfl arr) := by
-    unfold Hex.isolateDescartes?
+    unfold Hex.ZPoly.isolateDescartes?
     simp only [hd]
     rw [ite_eq_left hp]
     rfl
@@ -598,9 +598,9 @@ private theorem isolateDescartes?_isSome_of_degree_pos (hdeg : 1 ≤ p.natDegree
 /-- The Descartes engine on a nonzero constant: the driver's `some 0` branch
 hands `assemble?` the empty array through the empty chain. -/
 private theorem isolateDescartes?_isSome_of_degree_zero (hd : p.degree? = some 0) :
-    (Hex.isolateDescartes? p).isSome := by
-  have heq : Hex.isolateDescartes? p = Hex.assemble? p (Hex.ZPoly.sturmChain p) rfl #[] := by
-    unfold Hex.isolateDescartes?; rw [hd]
+    (Hex.ZPoly.isolateDescartes? p).isSome := by
+  have heq : Hex.ZPoly.isolateDescartes? p = Hex.assemble? p (Hex.ZPoly.sturmChain p) rfl #[] := by
+    unfold Hex.ZPoly.isolateDescartes?; rw [hd]
   have hchain0 : Hex.ZPoly.sturmChain p = #[] := by
     unfold Hex.ZPoly.sturmChain; rw [hd]; rfl
   rw [heq]
@@ -610,15 +610,15 @@ private theorem isolateDescartes?_isSome_of_degree_zero (hd : p.degree? = some 0
 
 /-- **The Descartes engine succeeds on nonzero square-free input.**
 For nonzero `p` passing the executable `SquareFreeRat` test,
-`isolateDescartes? p ≠ none`, so the runtime never falls back to the Sturm
+`ZPoly.isolateDescartes? p ≠ none`, so the runtime never falls back to the Sturm
 engine.
 
 Positive degree is the real content (`isolateDescartes?_isSome_of_degree_pos`,
 the two-circle termination argument); a nonzero constant certifies through the
 empty chain. As with `isolateSturm?_isSome`, the `p ≠ 0` hypothesis is added
-because `SquareFreeRat 0` is vacuous while `isolateDescartes? 0 = none`. -/
+because `SquareFreeRat 0` is vacuous while `ZPoly.isolateDescartes? 0 = none`. -/
 theorem isolateDescartes?_isSome (p : Hex.ZPoly) (hp0 : p ≠ 0)
-    (hp : Hex.ZPoly.SquareFreeRat p) : (Hex.isolateDescartes? p).isSome := by
+    (hp : Hex.ZPoly.SquareFreeRat p) : (Hex.ZPoly.isolateDescartes? p).isSome := by
   rcases hd : p.degree? with _ | n
   · exact absurd hd (degree?_ne_none hp0)
   · rcases n with _ | n

--- a/HexRoots/IsolateAll.lean
+++ b/HexRoots/IsolateAll.lean
@@ -61,7 +61,7 @@ emission condition was not reached within that fuel bound. -/
     {name}`Hex.HasOnlySimpleRoots` does not force positive degree, so the degenerate
     inputs are pinned here: a nonzero constant returns `some #[]` (no roots to
     isolate), and the zero polynomial returns `none`. -/
-@[expose] def isolate (p : ZPoly) (_h : HasOnlySimpleRoots p) (atom_prec : Int)
+@[expose] def isolate? (p : ZPoly) (_h : HasOnlySimpleRoots p) (atom_prec : Int)
     (strategy : AtomStrategy := .nkThenPellet) :
     Option (Array (DyadicRootIsolation p)) :=
   if hd : 0 < p.natDegree then
@@ -73,7 +73,7 @@ emission condition was not reached within that fuel bound. -/
 /-- Start a local search for one simple root from a caller-selected square and
     refine its atom to at
     least `max atomPrec (mahlerPrec p)`. This is a deliberately local search:
-    unlike {name}`Hex.isolate`, it neither certifies every root nor establishes
+    unlike {name}`Hex.isolate?`, it neither certifies every root nor establishes
     pairwise disjointness against roots outside the returned atom. The
     self-contained {name}`Hex.AtomCertificate` is exactly the weaker fact
     needed by {name}`Hex.SimpleRoot.mk`. The returned atom is not promised to

--- a/HexRoots/README.md
+++ b/HexRoots/README.md
@@ -28,14 +28,14 @@ def p : ZPoly := DensePoly.ofCoeffs #[-1, -1, 0, 1]
 
 def roots : Option (Array (DyadicRootIsolation p)) :=
   if h : HasOnlySimpleRoots p then
-    isolate p h 32 .nkThenPellet
+    isolate? p h 32 .nkThenPellet
   else
     none
 ```
 
 # Functionality
 
-- `Hex.isolate p h precision strategy` returns pairwise-disjoint atoms for a
+- `Hex.isolate? p h precision strategy` returns pairwise-disjoint atoms for a
   polynomial whose roots are simple. A nonzero constant returns an empty
   array; the zero polynomial returns `none`.
 - `Hex.HasOnlySimpleRoots` is an executable, decidable precondition.

--- a/HexRoots/SPEC/hex-roots.md
+++ b/HexRoots/SPEC/hex-roots.md
@@ -422,7 +422,7 @@ def isolateAll? (p : ZPoly) (target : Int) (worklist : Array Component)
     positive degree, so the degenerate inputs are pinned here: a
     nonzero constant returns `some #[]` (no roots to isolate), and
     the zero polynomial returns `none`. -/
-def isolate (p : ZPoly) (h : Hex.HasOnlySimpleRoots p) (atom_prec : Int)
+def isolate? (p : ZPoly) (h : Hex.HasOnlySimpleRoots p) (atom_prec : Int)
     (strategy : AtomStrategy := .nkThenPellet) :
     Option (Array (DyadicRootIsolation p))
 
@@ -544,7 +544,7 @@ already a target-ready atom with pairwise-disjoint discs. At the
 normalized depth, every component is
 root-bearing; the Mathlib companion proves that all three strategies
 certify it as an atom and that the atom discs are pairwise disjoint.
-Thus `isolate` returns `some` for every nonzero squarefree input.
+Thus `isolate?` returns `some` for every nonzero squarefree input.
 `stopSlack` leaves three further rounds for the general driver and
 non-squarefree inputs. A `none` from a driver means only that its full
 emission condition was not reached within the fixed fuel bound; it does
@@ -620,7 +620,7 @@ one-square witness certifies. Roots on a grid *line* keep a two-square
 or four-square component under pure subdivision. Newton recentring is
 what turns those into single-square atoms.
 
-For polynomials with multiple roots there is no `isolate` analogue.
+For polynomials with multiple roots there is no `isolate?` analogue.
 Use `isolateAll?` directly: a multiple root never atomizes (the `k = 1`
 witness requires `c₁` bounded away from 0, and `c₁ → 0` near a
 multiple root), so it appears in the output as a cluster with its
@@ -772,7 +772,7 @@ def RefinedIsolation.refineTo? (r : RefinedIsolation p) (target : Int)
 which floors the target at `mahlerPrec p` (so the subtype re-wrap
 always succeeds on a `some`) and derives the identity proof from the
 decidable `Intersects` re-check via `Quot.sound`; and
-`DyadicRootIsolation.toRefined?` records that an `isolate` output
+`DyadicRootIsolation.toRefined?` records that an `isolate?` output
 meets the separation precision. `refineTo?` preserves the root
 (`sameRoot r r' = true`, proved meaningful in the companion), so
 callers can substitute the refined representative wherever the
@@ -852,7 +852,7 @@ is made here for pure Pellet refinement of a non-squarefree ambient polynomial.
   worklist, including the local first-refinable-atom search, `stopDepth`, the
   Φ termination measure discussion, and `DyadicRootIsolation.refineTo?` as a
   thin wrapper.
-- `HexRoots/IsolateAll.lean`: `isolateAll?`, `isolate`, and the local
+- `HexRoots/IsolateAll.lean`: `isolateAll?`, `isolate?`, and the local
   `isolateOne?` entry point as thin wrappers over the shared driver loops, and
   the refined threading operation `RefinedIsolation.refineTo?` (below).
 - `HexRoots/SimpleRoot.lean`: `RefinedIsolation`, `Intersects`,
@@ -947,7 +947,7 @@ bit-length at precision `prec`.
   the two base squares are concentric. This does not change the
   asymptotic bound, but removes the repeated dominant `O(n²)` shift
   from those paths.
-- `isolate` for degree `n`, well-separated roots, target precision
+- `isolate?` for degree `n`, well-separated roots, target precision
   `prec`: heuristically `O(n³ · B²)` bit operations. Tight root
   clusters add subdivision depth up to `O(mahlerPrec p)`.
 
@@ -956,7 +956,7 @@ bit-length at precision `prec`.
 Regression ceilings anchored to measured reality (`chungus2`, AMD EPYC 9455,
 96 logical CPUs with substantial idle capacity, Lean 4.32.0-rc1). Every pinned row runs the compiled expression
 `isolateAll? (seededPoly degree) target #[Component.cauchy ...]`; this avoids
-`isolate`'s higher `separationDepth` target and makes the stated precision the
+`isolate?`'s higher `separationDepth` target and makes the stated precision the
 actual driver target. Degree 10 and 20 use three measured cold calls with no
 discarded warmup, degree 50 uses two, and degree 100 uses one. The direct
 driver prints and checks the returned atom count; unlike the canonical fixed

--- a/HexRootsMathlib/Completeness/DriverCompleteness.lean
+++ b/HexRootsMathlib/Completeness/DriverCompleteness.lean
@@ -1282,9 +1282,9 @@ private theorem array_mapM_atoms {p : Hex.ZPoly}
 /-- Every nonzero squarefree executable polynomial is successfully isolated
 by each atom strategy. Nonzero constants take the explicit empty-output
 branch; positive-degree inputs use the complete Cauchy-started driver. -/
-theorem isolate_exists (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolate?_exists (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (hp : p ≠ 0) (atomPrec : Int) (strategy : Hex.AtomStrategy) :
-    ∃ atoms, Hex.isolate p h atomPrec strategy = some atoms := by
+    ∃ atoms, Hex.isolate? p h atomPrec strategy = some atoms := by
   have hpSize : p.size ≠ 0 := by
     intro hsize0
     apply hp
@@ -1308,38 +1308,38 @@ theorem isolate_exists (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
       (le_max_right _ _) strategy hd
     obtain ⟨atoms, hmap⟩ := array_mapM_atoms rs hatoms
     refine ⟨atoms, ?_⟩
-    rw [Hex.isolate, dite_eq_left hd]
+    rw [Hex.isolate?, dite_eq_left hd]
     change (Hex.isolateAll? p target #[Hex.Component.cauchy p hd] strategy).bind
       (fun rs => rs.mapM Hex.Certified.asAtom?) = some atoms
     rw [hall]
     exact hmap
   · refine ⟨#[], ?_⟩
-    rw [Hex.isolate, dite_eq_right hd]
+    rw [Hex.isolate?, dite_eq_right hd]
     simp [hpSize]
 
 /-- A nonzero squarefree polynomial has a successful isolation whose atoms
 enumerate its complex roots exactly, without duplicates, at the requested
 precision.  This bundles driver completeness with the principal soundness
 contracts for proof-facing clients. -/
-theorem isolate_spec (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolate?_spec (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (hp : p ≠ 0) (atomPrec : Int)
     (strategy : Hex.AtomStrategy := .nkThenPellet) :
     ∃ atoms : Array (Hex.DyadicRootIsolation p),
-      Hex.isolate p h atomPrec strategy = some atoms ∧
+      Hex.isolate? p h atomPrec strategy = some atoms ∧
       atoms.size = (toPolyℂ p).natDegree ∧
       (atoms.toList.map HexRootsMathlib.DyadicRootIsolation.root).toFinset =
         (toPolyℂ p).roots.toFinset ∧
       ∀ iso ∈ atoms.toList, atomPrec ≤ iso.square.prec := by
-  obtain ⟨atoms, hrun⟩ := isolate_exists p h hp atomPrec strategy
-  obtain ⟨hroots, hprec⟩ := isolate_sound p h atomPrec strategy hrun
-  exact ⟨atoms, hrun, isolate_count p h atomPrec strategy hrun,
+  obtain ⟨atoms, hrun⟩ := isolate?_exists p h hp atomPrec strategy
+  obtain ⟨hroots, hprec⟩ := isolate?_sound p h atomPrec strategy hrun
+  exact ⟨atoms, hrun, isolate?_count p h atomPrec strategy hrun,
     hroots, hprec⟩
 
 /-- Boolean `isSome` form of full driver completeness. -/
-theorem isolate_isSome (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolate?_isSome (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (hp : p ≠ 0) (atomPrec : Int) (strategy : Hex.AtomStrategy) :
-    (Hex.isolate p h atomPrec strategy).isSome = true := by
-  obtain ⟨atoms, hatoms⟩ := isolate_exists p h hp atomPrec strategy
+    (Hex.isolate? p h atomPrec strategy).isSome = true := by
+  obtain ⟨atoms, hatoms⟩ := isolate?_exists p h hp atomPrec strategy
   rw [hatoms]
   rfl
 

--- a/HexRootsMathlib/Examples.lean
+++ b/HexRootsMathlib/Examples.lean
@@ -293,13 +293,13 @@ theorem pisot_roots :
 the three explicitly bounded roots above. -/
 theorem isolate_pisot :
     ∃ atoms : Array (DyadicRootIsolation pisot),
-      isolate pisot pisot_simple 32 .nk = some atoms ∧
+      isolate? pisot pisot_simple 32 .nk = some atoms ∧
       atoms.size = 3 ∧
       (atoms.toList.map HexRootsMathlib.DyadicRootIsolation.root).toFinset =
         {pisotRealRoot, pisotLowerRoot, pisotUpperRoot} ∧
       ∀ iso ∈ atoms.toList, 32 ≤ iso.square.prec := by
   obtain ⟨atoms, hrun, hcount, hroots, hprec⟩ :=
-    isolate_spec pisot pisot_simple pisot_ne_zero 32 .nk
+    isolate?_spec pisot pisot_simple pisot_ne_zero 32 .nk
   exact ⟨atoms, hrun, hcount.trans natDegree_pisot,
     hroots.trans pisot_roots, hprec⟩
 

--- a/HexRootsMathlib/Isolate.lean
+++ b/HexRootsMathlib/Isolate.lean
@@ -15,7 +15,7 @@ public section
 /-!
 # Exact atom enumeration
 
-Successful `Hex.isolate` calls enumerate the complex roots exactly, for every
+Successful `Hex.isolate?` calls enumerate the complex roots exactly, for every
 atom strategy and including the executable zero and constant branches.
 -/
 
@@ -94,11 +94,11 @@ theorem array_mapM_isSome {α β : Type*} {f : α → Option β}
 /-- In the positive-degree branch, successful isolation is a successful
 Cauchy-started general driver run whose results correspond indexwise to the
 returned atoms. -/
-theorem isolate_run (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolate?_run (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (atomPrec : Int) (strategy : Hex.AtomStrategy)
     (hdegree : 0 < p.natDegree)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate p h atomPrec strategy = some atoms) :
+    (hrun : Hex.isolate? p h atomPrec strategy = some atoms) :
     ∃ rs : Array (Hex.Certified p),
       Hex.isolateAll? p (max atomPrec (Hex.separationDepth p : Int))
         #[Hex.Component.cauchy p hdegree] strategy = some rs ∧
@@ -106,7 +106,7 @@ theorem isolate_run (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
       ∀ (i : Nat) (hi : i < rs.size) (hj : i < atoms.size),
         rs[i] = .atom atoms[i] := by
   have hrun' := hrun
-  rw [Hex.isolate, dite_eq_left hdegree] at hrun'
+  rw [Hex.isolate?, dite_eq_left hdegree] at hrun'
   let target := max atomPrec (Hex.separationDepth p : Int)
   cases hall : Hex.isolateAll? p target
       #[Hex.Component.cauchy p hdegree] strategy with
@@ -130,15 +130,15 @@ theorem isolate_run (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
 
 /-- Every root belongs to one of the atoms returned by successful
 positive-degree isolation. -/
-theorem isolate_root_mem_of_pos (p : Hex.ZPoly)
+theorem isolate?_root_mem_of_pos (p : Hex.ZPoly)
     (h : Hex.HasOnlySimpleRoots p) (atomPrec : Int)
     (strategy : Hex.AtomStrategy) (hdegree : 0 < p.natDegree)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate p h atomPrec strategy = some atoms)
+    (hrun : Hex.isolate? p h atomPrec strategy = some atoms)
     {z : ℂ} (hzroot : (toPolyℂ p).IsRoot z) :
     ∃ iso ∈ atoms.toList, DyadicRootIsolation.root iso = z := by
   obtain ⟨rs, hall, hsize, hrel⟩ :=
-    isolate_run p h atomPrec strategy hdegree hrun
+    isolate?_run p h atomPrec strategy hdegree hrun
   obtain ⟨r, hr, hzr⟩ :=
     isolateAll_cauchy_covers p hdegree hall hzroot
   obtain ⟨i, hiList, hir⟩ := List.getElem_of_mem hr
@@ -156,14 +156,14 @@ theorem isolate_root_mem_of_pos (p : Hex.ZPoly)
 
 /-- A successful non-positive-degree call is the nonzero constant branch and
 returns no atoms, independently of strategy. -/
-theorem isolate_nonpositive (p : Hex.ZPoly)
+theorem isolate?_nonpositive (p : Hex.ZPoly)
     (h : Hex.HasOnlySimpleRoots p) (atomPrec : Int)
     (strategy : Hex.AtomStrategy) (hdegree : ¬0 < p.natDegree)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate p h atomPrec strategy = some atoms) :
+    (hrun : Hex.isolate? p h atomPrec strategy = some atoms) :
     p.size ≠ 0 ∧ atoms = #[] := by
   have hrun' := hrun
-  rw [Hex.isolate, dite_eq_right hdegree] at hrun'
+  rw [Hex.isolate?, dite_eq_right hdegree] at hrun'
   by_cases hp : p.size = 0
   · simp [hp] at hrun'
   · have hatoms : atoms = #[] := by
@@ -172,15 +172,15 @@ theorem isolate_nonpositive (p : Hex.ZPoly)
 
 /-- Every returned atom meets the full driver target, not only the requested
 atom precision. -/
-theorem isolate_prec (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolate?_prec (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (atomPrec : Int) (strategy : Hex.AtomStrategy)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate p h atomPrec strategy = some atoms) :
+    (hrun : Hex.isolate? p h atomPrec strategy = some atoms) :
     ∀ iso ∈ atoms.toList,
       max atomPrec (Hex.separationDepth p : Int) ≤ iso.square.prec := by
   by_cases hdegree : 0 < p.natDegree
   · obtain ⟨rs, hall, hsize, hrel⟩ :=
-      isolate_run p h atomPrec strategy hdegree hrun
+      isolate?_run p h atomPrec strategy hdegree hrun
     intro iso hiso
     obtain ⟨i, hiList, hir⟩ := List.getElem_of_mem hiso
     have hi : i < atoms.size := by simpa using hiList
@@ -192,16 +192,16 @@ theorem isolate_prec (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     rw [← hir]
     exact hready.1
   · obtain ⟨-, hatoms⟩ :=
-      isolate_nonpositive p h atomPrec strategy hdegree hrun
+      isolate?_nonpositive p h atomPrec strategy hdegree hrun
     subst atoms
     simp
 
 /-- Every successful isolation result can be wrapped as a
 `RefinedIsolation`: the driver's separation target dominates `mahlerPrec`. -/
-theorem isolate_refined (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolate?_refined (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (atomPrec : Int) (strategy : Hex.AtomStrategy)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate p h atomPrec strategy = some atoms) :
+    (hrun : Hex.isolate? p h atomPrec strategy = some atoms) :
     ∀ iso ∈ atoms.toList, (Hex.mahlerPrec p : Int) ≤ iso.square.prec := by
   have hsepNat : Hex.mahlerPrec p ≤ Hex.separationDepth p := by
     rw [Hex.separationDepth]
@@ -210,20 +210,20 @@ theorem isolate_refined (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
       (Hex.separationDepth p : Int) := by exact_mod_cast hsepNat
   intro iso hiso
   exact hsep.trans <| (le_max_right atomPrec
-    (Hex.separationDepth p : Int)).trans <| isolate_prec p h atomPrec
+    (Hex.separationDepth p : Int)).trans <| isolate?_prec p h atomPrec
       strategy hrun iso hiso
 
 /-- Distinct output indices select distinct semantic roots. -/
-theorem isolate_roots_ne (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolate?_roots_ne (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (atomPrec : Int) (strategy : Hex.AtomStrategy)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate p h atomPrec strategy = some atoms)
+    (hrun : Hex.isolate? p h atomPrec strategy = some atoms)
     {i j : Nat} (hi : i < atoms.size) (hj : j < atoms.size) (hij : i ≠ j) :
     DyadicRootIsolation.root atoms[i] ≠
       DyadicRootIsolation.root atoms[j] := by
   by_cases hdegree : 0 < p.natDegree
   · obtain ⟨rs, hall, hsize, hrel⟩ :=
-      isolate_run p h atomPrec strategy hdegree hrun
+      isolate?_run p h atomPrec strategy hdegree hrun
     have hi' : i < rs.size := by simpa [hsize] using hi
     have hj' : j < rs.size := by simpa [hsize] using hj
     have hri := hrel i hi' hi
@@ -241,22 +241,22 @@ theorem isolate_roots_ne (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     rw [heq] at hmemi
     exact (Set.disjoint_left.mp hdisj) hmemi hmemj
   · obtain ⟨-, hatoms⟩ :=
-      isolate_nonpositive p h atomPrec strategy hdegree hrun
+      isolate?_nonpositive p h atomPrec strategy hdegree hrun
     subst atoms
     simp at hi
 
 /-- Distinct output atoms have disjoint closed circumscribed discs, for every
 strategy accepted by the general isolation driver. -/
-theorem isolate_disjoint (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolate?_disjoint (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (atomPrec : Int) (strategy : Hex.AtomStrategy)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate p h atomPrec strategy = some atoms)
+    (hrun : Hex.isolate? p h atomPrec strategy = some atoms)
     {i j : Nat} (hi : i < atoms.size) (hj : j < atoms.size) (hij : i ≠ j) :
     Disjoint (DyadicSquare.closedDisc atoms[i].square)
       (DyadicSquare.closedDisc atoms[j].square) := by
   by_cases hdegree : 0 < p.natDegree
   · obtain ⟨rs, hall, hsize, hrel⟩ :=
-      isolate_run p h atomPrec strategy hdegree hrun
+      isolate?_run p h atomPrec strategy hdegree hrun
     have hi' : i < rs.size := by simpa [hsize] using hi
     have hj' : j < rs.size := by simpa [hsize] using hj
     have hri := hrel i hi' hi
@@ -265,22 +265,22 @@ theorem isolate_disjoint (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     rw [hri, hrj] at hdisj
     exact hdisj
   · obtain ⟨-, hatoms⟩ :=
-      isolate_nonpositive p h atomPrec strategy hdegree hrun
+      isolate?_nonpositive p h atomPrec strategy hdegree hrun
     subst atoms
     simp at hi
 
 /-- The number of returned atoms is the polynomial's complex natural degree.
-Together with `isolate_roots_ne`, this records that the exact enumeration has
+Together with `isolate?_roots_ne`, this records that the exact enumeration has
 no duplicate representatives. -/
-theorem isolate_count (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolate?_count (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (atomPrec : Int) (strategy : Hex.AtomStrategy)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate p h atomPrec strategy = some atoms) :
+    (hrun : Hex.isolate? p h atomPrec strategy = some atoms) :
     atoms.size = (toPolyℂ p).natDegree := by
   classical
   by_cases hdegree : 0 < p.natDegree
   · obtain ⟨rs, hall, hsize, hrel⟩ :=
-      isolate_run p h atomPrec strategy hdegree hrun
+      isolate?_run p h atomPrec strategy hdegree hrun
     calc
       atoms.size = rs.size := hsize.symm
       _ = ∑ _i : Fin rs.size, 1 := by simp
@@ -292,7 +292,7 @@ theorem isolate_count (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
         rfl
       _ = (toPolyℂ p).natDegree := isolateAll_count p hdegree hall
   · obtain ⟨-, hatoms⟩ :=
-      isolate_nonpositive p h atomPrec strategy hdegree hrun
+      isolate?_nonpositive p h atomPrec strategy hdegree hrun
     subst atoms
     rw [Array.size_empty, natDegree_toPolyℂ]
     exact Nat.eq_zero_of_not_pos hdegree |>.symm
@@ -300,10 +300,10 @@ theorem isolate_count (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
 /-- Successful isolation enumerates exactly the distinct complex roots and
 meets the requested precision, for every strategy and every executable edge
 case. -/
-theorem isolate_sound (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolate?_sound (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (atomPrec : Int) (strategy : Hex.AtomStrategy)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate p h atomPrec strategy = some atoms) :
+    (hrun : Hex.isolate? p h atomPrec strategy = some atoms) :
     (atoms.toList.map DyadicRootIsolation.root).toFinset =
         (toPolyℂ p).roots.toFinset ∧
       ∀ iso ∈ atoms.toList, atomPrec ≤ iso.square.prec := by
@@ -326,14 +326,14 @@ theorem isolate_sound (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
         have hzroot : (toPolyℂ p).IsRoot z :=
           (mem_roots hq).mp (Multiset.mem_toFinset.mp hz)
         obtain ⟨iso, hiso, hroot⟩ :=
-          isolate_root_mem_of_pos p h atomPrec strategy hdegree hrun hzroot
+          isolate?_root_mem_of_pos p h atomPrec strategy hdegree hrun hzroot
         rw [List.mem_toFinset]
         exact List.mem_map.mpr ⟨iso, hiso, hroot⟩
     · intro iso hiso
       exact (le_max_left atomPrec (Hex.separationDepth p : Int)).trans <|
-        isolate_prec p h atomPrec strategy hrun iso hiso
+        isolate?_prec p h atomPrec strategy hrun iso hiso
   · obtain ⟨hp, hatoms⟩ :=
-      isolate_nonpositive p h atomPrec strategy hdegree hrun
+      isolate?_nonpositive p h atomPrec strategy hdegree hrun
     have hroots : (toPolyℂ p).roots = 0 := by
       apply Multiset.eq_zero_of_forall_notMem
       intro z hz

--- a/HexRootsMathlib/IsolateTotal.lean
+++ b/HexRootsMathlib/IsolateTotal.lean
@@ -24,63 +24,63 @@ noncomputable section
 
 /-- Isolate all complex roots of a nonzero squarefree integer polynomial.
 
-Unlike `Hex.isolate`, this proof-facing wrapper cannot return `none`: its
+Unlike `Hex.isolate?`, this proof-facing wrapper cannot return `none`: its
 required hypotheses discharge the driver's completeness conditions. The
-result is characterized by `isolate!_eq` as the successful executable output,
+result is characterized by `isolate_eq` as the successful executable output,
 with the same atom strategy and requested-precision parameters. -/
-def isolate! (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p) (hp : p ≠ 0)
+def isolate (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p) (hp : p ≠ 0)
     (atomPrec : Int) (strategy : Hex.AtomStrategy := .nkThenPellet) :
     Array (Hex.DyadicRootIsolation p) :=
-  (isolate_exists p h hp atomPrec strategy).choose
+  (isolate?_exists p h hp atomPrec strategy).choose
 
-/-- The total wrapper is exactly the successful result of `Hex.isolate`. -/
-theorem isolate!_eq (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+/-- The total wrapper is exactly the successful result of `Hex.isolate?`. -/
+theorem isolate_eq (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (hp : p ≠ 0) (atomPrec : Int)
     (strategy : Hex.AtomStrategy := .nkThenPellet) :
-    Hex.isolate p h atomPrec strategy = some (isolate! p h hp atomPrec strategy) :=
-  (isolate_exists p h hp atomPrec strategy).choose_spec
+    Hex.isolate? p h atomPrec strategy = some (isolate p h hp atomPrec strategy) :=
+  (isolate?_exists p h hp atomPrec strategy).choose_spec
 
 /-- The total wrapper returns one atom for each complex root, counted with
 multiplicity. -/
-theorem isolate!_count (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolate_count (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (hp : p ≠ 0) (atomPrec : Int)
     (strategy : Hex.AtomStrategy := .nkThenPellet) :
-    (isolate! p h hp atomPrec strategy).size =
+    (isolate p h hp atomPrec strategy).size =
       (HexRootsMathlib.toPolyℂ p).natDegree :=
-  isolate_count p h atomPrec strategy (isolate!_eq p h hp atomPrec strategy)
+  isolate?_count p h atomPrec strategy (isolate_eq p h hp atomPrec strategy)
 
 /-- The semantic roots selected by the returned atoms are exactly the roots of
 the input polynomial. -/
-theorem isolate!_roots (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolate_roots (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (hp : p ≠ 0) (atomPrec : Int)
     (strategy : Hex.AtomStrategy := .nkThenPellet) :
-    ((isolate! p h hp atomPrec strategy).toList.map
+    ((isolate p h hp atomPrec strategy).toList.map
       HexRootsMathlib.DyadicRootIsolation.root).toFinset =
         (HexRootsMathlib.toPolyℂ p).roots.toFinset :=
-  (isolate_sound p h atomPrec strategy
-    (isolate!_eq p h hp atomPrec strategy)).1
+  (isolate?_sound p h atomPrec strategy
+    (isolate_eq p h hp atomPrec strategy)).1
 
 /-- Every returned atom meets the requested precision. -/
-theorem isolate!_prec (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolate_prec (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (hp : p ≠ 0) (atomPrec : Int)
     (strategy : Hex.AtomStrategy := .nkThenPellet) :
-    ∀ iso ∈ (isolate! p h hp atomPrec strategy).toList,
+    ∀ iso ∈ (isolate p h hp atomPrec strategy).toList,
       atomPrec ≤ iso.square.prec :=
-  (isolate_sound p h atomPrec strategy
-    (isolate!_eq p h hp atomPrec strategy)).2
+  (isolate?_sound p h atomPrec strategy
+    (isolate_eq p h hp atomPrec strategy)).2
 
 /-- Distinct atoms returned by the total wrapper have disjoint closed
 circumscribed discs. -/
-theorem isolate!_disjoint (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolate_disjoint (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (hp : p ≠ 0) (atomPrec : Int)
     (strategy : Hex.AtomStrategy := .nkThenPellet)
-    {i j : Nat} (hi : i < (isolate! p h hp atomPrec strategy).size)
-    (hj : j < (isolate! p h hp atomPrec strategy).size) (hij : i ≠ j) :
+    {i j : Nat} (hi : i < (isolate p h hp atomPrec strategy).size)
+    (hj : j < (isolate p h hp atomPrec strategy).size) (hij : i ≠ j) :
     Disjoint
-      (DyadicSquare.closedDisc (isolate! p h hp atomPrec strategy)[i].square)
-      (DyadicSquare.closedDisc (isolate! p h hp atomPrec strategy)[j].square) :=
-  isolate_disjoint p h atomPrec strategy
-    (isolate!_eq p h hp atomPrec strategy) hi hj hij
+      (DyadicSquare.closedDisc (isolate p h hp atomPrec strategy)[i].square)
+      (DyadicSquare.closedDisc (isolate p h hp atomPrec strategy)[j].square) :=
+  isolate?_disjoint p h atomPrec strategy
+    (isolate_eq p h hp atomPrec strategy) hi hj hij
 
 end
 

--- a/HexRootsMathlib/NKDriver.lean
+++ b/HexRootsMathlib/NKDriver.lean
@@ -143,7 +143,7 @@ exactly to the returned NK atoms. -/
 theorem isolate_nk_run (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (atomPrec : Int) (hdegree : 0 < p.natDegree)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate p h atomPrec .nk = some atoms) :
+    (hrun : Hex.isolate? p h atomPrec .nk = some atoms) :
     ∃ rs : Array (Hex.Certified p),
       Hex.isolateAll? p (max atomPrec (Hex.separationDepth p : Int))
         #[Hex.Component.cauchy p hdegree] .nk = some rs ∧
@@ -152,7 +152,7 @@ theorem isolate_nk_run (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
         rs[i] = .atom atoms[i] ∧ Hex.nkWitness p atoms[i].square ∧
           atoms[i].witness.isNK = true := by
   have hrun' := hrun
-  rw [Hex.isolate, dite_eq_left hdegree] at hrun'
+  rw [Hex.isolate?, dite_eq_left hdegree] at hrun'
   let target := max atomPrec (Hex.separationDepth p : Int)
   cases hall : Hex.isolateAll? p target
       #[Hex.Component.cauchy p hdegree] .nk with
@@ -186,7 +186,7 @@ requested precision and contains a unique interior simple root. -/
 theorem isolate_nk_simple (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (atomPrec : Int) (hdegree : 0 < p.natDegree)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate p h atomPrec .nk = some atoms)
+    (hrun : Hex.isolate? p h atomPrec .nk = some atoms)
     {i : Nat} (hi : i < atoms.size) :
     atomPrec ≤ atoms[i].square.prec ∧
       Hex.nkWitness p atoms[i].square ∧
@@ -210,7 +210,7 @@ disjoint closed circumscribed discs. -/
 theorem isolate_nk_disjoint (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (atomPrec : Int) (hdegree : 0 < p.natDegree)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate p h atomPrec .nk = some atoms)
+    (hrun : Hex.isolate? p h atomPrec .nk = some atoms)
     {i j : Nat} (hi : i < atoms.size) (hj : j < atoms.size) (hij : i ≠ j) :
     Disjoint (DyadicSquare.closedDisc atoms[i].square)
       (DyadicSquare.closedDisc atoms[j].square) := by
@@ -229,7 +229,7 @@ theorem isolate_nk_covers_once_of_pos (p : Hex.ZPoly)
     (h : Hex.HasOnlySimpleRoots p) (atomPrec : Int)
     (hdegree : 0 < p.natDegree)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate p h atomPrec .nk = some atoms)
+    (hrun : Hex.isolate? p h atomPrec .nk = some atoms)
     {z : ℂ} (hzroot : (toPolyℂ p).IsRoot z) :
     ∃! i : Fin atoms.size,
       z ∈ DyadicSquare.closedSquare atoms[i].square := by
@@ -288,10 +288,10 @@ theorem isolate_nk_nonpositive (p : Hex.ZPoly)
     (h : Hex.HasOnlySimpleRoots p) (atomPrec : Int)
     (hdegree : ¬0 < p.natDegree)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate p h atomPrec .nk = some atoms) :
+    (hrun : Hex.isolate? p h atomPrec .nk = some atoms) :
     p.size ≠ 0 ∧ atoms = #[] := by
   have hrun' := hrun
-  rw [Hex.isolate, dite_eq_right hdegree] at hrun'
+  rw [Hex.isolate?, dite_eq_right hdegree] at hrun'
   by_cases hp : p.size = 0
   · simp [hp] at hrun'
   · have hatoms : atoms = #[] := by
@@ -303,7 +303,7 @@ exactly one returned atom, including the vacuous nonzero-constant branch. -/
 theorem isolate_nk_covers_once (p : Hex.ZPoly)
     (h : Hex.HasOnlySimpleRoots p) (atomPrec : Int)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate p h atomPrec .nk = some atoms)
+    (hrun : Hex.isolate? p h atomPrec .nk = some atoms)
     {z : ℂ} (hzroot : (toPolyℂ p).IsRoot z) :
     ∃! i : Fin atoms.size,
       z ∈ DyadicSquare.closedSquare atoms[i].square := by
@@ -317,7 +317,7 @@ theorem isolate_nk_covers_once (p : Hex.ZPoly)
 theorem isolate_nk_pairwise (p : Hex.ZPoly)
     (h : Hex.HasOnlySimpleRoots p) (atomPrec : Int)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate p h atomPrec .nk = some atoms)
+    (hrun : Hex.isolate? p h atomPrec .nk = some atoms)
     {i j : Nat} (hi : i < atoms.size) (hj : j < atoms.size) (hij : i ≠ j) :
     Disjoint (DyadicSquare.closedDisc atoms[i].square)
       (DyadicSquare.closedDisc atoms[j].square) := by
@@ -332,7 +332,7 @@ precision and has the unique interior simple-root contract. -/
 theorem isolate_nk_atom_sound (p : Hex.ZPoly)
     (h : Hex.HasOnlySimpleRoots p) (atomPrec : Int)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate p h atomPrec .nk = some atoms)
+    (hrun : Hex.isolate? p h atomPrec .nk = some atoms)
     {i : Nat} (hi : i < atoms.size) :
     atomPrec ≤ atoms[i].square.prec ∧
       Hex.nkWitness p atoms[i].square ∧

--- a/HexRootsMathlib/README.md
+++ b/HexRootsMathlib/README.md
@@ -27,7 +27,7 @@ import HexRootsMathlib
 
 # Functionality
 
-`HexRootsMathlib.isolate!` removes the executable `Option` when the caller has
+`HexRootsMathlib.isolate` removes the executable `Option` when the caller has
 the hypotheses required by completeness:
 
 ```lean
@@ -39,21 +39,21 @@ def p : ZPoly := DensePoly.ofCoeffs #[-1, -1, 0, 1]
 variable (hsimple : HasOnlySimpleRoots p) (hnonzero : p ≠ 0)
 
 noncomputable def roots : Array (DyadicRootIsolation p) :=
-  isolate! p hsimple hnonzero 32
+  isolate? p hsimple hnonzero 32
 ```
 
 The associated theorems are the main consumption surface:
 
 ```lean
-isolate!_eq     -- the array is the successful Hex.isolate result
-isolate!_count  -- one atom per complex root
-isolate!_roots  -- selected semantic roots equal p.roots.toFinset
-isolate!_prec   -- every square meets the requested precision
-isolate!_disjoint -- distinct squares have disjoint circumscribed discs
+isolate_eq     -- the array is the successful Hex.isolate? result
+isolate?_count  -- one atom per complex root
+isolate_roots  -- selected semantic roots equal p.roots.toFinset
+isolate?_prec   -- every square meets the requested precision
+isolate?_disjoint -- distinct squares have disjoint circumscribed discs
 ```
 
-Clients that already have a successful `Hex.isolate` call can instead use
-`isolate_sound`, `isolate_count`, `isolate_disjoint`, and the atom-level
+Clients that already have a successful `Hex.isolate?` call can instead use
+`isolate?_sound`, `isolate?_count`, `isolate?_disjoint`, and the atom-level
 semantic root API.
 
 # Verification

--- a/HexRootsMathlib/SPEC/hex-roots-mathlib.md
+++ b/HexRootsMathlib/SPEC/hex-roots-mathlib.md
@@ -20,7 +20,7 @@ its separation contract. **Completeness** proves that the actual driver either
 uses its verified Pellet-bearing all-atoms local finisher, directly emits an
 already-ready NK-only atom array, or reaches a normalized depth where every
 retained component certifies as one atom, so
-`isolate` never returns `none` on nonzero squarefree input under any atom
+`isolate?` never returns `none` on nonzero squarefree input under any atom
 strategy. One-atom refinement is additionally total under the default mixed
 strategy whenever the selected atom has reached `mahlerPrec`; this local result
 allows repeated roots elsewhere in the ambient polynomial. The soundness
@@ -85,7 +85,7 @@ third candidate-contribution slice
 experiment in hex-roots settles on Newton-Kantorovich atoms, the
 Rouché-on-circles development below is needed only for `k ≥ 2`
 cluster soundness and the Pellet atom disjunct, and drops off the
-critical path for `isolate` on squarefree inputs (whose soundness
+critical path for `isolate?` on squarefree inputs (whose soundness
 then rests on `T_0` coverage, a triangle inequality, plus
 Newton-Kantorovich and the Mahler separation bound).
 
@@ -363,7 +363,7 @@ developments above.
   soundness. Retained squares cover every root, output discs are pairwise
   disjoint, and each certificate has its asserted multiplicity count. Thus
   the general driver's certificate counts sum to the polynomial degree; when
-  `isolate` successfully extracts only atoms, their distinct semantic roots
+  `isolate?` successfully extracts only atoms, their distinct semantic roots
   enumerate the root finset exactly.
   ```lean
   theorem isolateAll_count (p : ZPoly)
@@ -371,15 +371,15 @@ developments above.
       (hr : isolateAll? p target #[Component.cauchy p h] strategy = some result) :
       ∑ i : Fin result.size, Certified.count result[i] = (toPolyℂ p).natDegree
 
-  theorem isolate_sound (p : ZPoly) (h : Hex.HasOnlySimpleRoots p)
+  theorem isolate?_sound (p : ZPoly) (h : Hex.HasOnlySimpleRoots p)
       (atom_prec : Int) (strategy : AtomStrategy) {atoms}
-      (ha : isolate p h atom_prec strategy = some atoms) :
+      (ha : isolate? p h atom_prec strategy = some atoms) :
       (atoms.toList.map (·.root)).toFinset = (toPolyℂ p).roots.toFinset ∧
       ∀ a ∈ atoms, atom_prec ≤ a.square.prec
   ```
   (`HasOnlySimpleRoots p` does *not* rule out `p = 0` (the
   executable gcd of `0` and `0` is `0`, of size `0 ≤ 1`), but
-  `isolate 0 _ _ = none` by definition, so the `ha` hypothesis
+  `isolate? 0 _ _ = none` by definition, so the `ha` hypothesis
   supplies nonzeroness; a nonzero constant returns `some #[]` and
   both sides are empty. The rational-separability correspondence in
   `HasOnlySimpleRoots.lean` carries a `p ≠ 0` hypothesis for the same reason.)
@@ -390,23 +390,23 @@ developments above.
   quotient equality remains available to Mathlib-free callers.
 - `HexRootsMathlib/IsolateTotal.lean`: the none-free consumption surface.
   ```lean
-  noncomputable def isolate! (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+  noncomputable def isolate (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
       (hp : p ≠ 0) (atomPrec : Int)
       (strategy : Hex.AtomStrategy := .nkThenPellet) :
       Array (Hex.DyadicRootIsolation p)
   ```
-  Unlike `Hex.isolate`, this proof-facing wrapper cannot return `none`:
+  Unlike `Hex.isolate?`, this proof-facing wrapper cannot return `none`:
   its hypotheses discharge the driver's completeness conditions and the
-  result is extracted from `isolate_exists`. It is characterized by
-  `isolate!_eq` (it is exactly the successful executable output), and
-  its behaviour is packaged by `isolate!_count` (one atom per root,
-  with multiplicity), `isolate!_roots` (the selected semantic roots are
-  exactly the root finset), `isolate!_prec` (every atom meets the
-  requested precision), and `isolate!_disjoint` (distinct atoms have
+  result is extracted from `isolate?_exists`. It is characterized by
+  `isolate_eq` (it is exactly the successful executable output), and
+  its behaviour is packaged by `isolate?_count` (one atom per root,
+  with multiplicity), `isolate_roots` (the selected semantic roots are
+  exactly the root finset), `isolate?_prec` (every atom meets the
+  requested precision), and `isolate?_disjoint` (distinct atoms have
   disjoint closed circumscribed discs).
 - `HexRootsMathlib/Examples.lean`: compiled regression examples for the
   public surface (kernel-`decide` witness checks on committed dyadic
-  fixtures and `isolate!`-based root extraction). Deliberately excluded
+  fixtures and `isolate?`-based root extraction). Deliberately excluded
   from the umbrella and built through the release-tests target so CI
   cannot silently lose it.
 
@@ -490,9 +490,9 @@ and it is the analytically hardest part:
     induction for `isolateLoop`/`isolateAll?`, and proves:
 
     ```lean
-    theorem isolate_isSome (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+    theorem isolate?_isSome (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
         (hp : p ≠ 0) (atomPrec : Int) (strategy : Hex.AtomStrategy) :
-        (Hex.isolate p h atomPrec strategy).isSome = true
+        (Hex.isolate? p h atomPrec strategy).isSome = true
     ```
 
     Nonzero constants take the executable empty-output branch. Positive-degree
@@ -591,14 +591,14 @@ dimensions. Polynomial and executable-witness specialization belongs in
 
 ## Headline correctness theorem
 
-`HexRootsMathlib.isolate_sound`: a successful run of the executable
+`HexRootsMathlib.isolate?_sound`: a successful run of the executable
 isolator on a nonzero polynomial with only simple roots returns atoms
 whose semantic roots enumerate the root finset of the polynomial
 exactly, every atom meeting the requested precision. This is the
 end-to-end post-condition of the public API. Totality under the same
-hypotheses is `isolate_isSome` (the completeness development's
-terminal theorem), packaged for consumers as the none-free `isolate!`
-wrapper with its characterisation family (`isolate!_eq`, `_count`,
+hypotheses is `isolate?_isSome` (the completeness development's
+terminal theorem), packaged for consumers as the none-free `isolate`
+wrapper with its characterisation family (`isolate_eq`, `_count`,
 `_roots`, `_prec`, `_disjoint`); the general-multiplicity count
 identity is `isolateAll_count`. Those are independently justified
 public API, and the correspondence and completeness theorems above are

--- a/PLAN/Releases.md
+++ b/PLAN/Releases.md
@@ -72,7 +72,7 @@ example that exercises the advertised user story end-to-end.
   integer polynomial. Results carry checked coverage, uniqueness,
   disjointness, count, and precision guarantees.
 - **Integration example:** `Examples/Release5.lean` — use the none-free
-  `HexRootsMathlib.isolate!` wrapper for complex roots and the
+  `HexRootsMathlib.isolate` wrapper for complex roots and the
   `isolate_roots` elaborator for repeated real roots.
 
 ## Release readiness predicate

--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -89,7 +89,7 @@ Mathlib, and supplies correspondence proofs or Mathlib-facing APIs):
 - **hex-gram-schmidt-mathlib**: `GramSchmidt.Int.basis` = Mathlib's `gramSchmidt`
 - **hex-poly-z-mathlib**: `DensePoly Int ≃+* Polynomial ℤ`, Mignotte bound (via Mathlib's Mahler measure)
 - **hex-roots-mathlib**: Pellet's test on circles (built from `circleIntegral`), the Mahler separation bound, soundness of refinement and `isolate`
-- **hex-real-roots-mathlib**: Sturm's theorem (counting form over `Polynomial ℝ`), chain correspondence, soundness and completeness of `isolate?`
+- **hex-real-roots-mathlib**: Sturm's theorem (counting form over `Polynomial ℝ`), chain correspondence, soundness and completeness of `ZPoly.isolate?`
 - **hex-interval-mathlib**: real semantics, verified arithmetic and elementary-function propagators, certificate replay, and the `interval` tactic
 - **hex-resultant-mathlib**: executable resultant agreement with `Polynomial.resultant`, specialization, root-product, and discriminant theorems
 - **hex-number-field-mathlib**: fixed-field correspondence, exactification, lazy arithmetic, and algebraic-coefficient root completeness
@@ -682,7 +682,7 @@ for developments whose source-local move has not happened yet.
 - [hex-roots.md](../../HexRoots/SPEC/hex-roots.md): certified complex root isolation for `Z[x]`
 - [hex-roots-mathlib](../../HexRootsMathlib/SPEC/hex-roots-mathlib.md): Pellet's test on circles, the Mahler separation bound, soundness of refinement and `isolate`
 - [hex-real-roots.md](../../HexRealRoots/SPEC/hex-real-roots.md): certified real root isolation for `Z[x]`, Sturm-count witnesses, Descartes search with Sturm fallback
-- [hex-real-roots-mathlib.md](../../HexRealRootsMathlib/SPEC/hex-real-roots-mathlib.md): Sturm's theorem, chain correspondence, soundness and completeness of `isolate?`
+- [hex-real-roots-mathlib.md](../../HexRealRootsMathlib/SPEC/hex-real-roots-mathlib.md): Sturm's theorem, chain correspondence, soundness and completeness of `ZPoly.isolate?`
 - [hex-interval.md](../../HexInterval/SPEC/hex-interval.md): exact interval data, shared programs, and budgeted propagation search
 - [hex-interval-mathlib.md](hex-interval-mathlib.md): real semantics, verified propagators, proof replay, and the `interval` tactic
 - **hex-interval-algebraic** (planned): Mathlib-facing interval providers backed by certified real and complex polynomial root isolation; its provider contract is specified in [hex-interval.md](../../HexInterval/SPEC/hex-interval.md#specialized-algebraic-solvers-before-generic-propagation)

--- a/bench/HexNumberField/Bench.lean
+++ b/bench/HexNumberField/Bench.lean
@@ -248,7 +248,7 @@ def runAddEliminant : Unit → IO UInt64 := fun _ => do
 def runIsolateAdd : Unit → IO UInt64 := fun _ => do
   let input ← requireSome "lazy/isolate-add" (← isolateInputRef.get)
   let isolations ← requireSome "lazy/isolate-add"
-    (isolate input.polynomial input.simple (input.depth : Int))
+    (isolate? input.polynomial input.simple (input.depth : Int))
   return isolations.foldl
     (fun checksum isolation =>
       mixHash checksum (squareChecksum isolation.square))
@@ -836,7 +836,7 @@ general constructor remains the fixture for ladders whose polynomial is not
 the binomial used to choose `ladderRootSeed`. -/
 private def refinedOf? (p : ZPoly) (h : HasOnlySimpleRoots p) :
     Option (RefinedIsolation p) := do
-  let isolations ← isolate p h (separationDepth p : Int)
+  let isolations ← isolate? p h (separationDepth p : Int)
   let iso ← isolations[0]?
   iso.toRefined?
 
@@ -845,9 +845,9 @@ candidate factor. This pins exactification fixtures to the intended factor
 rather than to the enclosing isolator's emission order. -/
 private def refinedFactor? (p q : ZPoly) (hp : HasOnlySimpleRoots p)
     (hq : HasOnlySimpleRoots q) : Option (RefinedIsolation p) := do
-  let pIsolations ← isolate p hp (separationDepth p : Int)
+  let pIsolations ← isolate? p hp (separationDepth p : Int)
   let pRefined ← pIsolations.mapM DyadicRootIsolation.toRefined?
-  let qIsolations ← isolate q hq (separationDepth q : Int)
+  let qIsolations ← isolate? q hq (separationDepth q : Int)
   let qIsolation ← qIsolations[0]?
   let qRefined ← qIsolation.toRefined?
   pRefined.toList.find? fun rep =>

--- a/bench/HexRealRoots/Bench.lean
+++ b/bench/HexRealRoots/Bench.lean
@@ -11,7 +11,7 @@ import LeanBench
 Benchmark registrations for `hex-real-roots`.
 
 This Phase 4 slice measures the certified real-root isolation surface: the
-two isolation engines through the public `isolate?`/`isolateSturm?` drivers,
+two isolation engines through the public `ZPoly.isolate?`/`ZPoly.isolateSturm?` drivers,
 the Sturm-chain and sign-variation primitives, the Möbius transform, the
 `rootBound`/`sepPrec` closed forms, and the `refineTo` refinement loop.
 
@@ -21,7 +21,7 @@ the scalar result, so the harness's hash column doubles as a
 cross-implementation conformance check.
 
 Input families (per `HexRealRoots/SPEC/hex-real-roots.md` §"Time budgets" and the
-conformance §"local" tier). `isolate?` is deliberately exercised on three
+conformance §"local" tier). `ZPoly.isolate?` is deliberately exercised on three
 structurally different families, never a single happy-path shape:
 
 * `well-separated-products`: `∏_{k=1}^{n} (x − k)`, `n` unit-separated integer
@@ -38,7 +38,7 @@ structurally different families, never a single happy-path shape:
 
 `compare runIsolateDescartesFirst runIsolateSturm` (shared
 `well-separated-products` domain) is the intentional cross-engine equivalence
-check: `isolate?` runs Descartes-first, `isolateSturm?` is the certified
+check: `ZPoly.isolate?` runs Descartes-first, `ZPoly.isolateSturm?` is the certified
 fallback, and both must hash-agree on the isolation endpoints at every common
 degree.
 
@@ -176,20 +176,20 @@ def refineP : ZPoly := DensePoly.ofCoeffs #[(-5 : Int), 1]
 
 /-! # Timed targets. -/
 
-/-- `isolate?` on the well-separated integer-root product. -/
-def runIsolateWellSep (p : ZPoly) : Int := isolationsChecksum (isolate? p)
+/-- `ZPoly.isolate?` on the well-separated integer-root product. -/
+def runIsolateWellSep (p : ZPoly) : Int := isolationsChecksum (ZPoly.isolate? p)
 
-/-- `isolate?` on the Chebyshev-clustered polynomial. -/
-def runIsolateChebyshev (p : ZPoly) : Int := isolationsChecksum (isolate? p)
+/-- `ZPoly.isolate?` on the Chebyshev-clustered polynomial. -/
+def runIsolateChebyshev (p : ZPoly) : Int := isolationsChecksum (ZPoly.isolate? p)
 
-/-- `isolate?` on the Mignotte worst-case polynomial. -/
-def runIsolateMignotte (p : ZPoly) : Int := isolationsChecksum (isolate? p)
+/-- `ZPoly.isolate?` on the Mignotte worst-case polynomial. -/
+def runIsolateMignotte (p : ZPoly) : Int := isolationsChecksum (ZPoly.isolate? p)
 
-/-- `isolate?` (Descartes-first) on the shared compare domain. -/
-def runIsolateDescartesFirst (p : ZPoly) : Int := isolationsChecksum (isolate? p)
+/-- `ZPoly.isolate?` (Descartes-first) on the shared compare domain. -/
+def runIsolateDescartesFirst (p : ZPoly) : Int := isolationsChecksum (ZPoly.isolate? p)
 
-/-- `isolateSturm?` (certified engine) on the shared compare domain. -/
-def runIsolateSturm (p : ZPoly) : Int := isolationsChecksum (isolateSturm? p)
+/-- `ZPoly.isolateSturm?` (certified engine) on the shared compare domain. -/
+def runIsolateSturm (p : ZPoly) : Int := isolationsChecksum (ZPoly.isolateSturm? p)
 
 /-- Build the Sturm chain of the dense fixture and checksum it. -/
 def runSturmChain (p : ZPoly) : Int := chainChecksum (ZPoly.sturmChain p)
@@ -216,7 +216,7 @@ def runSepPrec (p : ZPoly) : Int := Int.ofNat (sepPrec p)
 /-- Refine the first isolation of `x − 5` to precision `8·(n + 1)`; the
 escalating target drives a bisection depth linear in `n`. -/
 def runRefineTo (n : Nat) : Int :=
-  match isolate? refineP with
+  match ZPoly.isolate? refineP with
   | none => -1
   | some rs =>
     match rs.isolations[0]? with
@@ -232,7 +232,7 @@ step and how the fixture parameter maps onto that step's input size, per
 `SPEC/benchmarking.md`.
 -/
 
-/- `isolate?` on `∏(x−k)`. SPEC §"Complexity contract": well-separated roots
+/- `ZPoly.isolate?` on `∏(x−k)`. SPEC §"Complexity contract": well-separated roots
 resolve in `O(n + log(rootBound/gap))` bisection levels; with `O(n)` unresolved
 intervals per level that is `O(n²)` Möbius transforms, each an `O(n²)` integer
 Taylor shift, so `O(n⁴)` integer operations. Coefficient growth of `∏(x−k)`
@@ -249,7 +249,7 @@ setup_benchmark runIsolateWellSep n => n ^ 4
     signalFloorMultiplier := 1.0
   }
 
-/- `isolate?` on `T_n`. The clustered roots near `±1` (gaps `~1/n²`) force
+/- `ZPoly.isolate?` on `T_n`. The clustered roots near `±1` (gaps `~1/n²`) force
 `O(log n)` extra bisection levels versus the well-separated family, but the
 dominant asymptotic is still `O(n²)` Möbius transforms of `O(n²)` cost each,
 i.e. `O(n⁴)`; coefficient magnitude `~2^n` (`h ~ n`) is the bignum factor. -/
@@ -265,7 +265,7 @@ setup_benchmark runIsolateChebyshev n => n ^ 4
     signalFloorMultiplier := 1.0
   }
 
-/- `isolate?` on the Mignotte worst case. SPEC §"Complexity contract": bisection
+/- `ZPoly.isolate?` on the Mignotte worst case. SPEC §"Complexity contract": bisection
 depth is `O(n·(h + log n))` and each node is one `O(n²)` Möbius transform. The
 Mignotte polynomial has `O(1)` real roots (the close pair), so the bisection
 tree width is `O(1)` and the node count is `O(depth) = O(n)` at fixed `a`
@@ -285,7 +285,7 @@ setup_benchmark runIsolateMignotte n => n ^ 3
     signalFloorMultiplier := 1.0
   }
 
-/- Compare leg (Descartes-first `isolate?`). Shared `well-separated-products`
+/- Compare leg (Descartes-first `ZPoly.isolate?`). Shared `well-separated-products`
 domain with `runIsolateSturm`; same `O(n⁴)` textbook model as
 `runIsolateWellSep` since it is the same driver on the same inputs. -/
 -- Declared cost-model: worst-case O(n^4) integer operations, textbook Descartes bisection.
@@ -306,7 +306,7 @@ total degree `O(n²)` — and the primitive chain's coefficients grow to `O(n·h
 bits (SPEC §"Complexity contract"), so each node's bignum evaluation carries an
 extra factor of `O(n)` over the Descartes engine's bounded-coefficient Möbius
 transform: `O(n²)` nodes × `O(n²)` Horner × `O(n)` bit-growth = `O(n⁵)`. This
-super-`O(n⁴)` cost is exactly why `isolate?` runs Descartes first; the compare's
+super-`O(n⁴)` cost is exactly why `ZPoly.isolate?` runs Descartes first; the compare's
 relative-timing summary makes the gap concrete. -/
 -- Declared cost-model: O(n^5) bit-operations, full-chain-per-node Sturm bisection with O(n·h) coefficient growth.
 setup_benchmark runIsolateSturm n => n ^ 5

--- a/bench/HexRoots/Bench.lean
+++ b/bench/HexRoots/Bench.lean
@@ -286,7 +286,7 @@ def refinePoly : ZPoly := DensePoly.ofCoeffs #[6, -7, 0, 1]
 refined form against itself. `none` never occurs for this squarefree fixture. -/
 def refineAtom? : Option (DyadicRootIsolation refinePoly) :=
   if h : HasOnlySimpleRoots refinePoly then
-    match isolate refinePoly h 0 with
+    match isolate? refinePoly h 0 with
     | some atoms => atoms[0]?
     | none => none
   else none
@@ -338,7 +338,7 @@ def isolateAllChecksum (p : ZPoly) : UInt64 :=
 strategy-invariant projection; `0` for non-squarefree or degenerate inputs. -/
 def isolateDigest (strategy : AtomStrategy) (p : ZPoly) : UInt64 :=
   if h : HasOnlySimpleRoots p then
-    match isolate p h 0 strategy with
+    match isolate? p h 0 strategy with
     | some atoms => rootsDigest atoms
     | none => 0
   else 0

--- a/conformance/HexRealRoots/Conformance.lean
+++ b/conformance/HexRealRoots/Conformance.lean
@@ -22,11 +22,11 @@ Covered operations:
 - `Hex.ZPoly.spem`
 - `Hex.ZPoly.sturmChain`
 - `Hex.sturmVarAt`, `Hex.sturmVarNegInf`, `Hex.sturmVarPosInf`
-- `Hex.sturmCount`, `Hex.rootCount`
+- `Hex.ZPoly.sturmCount`, `Hex.ZPoly.rootCount`
 - `Hex.mobiusTransform`, `Hex.descartesVar`
 - `Hex.twoPow`, `Hex.ceilLog2Nat`, `Hex.ceilLog2Dyadic`
 - `Hex.rootBound`, `Hex.sepPrec`, `Hex.isolationDepth`
-- `Hex.isolateSturm?`, `Hex.isolateDescartes?`, `Hex.isolate?`
+- `Hex.ZPoly.isolateSturm?`, `Hex.ZPoly.isolateDescartes?`, `Hex.ZPoly.isolate?`
 - `Hex.RealRootIsolation.refine1`, `Hex.RealRootIsolation.refineTo`
 - `Hex.RealRootIsolation.refined`
 - `Hex.RefinedRealIsolation.sameRoot` (and the `Overlaps` decidability instance)
@@ -36,15 +36,15 @@ Covered properties:
 - `evalDyadic` is exact: the sign at a dyadic point matches the hand-computed
   value, hitting `0` exactly at a rational root.
 - `signVar` skips zeros: the variation count of `(+, 0, −)` is `1`.
-- `sturmCount` is additive across a split point:
+- `ZPoly.sturmCount` is additive across a split point:
   `count (a, c] = count (a, b] + count (b, c]`.
-- `rootCount` equals the number of real roots and equals the isolation count of
-  `isolate?` (completeness certificate).
+- `ZPoly.rootCount` equals the number of real roots and equals the isolation count of
+  `ZPoly.isolate?` (completeness certificate).
 - Every emitted isolation brackets a genuine sign change of `evalDyadic` (or a
   root exactly at the included upper endpoint), so a real root sits in each
   half-open interval.
 - Emitted isolations are ordered and pairwise disjoint (`upperᵢ ≤ lowerᵢ₊₁`).
-- The Sturm engine returns `some` and agrees with `isolate?` on the isolation
+- The Sturm engine returns `some` and agrees with `ZPoly.isolate?` on the isolation
   *count* (the intervals themselves need not coincide, and do not for
   `x³ − x − 1`).
 - `mobiusTransform` produces the literal SPEC numerator on committed intervals,
@@ -62,8 +62,8 @@ Covered properties:
   square-free primitive inputs and strips repeated factors otherwise.
 
 Covered edge cases:
-- the zero polynomial (`isolate? = none`) and a nonzero constant
-  (`isolate?` is `some` with an empty isolation array).
+- the zero polynomial (`ZPoly.isolate? = none`) and a nonzero constant
+  (`ZPoly.isolate?` is `some` with an empty isolation array).
 - a linear polynomial whose single root is captured by the whole initial
   interval without any bisection.
 - a dyadic root that a bisection midpoint hits exactly (`2x² − 5x + 2`, and the
@@ -189,32 +189,32 @@ private def refinedSubinterval {p : ZPoly} (i : RealRootIsolation p) : Option Bo
 
 /-! # Whole-run isolation, per fixture.
 
-For each fixture: the exact interval endpoints of `isolate?` (a human-readable
+For each fixture: the exact interval endpoints of `ZPoly.isolate?` (a human-readable
 regression pin, cross-checked against `python-flint` in the oracle PR); the
 independent teeth that make the pin more than a determinism check — the emitted
-count equals the mathematically known real-root count `rootCount`, every
+count equals the mathematically known real-root count `ZPoly.rootCount`, every
 interval brackets a real root, and the intervals are ordered and disjoint; and
 the Sturm engine's count agreement.
 
 The Descartes engine's per-fixture `some`/agreement stand-ins are retired: the
 companion theorem `HexRealRootsMathlib.isolateDescartes?_isSome` now carries the
-claim that `isolateDescartes?` never falls back on nonzero square-free input, so
-re-testing it here is noise. The zero / non-square-free `isolateDescartes? =
+claim that `ZPoly.isolateDescartes?` never falls back on nonzero square-free input, so
+re-testing it here is noise. The zero / non-square-free `ZPoly.isolateDescartes? =
 none` rejections below stay: they test the engine's input-contract
 classification, not the termination theorem. -/
 
-/-- Assert the shared per-fixture invariants, given the expected `isolate?`
+/-- Assert the shared per-fixture invariants, given the expected `ZPoly.isolate?`
 endpoints and the known real-root count `n`. Bundled so each fixture is one
 `#guard` block with no copy-pasted body. -/
 private def isolatesAs (p : ZPoly) (expected : Array (Dyadic × Dyadic)) (n : Nat) : Bool :=
-  -- `isolate?` yields the committed endpoints (oracle-verified in the oracle PR).
-  (endpoints (isolate? p) == some expected) &&
+  -- `ZPoly.isolate?` yields the committed endpoints (oracle-verified in the oracle PR).
+  (endpoints (ZPoly.isolate? p) == some expected) &&
   -- Completeness: one isolation per real root, matching the independent count.
-  (isoCount (isolate? p) == some n) && (rootCount p == n) &&
+  (isoCount (ZPoly.isolate? p) == some n) && (ZPoly.rootCount p == n) &&
   -- Each interval brackets a real root; the whole run is ordered and disjoint.
-  allBracket (isolate? p) && ((endpoints (isolate? p)).elim false sortedDisjoint) &&
+  allBracket (ZPoly.isolate? p) && ((endpoints (ZPoly.isolate? p)).elim false sortedDisjoint) &&
   -- Sturm engine: returns `some` and agrees on the isolation count.
-  (isolateSturm? p).isSome && (isoCount (isolateSturm? p) == some n)
+  (ZPoly.isolateSturm? p).isSome && (isoCount (ZPoly.isolateSturm? p) == some n)
 
 #guard isolatesAs linear #[(di (-8), di 8)] 1
 #guard isolatesAs quadPair #[(di (-4), di 0), (di 0, di 4)] 2
@@ -233,29 +233,29 @@ private def isolatesAs (p : ZPoly) (expected : Array (Dyadic × Dyadic)) (n : Na
 
 -- The Sturm engine's intervals need NOT coincide with the driver's: for
 -- `x³ − x − 1` the Sturm search emits the whole initial interval `(−4, 4]` (the
--- count is already `1`, so it never bisects) while `isolate?` (Descartes-first)
+-- count is already `1`, so it never bisects) while `ZPoly.isolate?` (Descartes-first)
 -- narrows to `(0, 4]`. Only the count is invariant across engines.
-#guard endpoints (isolateSturm? cubicSingle) = some #[(di (-4), di 4)]
-#guard endpoints (isolate? cubicSingle) = some #[(di 0, di 4)]
+#guard endpoints (ZPoly.isolateSturm? cubicSingle) = some #[(di (-4), di 4)]
+#guard endpoints (ZPoly.isolate? cubicSingle) = some #[(di 0, di 4)]
 
 /-! # Edge cases: zero, constant, non-square-free. -/
 
 -- The zero polynomial is rejected by every engine (input-contract classification,
 -- independent of the termination theorem).
-#guard isolate? zeroPoly = none
-#guard isolateSturm? zeroPoly = none
-#guard isolateDescartes? zeroPoly = none
+#guard ZPoly.isolate? zeroPoly = none
+#guard ZPoly.isolateSturm? zeroPoly = none
+#guard ZPoly.isolateDescartes? zeroPoly = none
 
--- A nonzero constant isolates with zero roots (empty chain, `rootCount = 0`),
+-- A nonzero constant isolates with zero roots (empty chain, `ZPoly.rootCount = 0`),
 -- through the full per-fixture invariant bundle.
 #guard isolatesAs const7 #[] 0
 
 -- Non-square-free rejection: both engines and the driver decline (input-contract
 -- classification), and the square-free core (`x² − 1`, from `(x − 1)²(x + 1)`)
 -- isolates its two roots through the full bundle.
-#guard isolate? nonSquareFree = none
-#guard isolateSturm? nonSquareFree = none
-#guard isolateDescartes? nonSquareFree = none
+#guard ZPoly.isolate? nonSquareFree = none
+#guard ZPoly.isolateSturm? nonSquareFree = none
+#guard ZPoly.isolateDescartes? nonSquareFree = none
 #guard (ZPoly.squareFreeCore nonSquareFree).toArray = #[(-1 : Int), 0, 1]
 #guard isolatesAs (ZPoly.squareFreeCore nonSquareFree) #[(di (-4), di 0), (di 0, di 4)] 2
 
@@ -339,20 +339,21 @@ private def isolatesAs (p : ZPoly) (expected : Array (Dyadic × Dyadic)) (n : Na
 #guard sturmVarNegInf (ZPoly.sturmChain const7) = 0
 #guard sturmVarPosInf (ZPoly.sturmChain const7) = 0
 
-/-! # `sturmCount` and `rootCount`. -/
+/-! # `ZPoly.sturmCount` and `ZPoly.rootCount`. -/
 
 -- `x² − 1`: `(−4, 4]` counts both roots, `(0, 4]` only `1`, `(1, 2]` excludes
 -- the left-endpoint root `1` (half-open) so `0`.
-#guard sturmCount quadPair ⟨di (-4), di 4, by decide⟩ = 2
-#guard sturmCount quadPair ⟨di 0, di 4, by decide⟩ = 1
-#guard sturmCount quadPair ⟨di 1, di 2, by decide⟩ = 0
+#guard ZPoly.sturmCount quadPair ⟨di (-4), di 4, by decide⟩ = 2
+#guard ZPoly.sturmCount quadPair ⟨di 0, di 4, by decide⟩ = 1
+#guard ZPoly.sturmCount quadPair ⟨di 1, di 2, by decide⟩ = 0
 -- Additivity across the split point `0`.
-#guard sturmCount quadPair ⟨di (-4), di 4, by decide⟩
-  = sturmCount quadPair ⟨di (-4), di 0, by decide⟩ + sturmCount quadPair ⟨di 0, di 4, by decide⟩
--- `rootCount` on committed inputs (independently known real-root counts).
-#guard rootCount quadPair = 2
-#guard rootCount quadNone = 0
-#guard rootCount cubicTriple = 3
+#guard ZPoly.sturmCount quadPair ⟨di (-4), di 4, by decide⟩
+  = ZPoly.sturmCount quadPair ⟨di (-4), di 0, by decide⟩
+    + ZPoly.sturmCount quadPair ⟨di 0, di 4, by decide⟩
+-- `ZPoly.rootCount` on committed inputs (independently known real-root counts).
+#guard ZPoly.rootCount quadPair = 2
+#guard ZPoly.rootCount quadNone = 0
+#guard ZPoly.rootCount cubicTriple = 3
 
 /-! # `mobiusTransform` and `descartesVar`. -/
 

--- a/conformance/HexRealRoots/EmitFixtures.lean
+++ b/conformance/HexRealRoots/EmitFixtures.lean
@@ -20,20 +20,20 @@ exact rational roots), never by re-running the Lean isolator.
 
 Operations covered:
 
-* `root_count`   — `Hex.rootCount p`, the total number of real roots,
+* `root_count`   — `Hex.ZPoly.rootCount p`, the total number of real roots,
   value an `Int`.
-* `isolations`   — the isolating intervals from `Hex.isolate? p`,
+* `isolations`   — the isolating intervals from `Hex.ZPoly.isolate? p`,
   value a matrix of rows `[lo_num, lo_exp, hi_num, hi_exp]`.  Each
   dyadic endpoint is encoded as `[num, exp]` with value `num · 2^(−exp)`
   (`Dyadic.zero` as `[0, 0]`, `Dyadic.ofOdd n k _` as `[n, k]`).
 * `isolate_none` — value `true` for the rejection cases (the zero
   polynomial and non-square-free inputs), where the driver declines.
 
-Records are emitted from the single top-level driver `Hex.isolate? p`.
+Records are emitted from the single top-level driver `Hex.ZPoly.isolate? p`.
 The Descartes/Sturm cross-engine agreement check this driver once
 carried (the executable stand-in for the termination theorem) is
 retired now that `HexRealRootsMathlib.isolateDescartes?_isSome` is
-proven; `isolate?` is Descartes-first, so on a square-free input its
+proven; `ZPoly.isolate?` is Descartes-first, so on a square-free input its
 output is exactly the Descartes engine's, and the emitted stream is
 unchanged.
 
@@ -68,8 +68,8 @@ private def isoRows {p : ZPoly} (res : RealRootIsolations p) : List (List Int) :
   res.isolations.toList.map fun iso =>
     dyadicPair iso.interval.lower ++ dyadicPair iso.interval.upper
 
-/-- Emit one case from the top-level driver `isolate? p`.  When
-`squarefree`, `isolate?` must return `some` (guaranteed by
+/-- Emit one case from the top-level driver `ZPoly.isolate? p`.  When
+`squarefree`, `ZPoly.isolate?` must return `some` (guaranteed by
 `isolate?_isSome`); the run is emitted from its output.  Otherwise it
 must return `none` and the case is a rejection.  Any deviation `throw`s,
 exiting non-zero. -/
@@ -77,18 +77,18 @@ private def emitCase (id : String) (coeffs : List Int) (squarefree : Bool) : IO 
   emitPolyFixture lib id coeffs
   let p : ZPoly := DensePoly.ofCoeffs coeffs.toArray
   if squarefree then
-    match isolate? p with
+    match ZPoly.isolate? p with
     | some r =>
-      emitResult lib id "root_count" (toString (rootCount p))
+      emitResult lib id "root_count" (toString (ZPoly.rootCount p))
       emitResult lib id "isolations" (intMatrixValue (isoRows r))
     | none =>
-      throw <| IO.userError s!"{lib}/{id}: isolate? fell back to none on a square-free input"
+      throw <| IO.userError s!"{lib}/{id}: ZPoly.isolate? fell back to none on a square-free input"
   else
-    match isolate? p with
+    match ZPoly.isolate? p with
     | none =>
       emitResult lib id "isolate_none" "true"
     | some _ =>
-      throw <| IO.userError s!"{lib}/{id}: expected isolate? to reject a non-square-free input"
+      throw <| IO.userError s!"{lib}/{id}: expected ZPoly.isolate? to reject a non-square-free input"
 
 /-! # SPEC core fixtures. -/
 

--- a/conformance/HexRealRootsMathlib/Conformance.lean
+++ b/conformance/HexRealRootsMathlib/Conformance.lean
@@ -13,7 +13,7 @@ Companion conformance checks for `HexRealRootsMathlib`.
 Oracle: none; checked against Mathlib root counts via the proven
 correspondence theorems. `rootCount_eq_card_roots` (and `squareFreeRat_iff` feeding its
 square-free hypothesis) is the bridge that ties the executable, computable
-`Hex.rootCount` to the noncomputable Mathlib `(toPolyℝ p).roots.card`. There is
+`Hex.ZPoly.rootCount` to the noncomputable Mathlib `(toPolyℝ p).roots.card`. There is
 no external oracle profile: the two sides are pinned independently — the
 executable side by `#guard` (native evaluation) and the Mathlib side by a
 hand-derived root-multiset computation proven as a theorem — and the correspond-
@@ -21,14 +21,14 @@ ence theorem certifies they agree.
 Mode: always for core.
 
 Covered operations:
-* `Hex.rootCount`, the executable real-root count, tied to the noncomputable
+* `Hex.ZPoly.rootCount`, the executable real-root count, tied to the noncomputable
   Mathlib count `(toPolyℝ p).roots.card` by `rootCount_eq_card_roots`.
 
 Covered properties:
-* `rootCount p = (toPolyℝ p).roots.card`, the root-count correspondence,
+* `ZPoly.rootCount p = (toPolyℝ p).roots.card`, the root-count correspondence,
   instantiated per fixture (executable side `#guard`ed, Mathlib side proven as a
   theorem from an independent factorisation).
-* the full formal tie on `x - 5`: `Hex.rootCount = 1` derived through
+* the full formal tie on `x - 5`: `Hex.ZPoly.rootCount = 1` derived through
   `rootCount_eq_card_roots` and `squareFreeRat_iff`, not read off evaluation.
 
 Covered edge cases:
@@ -45,14 +45,14 @@ Because Mathlib root counts are noncomputable, the checks are **theorems**, not
   an explicit `Polynomial ℝ` (mechanical `coeff` comparison).
 * `card_<fixture>` computes `(toPolyℝ <fixture>).roots.card` from that explicit
   polynomial by an independent Mathlib factorisation (the hand-derived count).
-* `#guard Hex.rootCount <fixture> = N` confirms the executable engine computes
+* `#guard Hex.ZPoly.rootCount <fixture> = N` confirms the executable engine computes
   the same `N` at runtime.
 
 This module certifies that the **theorem layer** connects — that the
 correspondence theorems instantiate and transport concrete counts — rather than
 re-running the executable oracle (which is `HexRealRoots.Conformance`'s job).
 The `x − 5` fixture carries the full formal tie: `rootCount_x_sub_5` derives
-`Hex.rootCount = 1` from `rootCount_eq_card_roots` and the independent
+`Hex.ZPoly.rootCount = 1` from `rootCount_eq_card_roots` and the independent
 `card_linear`, so the executable value (also `#guard`ed) is pinned by the
 theorem, not just by evaluation. The higher-degree fixtures certify each side
 independently against the same hand-derived count; their full ties would need a
@@ -181,18 +181,18 @@ private theorem card_const7 : (toPolyℝ const7).roots.card = 0 := by
 
 /-! # Executable root counts agree with the Mathlib counts (runtime). -/
 
-#guard Hex.rootCount linear = 1
-#guard Hex.rootCount quadPair = 2
-#guard Hex.rootCount quadNone = 0
-#guard Hex.rootCount cubicTriple = 3
-#guard Hex.rootCount const7 = 0
+#guard Hex.ZPoly.rootCount linear = 1
+#guard Hex.ZPoly.rootCount quadPair = 2
+#guard Hex.ZPoly.rootCount quadNone = 0
+#guard Hex.ZPoly.rootCount cubicTriple = 3
+#guard Hex.ZPoly.rootCount const7 = 0
 
 /-! # The full formal tie on the linear fixture.
 
 `rootCount_eq_card_roots` needs a `SquareFreeRat` witness; for `x − 5` it comes
 from `squareFreeRat_iff` and the irreducibility of the linear rational cast.
 Chained with `card_linear`, the correspondence theorem pins the executable
-`Hex.rootCount` to `1` as a theorem — the same value the `#guard` above
+`Hex.ZPoly.rootCount` to `1` as a theorem — the same value the `#guard` above
 evaluates. -/
 
 private theorem toPolyℚ_linear : toPolyℚ linear = X - C 5 := by
@@ -209,7 +209,7 @@ private theorem squareFreeRat_linear : Hex.ZPoly.SquareFreeRat linear := by
   rw [toPolyℚ_linear]
   exact (irreducible_X_sub_C (5 : ℚ)).squarefree
 
-private theorem rootCount_x_sub_5 : Hex.rootCount linear = 1 := by
+private theorem rootCount_x_sub_5 : Hex.ZPoly.rootCount linear = 1 := by
   rw [rootCount_eq_card_roots linear (by decide) squareFreeRat_linear, card_linear]
 
 /-! # End-to-end ergonomics regression on `x⁴ − 2`.

--- a/conformance/HexRoots/Conformance.lean
+++ b/conformance/HexRoots/Conformance.lean
@@ -185,9 +185,9 @@ rational-gcd computation whose well-founded recursion the kernel cannot unfold. 
     from the runtime decision procedure. -/
 private def isoAtoms (p : ZPoly) (prec : Int) (strat : AtomStrategy) :
     Option (Array (DyadicRootIsolation p)) :=
-  if h : HasOnlySimpleRoots p then isolate p h prec strat else none
+  if h : HasOnlySimpleRoots p then isolate? p h prec strat else none
 
-/-! # `isolate`: atom count, root coverage, geometry, strategy agreement.
+/-! # `isolate?`: atom count, root coverage, geometry, strategy agreement.
 
 Each squarefree fixture is isolated under all three strategies once; the single
 check per fixture asserts the atom count (its degree), the cross-strategy
@@ -242,14 +242,14 @@ under `nkThenPellet` alone for the same budget reason. -/
     | some ax => ax.size == 6 && ax.all fun i => onUnitCircle i.square
     | none => false)
 
-/-! # `isolate`: degenerate inputs.
+/-! # `isolate?`: degenerate inputs.
 
 `HasOnlySimpleRoots 0` holds (the gcd of `0` and its derivative is `0`, whose
 stored size is `0 ≤ 1`), so the zero polynomial reaches `isolate`, which pins it
 to `none`; a nonzero constant yields `some #[]`; the linear `x` yields a single
 atom whose disc covers the origin. -/
 
-#guard (if h : HasOnlySimpleRoots (0 : ZPoly) then (isolate (0 : ZPoly) h 8).isSome else true) == false
+#guard (if h : HasOnlySimpleRoots (0 : ZPoly) then (isolate? (0 : ZPoly) h 8).isSome else true) == false
 #guard (isoAtoms constant 8 .nkThenPellet).map (·.size) == some 0
 #guard
   (match isoAtoms linear 8 .nkThenPellet with
@@ -524,7 +524,7 @@ roots are preserved under every atom strategy. -/
 #guard (if HasOnlySimpleRoots mignotte then true else false)
 
 #guard (if h : HasOnlySimpleRoots mignotte then
-    match isolate mignotte h 8 with
+    match isolate? mignotte h 8 with
     | some ax =>
         ax.size == 5 &&
           -- the close pair: exactly two atom centres within 10⁻³ of 1/100
@@ -539,7 +539,7 @@ roots are preserved under every atom strategy. -/
   else false)
 
 #guard (if h : HasOnlySimpleRoots mignotte then
-    match isolate mignotte h 8 .nk, isolate mignotte h 8 .pellet with
+    match isolate? mignotte h 8 .nk, isolate? mignotte h 8 .pellet with
     | some a, some b => a.size == 5 && b.size == 5
     | _, _ => false
   else false)

--- a/examples/HexRootsDemo.lean
+++ b/examples/HexRootsDemo.lean
@@ -62,7 +62,7 @@ def showAtoms {q : ZPoly}
 def main : IO Unit := do
   IO.println "Certified isolation for p(x) = x^3 - x - 1"
   if h : HasOnlySimpleRoots p then
-    match isolate p h 32 .nk with
+    match isolate? p h 32 .nk with
     | none =>
         IO.eprintln "isolation unexpectedly exhausted its certified fuel"
     | some atoms =>

--- a/reports/hex-number-field-performance.md
+++ b/reports/hex-number-field-performance.md
@@ -1244,7 +1244,7 @@ fail mode 1 and reopen the finding. The raw local profile is
 | share | function |
 |---:|---|
 | 92.11% | `Hex.AlgebraicRoot.ofEliminant?` |
-| 92.11% | `Hex.isolate` / `isolateLoop` |
+| 92.11% | `Hex.isolate?` / `isolateLoop` |
 | 86.32% | `Hex.Component.refineAll` / `IsolationLoop.next` |
 | 84.83% | `Hex.taylor` |
 
@@ -1260,7 +1260,7 @@ fixed registration keeps this phase covered without making an asymptotic claim.
 |---:|---|
 | 95.63% | `Hex.AlgebraicRoot.exact?` |
 | 95.58% | `Hex.AlgebraicRoot.exactFactor?` |
-| 95.28% | `Hex.isolate` / `isolateLoop` |
+| 95.28% | `Hex.isolate?` / `isolateLoop` |
 | 47.39% | `Hex.AlgebraicNumber.canonicalRep?` / `ofNormalized?` |
 
 The former `runExactLadder` declared the classical BHKS factorization bound
@@ -1277,7 +1277,7 @@ the declared envelope over-predicts by `n^4.14`. This family is now the fixed
 | share | function |
 |---:|---|
 | 83.01% | `Hex.AlgebraicRoot.exactFactor?` |
-| 77.19% | `Hex.isolate` / `isolateLoop` |
+| 77.19% | `Hex.isolate?` / `isolateLoop` |
 | 38.53% | `Hex.AlgebraicNumber.canonicalRep?` |
 | **18.04%** | `Hex.ZPoly.factorize` |
 
@@ -1292,7 +1292,7 @@ BHKS factorization bound cannot support mode 2 for this end-to-end family.
 | share | `runExactFactorLadder` | `runCanonicalRepLadder` |
 |---:|---:|---:|
 | registered operation | 95.77% | 96.27% |
-| `Hex.isolate` / `isolateLoop` | 95.46% | 96.27% |
+| `Hex.isolate?` / `isolateLoop` | 95.46% | 96.27% |
 | `Hex.Component.refineAll` | 87.10% | 87.88% |
 | `Hex.exactRootFree` | 84.34% | 85.20% |
 | `Hex.taylor` | 77.35% | 78.18% |
@@ -1339,7 +1339,7 @@ this ladder's slower-than-declared verdict.
 
 | share | function |
 |---:|---|
-| 91.87% | `Hex.isolate` / `isolateLoop` |
+| 91.87% | `Hex.isolate?` / `isolateLoop` |
 | 91.45% | `Hex.QAdjoin.roots?` |
 | 91.45% | `Hex.QAdjoin.Roots.componentRoots?` |
 | 82.90% | `Hex.taylor` |
@@ -1362,7 +1362,7 @@ resultants even though neither entered the dominant inclusive ranking.
 |---:|---|
 | 92.96% | `Hex.QAdjoin.roots?` |
 | 92.94% | `Hex.QAdjoin.Roots.componentRoots?` |
-| 85.01% | `Hex.isolate` / `isolateLoop` |
+| 85.01% | `Hex.isolate?` / `isolateLoop` |
 | 78.37% | `Hex.taylor` |
 | 7.52% | `Hex.retainZero?` |
 | 7.43% | `Hex.QAdjoin.Roots.evalBall?` |

--- a/reports/hex-number-field-tower-performance.md
+++ b/reports/hex-number-field-tower-performance.md
@@ -650,7 +650,7 @@ these whole-capture shares is promoted to an exact within-target percentage.
 95.71% of the raw capture is inside `Hex.NumberTower.adjoin?`. The dominant
 phase is candidate-factor disambiguation under the fixed embedding:
 `RawEvaluation.vanishesAt?` 95.46% → `Hex.AlgebraicRoot.ofEliminant?`
-94.92% → the upstream isolation kernel `Hex.isolate`/`isolateLoop` 95.15%,
+94.92% → the upstream isolation kernel `Hex.isolate?`/`isolateLoop` 95.15%,
 with `Hex.taylor` 69.37% and dyadic Gauss arithmetic (`GaussDyadic.mul`
 46.63%) as the leaf work; `Internal.extend?` (level validation) is 31.88%
 and factor selection `selectFactor?` 63.62%. The factorization step itself
@@ -658,7 +658,7 @@ is not visible at this input because the quartic factors immediately; the
 cost is the SPEC's embedding invariant being enforced (`adjoin?` "selects
 the unique irreducible factor that vanishes at the requested AlgebraicRoot
 under the current embedding"). The isolation kernel that dominates is the
-same `Hex.isolate` measured by HexNumberField's and HexRoots' registered
+same `Hex.isolate?` measured by HexNumberField's and HexRoots' registered
 isolation ladders; its asymptotic evidence lives in those upstream reports,
 and the tower-level boundary is measured end to end by the registered
 `runAdjoin`/`runAdjoinIdentity` cases.
@@ -667,14 +667,14 @@ and the tower-level boundary is measured end to end by the registered
 
 `runSplit`: 99.90% inside `Hex.NumberTower.splitAux`; root retention and
 adjoining dominate through the same disambiguation path
-(`RawEvaluation.vanishesAt?` 66.97%, `Hex.isolate` 64.55%), with the
+(`RawEvaluation.vanishesAt?` 66.97%, `Hex.isolate?` 64.55%), with the
 remainder in the tower factorization it repeats after each extension.
 `runFlatten`: 97.93% inside the target, 97.36% in
 `Hex.NumberTower.flatten?`, dominated by the primitive-element candidate
 search `Flatten.searchRecoveredAux` 90.20% whose cost is
 `Flatten.candidateAt?` → `Hex.AlgebraicPoly.Common.shift?` 83.22% (the
 integer eliminant of `θ + cα`) and the canonical exactification
-`Hex.AlgebraicRoot.exact?` 61.83%, both running the upstream `Hex.isolate`
+`Hex.AlgebraicRoot.exact?` 61.83%, both running the upstream `Hex.isolate?`
 kernel (94.99%). The flattening components the search feeds are the
 registered `runBasisImages`, `runCertifies`, `runCoordinateMaps`,
 `runRecoverPair`, and `runRecoverSearch` cases; the eliminant/exactification

--- a/reports/hex-real-roots-performance.md
+++ b/reports/hex-real-roots-performance.md
@@ -17,7 +17,7 @@ sites in `bench/HexRealRoots/Bench.lean`:
 - `Hex.RealRootsBench.runSepPrec`: `n`
 - `Hex.RealRootsBench.runRefineTo`: `n`
 
-The `isolate?` surface is exercised on three structurally different input
+The `ZPoly.isolate?` surface is exercised on three structurally different input
 families, never a single happy-path shape:
 `well-separated-products` (∏(x−k)), `chebyshev-clustered` (integer `T_n`), and
 `mignotte-worst-case` (`xⁿ−(a·x−1)²`, `a = 1000`). The Sturm-chain,
@@ -97,13 +97,13 @@ lake exe hexrealroots_bench compare \
 
 reports `agreement: all functions agree on common params` over the shared
 `well-separated-products` domain (`4, 8, 12, 16, 20`): the Descartes-first
-`isolate?` and the certified `isolateSturm?` engines produce identical
+`ZPoly.isolate?` and the certified `ZPoly.isolateSturm?` engines produce identical
 isolation-endpoint hashes (both `0x88e69732f982a9a0` at `n = 20`), the
 cross-implementation conformance check the compare group is for. The
 relative-timing summary quantifies the engine gap the declared models predict:
-`isolate?` (Descartes-first) is `O(n⁴)` while the Sturm-only engine is `O(n⁵)`
+`ZPoly.isolate?` (Descartes-first) is `O(n⁴)` while the Sturm-only engine is `O(n⁵)`
 (full Sturm-chain evaluation per node with `O(n·h)` coefficient growth), which
-is why `isolate?` runs Descartes first.
+is why `ZPoly.isolate?` runs Descartes first.
 
 ### SPEC time budgets
 
@@ -170,7 +170,7 @@ are developer-local under `/tmp` and are not committed.
 `lean_dec_ref`), Hex/Lean own code 9.9% (`Array.ofFn`, the Möbius
 `compose`/`mul` folds). The huge `∏(x−k)` coefficients (`~n!`, `O(n log n)`
 bits) make GMP arithmetic and its allocation traffic dominate; the inclusive
-cost flows through `isolate?` → `isolateDescartes?` → `mobiusTransform`, both
+cost flows through `ZPoly.isolate?` → `ZPoly.isolateDescartes?` → `mobiusTransform`, both
 of which carry their own registrations.
 
 ### `chebyshev-clustered`
@@ -188,7 +188,7 @@ the deeper bisection the clustering forces.
 allocation 40.2%, GMP 32.5% (`realloc`/`__gmp_default_reallocate`-heavy), Lean
 runtime 13.2%, own code 11.1%. The large `a = 1000` coefficients and the
 close-pair bisection depth make reallocation of growing GMP limbs the dominant
-leaf cost; inclusive cost is the registered `isolate?` path.
+leaf cost; inclusive cost is the registered `ZPoly.isolate?` path.
 
 ### `dense-primitive`
 
@@ -202,7 +202,7 @@ pseudo-division with `O(n·h)`-bit operands — and the inclusive cost is the
 registered `runSturmChain` (`ZPoly.sturmChain`) target itself.
 
 No unregistered dominant inclusive helper appears in any of the four profiles:
-every dominant path terminates in a registered bench target (`isolate?`,
+every dominant path terminates in a registered bench target (`ZPoly.isolate?`,
 `mobiusTransform`, or `sturmChain`), so the Attribution rule is satisfied and
 no new target is required.
 


### PR DESCRIPTION
This PR moves `isolate?`, `isolateSturm?`, `isolateDescartes?`, `rootCount` and `sturmCount` out of the bare `Hex` namespace into `Hex.ZPoly`, where the rest of the integer-polynomial surface already lives. `ZPoly` abbreviates `DensePoly Int`, but dot notation resolves through the abbreviation, so `p.isolate?` still reads the way it did.

It renames `Hex.isolate` to `Hex.isolate?`, matching every other `Option`-valued driver in the tree, and renames the total wrapper `HexRootsMathlib.isolate!` to `isolate`: the `!` promised a panic the definition never had. Dropping the `!` collides with the lemma family about the executable form, so the twelve lemmas stated in terms of `Hex.isolate? … = some atoms` become `isolate?_*` (`_run`, `_root_mem_of_pos`, `_nonpositive`, `_prec`, `_refined`, `_roots_ne`, `_disjoint`, `_count`, `_sound`, `_exists`, `_spec`, `_isSome`), leaving `isolate_*` to the total wrapper. That is the same rule the rename itself applies, and it matches `isolateSturm?_isSome`.

Finally, `widthTarget` no longer rejects widths finer than `2⁻⁴⁰⁹⁶`, and no longer finds the bit target by doubling. Writing `a` and `b` for the bit lengths of the requested width's numerator and denominator, the least `k` with `2 ⁻ᵏ ≤ q` is `a − b` or one more, so one `Nat.log2` pair and one comparison replace the loop and its bound. A very fine width now costs what isolating to it costs and nothing extra. The cap's diagnostic, its `#guard_msgs` test, and the sentences describing it in the manual and the SPEC are gone.

Stacked on #10079; review that first. `lake build`, `lake build HexConformance`, `lake build HexReleaseTests`, `check_dag.py`, `check_phase4.py`, `check_phase7.py`, `check_released_manifest.py`, `check_manual_split.py`, `check_trust_surface.py` and `check_factor_sweep_freshness.py` are green locally.

One residual worth a reviewer's eye: `Hex.ZPoly.isolate?` is now real-root isolation while `Hex.isolate?` is complex-root isolation. They cannot share `ZPoly.isolate?`, but the pair is still easy to misread, so a further rename on the complex side may be worth doing.

🤖 Prepared with Claude Code