### PR TITLE
doc(number-field-tower): name the Mathlib companion library in full

### DIFF
--- a/HexManual/Chapters/HexNumberFieldTower.lean
+++ b/HexManual/Chapters/HexNumberFieldTower.lean
@@ -76,8 +76,9 @@ def sqrt2 : AlgebraicNumber :=
 def sqrt3 : AlgebraicNumber :=
   (ZPoly.algebraicRoots #p[-3, 0, 1])[1]!
 
--- `adjoin` is the companion's total form of `adjoin?`,
--- which never returns `none` (`adjoin?_isSome`).
+-- `adjoin` is the Mathlib companion library's total
+-- form of `adjoin?`, which never returns `none`
+-- (`adjoin?_isSome`).
 def Q2 : Extension NumberTower.rat :=
   adjoin NumberTower.rat sqrt2.toRoot
 abbrev T2 : NumberTower := Q2.tower


### PR DESCRIPTION
This PR spells out which library `adjoin` comes from in the `HexNumberFieldTower` chapter's first example. "the companion's total form" left the reader to guess what the companion is; it now reads "the Mathlib companion library's total form".

🤖 Prepared with Claude Code