### PR TITLE
fix(mv-gcd): replay rational certificates with canonical arithmetic

### DIFF
--- a/HexMvFactor/SPEC/hex-mv-factor.md
+++ b/HexMvFactor/SPEC/hex-mv-factor.md
@@ -1401,7 +1401,10 @@ with what those call: `MvPoly` multiplication, powering, and equality,
 `imageAt`, `lcIn`, `toUnivariate`, `constIn`, `MvPoly.eval`,
 `polyNormalize`, `scalarContent`, hex-mv-gcd's `checkContent`,
 `DensePoly` content, primitive part, degree and equality, and `List`
-length and indexing. Each is `@[expose]`.
+length and indexing. Each is `@[expose]`. The shared GCD content checker
+also includes canonical rational-leaf replay in its transitive dependency
+closure, although `RatModel.not_int` rules out that leaf for these integer
+coefficients; see hex-mv-gcd's kernel-exposure contract.
 
 Nothing in the pipeline is in that closure: point search, prime search,
 `witnessOf?`, the lift, and the recombination enumeration are search

--- a/HexMvGcd/Brown.lean
+++ b/HexMvGcd/Brown.lean
@@ -703,6 +703,7 @@ def ratLiftCoprime? {n : Nat}
   if left.scale == 0 || right.scale == 0 then (none, cfg.rand)
   else
     let run := gcdCertWith cfg left.poly right.poly
+    -- `RatModel.not_int` rules out a leaf in this integer evidence.
     match Cert.stripCoprime? run.cert.coprime with
     | none => (none, run.rand)
     | some integerCert =>

--- a/HexMvGcd/Brown.lean
+++ b/HexMvGcd/Brown.lean
@@ -703,9 +703,12 @@ def ratLiftCoprime? {n : Nat}
   if left.scale == 0 || right.scale == 0 then (none, cfg.rand)
   else
     let run := gcdCertWith cfg left.poly right.poly
-    let cert := CoprimeCert.ratLift left.scale right.scale
-      left.poly right.poly run.cert.coprime
-    (if checkCoprime f h cert then some cert else none, run.rand)
+    match Cert.stripCoprime? run.cert.coprime with
+    | none => (none, run.rand)
+    | some integerCert =>
+        let cert := CoprimeCert.ratLift left.scale right.scale
+          left.poly right.poly integerCert
+        (if checkCoprime f h cert then some cert else none, run.rand)
 
 /-- Offer a rational gcd candidate using exact divisions and a `ratLift`
 cofactor certificate, threading the integer dispatcher's random state. -/

--- a/HexMvGcd/Cert.lean
+++ b/HexMvGcd/Cert.lean
@@ -43,23 +43,6 @@ def imageAt {n : Nat} {R : Type u}
   DensePoly.ofList <| (List.range q.size).map fun k =>
     MvPoly.eval a (MvPoly.mapCoeffs φ.toField (q.coeff k))
 
