### PR TITLE
feat(mv-gcd): prove radical divisibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
       - name: Build conformance + emit-fixture targets
         run: |
           lake build \
-            HexConformance NautyFFI/nautyffi_tests hextruncatedseries_emit_fixtures \
+            HexConformance HexMvFactorizationTests NautyFFI/nautyffi_tests hextruncatedseries_emit_fixtures \
             hexmvpoly_emit_fixtures hexsparsepoly_emit_fixtures \
             hexmodular_emit_fixtures hexpolyzgcd_emit_fixtures \
             hexpolysmith_emit_fixtures \

--- a/HexMvGcd/Squarefree.lean
+++ b/HexMvGcd/Squarefree.lean
@@ -624,9 +624,42 @@ theorem radical_squarefree [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
     (p : MvPoly n R cmp) (hp : p ≠ 0) : Squarefree (radical p) := by
   sorry
 
+/-- The radical divides the original input, including its scalar content
+and normalization unit. -/
 theorem radical_dvd [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
     (p : MvPoly n R cmp) : radical p ∣ p := by
-  sorry
+  let q := polyNormalize (primPart p)
+  rcases (polyIsUnit_iff (polyNormUnit (primPart p))).mp
+      (polyNormUnit_isUnit (primPart p)) with ⟨u, hu⟩
+  have hrestore : C (content p) * u * q = p := by
+    calc
+      C (content p) * u * q =
+          C (content p) * (primPart p * (polyNormUnit (primPart p) * u)) := by
+        simp only [q, polyNormalize]
+        grind
+      _ = p := by rw [hu, mul_one, content_mul_primPart]
+  unfold radical
+  change (if q == 0 then 0 else quotient q (gcdList (q :: derivatives q))) ∣ p
+  by_cases hq : q = 0
+  · simp only [hq, beq_self_eq_true, ite_true, mul_zero] at hrestore ⊢
+    rw [← hrestore]
+    exact ⟨0, (mul_zero 0).symm⟩
+  · simp only [beq_iff_eq, hq, ite_false]
+    have hd : gcdList (q :: derivatives q) ∣ q :=
+      gcdList_dvd (List.mem_cons_self ..)
+    have hd0 : gcdList (q :: derivatives q) ≠ 0 := by
+      intro hzero
+      rcases hd with ⟨r, hr⟩
+      rw [hzero, mul_zero] at hr
+      exact hq hr
+    have hquot := quotient_mul_of_dvd hd0 hd
+    refine ⟨C (content p) * u * gcdList (q :: derivatives q), ?_⟩
+    calc
+      p = C (content p) * u * q := hrestore.symm
+      _ = (C (content p) * u * gcdList (q :: derivatives q)) *
+          quotient q (gcdList (q :: derivatives q)) := by
+        rw [mul_assoc (C (content p) * u),
+          mul_comm (gcdList _) (quotient ..), hquot]
 
 omit [LawfulGcdOps R] [LawfulBezoutOps R] in
 @[simp] theorem radical_zero [IsMonomialOrder cmp] [NatCast R] [NatNoZero R] :

--- a/HexMvGcd/Squarefree.lean
+++ b/HexMvGcd/Squarefree.lean
@@ -629,15 +629,8 @@ and normalization unit. -/
 theorem radical_dvd [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
     (p : MvPoly n R cmp) : radical p ∣ p := by
   let q := polyNormalize (primPart p)
-  rcases (polyIsUnit_iff (polyNormUnit (primPart p))).mp
-      (polyNormUnit_isUnit (primPart p)) with ⟨u, hu⟩
-  have hrestore : C (content p) * u * q = p := by
-    calc
-      C (content p) * u * q =
-          C (content p) * (primPart p * (polyNormUnit (primPart p) * u)) := by
-        simp only [q, polyNormalize]
-        grind
-      _ = p := by rw [hu, mul_one, content_mul_primPart]
+  have hrestore : C (sqfPrimitiveSplit p).1 * q = p :=
+    sqfPrimitiveSplit_product p
   unfold radical
   change (if q == 0 then 0 else quotient q (gcdList (q :: derivatives q))) ∣ p
   by_cases hq : q = 0
@@ -653,12 +646,12 @@ theorem radical_dvd [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
       rw [hzero, mul_zero] at hr
       exact hq hr
     have hquot := quotient_mul_of_dvd hd0 hd
-    refine ⟨C (content p) * u * gcdList (q :: derivatives q), ?_⟩
+    refine ⟨C (sqfPrimitiveSplit p).1 * gcdList (q :: derivatives q), ?_⟩
     calc
-      p = C (content p) * u * q := hrestore.symm
-      _ = (C (content p) * u * gcdList (q :: derivatives q)) *
+      p = C (sqfPrimitiveSplit p).1 * q := hrestore.symm
+      _ = (C (sqfPrimitiveSplit p).1 * gcdList (q :: derivatives q)) *
           quotient q (gcdList (q :: derivatives q)) := by
-        rw [mul_assoc (C (content p) * u),
+        rw [mul_assoc (C (sqfPrimitiveSplit p).1),
           mul_comm (gcdList _) (quotient ..), hquot]
 
 omit [LawfulGcdOps R] [LawfulBezoutOps R] in

--- a/HexMvHensel/UniTests.lean
+++ b/HexMvHensel/UniTests.lean
@@ -8,6 +8,7 @@ module
 
 import all HexMvHensel.Uni
 import all HexPoly.Dense
+import all HexPoly.Instances
 import all HexPoly.Operations
 import all HexPoly.Euclid.DivGcd
 import all HexPoly.Euclid.MulRing

--- a/conformance/HexMvGcd/Conformance.lean
+++ b/conformance/HexMvGcd/Conformance.lean
@@ -21,8 +21,10 @@ Covered properties:
 - gcds divide both inputs and their cofactors reconstruct both inputs
 - route-0 factors are restored after checked gcd on the reduced pair
 - squarefree factors reassemble the input with positive sorted multiplicities
+- radicals divide the input, restoring scalar content and repeated factors
 Covered edge cases:
-- arities zero and one, zero, units, constants, and scalar content
+- arities zero and one, zero, units, constants, and negative scalar content
+- rational normalization by a nonintegral coefficient
 - pure monomial and recursive-content gcds
 - heuristic false positives, bad Brown points, unlucky images, and restarts
 - high and gapped multiplicities, repeated content, and every-variable factors
@@ -239,7 +241,7 @@ private def sqfContract {n : Nat} (p : MvPoly n Int Mono.lex) : Bool :=
 -- Zero and nonzero scalars use different branches of the radical.
 #guard radical (0 : P2) == 0
 #guard radical (C (-12) : P2) == 1
-#guard radical (C (-12) : MvPoly 0 Int Mono.lex) == 1
+#guard radical (C (-12) : P0) == 1
 
 -- Exact division restores both the negative scalar content and the repeated
 -- factors omitted by the normalized radical.
@@ -249,6 +251,18 @@ private def sqfContract {n : Nat} (p : MvPoly n Int Mono.lex) : Bool :=
   let p := C (-6) * (x + 1) ^ 3 * (y + 2) ^ 2
   radical p == (x + 1) * (y + 2) &&
     divExact? p (radical p) == some (C (-6) * (x + 1) ^ 2 * (y + 2))
+
+#guard
+  let x : Q2 := X 0
+  let y : Q2 := X 1
+  let p := C (1 / 2 : Rat) * (x + 1) ^ 3 * (y + 2) ^ 2
+  radical p == (x + 1) * (y + 2) &&
+    divExact? p (radical p) == some (C (1 / 2 : Rat) * (x + 1) ^ 2 * (y + 2))
+
+-- Divisibility still inherits the unfinished GCD checker and producer proofs.
+/-- info: 'Hex.MvPoly.radical_dvd' depends on axioms: [propext, sorryAx, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms Hex.MvPoly.radical_dvd
 
 /-! Positive-characteristic exact decisions. -/
 

--- a/conformance/HexMvGcd/Conformance.lean
+++ b/conformance/HexMvGcd/Conformance.lean
@@ -236,6 +236,20 @@ private def sqfContract {n : Nat} (p : MvPoly n Int Mono.lex) : Bool :=
   let p := (x + y + 1) ^ 3 * (x + 2)
   radical p == (x + 2) * (x + y + 1) && isSquarefree (radical p)
 
+-- Zero and nonzero scalars use different branches of the radical.
+#guard radical (0 : P2) == 0
+#guard radical (C (-12) : P2) == 1
+#guard radical (C (-12) : MvPoly 0 Int Mono.lex) == 1
+
+-- Exact division restores both the negative scalar content and the repeated
+-- factors omitted by the normalized radical.
+#guard
+  let x : P2 := X 0
+  let y : P2 := X 1
+  let p := C (-6) * (x + 1) ^ 3 * (y + 2) ^ 2
+  radical p == (x + 1) * (y + 2) &&
+    divExact? p (radical p) == some (C (-6) * (x + 1) ^ 2 * (y + 2))
+
 /-! Positive-characteristic exact decisions. -/
 
 private theorem boundsThree : ZMod64.Bounds 3 := ⟨by decide, by decide⟩


### PR DESCRIPTION
Prove the existing `radical_dvd` contract: the computed radical divides the original polynomial, including zero inputs, scalar content, and the normalization unit. The proof follows the executable's exact quotient, proves its GCD denominator is nonzero, and uses `sqfPrimitiveSplit_product` to restore the input.

Add radical conformance cases for zero, negative constants, arity zero, and repeated multivariate factors with integer and rational content. A guarded axiom audit records the theorem's inherited dependency on unfinished GCD proofs.

The required `HexMvFactorizationTests` target previously failed because `HexMvHensel.UniTests` lacked its dense-polynomial instance import, and CI did not build that test target. Supply the import and extend the existing CI job to build the full test stack.

This is an incremental proof slice for #10082; keep that completion tracker open. It removes one literal `sorry` without changing signatures or algorithms. `radical_dvd` still inherits `sorryAx` through `gcdList_dvd` and the existing GCD checker/producer proofs. No phase counters advance.

Validation:
- Built `HexMvGcd HexMvHensel HexMvFactor HexMvFactorizationTests`, all three conformance modules, and all three fixture emitters; rebuilt the affected conformance and test targets after revisions.
- Freshly emitted fixtures match the committed files exactly; SymPy checked 30 GCD, 25 Hensel, and 31 factorization cases with no failures.
- All 19 GCD benchmark smoke checks passed with Singular and python-flint available. This is smoke verification, not new performance evidence.
- DAG, phase 4/7, release-manifest, source-size, copyright, and whitespace checks passed.
- Whole-graph `lake build` passed (10,746 jobs), including `HexManual`; the final incremental rebuild also passed.