-/-- Computational core of `imageAt`, taking the underlying coefficient map. -/
-def imageAtRaw {n : Nat} {R : Type u}
-    {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
-    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
-    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    (P : ZMod64.Prime)
-    (φ : R → @ZMod64 P.m P.bounds)
-    (a : Fin n → @ZMod64 P.m P.bounds)
-    (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
-    [IsMonomialOrder cmp'] (f : MvPoly (n + 1) R cmp) :
-    @FpPoly P.m P.bounds :=
-  letI : ZMod64.Bounds P.m := P.bounds
-  letI : ZMod64.PrimeModulus P.m := ZMod64.primeModulusOfPrime P.prime
-  let q := toUnivariate i cmp' f
-  DensePoly.ofList <| (List.range q.size).map fun k =>
-    MvPoly.eval a (MvPoly.mapCoeffs φ (q.coeff k))
-
 /-- Coefficientwise cast from the integer model used by `ratLift`. -/
 def intModelToRat {n : Nat} {cmp : Mono n → Mono n → Ordering}
     [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
@@ -148,8 +131,8 @@ named lets producer proofs state the natural induction invariant. -/
       letI : ZMod64.Bounds P.m := P.bounds
       letI : ZMod64.PrimeModulus P.m :=
         ZMod64.primeModulusOfPrime P.prime
-      let fImage := imageAtRaw P φ.toField a i cmp' f
-      let hImage := imageAtRaw P φ.toField a i cmp' h
+      let fImage := imageAt P φ a i cmp' f
+      let hImage := imageAt P φ a i cmp' h
       let fView := toUnivariate i cmp' f
       let hView := toUnivariate i cmp' h
       exact decide (fImage.degree? = fView.degree?) &&
@@ -167,6 +150,8 @@ named lets producer proofs state the natural induction invariant. -/
         lower.content cmp' hView.toArray.toList right &&
         lower.coprime cmp' left.value right.value rest
 
+/-- Generic replay parameterized by a leaf checker. Soundness requires a
+separate contract for that callback; the public checkers fix it to `checkRatLeaf`. -/
 @[reducible] def Cert.checkOps {S : Type u} {E : Cert.Leaves.{v}}
     [Lean.Grind.CommRing S] [DecidableEq S] [BEq S] [LawfulBEq S]
     [Dvd S] [GcdOps S]
@@ -237,6 +222,16 @@ abbrev CheckOpsAt (R : Type u) [Lean.Grind.CommRing R] (n : Nat) :=
         gcd := fun cmp _ => checkGcdUsing (succCheckCoprime lower (cmp := cmp))
         content := fun cmp _ => checkContentUsing
           (checkGcdUsing (succCheckCoprime lower (cmp := cmp))) }
+
+/-- The public replay package is the generic core at rational leaves. -/
+theorem checkOps_eq {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+    [Dvd R] [GcdOps R] (n : Nat) :
+    checkOps (R := R) n = Cert.checkOps (fun _ _ => checkRatLeaf) n := by
+  induction n with
+  | zero => rfl
+  | succ n ih =>
+      simp only [checkOps, Cert.checkOps, ih]
 
 /-- Replay recursive coprimality evidence. -/
 @[reducible] def checkCoprime {n : Nat} {R : Type u}

--- a/HexMvGcd/Cert.lean
+++ b/HexMvGcd/Cert.lean
@@ -7,7 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexModArith.Modulus
-public import HexMvGcd.Instances
+public import HexMvGcd.CertData
 public import HexPolyFp
 
 @[expose] public section
@@ -23,7 +23,7 @@ certificates one arity lower.  Every cycle therefore decreases the arity.
 
 namespace Hex.MvPoly
 
-universe u
+universe u v
 
 /-- Coefficientwise image followed by evaluation of all remaining variables,
 leaving one dense univariate polynomial over the bundled prime field. -/
@@ -43,9 +43,7 @@ def imageAt {n : Nat} {R : Type u}
   DensePoly.ofList <| (List.range q.size).map fun k =>
     MvPoly.eval a (MvPoly.mapCoeffs φ.toField (q.coeff k))
 
-/-- Computational core of `imageAt`, separated from the law-bearing
-`CoeffHom` so dependent certificate elimination does not have to identify
-the constructor's stored operation dictionaries with the checker's ones. -/
+/-- Computational core of `imageAt`, taking the underlying coefficient map. -/
 def imageAtRaw {n : Nat} {R : Type u}
     {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
     [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
@@ -62,232 +60,6 @@ def imageAtRaw {n : Nat} {R : Type u}
   DensePoly.ofList <| (List.range q.size).map fun k =>
     MvPoly.eval a (MvPoly.mapCoeffs φ (q.coeff k))
 
-/-- A law-bearing coefficient embedding used by the internal
-universe-polymorphic form of rational lifting.  The public smart constructor
-fixes this to the canonical embedding from `Int` into `Rat`. -/
-structure CoeffEmbedding (S R : Type u)
-    where
-  toFun : S → R
-
-mutual
-  /-- Recursive evidence that two multivariate polynomials have no common
-  nonunit divisor.  The result sort is `Type (u + 1)`: because the
-  coefficient type `R : Type u` is itself an index, Lean's universe checker
-  rejects `Type u` before considering any constructor fields. -/
-  inductive CoprimeCert :
-      (n : Nat) → (R : Type u) → [Zero R] →
-      (cmp : Mono n → Mono n → Ordering) →
-      [Std.TransCmp cmp] → [Std.LawfulEqCmp cmp] → Type (u + 1)
-    | unit {n : Nat} {R : Type u} [Zero R]
-        {cmp : Mono n → Mono n → Ordering}
-        [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] :
-        CoprimeCert n R cmp
-    | base {R : Type u} [Zero R]
-        {cmp : Mono 0 → Mono 0 → Ordering}
-        [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
-        (u v : R) : CoprimeCert 0 R cmp
-    /-- A direct Bézout identity at any arity.  The checker replays the
-    polynomial identity instead of descending through a subresultant chain. -/
-    | bezout {n : Nat} {R : Type u}
-        [zeroR : Zero R]
-        {cmp : Mono n → Mono n → Ordering}
-        [outerTrans : Std.TransCmp cmp] [outerEq : Std.LawfulEqCmp cmp]
-        (u v : @MvPoly n R zeroR cmp outerTrans outerEq) :
-        @CoprimeCert n R zeroR cmp outerTrans outerEq
-    /-- Internal universe-polymorphic form of rational lifting.  The public
-    `CoprimeCert.ratLift` smart constructor fixes the embedded coefficient
-    type to `Int` and the target type to `Rat`. -/
-    | ratLiftCore {n : Nat} {R S : Type u}
-        [zeroR : Zero R] [One R] [Add R] [Mul R]
-        [Lean.Grind.CommRing S]
-        [DecidableEq S] [BEq S] [LawfulBEq S] [Dvd S] [GcdOps S]
-        {cmp : Mono n → Mono n → Ordering}
-        [outerTrans : Std.TransCmp cmp] [outerEq : Std.LawfulEqCmp cmp]
-        (embed : CoeffEmbedding S R)
-        (mapZero : embed.toFun 0 = 0)
-        (mapOne : embed.toFun 1 = 1)
-        (mapAdd : ∀ a b, embed.toFun (a + b) =
-          embed.toFun a + embed.toFun b)
-        (mapMul : ∀ a b, embed.toFun (a * b) =
-          embed.toFun a * embed.toFun b)
-        (injective : ∀ {a b}, embed.toFun a = embed.toFun b → a = b)
-        /- The two replayed scale factors and explicit inverse candidates.
-        The checker validates both inverse equations; this keeps the
-        universe-polymorphic core sound even though its target is not fixed
-        to the rational field. -/
-        (scaleL scaleR invL invR : R)
-        (left right : MvPoly n S cmp)
-        (cert : CoprimeCert n S cmp) :
-        @CoprimeCert n R zeroR cmp outerTrans outerEq
-    | split {n : Nat} {R : Type u} [zeroR : Zero R]
-        [One R] [Add R] [Mul R]
-        {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
-        [outerTrans : Std.TransCmp cmp] [outerEq : Std.LawfulEqCmp cmp]
-        (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
-        [order : IsMonomialOrder cmp']
-        (P : ZMod64.Prime)
-        (φ : @CoeffHom R P.m _ _ _ _ P.bounds)
-        (a : Fin n → @ZMod64 P.m P.bounds)
-        (α β : @FpPoly P.m P.bounds)
-        (left right : @ContentCert n R zeroR cmp'
-          order.toTransCmp order.toLawfulEqCmp)
-        (rest : @CoprimeCert n R zeroR cmp'
-          order.toTransCmp order.toLawfulEqCmp) :
-        @CoprimeCert (n + 1) R zeroR cmp outerTrans outerEq
-    | splitBezout {n : Nat} {R : Type u}
-        [zeroR : Zero R] [One R] [Add R] [Mul R]
-        {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
-        [outerTrans : Std.TransCmp cmp] [outerEq : Std.LawfulEqCmp cmp]
-        (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
-        [order : IsMonomialOrder cmp']
-        (u v : @MvPoly (n + 1) R zeroR cmp outerTrans outerEq)
-        (r : @MvPoly n R zeroR cmp' order.toTransCmp order.toLawfulEqCmp)
-        (left right : @ContentCert n R zeroR cmp'
-          order.toTransCmp order.toLawfulEqCmp)
-        (rest : @CoprimeCert n R zeroR cmp'
-          order.toTransCmp order.toLawfulEqCmp) :
-        @CoprimeCert (n + 1) R zeroR cmp outerTrans outerEq
-  /-- A gcd candidate, exact cofactors, and recursive coprimality evidence. -/
-  inductive GcdCert :
-      (n : Nat) → (R : Type u) → [Zero R] →
-      (cmp : Mono n → Mono n → Ordering) →
-      [Std.TransCmp cmp] → [Std.LawfulEqCmp cmp] → Type (u + 1)
-    /-- Package a gcd, its two exact cofactors, and evidence that the
-    cofactors are coprime. -/
-    | mk {n : Nat} {R : Type u} [Zero R]
-        {cmp : Mono n → Mono n → Ordering}
-        [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
-        (gcd cofL cofR : MvPoly n R cmp)
-        (coprime : CoprimeCert n R cmp) : GcdCert n R cmp
-
-  /-- A checked left fold of gcd over a coefficient list. -/
-  inductive ContentCert :
-      (n : Nat) → (R : Type u) → [Zero R] →
-      (cmp : Mono n → Mono n → Ordering) →
-      [Std.TransCmp cmp] → [Std.LawfulEqCmp cmp] → Type (u + 1)
-    | mk {n : Nat} {R : Type u} [Zero R]
-        {cmp : Mono n → Mono n → Ordering}
-        [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
-        (value : MvPoly n R cmp)
-        (steps : GcdCerts n R cmp) : ContentCert n R cmp
-
-  /-- Strictly-positive list used inside the mutual certificate block.
-  `List (GcdCert ...)` is a nested inductive occurrence, which Lean rejects
-  when the certificate indices contain local comparator instances. -/
-  inductive GcdCerts :
-      (n : Nat) → (R : Type u) → [Zero R] →
-      (cmp : Mono n → Mono n → Ordering) →
-      [Std.TransCmp cmp] → [Std.LawfulEqCmp cmp] → Type (u + 1)
-    | nil {n : Nat} {R : Type u} [Zero R]
-        {cmp : Mono n → Mono n → Ordering}
-        [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] : GcdCerts n R cmp
-    | cons {n : Nat} {R : Type u} [Zero R]
-        {cmp : Mono n → Mono n → Ordering}
-        [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
-        (head : GcdCert n R cmp) (tail : GcdCerts n R cmp) :
-        GcdCerts n R cmp
-end
-
-namespace CoprimeCert
-
-def intEmbeddingRat : CoeffEmbedding Int Rat where
-  toFun := fun z => (z : Rat)
-
-/-- Rational coprimality transported from primitive integer models.  This is
-the public, index-specialized constructor; the law-bearing generic embedding
-is an implementation detail needed to preserve universe polymorphism. -/
-def ratLift {n : Nat} {cmp : Mono n → Mono n → Ordering}
-    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
-    (scaleL scaleR : Rat) (left right : MvPoly n Int cmp)
-    (cert : CoprimeCert n Int cmp) : CoprimeCert n Rat cmp :=
-  .ratLiftCore intEmbeddingRat (by rfl) (by rfl)
-    (by intro a b; exact Rat.intCast_add a b)
-    (by intro a b; exact Rat.intCast_mul a b)
-    (by intro a b h; exact Rat.intCast_inj.mp h)
-    scaleL scaleR scaleL⁻¹ scaleR⁻¹ left right cert
-
-end CoprimeCert
-
-/-- Flat rational-lift data retained as a convenient standalone replay view.
-The checked certificate sum itself exposes `CoprimeCert.ratLift`; new
-producers use that constructor. -/
-structure RatLiftCert (n : Nat) (cmp : Mono n → Mono n → Ordering)
-    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
-  scaleL : Rat
-  scaleR : Rat
-  left : MvPoly n Int cmp
-  right : MvPoly n Int cmp
-  cert : CoprimeCert n Int cmp
-
-namespace GcdCerts
-
-variable {n : Nat} {R : Type u} [Zero R]
-  {cmp : Mono n → Mono n → Ordering}
-  [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
-
-@[reducible] def toList : GcdCerts n R cmp → List (GcdCert n R cmp)
-  | .nil => []
-  | .cons head tail => head :: toList tail
-
-@[reducible] def ofList : List (GcdCert n R cmp) → GcdCerts n R cmp
-  | [] => .nil
-  | head :: tail => .cons head (ofList tail)
-
-end GcdCerts
-
-namespace GcdCert
-
-variable {n : Nat} {R : Type u} [Zero R]
-  {cmp : Mono n → Mono n → Ordering}
-  [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
-
-@[reducible] def gcd : GcdCert n R cmp → MvPoly n R cmp
-  | .mk gcd _ _ _ => gcd
-
-@[reducible] def cofL : GcdCert n R cmp → MvPoly n R cmp
-  | .mk _ cofL _ _ => cofL
-
-@[reducible] def cofR : GcdCert n R cmp → MvPoly n R cmp
-  | .mk _ _ cofR _ => cofR
-
-@[reducible] def coprime : GcdCert n R cmp → CoprimeCert n R cmp
-  | .mk _ _ _ coprime => coprime
-
-end GcdCert
-
-namespace ContentCert
-
-variable {n : Nat} {R : Type u} [Zero R]
-  {cmp : Mono n → Mono n → Ordering}
-  [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
-
-@[reducible] def value : ContentCert n R cmp → MvPoly n R cmp
-  | .mk value _ => value
-
-@[reducible] def steps : ContentCert n R cmp → List (GcdCert n R cmp)
-  | .mk _ steps => steps.toList
-
-/-- Public list-based constructor; the strictly-positive internal list is an
-implementation detail of Lean's mutual-inductive positivity checker. -/
-@[reducible] def ofSteps (value : MvPoly n R cmp) (steps : List (GcdCert n R cmp)) :
-    ContentCert n R cmp :=
-  .mk value (GcdCerts.ofList steps)
-
-@[simp] theorem value_ofSteps (value : MvPoly n R cmp)
-    (steps : List (GcdCert n R cmp)) :
-    (ofSteps value steps).value = value := by
-  rfl
-
-@[simp] theorem steps_ofSteps (value : MvPoly n R cmp)
-    (steps : List (GcdCert n R cmp)) :
-    (ofSteps value steps).steps = steps := by
-  induction steps with
-  | nil => rfl
-  | cons step steps ih =>
-      simp only [ContentCert.steps, GcdCerts.toList, ih]
-
-end ContentCert
-
 /-- Coefficientwise cast from the integer model used by `ratLift`. -/
 def intModelToRat {n : Nat} {cmp : Mono n → Mono n → Ordering}
     [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
@@ -298,22 +70,23 @@ def intModelToRat {n : Nat} {cmp : Mono n → Mono n → Ordering}
 Lean's well-founded mutual-recursion compiler: recursive certificate calls
 always move to the already-built lower-arity package, while content folds are
 ordinary structural recursion on their two lists. -/
-structure CheckOpsAt (R : Type u) [Zero R] (n : Nat) : Type (u + 1) where
+structure Cert.CheckOpsAt (R : Type u) [Lean.Grind.CommRing R]
+    (E : Cert.Leaves.{v}) (n : Nat) : Type (max (u + 1) (v + 1)) where
   coprime : (cmp : Mono n → Mono n → Ordering) → [IsMonomialOrder cmp] →
-    MvPoly n R cmp → MvPoly n R cmp → CoprimeCert n R cmp → Bool
+    MvPoly n R cmp → MvPoly n R cmp → Cert.Coprime R E n cmp → Bool
   gcd : (cmp : Mono n → Mono n → Ordering) → [IsMonomialOrder cmp] →
-    MvPoly n R cmp → MvPoly n R cmp → GcdCert n R cmp → Bool
+    MvPoly n R cmp → MvPoly n R cmp → Cert.Gcd R E n cmp → Bool
   content : (cmp : Mono n → Mono n → Ordering) → [IsMonomialOrder cmp] →
-    List (MvPoly n R cmp) → ContentCert n R cmp → Bool
+    List (MvPoly n R cmp) → Cert.Content R E n cmp → Bool
 
-@[reducible] def checkGcdUsing {n : Nat} {R : Type u}
+@[reducible] def checkGcdUsing {n : Nat} {R : Type u} {E : Cert.Leaves.{v}}
     {cmp : Mono n → Mono n → Ordering}
     [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
     [Dvd R] [GcdOps R] [IsMonomialOrder cmp]
     (coprime : MvPoly n R cmp → MvPoly n R cmp →
-      CoprimeCert n R cmp → Bool)
-    (f h : MvPoly n R cmp) (cert : GcdCert n R cmp) : Bool :=
+      Cert.Coprime R E n cmp → Bool)
+    (f h : MvPoly n R cmp) (cert : Cert.Gcd R E n cmp) : Bool :=
   (cert.gcd * cert.cofL == f) &&
     (cert.gcd * cert.cofR == h) &&
     (polyNormalize cert.gcd == cert.gcd) &&
@@ -323,58 +96,54 @@ structure CheckOpsAt (R : Type u) [Zero R] (n : Nat) : Type (u + 1) where
 public checker fixes that accumulator to zero; keeping the general recursion
 named lets producer proofs state the natural induction invariant. -/
 
-@[reducible] def checkContentSteps {n : Nat} {R : Type u}
+@[reducible] def checkContentSteps {n : Nat} {R : Type u} {E : Cert.Leaves.{v}}
     {cmp : Mono n → Mono n → Ordering}
     [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
     [Dvd R] [GcdOps R] [IsMonomialOrder cmp]
-    (gcd : MvPoly n R cmp → MvPoly n R cmp → GcdCert n R cmp → Bool)
+    (gcd : MvPoly n R cmp → MvPoly n R cmp → Cert.Gcd R E n cmp → Bool)
     (value acc : MvPoly n R cmp) :
-    List (MvPoly n R cmp) → List (GcdCert n R cmp) → Bool
+    List (MvPoly n R cmp) → List (Cert.Gcd R E n cmp) → Bool
   | [], [] => acc == value
   | q :: qs, step :: steps =>
       gcd acc q step && checkContentSteps gcd value step.gcd qs steps
   | _, _ => false
 
-@[reducible] def checkContentUsing {n : Nat} {R : Type u}
+@[reducible] def checkContentUsing {n : Nat} {R : Type u} {E : Cert.Leaves.{v}}
     {cmp : Mono n → Mono n → Ordering}
     [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
     [Dvd R] [GcdOps R] [IsMonomialOrder cmp]
-    (gcd : MvPoly n R cmp → MvPoly n R cmp → GcdCert n R cmp → Bool)
-    (coeffs : List (MvPoly n R cmp)) (cert : ContentCert n R cmp) : Bool :=
+    (gcd : MvPoly n R cmp → MvPoly n R cmp → Cert.Gcd R E n cmp → Bool)
+    (coeffs : List (MvPoly n R cmp)) (cert : Cert.Content R E n cmp) : Bool :=
   checkContentSteps gcd cert.value 0 coeffs cert.steps
 
-/-! The rational-lift branch contains an embedded coefficient certificate at
-the same arity.  Its replay therefore uses this independent structural
-package, which rejects nested lifts, instead of recursing through the main
-coefficient-polymorphic package.  This keeps both definitions structurally
-recursive. -/
-
-@[reducible] def baseCheckNoLift {S : Type u}
+@[reducible] def Cert.baseCheck {S : Type u} {E : Cert.Leaves.{v}}
     [Lean.Grind.CommRing S] [DecidableEq S] [BEq S] [LawfulBEq S]
     [Dvd S] [GcdOps S]
     {cmp : Mono 0 → Mono 0 → Ordering}
     [IsMonomialOrder cmp]
-    (f h : MvPoly 0 S cmp) (cert : CoprimeCert 0 S cmp) : Bool :=
+    (checkLeaf : MvPoly 0 S cmp → MvPoly 0 S cmp → E 0 cmp → Bool)
+    (f h : MvPoly 0 S cmp) (cert : Cert.Coprime S E 0 cmp) : Bool :=
   match cert with
   | .unit => polyIsUnit f || polyIsUnit h
   | .base u v => u * coeff Mono.zero f + v * coeff Mono.zero h == 1
   | .bezout u v => u * f + v * h == 1
-  | _ => false
+  | .leaf data => checkLeaf f h data
 
-@[reducible] def succCheckNoLift {n : Nat} {S : Type u}
+@[reducible] def Cert.succCheck {n : Nat} {S : Type u} {E : Cert.Leaves.{v}}
     [Lean.Grind.CommRing S] [DecidableEq S] [BEq S] [LawfulBEq S]
     [Dvd S] [GcdOps S]
-    (lower : CheckOpsAt S n)
+    (lower : Cert.CheckOpsAt S E n)
     {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
     [IsMonomialOrder cmp]
+    (checkLeaf : MvPoly (n + 1) S cmp → MvPoly (n + 1) S cmp → E (n + 1) cmp → Bool)
     (f h : MvPoly (n + 1) S cmp)
-    (cert : CoprimeCert (n + 1) S cmp) : Bool := by
+    (cert : Cert.Coprime S E (n + 1) cmp) : Bool := by
   cases cert with
   | unit => exact polyIsUnit f || polyIsUnit h
   | bezout u v => exact u * f + v * h == 1
-  | ratLiftCore => exact false
+  | leaf data => exact checkLeaf f h data
   | split i cmp' P φ a α β left right rest =>
       letI : ZMod64.Bounds P.m := P.bounds
       letI : ZMod64.PrimeModulus P.m :=
@@ -398,95 +167,61 @@ recursive. -/
         lower.content cmp' hView.toArray.toList right &&
         lower.coprime cmp' left.value right.value rest
 
-@[reducible] def noLiftOps {S : Type u}
-    [Lean.Grind.CommRing S] [DecidableEq S] [BEq S] [LawfulBEq S]
-    [Dvd S] [GcdOps S] : (n : Nat) → CheckOpsAt S n
-  | 0 =>
-      { coprime := fun cmp _ => baseCheckNoLift (cmp := cmp)
-        gcd := fun cmp _ => checkGcdUsing (baseCheckNoLift (cmp := cmp))
-        content := fun cmp _ => checkContentUsing
-          (checkGcdUsing (baseCheckNoLift (cmp := cmp))) }
-  | n + 1 =>
-      let lower := noLiftOps n
-      { coprime := fun cmp _ => succCheckNoLift lower (cmp := cmp)
-        gcd := fun cmp _ => checkGcdUsing (succCheckNoLift lower (cmp := cmp))
-        content := fun cmp _ => checkContentUsing
-          (checkGcdUsing (succCheckNoLift lower (cmp := cmp))) }
-
-/-- Replay the payload of the equality-packed rational-lift constructor. -/
-@[reducible] def checkRatLiftCoreUsing {n : Nat} {R S : Type u}
-    [zeroR : Zero R]
+@[reducible] def Cert.checkOps {S : Type u} {E : Cert.Leaves.{v}}
     [Lean.Grind.CommRing S] [DecidableEq S] [BEq S] [LawfulBEq S]
     [Dvd S] [GcdOps S]
-    {cmp : Mono n → Mono n → Ordering}
-    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
-    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [GcdOps R] [IsMonomialOrder cmp]
-    (f h : MvPoly n R cmp) (embed : CoeffEmbedding S R)
-    (scaleL scaleR invL invR : R) (left right : MvPoly n S cmp)
-    (cert : CoprimeCert n S cmp) : Bool :=
-  decide (scaleL ≠ 0) && decide (scaleR ≠ 0) &&
-    (scaleL * invL == 1) && (scaleR * invR == 1) &&
-    (f == C scaleL * mapCoeffs embed.toFun left) &&
-    (h == C scaleR * mapCoeffs embed.toFun right) &&
-    decide (scalarContent left = 1) &&
-    decide (scalarContent right = 1) &&
-    (noLiftOps n).coprime cmp left right cert
+    (checkLeaf : (n : Nat) → (cmp : Mono n → Mono n → Ordering) →
+      [IsMonomialOrder cmp] → MvPoly n S cmp → MvPoly n S cmp → E n cmp → Bool) :
+    (n : Nat) → Cert.CheckOpsAt S E n
+  | 0 =>
+      { coprime := fun cmp _ => Cert.baseCheck (cmp := cmp) (checkLeaf 0 cmp)
+        gcd := fun cmp _ => checkGcdUsing (Cert.baseCheck (cmp := cmp) (checkLeaf 0 cmp))
+        content := fun cmp _ => checkContentUsing
+          (checkGcdUsing (Cert.baseCheck (cmp := cmp) (checkLeaf 0 cmp))) }
+  | n + 1 =>
+      let lower := Cert.checkOps checkLeaf n
+      { coprime := fun cmp _ => Cert.succCheck lower (cmp := cmp) (checkLeaf (n + 1) cmp)
+        gcd := fun cmp _ => checkGcdUsing (Cert.succCheck lower (cmp := cmp) (checkLeaf (n + 1) cmp))
+        content := fun cmp _ => checkContentUsing
+          (checkGcdUsing (Cert.succCheck lower (cmp := cmp) (checkLeaf (n + 1) cmp))) }
+
+/-- Replay rational scaling and primitive integer-model coprimality. -/
+@[reducible] def checkRatLift {n : Nat} {cmp : Mono n → Mono n → Ordering}
+    [IsMonomialOrder cmp]
+    (f h : MvPoly n Rat cmp) (lift : RatLiftCert n cmp) : Bool :=
+  decide (lift.scaleL ≠ 0) && decide (lift.scaleR ≠ 0) &&
+    (f == C lift.scaleL * intModelToRat lift.left) &&
+    (h == C lift.scaleR * intModelToRat lift.right) &&
+    decide (scalarContent lift.left = 1) &&
+    decide (scalarContent lift.right = 1) &&
+    (Cert.checkOps (S := Int) (E := Cert.NoLeaves)
+      (fun _ _ _ _ _ impossible => nomatch impossible) n).coprime
+        cmp lift.left lift.right lift.cert
+
+/-- Replay a rational leaf entirely with canonical `Int` and `Rat` operations. -/
+@[reducible] def checkRatLeaf {n : Nat} {R : Type u} [Lean.Grind.CommRing R]
+    [DecidableEq R] [BEq R] [LawfulBEq R]
+    {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+    (f h : MvPoly n R cmp) (leaf : RatLeaf R n cmp) : Bool :=
+  checkRatLift (mapCoeffs leaf.model.toRat f) (mapCoeffs leaf.model.toRat h) leaf.data
+
+/-- Replay package for certificates with canonical rational leaves. -/
+abbrev CheckOpsAt (R : Type u) [Lean.Grind.CommRing R] (n : Nat) :=
+  Cert.CheckOpsAt R (RatLeaf R) n
 
 @[reducible] def baseCheckCoprime {R : Type u}
-    {cmp : Mono 0 → Mono 0 → Ordering}
-    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [GcdOps R] [IsMonomialOrder cmp]
+    [Dvd R] [GcdOps R]
+    {cmp : Mono 0 → Mono 0 → Ordering} [IsMonomialOrder cmp]
     (f h : MvPoly 0 R cmp) (cert : CoprimeCert 0 R cmp) : Bool :=
-  match cert with
-  | .unit => polyIsUnit f || polyIsUnit h
-  | .base u v => u * coeff Mono.zero f + v * coeff Mono.zero h == 1
-  | .bezout u v => u * f + v * h == 1
-  | @CoprimeCert.ratLiftCore _ _ S _ _ _ _ _ringModel _decModel
-      _beqModel _lawfulModel _dvdModel _gcdModel _ _ _ embed _ _ _ _ _
-      scaleL scaleR invL invR left right cert =>
-      checkRatLiftCoreUsing (S := S) f h embed scaleL scaleR invL invR
-        left right cert
+  Cert.baseCheck checkRatLeaf f h cert
 
 @[reducible] def succCheckCoprime {n : Nat} {R : Type u}
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [GcdOps R]
-    (lower : CheckOpsAt R n)
-    {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
-    [IsMonomialOrder cmp]
-    (f h : MvPoly (n + 1) R cmp)
-    (cert : CoprimeCert (n + 1) R cmp) : Bool := by
-  cases cert with
-  | unit => exact polyIsUnit f || polyIsUnit h
-  | bezout u v => exact u * f + v * h == 1
-  | @ratLiftCore _ _ S _ _ _ _ ringModel decModel beqModel
-      lawfulModel dvdModel gcdModel _ _ _ embed _ _ _ _ _
-      scaleL scaleR invL invR left right cert =>
-      exact checkRatLiftCoreUsing (S := S) f h embed
-        scaleL scaleR invL invR left right cert
-  | split i cmp' P φ a α β left right rest =>
-      letI : ZMod64.Bounds P.m := P.bounds
-      letI : ZMod64.PrimeModulus P.m :=
-        ZMod64.primeModulusOfPrime P.prime
-      let fImage := imageAtRaw P φ.toField a i cmp' f
-      let hImage := imageAtRaw P φ.toField a i cmp' h
-      let fView := toUnivariate i cmp' f
-      let hView := toUnivariate i cmp' h
-      exact decide (fImage.degree? = fView.degree?) &&
-        decide (hImage.degree? = hView.degree?) &&
-        (α * fImage + β * hImage == 1) &&
-        lower.content cmp' fView.toArray.toList left &&
-        lower.content cmp' hView.toArray.toList right &&
-        lower.coprime cmp' left.value right.value rest
-  | splitBezout i cmp' u v r left right rest =>
-      let fView := toUnivariate i cmp' f
-      let hView := toUnivariate i cmp' h
-      exact decide (r ≠ 0) &&
-        (u * f + v * h == constIn i cmp' r) &&
-        lower.content cmp' fView.toArray.toList left &&
-        lower.content cmp' hView.toArray.toList right &&
-        lower.coprime cmp' left.value right.value rest
+    [Dvd R] [GcdOps R] (lower : CheckOpsAt R n)
+    {cmp : Mono (n + 1) → Mono (n + 1) → Ordering} [IsMonomialOrder cmp]
+    (f h : MvPoly (n + 1) R cmp) (cert : CoprimeCert (n + 1) R cmp) : Bool :=
+  Cert.succCheck lower checkRatLeaf f h cert
 
 @[reducible] def checkOps {R : Type u}
     [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
@@ -530,17 +265,6 @@ one checked gcd step per coefficient. -/
     [Dvd R] [GcdOps R] [IsMonomialOrder cmp]
     (coeffs : List (MvPoly n R cmp)) (cert : ContentCert n R cmp) : Bool :=
   (checkOps (R := R) n).content cmp coeffs cert
-
-/-- Replay rational scaling and primitive integer-model coprimality. -/
-@[reducible] def checkRatLift {n : Nat} {cmp : Mono n → Mono n → Ordering}
-    [IsMonomialOrder cmp]
-    (f h : MvPoly n Rat cmp) (lift : RatLiftCert n cmp) : Bool :=
-  decide (lift.scaleL ≠ 0) && decide (lift.scaleR ≠ 0) &&
-    (f == C lift.scaleL * intModelToRat lift.left) &&
-    (h == C lift.scaleR * intModelToRat lift.right) &&
-    decide (scalarContent lift.left = 1) &&
-    decide (scalarContent lift.right = 1) &&
-    checkCoprime lift.left lift.right lift.cert
 
 /-- The semantic property witnessed by a coprimality certificate. -/
 def CoprimeCofactors {n : Nat} {R : Type u}

--- a/HexMvGcd/CertData.lean
+++ b/HexMvGcd/CertData.lean
@@ -8,6 +8,7 @@ module
 
 public import HexMvGcd.Instances
 public import HexModArith.Modulus
+public import HexPolyFp.Field
 
 @[expose] public section
 

--- a/HexMvGcd/CertData.lean
+++ b/HexMvGcd/CertData.lean
@@ -1,0 +1,344 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvGcd.Instances
+public import HexModArith.Modulus
+
+@[expose] public section
+
+/-!
+Certificate data for multivariate gcd replay. The coefficient ring is a fixed
+parameter of every recursive certificate. Optional leaves are parameterized
+separately, so the integer evidence inside a rational lift cannot contain
+another rational lift or replace the integer arithmetic.
+-/
+
+namespace Hex.MvPoly
+
+universe u v w
+
+namespace Cert
+
+/-- Optional leaf data at each arity and monomial order. -/
+abbrev Leaves := (n : Nat) → (cmp : Mono n → Mono n → Ordering) →
+  [Std.TransCmp cmp] → [Std.LawfulEqCmp cmp] → Type v
+
+mutual
+  /-- Recursive coprimality evidence over one fixed coefficient ring. -/
+  inductive Coprime (R : Type u) [Lean.Grind.CommRing R] (E : Leaves.{v}) :
+      (n : Nat) → (cmp : Mono n → Mono n → Ordering) →
+      [Std.TransCmp cmp] → [Std.LawfulEqCmp cmp] → Type (max u v)
+    | unit {n cmp} [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] : Coprime R E n cmp
+    | base {cmp} [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+        (u v : R) : Coprime R E 0 cmp
+    | bezout {n cmp} [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+        (u v : MvPoly n R cmp) : Coprime R E n cmp
+    | leaf {n cmp} [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+        (data : E n cmp) : Coprime R E n cmp
+    | split {n cmp} [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+        (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+        [IsMonomialOrder cmp'] (P : ZMod64.Prime)
+        (φ : @CoeffHom R P.m _ _ _ _ P.bounds)
+        (a : Fin n → @ZMod64 P.m P.bounds)
+        (α β : @FpPoly P.m P.bounds)
+        (left right : Content R E n cmp') (rest : Coprime R E n cmp') :
+        Coprime R E (n + 1) cmp
+    | splitBezout {n cmp} [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+        (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+        [IsMonomialOrder cmp'] (u v : MvPoly (n + 1) R cmp)
+        (r : MvPoly n R cmp')
+        (left right : Content R E n cmp') (rest : Coprime R E n cmp') :
+        Coprime R E (n + 1) cmp
+  /-- A gcd, exact cofactors, and their coprimality evidence. -/
+  inductive Gcd (R : Type u) [Lean.Grind.CommRing R] (E : Leaves.{v}) :
+      (n : Nat) → (cmp : Mono n → Mono n → Ordering) →
+      [Std.TransCmp cmp] → [Std.LawfulEqCmp cmp] → Type (max u v)
+    | mk {n cmp} [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+        (gcd cofL cofR : MvPoly n R cmp) (coprime : Coprime R E n cmp) : Gcd R E n cmp
+  /-- A coefficient gcd and the checked fold producing it. -/
+  inductive Content (R : Type u) [Lean.Grind.CommRing R] (E : Leaves.{v}) :
+      (n : Nat) → (cmp : Mono n → Mono n → Ordering) →
+      [Std.TransCmp cmp] → [Std.LawfulEqCmp cmp] → Type (max u v)
+    | mk {n cmp} [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+        (value : MvPoly n R cmp) (steps : Steps R E n cmp) : Content R E n cmp
+  /-- Strictly positive list of gcd certificates in a content fold. -/
+  inductive Steps (R : Type u) [Lean.Grind.CommRing R] (E : Leaves.{v}) :
+      (n : Nat) → (cmp : Mono n → Mono n → Ordering) →
+      [Std.TransCmp cmp] → [Std.LawfulEqCmp cmp] → Type (max u v)
+    | nil {n cmp} [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] : Steps R E n cmp
+    | cons {n cmp} [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+        (head : Gcd R E n cmp) (tail : Steps R E n cmp) : Steps R E n cmp
+end
+
+/-- Ordinary certificates have no optional leaves. -/
+abbrev NoLeaves : Leaves := fun _ _ _ _ => Empty
+
+end Cert
+
+/-- Ordinary integer evidence replayed with canonical integer arithmetic. -/
+abbrev IntCoprimeCert (n : Nat) (cmp : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] := Cert.Coprime Int Cert.NoLeaves n cmp
+
+/-- Rational scales and ordinary integer-model evidence. No coefficient
+operations or embeddings are certificate data. -/
+structure RatLiftCert (n : Nat) (cmp : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
+  scaleL : Rat
+  scaleR : Rat
+  left : MvPoly n Int cmp
+  right : MvPoly n Int cmp
+  cert : IntCoprimeCert n cmp
+
+/-- Identification of a coefficient ring with the canonical rational ring.
+The laws refer to the same ring parameter as the surrounding certificate;
+this representation witness supplies no replacement arithmetic for replay. -/
+structure RatModel (R : Type u) [Lean.Grind.CommRing R] where
+  toRat : R → Rat
+  fromRat : Rat → R
+  left_inv : ∀ x, fromRat (toRat x) = x
+  right_inv : ∀ x, toRat (fromRat x) = x
+  map_zero : toRat 0 = 0
+  map_one : toRat 1 = 1
+  map_add : ∀ x y, toRat (x + y) = toRat x + toRat y
+  map_mul : ∀ x y, toRat (x * y) = toRat x * toRat y
+
+/-- A rational representation reflects equality. -/
+theorem RatModel.injective {R : Type u} [Lean.Grind.CommRing R] (model : RatModel R) :
+    Function.Injective model.toRat := by
+  intro x y h
+  simpa only [model.left_inv] using congrArg model.fromRat h
+
+/-- Integer certificates cannot contain a rational-representation leaf. -/
+theorem RatModel.not_int (model : RatModel Int) : False := by
+  have htwo : model.toRat (2 : Int) = 2 := by
+    change model.toRat (1 + 1) = 2
+    rw [model.map_add, model.map_one]
+    decide +kernel
+  have hhalf := model.right_inv (1 / 2)
+  have heq : 2 * model.fromRat (1 / 2) = (1 : Int) := by
+    apply model.injective
+    rw [model.map_mul, htwo, hhalf, model.map_one]
+    decide +kernel
+  omega
+
+/-- The canonical rational coefficient representation. -/
+def RatModel.rat : RatModel Rat where
+  toRat := id
+  fromRat := id
+  left_inv _ := rfl
+  right_inv _ := rfl
+  map_zero := rfl
+  map_one := rfl
+  map_add _ _ := rfl
+  map_mul _ _ := rfl
+
+/-- A rational lift is available only in a coefficient ring identified with
+`Rat`; its models and recursive replay are always canonical integers. -/
+structure RatLeaf (R : Type u) [Lean.Grind.CommRing R]
+    (n : Nat) (cmp : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
+  model : RatModel R
+  data : RatLiftCert n cmp
+
+/-- Public coprimality evidence with canonical rational lift leaves. -/
+abbrev CoprimeCert (n : Nat) (R : Type u) [Lean.Grind.CommRing R]
+    (cmp : Mono n → Mono n → Ordering) [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] :=
+  Cert.Coprime R (RatLeaf R) n cmp
+
+/-- Public gcd certificate. -/
+abbrev GcdCert (n : Nat) (R : Type u) [Lean.Grind.CommRing R]
+    (cmp : Mono n → Mono n → Ordering) [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] :=
+  Cert.Gcd R (RatLeaf R) n cmp
+
+/-- Public coefficient-content certificate. -/
+abbrev ContentCert (n : Nat) (R : Type u) [Lean.Grind.CommRing R]
+    (cmp : Mono n → Mono n → Ordering) [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] :=
+  Cert.Content R (RatLeaf R) n cmp
+
+/-- Public list of gcd steps. -/
+abbrev GcdCerts (n : Nat) (R : Type u) [Lean.Grind.CommRing R]
+    (cmp : Mono n → Mono n → Ordering) [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] :=
+  Cert.Steps R (RatLeaf R) n cmp
+
+namespace CoprimeCert
+export Cert.Coprime (unit base bezout split splitBezout)
+
+/-- Canonical `Int → Rat` lifting from ordinary integer evidence. -/
+def ratLift {n : Nat} {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    (scaleL scaleR : Rat) (left right : MvPoly n Int cmp)
+    (cert : IntCoprimeCert n cmp) : CoprimeCert n Rat cmp :=
+  .leaf ⟨RatModel.rat, ⟨scaleL, scaleR, left, right, cert⟩⟩
+end CoprimeCert
+
+namespace GcdCert
+export Cert.Gcd (mk)
+end GcdCert
+
+namespace Cert.Steps
+
+variable {n : Nat} {R : Type u} [Lean.Grind.CommRing R] {E : Cert.Leaves.{v}}
+  {cmp : Mono n → Mono n → Ordering}
+  [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+
+@[reducible] def toList : Cert.Steps R E n cmp → List (Cert.Gcd R E n cmp)
+  | .nil => []
+  | .cons head tail => head :: toList tail
+
+@[reducible] def ofList : List (Cert.Gcd R E n cmp) → Cert.Steps R E n cmp
+  | [] => .nil
+  | head :: tail => .cons head (ofList tail)
+
+end Cert.Steps
+
+namespace Cert.Gcd
+
+variable {n : Nat} {R : Type u} [Lean.Grind.CommRing R] {E : Cert.Leaves.{v}}
+  {cmp : Mono n → Mono n → Ordering}
+  [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+
+@[reducible] def gcd : Cert.Gcd R E n cmp → MvPoly n R cmp
+  | .mk gcd _ _ _ => gcd
+
+@[reducible] def cofL : Cert.Gcd R E n cmp → MvPoly n R cmp
+  | .mk _ cofL _ _ => cofL
+
+@[reducible] def cofR : Cert.Gcd R E n cmp → MvPoly n R cmp
+  | .mk _ _ cofR _ => cofR
+
+@[reducible] def coprime : Cert.Gcd R E n cmp → Cert.Coprime R E n cmp
+  | .mk _ _ _ coprime => coprime
+
+end Cert.Gcd
+
+namespace Cert.Content
+
+variable {n : Nat} {R : Type u} [Lean.Grind.CommRing R] {E : Cert.Leaves.{v}}
+  {cmp : Mono n → Mono n → Ordering}
+  [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+
+@[reducible] def value : Cert.Content R E n cmp → MvPoly n R cmp
+  | .mk value _ => value
+
+@[reducible] def steps : Cert.Content R E n cmp → List (Cert.Gcd R E n cmp)
+  | .mk _ steps => steps.toList
+
+/-- Public list-based constructor; the strictly-positive internal list is an
+implementation detail of Lean's mutual-inductive positivity checker. -/
+@[reducible] def ofSteps (value : MvPoly n R cmp) (steps : List (Cert.Gcd R E n cmp)) :
+    Cert.Content R E n cmp :=
+  .mk value (Cert.Steps.ofList steps)
+
+@[simp] theorem value_ofSteps (value : MvPoly n R cmp)
+    (steps : List (Cert.Gcd R E n cmp)) :
+    (ofSteps value steps).value = value := by
+  rfl
+
+@[simp] theorem steps_ofSteps (value : MvPoly n R cmp)
+    (steps : List (Cert.Gcd R E n cmp)) :
+    (ofSteps value steps).steps = steps := by
+  induction steps with
+  | nil => rfl
+  | cons step steps ih =>
+      simp only [Cert.Content.steps, Cert.Steps.toList, ih]
+
+end Cert.Content
+
+namespace GcdCerts
+export Cert.Steps (nil cons)
+
+variable {n : Nat} {R : Type u} [Lean.Grind.CommRing R]
+  {cmp : Mono n → Mono n → Ordering} [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+@[reducible] def toList (steps : GcdCerts n R cmp) : List (GcdCert n R cmp) :=
+  Cert.Steps.toList steps
+@[reducible] def ofList (steps : List (GcdCert n R cmp)) : GcdCerts n R cmp :=
+  Cert.Steps.ofList steps
+end GcdCerts
+
+namespace GcdCert
+variable {n : Nat} {R : Type u} [Lean.Grind.CommRing R]
+  {cmp : Mono n → Mono n → Ordering} [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+@[reducible] def gcd (cert : GcdCert n R cmp) : MvPoly n R cmp := Cert.Gcd.gcd cert
+@[reducible] def cofL (cert : GcdCert n R cmp) : MvPoly n R cmp := Cert.Gcd.cofL cert
+@[reducible] def cofR (cert : GcdCert n R cmp) : MvPoly n R cmp := Cert.Gcd.cofR cert
+@[reducible] def coprime (cert : GcdCert n R cmp) : CoprimeCert n R cmp :=
+  Cert.Gcd.coprime cert
+end GcdCert
+
+namespace ContentCert
+export Cert.Content (mk)
+
+variable {n : Nat} {R : Type u} [Lean.Grind.CommRing R]
+  {cmp : Mono n → Mono n → Ordering} [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+@[reducible] def value (cert : ContentCert n R cmp) : MvPoly n R cmp :=
+  Cert.Content.value cert
+@[reducible] def steps (cert : ContentCert n R cmp) : List (GcdCert n R cmp) :=
+  Cert.Content.steps cert
+/-- Build a coefficient-content certificate from a list of gcd steps. -/
+@[reducible] def ofSteps (value : MvPoly n R cmp) (steps : List (GcdCert n R cmp)) :
+    ContentCert n R cmp := Cert.Content.ofSteps value steps
+@[simp] theorem value_ofSteps (value : MvPoly n R cmp) (steps : List (GcdCert n R cmp)) :
+    (ofSteps value steps).value = value := Cert.Content.value_ofSteps value steps
+@[simp] theorem steps_ofSteps (value : MvPoly n R cmp) (steps : List (GcdCert n R cmp)) :
+    (ofSteps value steps).steps = steps := Cert.Content.steps_ofSteps value steps
+end ContentCert
+
+namespace Cert
+
+variable {R : Type u} [Lean.Grind.CommRing R] {E : Leaves.{v}}
+
+/-- Extraction of ordinary evidence at one arity. -/
+structure StripOps (R : Type u) [Lean.Grind.CommRing R] (E : Leaves.{v}) (n : Nat) where
+  coprime : {cmp : Mono n → Mono n → Ordering} →
+    [Std.TransCmp cmp] → [Std.LawfulEqCmp cmp] →
+    Coprime R E n cmp → Option (Coprime R NoLeaves n cmp)
+
+/-- Extract ordinary evidence from a gcd using a supplied coprimality extractor. -/
+def stripGcdWith {n : Nat} {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    (strip : Coprime R E n cmp → Option (Coprime R NoLeaves n cmp))
+    (cert : Gcd R E n cmp) : Option (Gcd R NoLeaves n cmp) := do
+  return .mk cert.gcd cert.cofL cert.cofR (← strip cert.coprime)
+
+/-- Extract ordinary evidence from all gcd steps of a content fold. -/
+def stripContentWith {n : Nat} {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    (strip : Coprime R E n cmp → Option (Coprime R NoLeaves n cmp))
+    (cert : Content R E n cmp) : Option (Content R NoLeaves n cmp) := do
+  return Content.ofSteps cert.value (← cert.steps.mapM (stripGcdWith strip))
+
+/-- Extract ordinary certificates by arity, rejecting a leaf at any depth. -/
+def stripOps : (n : Nat) → StripOps R E n
+  | 0 => { coprime := fun cert =>
+      match cert with
+      | .unit => some .unit
+      | .base u v => some (.base u v)
+      | .bezout u v => some (.bezout u v)
+      | .leaf _ => none }
+  | n + 1 =>
+      let lower := stripOps n
+      { coprime := fun cert => by
+          cases cert with
+          | unit => exact some .unit
+          | bezout u v => exact some (.bezout u v)
+          | leaf _ => exact none
+          | split i cmp' P φ a α β left right rest => exact do
+              return .split i cmp' P φ a α β (← stripContentWith lower.coprime left)
+                (← stripContentWith lower.coprime right) (← lower.coprime rest)
+          | splitBezout i cmp' u v r left right rest => exact do
+              return .splitBezout i cmp' u v r (← stripContentWith lower.coprime left)
+                (← stripContentWith lower.coprime right) (← lower.coprime rest) }
+
+/-- Remove optional leaves before using an integer certificate in rational replay. -/
+def stripCoprime? {n : Nat} {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] (cert : Coprime R E n cmp) :
+    Option (Coprime R NoLeaves n cmp) := (stripOps n).coprime cert
+
+end Cert
+
+end Hex.MvPoly

--- a/HexMvGcd/CertTests.lean
+++ b/HexMvGcd/CertTests.lean
@@ -1,0 +1,149 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvGcd.Cert
+import all HexMvGcd.Cert
+import all HexMvGcd.CertData
+import all HexMvGcd.Normalize
+import all HexMvGcd.View
+import all HexMvPoly.Recursive
+import all HexMvPoly.Basic
+import all HexMvPoly.Ring
+import all HexPoly.Dense
+import all HexPoly.Operations
+
+@[expose] public section
+
+/-! Kernel regressions for canonical integer replay inside rational lifts. -/
+
+namespace Hex.MvPoly.CertTests
+
+open Hex
+
+abbrev P := MvPoly 1 Int Mono.lex
+abbrev Q := MvPoly 1 Rat Mono.lex
+
+def left : P := C 2 * X 0 + C 2
+def right : P := C 2 * X 0 + C 4
+
+/-- Operations that would accept every scalar as a unit. These must never
+be captured by a rational certificate or used for its integer replay. -/
+@[instance_reducible] def badOps : GcdOps Int where
+  gcd := fun _ _ => 1
+  exactDiv := Int.ediv
+  isUnit := fun _ => true
+  normUnit := fun _ => 1
+
+def leftContent : Cert.Content Int Cert.NoLeaves 0 Mono.lex :=
+  .ofSteps (C 2) [.mk (C 2) 0 1 .unit, .mk (C 2) 1 1 .unit]
+
+def rightContent : Cert.Content Int Cert.NoLeaves 0 Mono.lex :=
+  .ofSteps (C 2) [.mk (C 2) 0 (C 2) .unit, .mk (C 2) 1 1 .unit]
+
+/-- The Bézout equation is valid, but the two contents are not coprime. -/
+def badSource : IntCoprimeCert 1 Mono.lex :=
+  .splitBezout 0 Mono.lex (C (-1)) 1 (C 2) leftContent rightContent .unit
+
+def forged : CoprimeCert 1 Rat Mono.lex := by
+  letI : GcdOps Int := badOps
+  exact .ratLift 1 1 left right badSource
+
+theorem forged_rejected :
+    checkCoprime (intModelToRat left) (intModelToRat right) forged = false := by
+  decide +kernel
+
+theorem source_rejected :
+    (Cert.checkOps (S := Int) (E := Cert.NoLeaves)
+      (fun _ _ _ _ _ impossible => nomatch impossible) 1).coprime
+        Mono.lex left right badSource = false := by
+  change (_ && false) = false
+  exact Bool.and_false _
+
+theorem not_coprime : ¬ CoprimeCofactors left right := by
+  intro h
+  have hl : (C 2 : P) ∣ left := ⟨X 0 + 1, by decide +kernel⟩
+  have hr : (C 2 : P) ∣ right := ⟨X 0 + C 2, by decide +kernel⟩
+  have hu := (polyIsUnit_iff (C 2 : P)).mpr (h (C 2) hl hr)
+  have hn : polyIsUnit (C 2 : P) = false := by decide +kernel
+  rw [hn] at hu
+  contradiction
+
+def goodLift : RatLiftCert 1 Mono.lex :=
+  ⟨2, 3, X 0 + 1, X 0 + C 2, .bezout (C (-1)) 1⟩
+
+def scaledLeft : Q := C 2 * (X 0 + 1)
+def scaledRight : Q := C 3 * (X 0 + C 2)
+
+theorem lift_accepted : checkRatLift scaledLeft scaledRight goodLift = true := by
+  decide +kernel
+
+theorem wrapper_accepted : checkCoprime scaledLeft scaledRight
+    (.ratLift 2 3 (X 0 + 1) (X 0 + C 2) (.bezout (C (-1)) 1)) = true := by
+  decide +kernel
+
+theorem zero_scale_rejected :
+    checkRatLift 0 scaledRight { goodLift with scaleL := 0 } = false := by
+  decide +kernel
+
+theorem wrong_scale_rejected :
+    checkRatLift scaledLeft scaledRight { goodLift with scaleR := 4 } = false := by
+  decide +kernel
+
+theorem bad_evidence_rejected :
+    checkRatLift scaledLeft scaledRight { goodLift with cert := .unit } = false := by
+  decide +kernel
+
+/-- Even a dictionary in the caller's scope cannot change integer replay. -/
+theorem local_ops_rejected :
+    letI : GcdOps Int := badOps
+    checkRatLift scaledLeft scaledRight { goodLift with cert := .unit } = false := by
+  decide +kernel
+
+/-- Primitive but noncoprime models must fail even when a caller claims
+that every integer polynomial is a unit. -/
+def repeatedLift : CoprimeCert 1 Rat Mono.lex := by
+  letI : GcdOps Int := badOps
+  exact .ratLift 1 1 (X 0 + 1) (X 0 + 1) .unit
+
+theorem repeated_rejected :
+    checkCoprime (X 0 + 1) (X 0 + 1) repeatedLift = false := by
+  decide +kernel
+
+abbrev TestLeaves : Cert.Leaves := fun _ _ _ _ => Unit
+
+def nestedLeaf : Cert.Coprime Int TestLeaves 1 Mono.lex :=
+  .splitBezout 0 Mono.lex 0 1 1
+    (.ofSteps 1 [.mk 1 0 1 (.leaf ())]) (.ofSteps 1 []) .unit
+
+theorem leaf_rejected :
+    Cert.stripCoprime? (.leaf () : Cert.Coprime Int TestLeaves 0 Mono.lex) = none := by
+  rfl
+
+theorem nested_leaf_rejected : Cert.stripCoprime? nestedLeaf = none := by
+  rfl
+
+/-- No ordinary integer certificate admits a rational-representation leaf. -/
+theorem no_integer_lift (model : RatModel Int) : False := model.not_int
+
+/-- info: 'Hex.MvPoly.CertTests.forged_rejected' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms forged_rejected
+
+/-- info: 'Hex.MvPoly.CertTests.wrapper_accepted' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms wrapper_accepted
+
+/-- info: 'Hex.MvPoly.CertTests.repeated_rejected' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms repeated_rejected
+
+/-- info: 'Hex.MvPoly.CertTests.no_integer_lift' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms no_integer_lift
+
+end Hex.MvPoly.CertTests

--- a/HexMvGcd/CertTests.lean
+++ b/HexMvGcd/CertTests.lean
@@ -134,6 +134,10 @@ theorem no_integer_lift (model : RatModel Int) : False := model.not_int
 #guard_msgs in
 #print axioms forged_rejected
 
+/-- info: 'Hex.MvPoly.CertTests.not_coprime' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms not_coprime
+
 /-- info: 'Hex.MvPoly.CertTests.wrapper_accepted' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in
 #print axioms wrapper_accepted

--- a/HexMvGcd/Content.lean
+++ b/HexMvGcd/Content.lean
@@ -49,7 +49,7 @@ def primPart (p : MvPoly n R cmp) : MvPoly n R cmp :=
 The returned certificate stores every step that the checker replays. Steps are
 consed into a reversed accumulator and reversed once after the fold. -/
 def contentCertWith {R : Type u} {cmp : Mono n → Mono n → Ordering}
-    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] [Zero R]
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] [Lean.Grind.CommRing R]
     (produce : MvPoly n R cmp → MvPoly n R cmp → GcdCert n R cmp)
     (coeffs : List (MvPoly n R cmp)) : ContentCert n R cmp :=
   let pair := coeffs.foldl
@@ -61,7 +61,7 @@ def contentCertWith {R : Type u} {cmp : Mono n → Mono n → Ordering}
 
 /-- Forward-order specification of the reverse-accumulator content fold. -/
 private def contentTrace {R : Type u} {cmp : Mono n → Mono n → Ordering}
-    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] [Zero R]
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] [Lean.Grind.CommRing R]
     (produce : MvPoly n R cmp → MvPoly n R cmp → GcdCert n R cmp) :
     MvPoly n R cmp → List (MvPoly n R cmp) →
       MvPoly n R cmp × List (GcdCert n R cmp)
@@ -73,7 +73,7 @@ private def contentTrace {R : Type u} {cmp : Mono n → Mono n → Ordering}
 
 private theorem contentFold_eq_trace {R : Type u}
     {cmp : Mono n → Mono n → Ordering}
-    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] [Zero R]
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] [Lean.Grind.CommRing R]
     (produce : MvPoly n R cmp → MvPoly n R cmp → GcdCert n R cmp)
     (coeffs : List (MvPoly n R cmp)) (acc : MvPoly n R cmp)
     (done : List (GcdCert n R cmp)) :
@@ -94,7 +94,7 @@ private theorem contentFold_eq_trace {R : Type u}
 
 private theorem contentCertWith_eq_trace {R : Type u}
     {cmp : Mono n → Mono n → Ordering}
-    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] [Zero R]
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] [Lean.Grind.CommRing R]
     (produce : MvPoly n R cmp → MvPoly n R cmp → GcdCert n R cmp)
     (coeffs : List (MvPoly n R cmp)) :
     contentCertWith produce coeffs =
@@ -126,7 +126,7 @@ private theorem contentTrace_checks {R : Type u}
 /-- A producer-built fold has exactly one step per coefficient. -/
 theorem contentCertWith_length {R : Type u}
     {cmp : Mono n → Mono n → Ordering}
-    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] [Zero R]
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] [Lean.Grind.CommRing R]
     (produce : MvPoly n R cmp → MvPoly n R cmp → GcdCert n R cmp)
     (coeffs : List (MvPoly n R cmp)) :
     (contentCertWith produce coeffs).steps.length = coeffs.length := by
@@ -177,7 +177,9 @@ theorem contentCertWith_checks {R : Type u}
             (produce f h) = true := by
         simpa [checkGcd, checkOps] using hproduce
       simp only [checkContent, checkContentUsing]
-      rw [ContentCert.value_ofSteps, ContentCert.steps_ofSteps]
+      simp only [ContentCert.ofSteps]
+      rw [Cert.Content.value_ofSteps (E := RatLeaf R),
+        Cert.Content.steps_ofSteps (E := RatLeaf R)]
       exact contentTrace_checks
         (checkGcdUsing (baseCheckCoprime (cmp := cmp))) produce hp coeffs
         (0 : MvPoly 0 R cmp)
@@ -187,7 +189,9 @@ theorem contentCertWith_checks {R : Type u}
             f h (produce f h) = true := by
         simpa [checkGcd, checkOps] using hproduce
       simp only [checkContent, checkContentUsing]
-      rw [ContentCert.value_ofSteps, ContentCert.steps_ofSteps]
+      simp only [ContentCert.ofSteps]
+      rw [Cert.Content.value_ofSteps (E := RatLeaf R),
+        Cert.Content.steps_ofSteps (E := RatLeaf R)]
       exact contentTrace_checks
         (checkGcdUsing
           (succCheckCoprime (checkOps (R := R) n) (cmp := cmp)))

--- a/HexMvGcd/Fast.lean
+++ b/HexMvGcd/Fast.lean
@@ -298,8 +298,8 @@ def coprimeStep {n : Nat} {R : Type u}
       let main : Fin (n + 1) := ⟨0, by omega⟩
       let fView := toUnivariate main Mono.lex f
       let hView := toUnivariate main Mono.lex h
-      let fImage := imageAtRaw prime φ.toField points main Mono.lex f
-      let hImage := imageAtRaw prime φ.toField points main Mono.lex h
+      let fImage := imageAt prime φ points main Mono.lex f
+      let hImage := imageAt prime φ points main Mono.lex h
       if fImage.degree? != fView.degree? || hImage.degree? != hView.degree? then
         (none, rand')
       else

--- a/HexMvGcd/Fast.lean
+++ b/HexMvGcd/Fast.lean
@@ -53,14 +53,14 @@ def samplePoints {p : Nat} [ZMod64.Bounds p] (sampleFuel : Nat) :
       let (rest, rand'') ← samplePoints sampleFuel n rand'
       .ok (Fin.cases (ZMod64.ofNat p value) rest, rand'')
 
-structure GcdRun (n : Nat) (R : Type u) [Zero R]
+structure GcdRun (n : Nat) (R : Type u) [Lean.Grind.CommRing R]
     (cmp : Mono n → Mono n → Ordering)
     [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
   cert : GcdCert n R cmp
   rand : Rand
 
 /-- Untrusted fast-backend output. -/
-structure GcdProposal (n : Nat) (R : Type u) [Zero R]
+structure GcdProposal (n : Nat) (R : Type u) [Lean.Grind.CommRing R]
     (cmp : Mono n → Mono n → Ordering)
     [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
   cert? : Option (GcdCert n R cmp)
@@ -70,16 +70,16 @@ structure GcdProposal (n : Nat) (R : Type u) [Zero R]
 mandatory route-0 factor.  Implementations must treat their two polynomial
 arguments as the already-reduced problem and must not repeat structural
 reduction. -/
-class GcdProducer (R : Type u) [Zero R] where
+class GcdProducer (R : Type u) [Lean.Grind.CommRing R] where
   propose : {n : Nat} → (cmp : Mono n → Mono n → Ordering) →
     [IsMonomialOrder cmp] → GcdConfig →
     MvPoly n R cmp → MvPoly n R cmp → GcdProposal n R cmp
 
 /-- Abstract rings have no coefficient-specific speculative route. -/
-@[instance_reducible] def noFastProducer {R : Type u} [Zero R] : GcdProducer R where
+@[instance_reducible] def noFastProducer {R : Type u} [Lean.Grind.CommRing R] : GcdProducer R where
   propose := fun _ _ cfg _ _ => ⟨none, cfg.rand⟩
 
-instance (priority := 10) instNoFastProducer {R : Type u} [Zero R] :
+instance (priority := 10) instNoFastProducer {R : Type u} [Lean.Grind.CommRing R] :
     GcdProducer R := noFastProducer
 
 /-- Route 0: zero and unit cases, all represented by genuine replayable
@@ -267,7 +267,7 @@ def intCoeffHom (prime : ZMod64.Prime) :
 random state even when the image is inconclusive.  The coefficient
 homomorphism is explicit certificate data, so the same recursion serves
 integers and polynomial coefficients evaluated into their ground field. -/
-structure CoprimeOpsAt (R : Type u) [Zero R] [One R] [Add R] [Mul R]
+structure CoprimeOpsAt (R : Type u) [Lean.Grind.CommRing R]
     (n : Nat) where
   tryAt : (cmp : Mono n → Mono n → Ordering) →
     [IsMonomialOrder cmp] → (P : ZMod64.Prime) →

--- a/HexMvGcd/Prs.lean
+++ b/HexMvGcd/Prs.lean
@@ -28,7 +28,7 @@ universe u
 
 /-- Operations constructed together at one arity. Keeping the pair together
 makes every recursive call visibly decrease the arity. -/
-structure PrsOpsAt (R : Type u) [Zero R] (n : Nat) : Type (u + 1) where
+structure PrsOpsAt (R : Type u) [Lean.Grind.CommRing R] (n : Nat) : Type (u + 1) where
   gcdCert : (cmp : Mono n → Mono n → Ordering) → [IsMonomialOrder cmp] →
     MvPoly n R cmp → MvPoly n R cmp → GcdCert n R cmp
   coprimeCert : (cmp : Mono n → Mono n → Ordering) → [IsMonomialOrder cmp] →

--- a/HexMvGcd/README.md
+++ b/HexMvGcd/README.md
@@ -47,8 +47,14 @@ def y : P := X 1
 # Verification
 
 Candidate producers never establish correctness by themselves. Every public
-gcd is extracted from a certificate accepted by `checkGcd`; replay proves the
-two exact cofactor identities and the greatest-common-divisor property.
+gcd is extracted from a certificate accepted by `checkGcd`. The checker
+soundness theorems specify the two exact cofactor identities and the
+greatest-common-divisor property; their remaining proof gaps are tracked in
+[#10082](https://github.com/kim-em/hex-dev/issues/10082).
+
+Rational lifts carry ordinary integer certificates and replay them with
+canonical integer arithmetic. Certificates cannot replace those operations
+or nest another rational lift inside the integer evidence.
 
 ```lean
 theorem gcd_dvd_left (f g : P) : gcd f g ∣ f

--- a/HexMvGcd/SPEC/hex-mv-gcd.md
+++ b/HexMvGcd/SPEC/hex-mv-gcd.md
@@ -627,46 +627,51 @@ certificate contains two content certificates. Every occurrence is
 strictly positive and every cycle drops the arity before returning to a
 coprimality certificate.
 
+The recursive core has fixed parameters `R`, `[Lean.Grind.CommRing R]`,
+and a family `E` of optional leaves. Only the arity, comparator, and its
+representation instances are indices. The same ring parameter is used by
+all recursive evidence and by the laws in a `split` coefficient homomorphism;
+constructors cannot substitute operation dictionaries.
+
+| Core constructor | Evidence replayed |
+| --- | --- |
+| `Cert.Coprime.unit` | One input is a unit. |
+| `Cert.Coprime.base u v` | A scalar Bézout identity, at arity zero. |
+| `Cert.Coprime.bezout u v` | A polynomial Bézout identity. |
+| `Cert.Coprime.split` | A bundled prime, coefficient homomorphism, evaluation point, image Bézout coefficients, two lower-arity content folds, and their coprimality certificate. |
+| `Cert.Coprime.splitBezout` | A variable, a nonzero polynomial constant in that variable, its Bézout expression, two lower-arity content folds, and their coprimality certificate. |
+| `Cert.Coprime.leaf` | Data in `E` at the current arity and order. |
+| `Cert.Gcd.mk` | A gcd, two exact cofactors, and their coprimality certificate. |
+| `Cert.Content.mk` | A content value and a strictly positive list of gcd certificates. |
+
+Every arity-dropping constructor carries `[IsMonomialOrder cmp']`, which
+supplies both comparator instances required by its lower-arity values.
+`ContentCert.ofSteps` exposes the usual `List` interface to content folds.
+
+The public `CoprimeCert`, `GcdCert`, and `ContentCert` specialize this core
+to rational-lift leaves. Such a leaf contains a `RatModel R`: a ring
+isomorphism to canonical `Rat`, with both inverse laws and the ring-map
+laws proved for the fixed ambient ring. It identifies rational coefficient
+representations without restricting the universe of the generic API.
+In particular, `RatModel.not_int` rules out such a leaf over canonical `Int`.
+The rational payload itself has only the following data:
+
 ```lean
-mutual
-  inductive CoprimeCert :
-      (n : Nat) → (R : Type u) → [Zero R] →
-      (cmp : Mono n → Mono n → Ordering) →
-      [Std.TransCmp cmp] → [Std.LawfulEqCmp cmp] → Type u
-    | unit : CoprimeCert n R cmp
-    | base (u v : R) : CoprimeCert 0 R cmp
-    | bezout (u v : MvPoly n R cmp) : CoprimeCert n R cmp
-    | split (i : Fin (n+1)) (cmp' : Mono n → Mono n → Ordering)
-        [IsMonomialOrder cmp'] [One R] [Add R] [Mul R]
-        (P : ZMod64.Prime)
-        (φ : @CoeffHom R P.m _ _ _ _ P.bounds)
-        (a : Fin n → @ZMod64 P.m P.bounds)
-        (α β : @FpPoly P.m P.bounds)
-        (left right : ContentCert n R cmp')
-        (rest : CoprimeCert n R cmp') : CoprimeCert (n+1) R cmp
-    | splitBezout (i : Fin (n+1))
-        (cmp' : Mono n → Mono n → Ordering) [IsMonomialOrder cmp']
-        (u v : MvPoly (n+1) R cmp) (r : MvPoly n R cmp')
-        (left right : ContentCert n R cmp')
-        (rest : CoprimeCert n R cmp') : CoprimeCert (n+1) R cmp
-    | ratLift (scaleL scaleR : Rat) (left right : MvPoly n Int cmp)
-        (cert : CoprimeCert n Int cmp) : CoprimeCert n Rat cmp
+abbrev IntCoprimeCert (n : Nat) (cmp : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] :=
+  Cert.Coprime Int Cert.NoLeaves n cmp
 
-  inductive GcdCert :
-      (n : Nat) → (R : Type u) → [Zero R] →
-      (cmp : Mono n → Mono n → Ordering) →
-      [Std.TransCmp cmp] → [Std.LawfulEqCmp cmp] → Type u
-    | mk (gcd cofL cofR : MvPoly n R cmp) (coprime : CoprimeCert n R cmp)
+structure RatLiftCert (n : Nat) (cmp : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] where
+  scaleL : Rat
+  scaleR : Rat
+  left : MvPoly n Int cmp
+  right : MvPoly n Int cmp
+  cert : IntCoprimeCert n cmp
 
-  /-- A checked left fold of gcd over a polynomial's coefficient list.
-  `steps[k]` certifies the gcd of the previous accumulator and coefficient
-  `k`; `value` is the final accumulator. -/
-  inductive ContentCert :
-      (n : Nat) → (R : Type u) → [Zero R] →
-      (cmp : Mono n → Mono n → Ordering) →
-      [Std.TransCmp cmp] → [Std.LawfulEqCmp cmp] → Type u
-    | mk (value : MvPoly n R cmp) (steps : List (GcdCert n R cmp))
-end
+def CoprimeCert.ratLift (scaleL scaleR : Rat)
+    (left right : MvPoly n Int cmp) (cert : IntCoprimeCert n cmp) :
+    CoprimeCert n Rat cmp
 
 def GcdCert.gcd : GcdCert n R cmp → MvPoly n R cmp
 def GcdCert.cofL : GcdCert n R cmp → MvPoly n R cmp
@@ -679,11 +684,12 @@ def checkCoprime (f h : MvPoly n R cmp) : CoprimeCert n R cmp → Bool
 def checkGcd (f h : MvPoly n R cmp) : GcdCert n R cmp → Bool
 ```
 
-All three declarations use the identical index telescope shown above;
-`n`, `R`, `cmp`, and the representation instances are indices rather than
-mixing parameters and indices across the mutual block. Every arity-dropping
-constructor carries `[IsMonomialOrder cmp']`, which supplies both comparator
-instances required to form its lower-arity `MvPoly` values.
+`Cert.NoLeaves` is empty at every arity. Thus the integer payload has no
+rational lifts, including in nested coefficient-content folds. Its integer
+ring, gcd operations, and equality decisions are the canonical instances
+fixed by `checkRatLift`; no source domain, embedding, or replacement
+operations are certificate data. Caller-assembled certificates remain
+supported: acceptance must imply coprimality without producer provenance.
 
 `checkContent` starts at zero, requires exactly one `GcdCert` per
 coefficient, checks each certificate against the current accumulator and
@@ -974,7 +980,10 @@ having is under "Open questions"; it is not assumed anywhere above.
 `gcdCert` on `MvPoly n Rat cmp` scales both inputs to primitive integer
 polynomials, computes there, and scales back. Its cofactor certificate is
 `ratLift` with the two nonzero scales, the primitive integer models, and
-their checked integer coprimality certificate. This is a requirement
+their checked integer coprimality certificate. `Cert.stripCoprime?` extracts
+ordinary evidence from the producer result, traversing all content folds
+and rejecting any optional leaf before constructing the rational wrapper.
+This extraction performs no search and is outside kernel replay. This is a requirement
 rather than an option, and the benchmark family named below checks that
 the extended PRS is not taken merely because the input coefficients are
 rational.
@@ -1454,8 +1463,9 @@ contain `contentIn`, `gcd`, any `GcdProducer`, or `divExact?`; nested
 replay. The closure also includes `polyIsUnit`, `polyNormUnit`,
 `polyNormalize`, base `GcdOps.isUnit` / `normUnit`, and the coefficient
 equality decision (`BEq` with `LawfulBEq`). `ratLift` additionally reaches
-the `scalarContent` fold and coefficientwise `Int → Rat` map, neither of
-which calls a multivariate producer. Each operation in the closure is
+the canonical integer `scalarContent` fold, coefficientwise `Int → Rat`
+map, and the rational-representation map, none of which calls a multivariate
+producer. Each operation in the closure is
 `@[expose]`.
 
 Nothing in routes 1 through 4 is in that closure. Prime search,
@@ -1725,7 +1735,8 @@ HexMvGcd/
   View.lean         -- constIn and the degree helpers on the univariate view
   Normalize.lean    -- polyIsUnit, polyNormUnit, polyNormalize, scalarContent
   Gauss.lean        -- proof-only GcdDomainLaws lift and primitive descent
-  Cert.lean         -- three certificate types, ratLift, checker soundness
+  CertData.lean     -- fixed-ring recursive evidence and canonical rational lift data
+  Cert.lean         -- certificate replay and checker soundness
   Content.lean      -- certificate-producing content/primitive parts and Gauss laws
   Prs.lean          -- the extended-subresultant fallback, route 4
   Fast.lean         -- routes 0 and 1, tryCoprimeCert?

--- a/HexMvGcd/SPEC/hex-mv-gcd.md
+++ b/HexMvGcd/SPEC/hex-mv-gcd.md
@@ -690,6 +690,10 @@ ring, gcd operations, and equality decisions are the canonical instances
 fixed by `checkRatLift`; no source domain, embedding, or replacement
 operations are certificate data. Caller-assembled certificates remain
 supported: acceptance must imply coprimality without producer provenance.
+This is the soundness contract of `checkCoprime`, `checkGcd`, and
+`checkContent` at the public leaf family. The generic `Cert.checkOps`
+provides structural replay with a caller-supplied leaf checker; a soundness
+claim for another leaf family requires its own callback contract.
 
 `checkContent` starts at zero, requires exactly one `GcdCert` per
 coefficient, checks each certificate against the current accumulator and
@@ -714,6 +718,9 @@ are the stated scalar multiples of the coefficientwise `Int → Rat` images,
 that both integer models have `scalarContent = 1`, and that `cert` checks
 for those models. Gauss descent then transports integer coprimality to
 rational coprimality without a nonexistent `Rat → ZMod64` homomorphism.
+For a leaf over an arbitrary rational representation `R`, `checkRatLeaf`
+first maps both inputs coefficientwise through `model.toRat`, then runs
+this canonical `checkRatLift` replay.
 
 Indexing the certificate by the arity is what makes "each step removes a
 variable" true, and it is free: the constructor's result type says so.
@@ -1465,8 +1472,13 @@ replay. The closure also includes `polyIsUnit`, `polyNormUnit`,
 equality decision (`BEq` with `LawfulBEq`). `ratLift` additionally reaches
 the canonical integer `scalarContent` fold, coefficientwise `Int → Rat`
 map, and the rational-representation map, none of which calls a multivariate
-producer. Each operation in the closure is
-`@[expose]`.
+producer. Each operation in the closure is `@[expose]`.
+
+The shared public replay package retains the rational-leaf branch even
+when instantiated at `Int`. `RatModel.not_int` rules out data reaching that
+branch, but its canonical rational operations still belong to the full
+syntactic dependency closure. The ordinary integer replay inside a rational
+lift uses `Cert.NoLeaves` and has no such branch.
 
 Nothing in routes 1 through 4 is in that closure. Prime search,
 interpolation, CRT, and the extended subresultant chain are search; they

--- a/bench/HexMvGcd/Kernel.lean
+++ b/bench/HexMvGcd/Kernel.lean
@@ -85,31 +85,31 @@ private theorem modularDegreeX :
     letI : ZMod64.Bounds primeTwo.m := primeTwo.bounds
     letI : ZMod64.PrimeModulus primeTwo.m :=
       ZMod64.primeModulusOfPrime primeTwo.prime
-    decide ((imageAtRaw primeTwo (intCoeffHom primeTwo).toField noPoint
+    decide ((imageAt primeTwo (intCoeffHom primeTwo) noPoint
       0 Mono.lex x).degree? = (toUnivariate 0 Mono.lex x).degree?) = true := by
-  unfold x imageAtRaw
+  unfold x imageAt
   decide +kernel
 
 private theorem modularDegreeXPlusOne :
     letI : ZMod64.Bounds primeTwo.m := primeTwo.bounds
     letI : ZMod64.PrimeModulus primeTwo.m :=
       ZMod64.primeModulusOfPrime primeTwo.prime
-    decide ((imageAtRaw primeTwo (intCoeffHom primeTwo).toField noPoint
+    decide ((imageAt primeTwo (intCoeffHom primeTwo) noPoint
       0 Mono.lex (x + 1)).degree? =
         (toUnivariate 0 Mono.lex (x + 1)).degree?) = true := by
-  unfold x imageAtRaw
+  unfold x imageAt
   decide +kernel
 
 private theorem modularCombination :
     letI : ZMod64.Bounds primeTwo.m := primeTwo.bounds
     letI : ZMod64.PrimeModulus primeTwo.m :=
       ZMod64.primeModulusOfPrime primeTwo.prime
-    let fImage := imageAtRaw primeTwo (intCoeffHom primeTwo).toField
+    let fImage := imageAt primeTwo (intCoeffHom primeTwo)
       noPoint 0 Mono.lex x
-    let hImage := imageAtRaw primeTwo (intCoeffHom primeTwo).toField
+    let hImage := imageAt primeTwo (intCoeffHom primeTwo)
       noPoint 0 Mono.lex (x + 1)
     (1 * fImage + 1 * hImage == 1) = true := by
-  unfold x imageAtRaw
+  unfold x imageAt
   decide +kernel
 
 private def modularSplit : CoprimeCert 1 Int Mono.lex :=
@@ -159,6 +159,24 @@ theorem bezoutSplitValid : checkCoprime x (x + 1) bezoutSplit = true := by
 theorem bezoutSplitCorrupt :
     checkCoprime x (x + 1) badBezoutSplit = false := by
   decide +kernel
+
+private def strippedReplay (cert : CoprimeCert 1 Int Mono.lex) : Bool :=
+  match Cert.stripCoprime? cert with
+  | none => false
+  | some ordinary =>
+      (Cert.checkOps (S := Int) (E := Cert.NoLeaves)
+        (fun _ _ _ _ _ impossible => nomatch impossible) 1).coprime
+          Mono.lex x (x + 1) ordinary
+
+/-- Extraction preserves modular replay, including both content folds. -/
+theorem stripModularValid : strippedReplay modularSplit = true := by
+  change checkCoprime x (x + 1) modularSplit = true
+  exact modularSplitValid
+
+/-- Extraction preserves Bézout replay, including both content folds. -/
+theorem stripBezoutValid : strippedReplay bezoutSplit = true := by
+  change checkCoprime x (x + 1) bezoutSplit = true
+  exact bezoutSplitValid
 
 private def directBezout : CoprimeCert 1 Int Mono.lex :=
   .bezout (-1) 1

--- a/bench/HexMvGcd/Kernel.lean
+++ b/bench/HexMvGcd/Kernel.lean
@@ -121,16 +121,15 @@ private def badModularSplit : CoprimeCert 1 Int Mono.lex :=
     1 0 xContent xPlusOneContent .unit
 
 theorem modularSplitValid : checkCoprime x (x + 1) modularSplit = true := by
-  simp only [checkCoprime, succCheckCoprime, modularSplit]
+  simp only [checkCoprime, succCheckCoprime, Cert.succCheck, modularSplit]
   unfold checkContentUsing checkContentSteps checkGcdUsing
     xContent xPlusOneContent zeroZeroStep zeroOneStep oneOneStep
-  unfold baseCheckCoprime
+  unfold baseCheckCoprime Cert.baseCheck
   unfold Nat.Internal.elimOffset
   dsimp only
   simp only [modularDegreeX, modularDegreeXPlusOne, modularCombination,
     viewX, viewXPlusOne, polyNormalize_zero, normalizeOneP0]
-  simp only [checkContentSteps, GcdCert.gcd, GcdCert.cofL, GcdCert.cofR,
-    normalizeOneP0]
+  simp only [checkContentSteps, normalizeOneP0]
   decide +kernel
 
 theorem modularSplitCorrupt :
@@ -146,16 +145,15 @@ private def badBezoutSplit : CoprimeCert 1 Int Mono.lex :=
     xContent xPlusOneContent .unit
 
 theorem bezoutSplitValid : checkCoprime x (x + 1) bezoutSplit = true := by
-  unfold checkCoprime checkOps succCheckCoprime bezoutSplit
+  unfold checkCoprime checkOps succCheckCoprime Cert.succCheck bezoutSplit
   dsimp only
   unfold checkContentUsing checkContentSteps checkGcdUsing
     xContent xPlusOneContent zeroZeroStep zeroOneStep oneOneStep
-  unfold baseCheckCoprime
+  unfold baseCheckCoprime Cert.baseCheck
   unfold Nat.Internal.elimOffset
   dsimp only
   simp only [viewX, viewXPlusOne, polyNormalize_zero, normalizeOneP0]
-  simp only [checkContentSteps, GcdCert.gcd, GcdCert.cofL, GcdCert.cofR,
-    normalizeOneP0]
+  simp only [checkContentSteps, normalizeOneP0]
   decide +kernel
 
 theorem bezoutSplitCorrupt :
@@ -252,14 +250,14 @@ private theorem secondNestedGcd : secondNestedStep.gcd = 1 := by
 theorem nestedContentValid :
     checkContent [x, x + 1] nestedContent = true := by
   unfold checkContent checkOps checkContentUsing nestedContent
-  simp only [checkContentSteps, ContentCert.value, firstNestedGcd,
+  simp only [checkContentSteps, firstNestedGcd,
     secondNestedGcd, firstNestedValid, secondNestedValid]
   decide +kernel
 
 theorem nestedContentCorrupt :
     checkContent [x, x + 1] badNestedContent = false := by
   unfold checkContent checkOps checkContentUsing badNestedContent
-  simp only [checkContentSteps, ContentCert.value, firstNestedGcd,
+  simp only [checkContentSteps, firstNestedGcd,
     secondNestedGcd, firstNestedValid, secondNestedValid]
   decide +kernel
 
@@ -334,17 +332,8 @@ private def flatRatLift : RatLiftCert 0 Mono.lex where
 theorem flatRatLiftValid : checkRatLift (C 2) (C 3) flatRatLift = true := by
   decide +kernel
 
-private def identityEmbedding : CoeffEmbedding Int Int where
-  toFun := fun z => z
-
-/-- Mere nonzero scaling cannot witness coprimality outside a field. -/
-private def nonunitLift : CoprimeCert 0 Int Mono.lex :=
-  .ratLiftCore identityEmbedding (by rfl) (by rfl)
-    (by intros; rfl) (by intros; rfl) (by intro a b h; exact h)
-    2 2 1 1 1 1 .unit
-
-theorem nonunitLiftCorrupt :
-    checkCoprime (C 2) (C 2) nonunitLift = false := by
-  decide +kernel
+/-- Integer coefficients cannot supply a rational-lift representation. -/
+theorem noIntegerLift (model : RatModel Int) : False :=
+  model.not_int
 
 end Hex.MvGcdBench.Kernel

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -915,6 +915,7 @@ lean_lib HexMvFactorizationTests where
     `HexModular.LoopTests,
     `HexPolyZGcd.Kernel,
     `HexMvGcd.KernelTests,
+    `HexMvGcd.CertTests,
     `HexMvGcd.Eval,
     `HexMvGcd.SquarefreeTests,
     `HexMvHensel.KernelTests,


### PR DESCRIPTION
A caller-assembled rational-lift certificate could capture unlawful source `GcdOps`, causing the checker to accept noncoprime integer inputs. The counterexample on #10082 uses `2x + 2` and `2x + 4`, an identity embedding, and source operations that call every coefficient a unit.

Fix the certificate boundary by fixing the coefficient ring throughout recursive evidence and replacing the generic lift with canonical integer models, rational scales, and ordinary integer certificates. Rational representations carry proved ring-isomorphism laws; integer replay uses canonical operations and cannot contain nested lift leaves. The producer extracts ordinary evidence before building the rational wrapper. Update the SPEC, README, and replay probes for this API.

Validation:
- Kernel regressions reject the reported source certificate, malicious local dictionaries, repeated primitive factors, invalid scales, invalid recursive evidence, and nested optional leaves; valid rational lifts succeed. Guarded axiom audits contain no `sorryAx`.
- GCD, Hensel, factorization, the multivariate test target, and kernel replay probes build.
- Fresh fixtures match all committed fixtures; SymPy checks pass for all 86 cases.
- All 19 GCD benchmark smoke checks pass, including FLINT/Singular comparators.
- Whole-graph build (10,744 jobs), including `HexManual`, passes on the head rebased onto #10079.
- DAG, file-size, copyright, phase 4/7, release-manifest checks, and `git diff --check` pass.

This is a prerequisite repair for #10082. Existing checker/Gauss/PRS/squarefree proof gaps remain; no axioms or `sorry`s are added and no phase counters advance. The tracker stays open.
