### PR TITLE
refactor(roots): name the two isolators for what they find

### DIFF
--- a/Examples/Release5.lean
+++ b/Examples/Release5.lean
@@ -69,13 +69,13 @@ theorem complexInput_simple : HasOnlySimpleRoots complexInput := by
 
 /-- A none-free array of certified, pairwise-disjoint complex-root atoms. -/
 noncomputable def complexRoots :=
-  HexRootsMathlib.isolate complexInput complexInput_simple complexInput_ne 32
+  HexRootsMathlib.isolateComplexRoots complexInput complexInput_simple complexInput_ne 32
 
 example : complexRoots.size = 3 := by
   rw [show complexRoots.size =
       (HexRootsMathlib.toPolyℂ complexInput).natDegree by
     simpa [complexRoots] using
-    HexRootsMathlib.isolate_count complexInput complexInput_simple
+    HexRootsMathlib.isolateComplexRoots_count complexInput complexInput_simple
       complexInput_ne 32]
   exact complexInput_degree
 

--- a/HexIntervalAlgebraic/Experiment/PolynomialDispatch.lean
+++ b/HexIntervalAlgebraic/Experiment/PolynomialDispatch.lean
@@ -188,7 +188,7 @@ def realBackend? (p : ZPoly) (target : Int) : Option (Array RealRegion) := do
 /-- Plain square projection of the proof-carrying complex backend. -/
 def complexBackend? (p : ZPoly) (target : Int) : Option (Array DyadicSquare) :=
   if simple : HasOnlySimpleRoots p then
-    (Hex.isolate? p simple target .nk).map fun isolations =>
+    (Hex.ZPoly.isolateComplexRoots? p simple target .nk).map fun isolations =>
       isolations.map (fun isolation => isolation.square)
   else none
 

--- a/HexManual/Chapters/HexRealRoots.lean
+++ b/HexManual/Chapters/HexRealRoots.lean
@@ -49,7 +49,7 @@ squarefreeness is needed at the call site.
 tag := "hex-real-roots-core"
 %%%
 
-The computational package exposes {name}`Hex.ZPoly.isolate?`, which tries Descartes
+The computational package exposes {name}`Hex.ZPoly.isolateRealRoots?`, which tries Descartes
 search before falling back to Sturm bisection. The
 {name}`Hex.ZPoly.isolateDescartes?` and {name}`Hex.ZPoly.isolateSturm?` variants select one
 engine explicitly; {name}`Hex.ZPoly.rootCount` and {name}`Hex.ZPoly.sturmCount` expose the

--- a/HexManual/Chapters/HexRoots.lean
+++ b/HexManual/Chapters/HexRoots.lean
@@ -49,14 +49,14 @@ region is the square's circumscribed disc. A component that a Pellet witness
 certifies to hold `k ≥ 2` roots with multiplicity, most naturally a repeated
 root, is reported instead as a {deftech}_cluster_. A nonzero polynomial with
 only simple roots isolates entirely into atoms; that is the case the
-user-facing {name}`Hex.isolate?` entry point below handles.
+user-facing {name}`Hex.ZPoly.isolateComplexRoots?` entry point below handles.
 
-# The `isolate?` entry point
+# The `ZPoly.isolateComplexRoots?` entry point
 %%%
 tag := "hex-roots-isolate"
 %%%
 
-For a nonzero polynomial with only simple roots, {name}`Hex.isolate?` runs the
+For a nonzero polynomial with only simple roots, {name}`Hex.ZPoly.isolateComplexRoots?` runs the
 whole isolator and returns `some` array of atoms, one per distinct complex
 root. It is `Option`-valued for the degenerate inputs the precondition still
 admits: the zero polynomial, which has every point as a root, gives `none`,
@@ -65,7 +65,7 @@ and a nonzero constant gives `some #[]`. It takes the polynomial as a
 roots are simple, a target precision in bits, and a choice of which atom
 certificate to attempt:
 
-{docstring Hex.isolate?}
+{docstring Hex.ZPoly.isolateComplexRoots?}
 
 The simple-root precondition is decidable, so discharging it is a matter of
 `by decide` in the common case, or a companion lemma for a named polynomial.
@@ -78,19 +78,19 @@ Proof-facing clients can avoid `Option` entirely. The companion's total
 wrapper requires the missing nonzero hypothesis and uses the driver
 completeness theorem to return the array directly:
 
-{docstring HexRootsMathlib.isolate}
+{docstring HexRootsMathlib.isolateComplexRoots}
 
 Completeness selects the wrapper's value from a successful executable run, and
 its principal theorems expose that run equation, the exact root count, the
 complete root set, and the requested precision:
 
-{docstring HexRootsMathlib.isolate_eq}
+{docstring HexRootsMathlib.isolateComplexRoots_eq}
 
-{docstring HexRootsMathlib.isolate_count}
+{docstring HexRootsMathlib.isolateComplexRoots_count}
 
-{docstring HexRootsMathlib.isolate_roots}
+{docstring HexRootsMathlib.isolateComplexRoots_roots}
 
-{docstring HexRootsMathlib.isolate_prec}
+{docstring HexRootsMathlib.isolateComplexRoots_prec}
 
 The strategy argument, a {name}`Hex.AtomStrategy`, selects which certificate
 form the driver attempts, and in which order: `.nk` for the
@@ -138,7 +138,8 @@ both other roots have norm below one, which is the Pisot condition for `β`.
 
 {docstring HexRootsMathlib.Examples.pisot}
 
-The polynomial has only simple roots, so it meets {name}`Hex.isolate?`'s precondition. The
+The polynomial has only simple roots, so it meets
+{name}`Hex.ZPoly.isolateComplexRoots?`'s precondition. The
 companion proves this once, from a Bézout identity for `p` and `p'`, and
 reusing that lemma discharges the precondition:
 
@@ -173,11 +174,12 @@ statement of what it found.
 tag := "hex-roots-soundness"
 %%%
 
-A successful {name}`Hex.isolate?` run is not just a list of squares; the companion reads a
+A successful {name}`Hex.ZPoly.isolateComplexRoots?` run is not just a list of
+squares; the companion reads a
 complete root enumeration out of it. Each atom names a genuine complex root,
 distinct atoms name distinct roots, and together they exhaust the root set:
 
-{docstring HexRootsMathlib.isolate?_sound}
+{docstring HexRootsMathlib.isolateComplexRoots?_sound}
 
 The root an atom names is a semantic value, not part of the executable data.
 The companion selects it from the atom's certificate:
@@ -246,16 +248,16 @@ Everything the driver computes is executable and Mathlib-free.
 input becomes a complex polynomial through {name}`HexRootsMathlib.toPolyℂ`,
 and the executable certificates become statements about its root set in
 `Polynomial ℂ`. The correspondence has two halves. Soundness is
-{name}`HexRootsMathlib.isolate?_sound` from
+{name}`HexRootsMathlib.isolateComplexRoots?_sound` from
 {ref "hex-roots-soundness"}[the certificate section]: a successful run
 enumerates exactly the distinct complex roots, at the requested precision.
 Completeness is the converse guarantee, that on a nonzero polynomial with
 only simple roots the search cannot fail, for every strategy and every
 requested precision:
 
-{docstring HexRootsMathlib.isolate?_isSome}
+{docstring HexRootsMathlib.isolateComplexRoots?_isSome}
 
-Completeness is what lets the total wrapper {name}`HexRootsMathlib.isolate`
+Completeness is what lets the total wrapper {name}`HexRootsMathlib.isolateComplexRoots`
 from {ref "hex-roots-isolate"}[the entry-point section] drop the `Option`
 and return the atom array directly, with its run equation, root count,
 root set, and precision exposed by the `isolate_*` theorems shown there.
@@ -263,7 +265,7 @@ One further guarantee is stated on the wrapper: distinct atoms have
 disjoint closed circumscribed discs, so the certified enclosures never
 overlap and each root is separated from every other by exact dyadic data.
 
-{docstring HexRootsMathlib.isolate_disjoint}
+{docstring HexRootsMathlib.isolateComplexRoots_disjoint}
 
 Behind these statements the companion develops the analysis the
 certificates rely on: a ported Newton-Kantorovich contraction theorem, the
@@ -292,6 +294,7 @@ isolator, and is consumed through its Mathlib companion:
   Newton-Kantorovich theorem and develops the argument principle, Rouché's
   theorem, and the Mahler separation bound for polynomials on circles, then
   proves soundness and completeness of the isolator: every certificate names
-  the roots it claims, and {name}`Hex.isolate?` never fails on a nonzero squarefree input.
+  the roots it claims, and {name}`Hex.ZPoly.isolateComplexRoots?` never fails
+  on a nonzero squarefree input.
   The Mathlib dependency lives entirely in this companion; a {name}`Hex.ZPoly` input
   keeps the executable core Mathlib-free.

--- a/HexNumberField/Basic.lean
+++ b/HexNumberField/Basic.lean
@@ -86,7 +86,7 @@ def IsCanonical (p : ZPoly) (squarefree : HasOnlySimpleRoots p)
     (p ≠ ZPoly.X ∧
       ∃ (isolations : Array (DyadicRootIsolation p))
         (refined : Array (RefinedIsolation p)),
-        isolate? p squarefree (separationDepth p : Int) = some isolations ∧
+        ZPoly.isolateComplexRoots? p squarefree (separationDepth p : Int) = some isolations ∧
           isolations.mapM DyadicRootIsolation.toRefined? = some refined ∧
           rep ∈ refined.toList)
 
@@ -97,7 +97,7 @@ def canonicalRep? (p : ZPoly) (squarefree : HasOnlySimpleRoots p)
     (rep : RefinedIsolation p) (hzero : p ≠ ZPoly.X) :
     Option {r : RefinedIsolation p //
       IsCanonical p squarefree r ∧ r.sameRoot rep = true} :=
-  match hisolate : isolate? p squarefree (separationDepth p : Int) with
+  match hisolate : ZPoly.isolateComplexRoots? p squarefree (separationDepth p : Int) with
   | none => none
   | some isolations =>
       match hrefine : isolations.mapM DyadicRootIsolation.toRefined? with
@@ -193,7 +193,7 @@ private def zeroRaw : AlgebraicNumber :=
 -- Keep executable evidence that the ordinary isolator also meets its stated
 -- completeness bound on `X`; the explicit zero path makes totality independent
 -- of this bounded computation.
-#guard (isolate? ZPoly.X zero_squarefree
+#guard (ZPoly.isolateComplexRoots? ZPoly.X zero_squarefree
   (separationDepth ZPoly.X : Int)).isSome
 
 /-- The canonical algebraic number zero, represented by the fixed explicit

--- a/HexNumberField/Convert.lean
+++ b/HexNumberField/Convert.lean
@@ -75,7 +75,7 @@ def exactFactor? (a : AlgebraicRoot) (q : ZPoly) : Option AlgebraicNumber :=
       if hdegree : 0 < q.natDegree then
         if hirred : ZPoly.isIrreducible q = true then
           if hsquarefree : HasOnlySimpleRoots q then do
-            let isolations ← isolate? q hsquarefree (separationDepth q : Int)
+            let isolations ← ZPoly.isolateComplexRoots? q hsquarefree (separationDepth q : Int)
             let refined ← isolations.mapM DyadicRootIsolation.toRefined?
             let comparable ← refined.mapM fun r =>
               (r.refineTo? (mahlerPrec a.p : Int)).unattach
@@ -270,7 +270,7 @@ def toAlgebraicNumber? [ZPoly.CheckedIrreducible p]
       if hdegree : 0 < q.natDegree then
         if hirred : ZPoly.isIrreducible q = true then
           if hsquarefree : HasOnlySimpleRoots q then do
-            let isolations ← isolate? q hsquarefree (separationDepth q : Int)
+            let isolations ← ZPoly.isolateComplexRoots? q hsquarefree (separationDepth q : Int)
             let refined ← isolations.mapM DyadicRootIsolation.toRefined?
             let requested : Int := mahlerPrec q
             let target := requested + (approxGuardBits rep.1.square a.coeffs : Int)

--- a/HexNumberField/IntegerRoots.lean
+++ b/HexNumberField/IntegerRoots.lean
@@ -115,7 +115,7 @@ def algebraicRoots? (p : ZPoly) : Option (Array AlgebraicNumber) :=
       if hpos : 0 < q.leadingCoeff then
         if hdeg : 0 < q.natDegree then
           if hsimple : HasOnlySimpleRoots q then do
-            let isolations ← isolate? q hsimple (separationDepth q : Int)
+            let isolations ← ZPoly.isolateComplexRoots? q hsimple (separationDepth q : Int)
             let refined ← isolations.mapM DyadicRootIsolation.toRefined?
             let roots ← refined.mapM fun rep =>
               (AlgebraicRoot.ofRefined q hprim hpos hdeg hsimple rep).exact?

--- a/HexNumberField/Lazy.lean
+++ b/HexNumberField/Lazy.lean
@@ -184,7 +184,7 @@ def ofEliminant? (raw : ZPoly)
         if hsimple : HasOnlySimpleRoots p then do
           let prec : Int := separationDepth p
           let ball ← ballAt prec
-          let isolations ← isolate? p hsimple prec
+          let isolations ← ZPoly.isolateComplexRoots? p hsimple prec
           let refined ← isolations.mapM DyadicRootIsolation.toRefined?
           match refined.toList.filter fun r => r.1.square.meetsBall ball with
           | [matching] =>

--- a/HexNumberField/Roots.lean
+++ b/HexNumberField/Roots.lean
@@ -174,7 +174,8 @@ def componentRoots? [ZPoly.CheckedIrreducible p]
     if hpos : 0 < eliminant.leadingCoeff then
       if hdegree : 0 < eliminant.natDegree then
         if hsimple : HasOnlySimpleRoots eliminant then do
-          let isolations ← isolate? eliminant hsimple (separationDepth eliminant : Int)
+          let isolations ← ZPoly.isolateComplexRoots? eliminant hsimple
+            (separationDepth eliminant : Int)
           let refined ← isolations.mapM DyadicRootIsolation.toRefined?
           let evaluationEliminant := evalEliminant f eliminant
           refined.foldlM

--- a/HexNumberFieldMathlib/Basic.lean
+++ b/HexNumberFieldMathlib/Basic.lean
@@ -267,7 +267,7 @@ private theorem RefinedIsolation.eq_of_canonical {p : ZPoly}
         · simp at htoJ
       have hij : i = j := by
         by_contra hij
-        apply HexRootsMathlib.isolate?_roots_ne p squarefree₁
+        apply HexRootsMathlib.isolateComplexRoots?_roots_ne p squarefree₁
           (separationDepth p : Int) .nkThenPellet hisolate hi hj hij
         rw [← hrawI, ← hrawJ]
         change HexRootsMathlib.DyadicRootIsolation.root r.1 =

--- a/HexNumberFieldMathlib/ComponentRoots.lean
+++ b/HexNumberFieldMathlib/ComponentRoots.lean
@@ -189,7 +189,7 @@ theorem componentRoots?_sound [ZPoly.CheckedIrreducible p]
       next hdegree =>
         split at hrun
         next hsimple =>
-          cases hisolate : isolate? (ZPoly.squareFreeCore (normEliminant f))
+          cases hisolate : ZPoly.isolateComplexRoots? (ZPoly.squareFreeCore (normEliminant f))
               hsimple (separationDepth
                 (ZPoly.squareFreeCore (normEliminant f)) : Int) with
           | none => simp [hisolate] at hrun
@@ -285,7 +285,7 @@ theorem componentRoots?_complete [ZPoly.CheckedIrreducible p]
       next hdegree =>
         split at hrun
         next hsimple =>
-          cases hisolate : isolate? (ZPoly.squareFreeCore (normEliminant f))
+          cases hisolate : ZPoly.isolateComplexRoots? (ZPoly.squareFreeCore (normEliminant f))
               hsimple (separationDepth
                 (ZPoly.squareFreeCore (normEliminant f)) : Int) with
           | none => simp [hisolate] at hrun
@@ -302,7 +302,7 @@ theorem componentRoots?_complete [ZPoly.CheckedIrreducible p]
                   simp only [Option.bind_some] at hrun
                   rw [← Array.foldlM_toList] at hrun
                   obtain ⟨iso, hiso, hisoRoot⟩ :=
-                    HexRootsMathlib.isolate?_root_mem_of_pos
+                    HexRootsMathlib.isolateComplexRoots?_root_mem_of_pos
                       (ZPoly.squareFreeCore (normEliminant f)) hsimple
                       (separationDepth
                         (ZPoly.squareFreeCore (normEliminant f)) : Int)

--- a/HexNumberFieldMathlib/Exact.lean
+++ b/HexNumberFieldMathlib/Exact.lean
@@ -44,23 +44,23 @@ theorem ofNormalized?_isSome
       intro hp
       rw [hp] at pos_degree
       simp at pos_degree
-    have hisolate := HexRootsMathlib.isolate?_isSome p squarefree hpne
+    have hisolate := HexRootsMathlib.isolateComplexRoots?_isSome p squarefree hpne
       (separationDepth p : Int) .nkThenPellet
-    cases hrun : isolate? p squarefree (separationDepth p : Int) with
+    cases hrun : ZPoly.isolateComplexRoots? p squarefree (separationDepth p : Int) with
     | none => simp [hrun] at hisolate
     | some isolations =>
         have hmapSome := HexRootsMathlib.array_mapM_isSome
           (xs := isolations) (f := DyadicRootIsolation.toRefined?)
           (fun iso hiso => by
             unfold DyadicRootIsolation.toRefined?
-            rw [dite_eq_left (HexRootsMathlib.isolate?_refined p squarefree
+            rw [dite_eq_left (HexRootsMathlib.isolateComplexRoots?_refined p squarefree
               (separationDepth p : Int) .nkThenPellet hrun iso hiso)]
             rfl)
         cases hmap : isolations.mapM DyadicRootIsolation.toRefined? with
         | none => simp [hmap] at hmapSome
         | some refined =>
             obtain ⟨iso, hiso, hisoRoot⟩ :=
-              HexRootsMathlib.isolate?_root_mem_of_pos p squarefree
+              HexRootsMathlib.isolateComplexRoots?_root_mem_of_pos p squarefree
                 (separationDepth p : Int) .nkThenPellet pos_degree hrun
                 (HexRootsMathlib.RefinedIsolation.isRoot rep)
             obtain ⟨i, hiList, hidx⟩ := List.getElem_of_mem hiso
@@ -176,16 +176,16 @@ theorem exactFactor?_isSome (a : AlgebraicRoot) (q : ZPoly)
     intro hq
     rw [hq] at hdegree
     simp at hdegree
-  have hisolate := HexRootsMathlib.isolate?_isSome q hsimple hqne
+  have hisolate := HexRootsMathlib.isolateComplexRoots?_isSome q hsimple hqne
     (separationDepth q : Int) .nkThenPellet
-  cases hrun : isolate? q hsimple (separationDepth q : Int) with
+  cases hrun : ZPoly.isolateComplexRoots? q hsimple (separationDepth q : Int) with
   | none => simp [hrun] at hisolate
   | some isolations =>
       have hmapSome := HexRootsMathlib.array_mapM_isSome
         (xs := isolations) (f := DyadicRootIsolation.toRefined?)
         (fun iso hiso => by
           unfold DyadicRootIsolation.toRefined?
-          rw [dite_eq_left (HexRootsMathlib.isolate?_refined q hsimple
+          rw [dite_eq_left (HexRootsMathlib.isolateComplexRoots?_refined q hsimple
             (separationDepth q : Int) .nkThenPellet hrun iso hiso)]
           rfl)
       cases hmap : isolations.mapM DyadicRootIsolation.toRefined? with
@@ -208,7 +208,7 @@ theorem exactFactor?_isSome (a : AlgebraicRoot) (q : ZPoly)
           | none => simp [hrefine] at hrefineSome
           | some comparable =>
               obtain ⟨iso, hiso, hisoRoot⟩ :=
-                HexRootsMathlib.isolate?_root_mem_of_pos q hsimple
+                HexRootsMathlib.isolateComplexRoots?_root_mem_of_pos q hsimple
                   (separationDepth q : Int) .nkThenPellet hdegree hrun hroot
               obtain ⟨i, hiList, hidx⟩ := List.getElem_of_mem hiso
               have hi : i < isolations.size := by simpa using hiList
@@ -1231,16 +1231,16 @@ theorem toAlgebraicNumber?_isSome [ZPoly.CheckedIrreducible p]
         intro hzero
         rw [hzero] at hdegree
         simp at hdegree
-      have hisolate := HexRootsMathlib.isolate?_isSome q hsimple hqne
+      have hisolate := HexRootsMathlib.isolateComplexRoots?_isSome q hsimple hqne
         (separationDepth q : Int) .nkThenPellet
-      cases hrun : isolate? q hsimple (separationDepth q : Int) with
+      cases hrun : ZPoly.isolateComplexRoots? q hsimple (separationDepth q : Int) with
       | none => simp [hrun] at hisolate
       | some isolations =>
           have hmapSome := HexRootsMathlib.array_mapM_isSome
             (xs := isolations) (f := DyadicRootIsolation.toRefined?)
             (fun iso hiso => by
               unfold DyadicRootIsolation.toRefined?
-              rw [dite_eq_left (HexRootsMathlib.isolate?_refined q hsimple
+              rw [dite_eq_left (HexRootsMathlib.isolateComplexRoots?_refined q hsimple
                 (separationDepth q : Int) .nkThenPellet hrun iso hiso)]
               rfl)
           cases hmap : isolations.mapM DyadicRootIsolation.toRefined? with
@@ -1262,7 +1262,7 @@ theorem toAlgebraicNumber?_isSome [ZPoly.CheckedIrreducible p]
                   Polynomial.eval_map]
                 exact hrootRat
               obtain ⟨iso, hiso, hisoRoot⟩ :=
-                HexRootsMathlib.isolate?_root_mem_of_pos q hsimple
+                HexRootsMathlib.isolateComplexRoots?_root_mem_of_pos q hsimple
                   (separationDepth q : Int) .nkThenPellet hdegree hrun hroot
               obtain ⟨i, hiList, hidx⟩ := List.getElem_of_mem hiso
               have hi : i < isolations.size := by simpa using hiList

--- a/HexNumberFieldMathlib/IntegerRoots.lean
+++ b/HexNumberFieldMathlib/IntegerRoots.lean
@@ -56,7 +56,7 @@ private theorem algebraicRoots?_eq_of_pos (p : ZPoly)
     (hdeg : 0 < (ZPoly.squareFreeCore p).natDegree)
     (hsimple : HasOnlySimpleRoots (ZPoly.squareFreeCore p)) :
     ZPoly.algebraicRoots? p =
-      (isolate? (ZPoly.squareFreeCore p) hsimple
+      (ZPoly.isolateComplexRoots? (ZPoly.squareFreeCore p) hsimple
           (separationDepth (ZPoly.squareFreeCore p) : Int)).bind fun isolations =>
         (isolations.mapM DyadicRootIsolation.toRefined?).bind fun refined =>
           (refined.mapM fun rep =>
@@ -98,14 +98,14 @@ theorem algebraicRoots?_isSome (p : ZPoly) : (ZPoly.algebraicRoots? p).isSome :=
       simp [hp]
     have hcne : ZPoly.squareFreeCore p ≠ 0 := ZPoly.squareFreeCore_ne_zero p hpne
     rw [algebraicRoots?_eq_of_pos p h0 hprim hpos hdeg hsimple]
-    have hisolateSome := isolate?_isSome (ZPoly.squareFreeCore p) hsimple hcne
+    have hisolateSome := isolateComplexRoots?_isSome (ZPoly.squareFreeCore p) hsimple hcne
       (separationDepth (ZPoly.squareFreeCore p) : Int) .nkThenPellet
     obtain ⟨isolations, hisolate⟩ := Option.isSome_iff_exists.mp hisolateSome
     rw [hisolate, Option.bind_some]
     have hmapSome := array_mapM_isSome (xs := isolations)
       (f := DyadicRootIsolation.toRefined?) (fun iso hiso => by
         unfold DyadicRootIsolation.toRefined?
-        rw [dite_eq_left (isolate?_refined (ZPoly.squareFreeCore p) hsimple
+        rw [dite_eq_left (isolateComplexRoots?_refined (ZPoly.squareFreeCore p) hsimple
           (separationDepth (ZPoly.squareFreeCore p) : Int) .nkThenPellet hisolate
           iso hiso)]
         rfl)
@@ -168,14 +168,14 @@ theorem mem_algebraicRoots_iff (p : ZPoly) (hp : p ≠ 0) (z : ℂ) :
     have hcne : ZPoly.squareFreeCore p ≠ 0 := ZPoly.squareFreeCore_ne_zero p hp
     have heq := algebraicRoots?_eq p
     rw [algebraicRoots?_eq_of_pos p h0 hprim hpos hdeg hsimple] at heq
-    have hisolateSome := isolate?_isSome (ZPoly.squareFreeCore p) hsimple hcne
+    have hisolateSome := isolateComplexRoots?_isSome (ZPoly.squareFreeCore p) hsimple hcne
       (separationDepth (ZPoly.squareFreeCore p) : Int) .nkThenPellet
     obtain ⟨isolations, hisolate⟩ := Option.isSome_iff_exists.mp hisolateSome
     rw [hisolate, Option.bind_some] at heq
     have hmapSome := array_mapM_isSome (xs := isolations)
       (f := DyadicRootIsolation.toRefined?) (fun iso hiso => by
         unfold DyadicRootIsolation.toRefined?
-        rw [dite_eq_left (isolate?_refined (ZPoly.squareFreeCore p) hsimple
+        rw [dite_eq_left (isolateComplexRoots?_refined (ZPoly.squareFreeCore p) hsimple
           (separationDepth (ZPoly.squareFreeCore p) : Int) .nkThenPellet hisolate
           iso hiso)]
         rfl)
@@ -222,7 +222,7 @@ theorem mem_algebraicRoots_iff (p : ZPoly) (hp : p ≠ 0) (z : ℂ) :
     · intro hz
       have hcoreRoot : (toPolyℂ (ZPoly.squareFreeCore p)).IsRoot z :=
         HexPolyZMathlib.isRoot_squareFreeCore hp hz
-      obtain ⟨iso, hiso, hisoRoot⟩ := isolate?_root_mem_of_pos (ZPoly.squareFreeCore p)
+      obtain ⟨iso, hiso, hisoRoot⟩ := isolateComplexRoots?_root_mem_of_pos (ZPoly.squareFreeCore p)
         hsimple (separationDepth (ZPoly.squareFreeCore p) : Int) .nkThenPellet hdeg
         hisolate hcoreRoot
       obtain ⟨i, hi, hidx⟩ := List.mem_iff_getElem.mp hiso
@@ -255,14 +255,14 @@ theorem algebraicRoots_nodup (p : ZPoly) :
     have hcne : ZPoly.squareFreeCore p ≠ 0 := ZPoly.squareFreeCore_ne_zero p hpne
     have heq := algebraicRoots?_eq p
     rw [algebraicRoots?_eq_of_pos p h0 hprim hpos hdeg hsimple] at heq
-    have hisolateSome := isolate?_isSome (ZPoly.squareFreeCore p) hsimple hcne
+    have hisolateSome := isolateComplexRoots?_isSome (ZPoly.squareFreeCore p) hsimple hcne
       (separationDepth (ZPoly.squareFreeCore p) : Int) .nkThenPellet
     obtain ⟨isolations, hisolate⟩ := Option.isSome_iff_exists.mp hisolateSome
     rw [hisolate, Option.bind_some] at heq
     have hmapSome := array_mapM_isSome (xs := isolations)
       (f := DyadicRootIsolation.toRefined?) (fun iso hiso => by
         unfold DyadicRootIsolation.toRefined?
-        rw [dite_eq_left (isolate?_refined (ZPoly.squareFreeCore p) hsimple
+        rw [dite_eq_left (isolateComplexRoots?_refined (ZPoly.squareFreeCore p) hsimple
           (separationDepth (ZPoly.squareFreeCore p) : Int) .nkThenPellet hisolate
           iso hiso)]
         rfl)
@@ -304,7 +304,7 @@ theorem algebraicRoots_nodup (p : ZPoly) :
     have hj : j.1 < roots.size := by simp
     by_contra hne
     have hne' : i.1 ≠ j.1 := fun h => hne (Fin.ext h)
-    have hroot := isolate?_roots_ne (ZPoly.squareFreeCore p) hsimple
+    have hroot := isolateComplexRoots?_roots_ne (ZPoly.squareFreeCore p) hsimple
       (separationDepth (ZPoly.squareFreeCore p) : Int) .nkThenPellet hisolate
       (i := i.1) (j := j.1) (by omega) (by omega) hne'
     have hij' : roots[i.1].toComplex = roots[j.1].toComplex := by

--- a/HexNumberFieldMathlib/Lazy.lean
+++ b/HexNumberFieldMathlib/Lazy.lean
@@ -897,7 +897,7 @@ theorem AlgebraicRoot.ofEliminant?_sound
                     simpa [p] using
                       HexPolyZMathlib.isRoot_squareFreeCore hrawne hroot
                   obtain ⟨iso, hiso, hisoRoot⟩ :=
-                    HexRootsMathlib.isolate?_root_mem_of_pos p hsimple
+                    HexRootsMathlib.isolateComplexRoots?_root_mem_of_pos p hsimple
                       (separationDepth p : Int) .nkThenPellet hdegree
                       hisolate hpRoot
                   obtain ⟨i, hiList, hidx⟩ := List.getElem_of_mem hiso
@@ -982,10 +982,10 @@ theorem AlgebraicRoot.ofEliminant?_isSome
   dsimp only
   rw [dite_eq_left hprim, dite_eq_left hpos, dite_eq_left hdegree, dite_eq_left hsimple]
   rw [hballAt]
-  have hisolateSome := HexRootsMathlib.isolate?_isSome
+  have hisolateSome := HexRootsMathlib.isolateComplexRoots?_isSome
     (ZPoly.squareFreeCore raw) hsimple hpne
     (separationDepth (ZPoly.squareFreeCore raw) : Int) .nkThenPellet
-  cases hisolate : isolate? (ZPoly.squareFreeCore raw) hsimple
+  cases hisolate : ZPoly.isolateComplexRoots? (ZPoly.squareFreeCore raw) hsimple
       (separationDepth (ZPoly.squareFreeCore raw) : Int) with
   | none => simp [hisolate] at hisolateSome
   | some isolations =>
@@ -994,7 +994,7 @@ theorem AlgebraicRoot.ofEliminant?_isSome
         (xs := isolations) (f := DyadicRootIsolation.toRefined?)
         (fun iso hiso => by
           unfold DyadicRootIsolation.toRefined?
-          rw [dite_eq_left (HexRootsMathlib.isolate?_refined
+          rw [dite_eq_left (HexRootsMathlib.isolateComplexRoots?_refined
             (ZPoly.squareFreeCore raw) hsimple
             (separationDepth (ZPoly.squareFreeCore raw) : Int)
             .nkThenPellet hisolate iso hiso)]
@@ -1027,7 +1027,7 @@ theorem AlgebraicRoot.ofEliminant?_isSome
               · exact (congrArg Subtype.val (Option.some.inj htoJ)).symm
               · simp at htoJ
             intro hroots
-            apply HexRootsMathlib.isolate?_roots_ne
+            apply HexRootsMathlib.isolateComplexRoots?_roots_ne
               (ZPoly.squareFreeCore raw) hsimple
               (separationDepth (ZPoly.squareFreeCore raw) : Int)
               .nkThenPellet hisolate
@@ -1036,7 +1036,7 @@ theorem AlgebraicRoot.ofEliminant?_isSome
               HexRootsMathlib.DyadicRootIsolation.root refined[j].1 at hroots
             simpa [hrawI, hrawJ] using hroots
           obtain ⟨iso, hiso, hisoRoot⟩ :=
-            HexRootsMathlib.isolate?_root_mem_of_pos
+            HexRootsMathlib.isolateComplexRoots?_root_mem_of_pos
               (ZPoly.squareFreeCore raw) hsimple
               (separationDepth (ZPoly.squareFreeCore raw) : Int)
               .nkThenPellet hdegree hisolate hpRoot

--- a/HexNumberFieldMathlib/Roots.lean
+++ b/HexNumberFieldMathlib/Roots.lean
@@ -272,9 +272,9 @@ theorem componentRoots?_isSome [ZPoly.CheckedIrreducible p]
   unfold componentRoots?
   dsimp only
   rw [dite_eq_left hprim, dite_eq_left hpos, dite_eq_left hdegree, dite_eq_left hsimple]
-  have hisolateSome := HexRootsMathlib.isolate?_isSome eliminant hsimple
+  have hisolateSome := HexRootsMathlib.isolateComplexRoots?_isSome eliminant hsimple
     heliminant (separationDepth eliminant : Int) .nkThenPellet
-  cases hisolate : isolate? eliminant hsimple
+  cases hisolate : ZPoly.isolateComplexRoots? eliminant hsimple
       (separationDepth eliminant : Int) with
   | none => simp [hisolate] at hisolateSome
   | some isolations =>
@@ -283,7 +283,7 @@ theorem componentRoots?_isSome [ZPoly.CheckedIrreducible p]
         (xs := isolations) (f := DyadicRootIsolation.toRefined?)
         (fun iso hiso => by
           unfold DyadicRootIsolation.toRefined?
-          rw [dite_eq_left (HexRootsMathlib.isolate?_refined eliminant hsimple
+          rw [dite_eq_left (HexRootsMathlib.isolateComplexRoots?_refined eliminant hsimple
             (separationDepth eliminant : Int) .nkThenPellet
             hisolate iso hiso)]
           rfl)

--- a/HexNumberFieldTower/Split.lean
+++ b/HexNumberFieldTower/Split.lean
@@ -235,7 +235,7 @@ def factorRoot? {T : NumberTower} (f : Poly T) : Option AlgebraicRoot := do
     if hpos : 0 < p.leadingCoeff then
       if hdegree : 0 < p.natDegree then
         if hsimple : HasOnlySimpleRoots p then do
-          let isolations ← isolate? p hsimple (separationDepth p : Int)
+          let isolations ← ZPoly.isolateComplexRoots? p hsimple (separationDepth p : Int)
           let refined ← isolations.mapM DyadicRootIsolation.toRefined?
           let candidates := refined.toList.map fun rep : RefinedIsolation p =>
             ({ p

--- a/HexNumberFieldTowerMathlib/Split.lean
+++ b/HexNumberFieldTowerMathlib/Split.lean
@@ -260,7 +260,7 @@ theorem factorRoot?_sound (T : NumberTower) (f : Poly T)
       next hdegree =>
         split at h
         next hsimple =>
-          cases hisolate : isolate? (factorEliminant f) hsimple
+          cases hisolate : ZPoly.isolateComplexRoots? (factorEliminant f) hsimple
               (separationDepth (factorEliminant f) : Int) with
           | none => simp [hisolate] at h
           | some isolations =>
@@ -368,10 +368,10 @@ theorem factorRoot?_isSome (T : NumberTower) (f : Poly T)
   unfold factorRoot?
   dsimp only
   rw [dite_eq_left hprim, dite_eq_left hpos, dite_eq_left hdegree, dite_eq_left hsimple]
-  have hisolateSome := HexRootsMathlib.isolate?_isSome
+  have hisolateSome := HexRootsMathlib.isolateComplexRoots?_isSome
     (factorEliminant f) hsimple hcoreNe
     (separationDepth (factorEliminant f) : Int) .nkThenPellet
-  cases hisolate : isolate? (factorEliminant f) hsimple
+  cases hisolate : ZPoly.isolateComplexRoots? (factorEliminant f) hsimple
       (separationDepth (factorEliminant f) : Int) with
   | none => simp [hisolate] at hisolateSome
   | some isolations =>
@@ -380,7 +380,7 @@ theorem factorRoot?_isSome (T : NumberTower) (f : Poly T)
         (xs := isolations) (f := DyadicRootIsolation.toRefined?)
         (fun iso hiso => by
           unfold DyadicRootIsolation.toRefined?
-          rw [dite_eq_left (HexRootsMathlib.isolate?_refined
+          rw [dite_eq_left (HexRootsMathlib.isolateComplexRoots?_refined
             (factorEliminant f) hsimple
             (separationDepth (factorEliminant f) : Int)
             .nkThenPellet hisolate iso hiso)]
@@ -391,7 +391,7 @@ theorem factorRoot?_isSome (T : NumberTower) (f : Poly T)
       | some refined =>
           simp only [Option.bind_some]
           obtain ⟨iso, hiso, hisoRoot⟩ :=
-            HexRootsMathlib.isolate?_root_mem_of_pos
+            HexRootsMathlib.isolateComplexRoots?_root_mem_of_pos
               (factorEliminant f) hsimple
               (separationDepth (factorEliminant f) : Int)
               .nkThenPellet hdegree hisolate hcoreRoot

--- a/HexRCF/DecisionCheck.lean
+++ b/HexRCF/DecisionCheck.lean
@@ -32,7 +32,7 @@ private def rawIsolations {p : ZPoly} (roots : Hex.RealRootIsolations p) :
 /-- Run executable isolation, validate the raw intervals against the carrier's
 literal replay, and refine touching intervals to strict separation. -/
 def buildIsolations? (carrier : CarrierCert) : Option IsolationCert :=
-  match Hex.ZPoly.isolate? carrier.carrier with
+  match Hex.ZPoly.isolateRealRoots? carrier.carrier with
   | none => none
   | some roots =>
       let raw := rawIsolations roots

--- a/HexRCF/SPEC/hex-rcf.md
+++ b/HexRCF/SPEC/hex-rcf.md
@@ -17,7 +17,7 @@ the body is false. For a false existential there is no single
 counterexample witness; the diagnostic instead reports that every
 relevant cell was checked and found false. Operational totality of the
 compiled builder follows from the squarefree carrier and
-`isolate?_isSome`, together with the structurally fuel-bounded
+`isolateRealRoots?_isSome`, together with the structurally fuel-bounded
 separation pass, from
 [hex-real-roots-mathlib](../../HexRealRootsMathlib/SPEC/hex-real-roots-mathlib.md).
 It is not exposed
@@ -192,7 +192,7 @@ proved equivalences.
    lemma for `Q = P*R` with `R ∣ Q'`. Since `Q` is the atom product,
    these are exactly the union of the atom root sets.
 
-   Run `Hex.ZPoly.isolate? P`; the compiled builder knows this succeeds from
+   Run `Hex.ZPoly.isolateRealRoots? P`; the compiled builder knows this succeeds from
    the squarefreeness theorem. If there are no nonconstant atoms, do
    not construct a carrier: the decomposition is the single cell `ℝ`
    and the sign matrix is the already-folded constant formula.

--- a/HexRealRoots/Isolate.lean
+++ b/HexRealRoots/Isolate.lean
@@ -25,18 +25,18 @@ public section
 /-!
 The top-level real-root isolation driver.
 
-`ZPoly.isolate?` runs the two engines over the same output type: the fast
+`ZPoly.isolateRealRoots?` runs the two engines over the same output type: the fast
 Descartes search first, falling back to the provably terminating Sturm
 search on its `none`. Both emit `RealRootIsolations p` — pairwise-disjoint,
 ordered, Sturm-count-certified isolations, one per real root — so the driver
 is a one-liner that keeps whichever engine's certified output arrives first.
 
-The companion `HexRealRootsMathlib` proves `ZPoly.isolate? p ≠ none` for squarefree
-`p` (`isolate?_isSome`), routed through the Sturm engine's completeness
+The companion `HexRealRootsMathlib` proves `ZPoly.isolateRealRoots? p ≠ none` for squarefree
+`p` (`isolateRealRoots?_isSome`), routed through the Sturm engine's completeness
 (`isolateSturm?_isSome`); the Descartes engine's own completeness waits on the
 unformalised two-circle theorem and no driver-level fact depends on it.
-Downstream libraries that need a total function (hex-rcf) combine `ZPoly.isolate?`
-with `isolate?_isSome`.
+Downstream libraries that need a total function (hex-rcf) combine `ZPoly.isolateRealRoots?`
+with `isolateRealRoots?_isSome`.
 -/
 namespace Hex
 
@@ -46,25 +46,25 @@ certified `RealRootIsolations p`, so the result carries a full Sturm-count
 witness regardless of which one found it. Returns `none` only when both
 engines decline (e.g. non-squarefree input); the companion proves this never
 happens for squarefree `p`. -/
-def ZPoly.isolate? (p : ZPoly) : Option (RealRootIsolations p) :=
+def ZPoly.isolateRealRoots? (p : ZPoly) : Option (RealRootIsolations p) :=
   ZPoly.isolateDescartes? p <|> ZPoly.isolateSturm? p
 
 /-! Sanity checks (kept light; conformance lives in the shared sub-project).
-Polynomials are kept tiny so kernel reduction of `ZPoly.isolate?` is fast; the
+Polynomials are kept tiny so kernel reduction of `ZPoly.isolateRealRoots?` is fast; the
 higher-degree fixtures live in the `#eval`-driven conformance suite. -/
 
 -- The zero polynomial and constants classify as `none`/isolations-of-a-root
--- exactly as the engines do: `ZPoly.isolate?` inherits each engine's contract.
-example : ZPoly.isolate? (DensePoly.ofCoeffs (#[] : Array Int)) = none := by decide
-example : (ZPoly.isolate? (DensePoly.ofCoeffs #[(7 : Int)])).isSome = true := by decide
+-- exactly as the engines do: `ZPoly.isolateRealRoots?` inherits each engine's contract.
+example : ZPoly.isolateRealRoots? (DensePoly.ofCoeffs (#[] : Array Int)) = none := by decide
+example : (ZPoly.isolateRealRoots? (DensePoly.ofCoeffs #[(7 : Int)])).isSome = true := by decide
 
 -- The positive-degree fixtures route through the Descartes engine's rational
 -- squarefree decision, which the kernel does not reduce across the module
 -- boundary (it goes through `ceilSqrt`), so they are exercised by `#eval` in
 -- the conformance suite rather than `decide` here. Representative results:
---   `ZPoly.isolate? (x − 5)`        ⇒ `some`, 1 isolation
---   `ZPoly.isolate? (x² − 1)`       ⇒ `some`, 2 isolations
---   `ZPoly.isolate? (x² + 1)`       ⇒ `some`, 0 isolations
---   `ZPoly.isolate? ((x−1)²(x+1))`  ⇒ `none` (not squarefree; both engines decline)
+--   `ZPoly.isolateRealRoots? (x − 5)`        ⇒ `some`, 1 isolation
+--   `ZPoly.isolateRealRoots? (x² − 1)`       ⇒ `some`, 2 isolations
+--   `ZPoly.isolateRealRoots? (x² + 1)`       ⇒ `some`, 0 isolations
+--   `ZPoly.isolateRealRoots? ((x−1)²(x+1))`  ⇒ `none` (not squarefree; both engines decline)
 
 end Hex

--- a/HexRealRoots/IsolateDescartes.lean
+++ b/HexRealRoots/IsolateDescartes.lean
@@ -47,7 +47,7 @@ the correctness.
 
 The per-node cost is one Möbius transform (`O(n²)` integer operations via
 Taylor shift) versus the Sturm engine's full chain evaluation, which is why
-this engine runs first in `ZPoly.isolate?`. The deferred companion theorem
+this engine runs first in `ZPoly.isolateRealRoots?`. The deferred companion theorem
 `isolateDescartes?_isSome` (the Obreshkoff two-circle theorem;
 Krandick–Mehlhorn 2006) says none of the `none` outcomes happen for
 square-free input at this depth budget — in particular a non-real conjugate
@@ -143,7 +143,7 @@ with `ZPoly.rootCount p`. The deferred companion theorem `isolateDescartes?_isSo
 input at this budget, so the driver's completeness — established through the
 Sturm engine — never waits on it. The per-node cost is one `O(n²)` Möbius
 transform against the Sturm engine's full chain evaluation, which is why this
-engine runs first in `ZPoly.isolate?`. -/
+engine runs first in `ZPoly.isolateRealRoots?`. -/
 def ZPoly.isolateDescartes? (p : ZPoly) : Option (RealRootIsolations p) :=
   match p.degree? with
   | none => none

--- a/HexRealRoots/README.md
+++ b/HexRealRoots/README.md
@@ -26,19 +26,19 @@ open Hex
 
 def p : ZPoly := DensePoly.ofCoeffs #[-2, 0, 0, 0, 1]
 
-#eval (ZPoly.isolate? p).map (fun roots => roots.isolations.size)
+#eval (ZPoly.isolateRealRoots? p).map (fun roots => roots.isolations.size)
 ```
 
 # Functionality
 
-- `Hex.ZPoly.isolate?` tries the Descartes search first and falls back to Sturm.
+- `Hex.ZPoly.isolateRealRoots?` tries the Descartes search first and falls back to Sturm.
 - `Hex.ZPoly.isolateSturm?` runs direct Sturm bisection.
 - `Hex.ZPoly.isolateDescartes?` runs only the Descartes search, while still
   certifying every emitted interval with Sturm.
 - `Hex.ZPoly.rootCount` computes the exact total real-root count.
 - `Hex.ZPoly.sturmCount` computes the exact count in one half-open interval.
 
-`ZPoly.isolate?` rejects the zero polynomial and, at the core level, expects a
+`ZPoly.isolateRealRoots?` rejects the zero polynomial and, at the core level, expects a
 squarefree positive-degree input. Nonzero constants produce an empty result.
 The Mathlib bridge's `isolate_roots` elaborator automatically passes through
 the squarefree core, so end users normally do not manage repeated roots

--- a/HexRealRoots/SPEC/hex-real-roots.md
+++ b/HexRealRoots/SPEC/hex-real-roots.md
@@ -267,13 +267,13 @@ evaluation, which is why this engine runs first.
 ## The driver
 
 ```lean
-def ZPoly.isolate? (p : ZPoly) : Option (RealRootIsolations p) :=
+def ZPoly.isolateRealRoots? (p : ZPoly) : Option (RealRootIsolations p) :=
   ZPoly.isolateDescartes? p <|> ZPoly.isolateSturm? p
 ```
 
-The companion proves `ZPoly.isolate? p ≠ none` for squarefree `p` (through
+The companion proves `ZPoly.isolateRealRoots? p ≠ none` for squarefree `p` (through
 the Sturm engine). Downstream libraries that need a total function
-(hex-rcf) obtain one by combining `ZPoly.isolate?` with that theorem.
+(hex-rcf) obtain one by combining `ZPoly.isolateRealRoots?` with that theorem.
 
 ## Termination
 
@@ -456,7 +456,7 @@ re-refine from a stored coarse representative. See
   `descartesVar`.
 - `HexRealRoots/IsolateSturm.lean`: the Sturm engine.
 - `HexRealRoots/IsolateDescartes.lean`: the Descartes engine.
-- `HexRealRoots/Isolate.lean`: `ZPoly.isolate?`.
+- `HexRealRoots/Isolate.lean`: `ZPoly.isolateRealRoots?`.
 - `HexRealRoots/Refine.lean`: `refine1`, `refineTo`.
 - `HexRealRoots/SimpleRealRoot.lean`: `RefinedRealIsolation`,
   `Overlaps`, `SimpleRealRoot`, `sameRoot`; the threading-pattern
@@ -496,7 +496,7 @@ python-flint (`fmpz_poly` real root API), FLINT/Arb.
 **Descartes-engine checks (retired).** While
 `isolateDescartes?_isSome` was open, the conformance suite asserted on
 every fixture that `ZPoly.isolateDescartes?` returns `some` and agrees with
-`ZPoly.isolate?`, standing in for the theorem. Now that
+`ZPoly.isolateRealRoots?`, standing in for the theorem. Now that
 `isolateDescartes?_isSome` is proven in the companion, those stand-ins
 are retired: the theorem carries the claim, and re-testing it per
 fixture is noise. The suite keeps only the ordinary input-contract
@@ -504,7 +504,7 @@ checks — the `ZPoly.isolateDescartes? = none` rejection of the zero and
 non-squarefree inputs (which test the engine's classification of
 inadmissible input, not the termination theorem) — and the executable
 `mobiusTransform`/`descartesVar` transform tests. `EmitFixtures` emits
-from `ZPoly.isolate?` alone; the cross-engine agreement check it once carried
+from `ZPoly.isolateRealRoots?` alone; the cross-engine agreement check it once carried
 is removed with the same change.
 
 ## Complexity contract
@@ -518,7 +518,7 @@ Write `n = deg p` and `h = log ‖p‖∞`.
   `O(n²)` dyadic operations per queried point, memoised per endpoint.
 - `mobiusTransform`: `O(n²)` integer operations per node.
 - `sepPrec p`, `rootBound p`: `O(n · h)` integer operations.
-- `ZPoly.isolate?`: the bisection tree has `O(n)` unresolved intervals per
+- `ZPoly.isolateRealRoots?`: the bisection tree has `O(n)` unresolved intervals per
   level and depth at most `isolationDepth p = O(n·(h + log n))`, so
   `O(n² · (h + log n))` Möbius transforms in the worst case,
   dominated by Mignotte-style clustered inputs. Mignotte inputs

--- a/HexRealRootsMathlib/Drivers.lean
+++ b/HexRealRootsMathlib/Drivers.lean
@@ -13,7 +13,7 @@ public import HexRealRoots.Isolate
 public import HexRealRoots.Refine
 -- `import all` on the executable modules so the non-`@[expose]` bodies of the
 -- isolation engines (`sturmChain`, `sturmVarAt`, `sturmVisit`, `refine1`,
--- `ZPoly.isolateSturm?`, `ZPoly.isolate?`, and the dyadic evaluation helpers) unfold here.
+-- `ZPoly.isolateSturm?`, `ZPoly.isolateRealRoots?`, and the dyadic evaluation helpers) unfold here.
 import all HexRealRootsMathlib.Separation
 import all HexRealRoots.Basic
 import all HexRealRoots.Chain
@@ -31,7 +31,7 @@ public section
 * `refine1_isolates_same`: one bisection refinement preserves the isolated root
   and halves the interval width (the fallback branch is unreachable for
   squarefree `p`).
-* `isolateSturm?_isSome`, `isolate?_isSome`: the Sturm engine (and hence the
+* `isolateSturm?_isSome`, `isolateRealRoots?_isSome`: the Sturm engine (and hence the
   top-level driver) succeeds on nonzero squarefree input (positive degree is
   the real content; a nonzero constant certifies through the empty chain).
 
@@ -708,12 +708,12 @@ theorem isolateSturm?_isSome (p : Hex.ZPoly) (hp0 : p ≠ 0)
         (by simp [Hex.DensePoly.natDegree_eq_degree?_getD, hd]) hp
 
 /-- **The top-level driver succeeds on nonzero squarefree input.** A one-liner
-over `isolateSturm?_isSome`: `ZPoly.isolate?` keeps whichever engine's certified
+over `isolateSturm?_isSome`: `ZPoly.isolateRealRoots?` keeps whichever engine's certified
 output arrives first, and the Sturm engine always has one. -/
-theorem isolate?_isSome (p : Hex.ZPoly) (hp0 : p ≠ 0)
-    (hp : Hex.ZPoly.SquareFreeRat p) : (Hex.ZPoly.isolate? p).isSome := by
+theorem isolateRealRoots?_isSome (p : Hex.ZPoly) (hp0 : p ≠ 0)
+    (hp : Hex.ZPoly.SquareFreeRat p) : (Hex.ZPoly.isolateRealRoots? p).isSome := by
   have hs := isolateSturm?_isSome p hp0 hp
-  unfold Hex.ZPoly.isolate?
+  unfold Hex.ZPoly.isolateRealRoots?
   cases hD : Hex.ZPoly.isolateDescartes? p with
   | some a => rfl
   | none => rw [hD] at *; simpa using hs

--- a/HexRealRootsMathlib/IsolateRootsElab.lean
+++ b/HexRealRootsMathlib/IsolateRootsElab.lean
@@ -210,9 +210,10 @@ structure IsoData where
 constant Sturm tail), optionally refining every root to width `2 ^ (-widthK)`
 through the cached-chain `refineToWithChain`. -/
 meta def runBackend (f : Hex.ZPoly) (widthK : Option Int) : MetaM IsoData := do
-  let some out := Hex.ZPoly.isolate? f
-    | throwError "isolate_roots: internal error: the backend ZPoly.isolate? returned none on \
-        square-free input (please report this as a bug)"
+  let some out := Hex.ZPoly.isolateRealRoots? f
+    | throwError "isolate_roots: internal error: the backend \
+        ZPoly.isolateRealRoots? returned none on square-free input \
+        (please report this as a bug)"
   let chain := Hex.ZPoly.sturmChain f
   let isos := out.isolations
   let refined := match widthK with

--- a/HexRealRootsMathlib/IsolateRootsTests.lean
+++ b/HexRealRootsMathlib/IsolateRootsTests.lean
@@ -61,7 +61,7 @@ def x4m2 : ZPoly := DensePoly.ofCoeffs #[(-2 : Int), 0, 0, 0, 1]
 theorem sqfree_x4m2 : ZPoly.SquareFreeRat x4m2 :=
   squareFreeRat_of_hasSquarefreeSturmChain _ (by decide)
 
-/-- The complete run of `x⁴ − 2`: the two ZPoly.isolate? intervals `(-4, 0]`, `(0, 4]`. -/
+/-- The complete run of `x⁴ − 2`: the two ZPoly.isolateRealRoots? intervals `(-4, 0]`, `(0, 4]`. -/
 def runX4m2 : RealRootIsolations x4m2 where
   isolations :=
     #[⟨⟨Dyadic.ofInt (-4), Dyadic.ofInt 0, by decide⟩, by decide⟩,

--- a/HexRealRootsMathlib/SPEC/hex-real-roots-mathlib.md
+++ b/HexRealRootsMathlib/SPEC/hex-real-roots-mathlib.md
@@ -4,7 +4,7 @@ Mathlib companion for [hex-real-roots](https://github.com/leanprover/hex-real-ro
 **soundness** of the certified isolations (a `RealRootIsolation`
 witness implies a unique real root in its half-open interval, and a
 `RealRootIsolations` value captures every real root exactly once) and
-**completeness** of the driver (`ZPoly.isolate? p ≠ none` for squarefree
+**completeness** of the driver (`ZPoly.isolateRealRoots? p ≠ none` for squarefree
 `p`, through the Sturm engine). One theorem is deferred: that the
 Descartes engine alone never falls back. It is stated here, its
 prerequisite is named, and nothing else depends on it.
@@ -483,8 +483,8 @@ and cited from each. Neither companion should carry a private copy.
 theorem isolateSturm?_isSome (p : ZPoly) (hp : SquareFreeRat p) :
     (Hex.ZPoly.isolateSturm? p).isSome
 
-theorem isolate?_isSome (p : ZPoly) (hp : SquareFreeRat p) :
-    (Hex.ZPoly.isolate? p).isSome
+theorem isolateRealRoots?_isSome (p : ZPoly) (hp : SquareFreeRat p) :
+    (Hex.ZPoly.isolateRealRoots? p).isSome
 ```
 
 Note this argument needs only the real-pair instances of
@@ -573,11 +573,11 @@ Status and boundaries:
   proof (Obreschkoff 1963; Krandick-Mehlhorn 2006, Eigenwillig 2008)
   runs by induction on multiplying in linear and conjugate-quadratic
   factors, with sector inequalities on coefficient sequences.
-- **Nothing else waited for it.** `isolate?_isSome`, all soundness
+- **Nothing else waited for it.** `isolateRealRoots?_isSome`, all soundness
   theorems, and hex-rcf's decision procedure were complete without it;
   its value is to retire the Sturm fallback path from the trusted
   runtime story. The executable conformance stand-ins for this
-  theorem (`ZPoly.isolateDescartes?` succeeds and agrees with `ZPoly.isolate?` per
+  theorem (`ZPoly.isolateDescartes?` succeeds and agrees with `ZPoly.isolateRealRoots?` per
   fixture) are retired in the same change now that the theorem carries
   the claim.
 - Like the Sturm slice, the sector/region/parity development is stated
@@ -607,7 +607,7 @@ HexRealRootsMathlib/
   IsolateRoots.lean    -- IsolatedRealRoots, its constructors, the
                           bridge tactic, and the isolate_roots
                           term elaborator
-  Drivers.lean         -- isolateSturm?_isSome, isolate?_isSome,
+  Drivers.lean         -- isolateSturm?_isSome, isolateRealRoots?_isSome,
                           refine1_isolates_same
   SimpleRealRoot.lean  -- overlaps_iff_same_root, toReal, sameRoot_iff
   TwoCircle.lean       -- the deferred development

--- a/HexRoots/IsolateAll.lean
+++ b/HexRoots/IsolateAll.lean
@@ -12,14 +12,14 @@ public import HexRoots.SimpleRoot
 public section
 
 /-!
-The end-to-end drivers `isolateAll?`, `isolate`, and `isolateOne?`, thin
+The end-to-end drivers `isolateAll?`, `ZPoly.isolateComplexRoots?`, and `isolateOne?`, thin
 wrappers over the shared refinement loops.
 
 `isolateAll?` globally refines and reglues an arbitrary worklist through
 `completenessDepth`, then continues until every component certifies at prec
 at least `target` with pairwise disjoint circumscribed discs. It sizes the
 fuel from the worklist's coarsest prec so the loop reaches
-`stopDepth p target` before giving up. `isolate` is the all-atoms driver for
+`stopDepth p target` before giving up. `ZPoly.isolateComplexRoots?` is the all-atoms driver for
 polynomials with only simple roots: it starts from `Component.cauchy`, uses
 `target := max atom_prec (separationDepth p)`, and requires every result to
 be an atom, pinning the degenerate inputs (nonzero constant to `some #[]`,
@@ -61,7 +61,7 @@ emission condition was not reached within that fuel bound. -/
     {name}`Hex.HasOnlySimpleRoots` does not force positive degree, so the degenerate
     inputs are pinned here: a nonzero constant returns `some #[]` (no roots to
     isolate), and the zero polynomial returns `none`. -/
-@[expose] def isolate? (p : ZPoly) (_h : HasOnlySimpleRoots p) (atom_prec : Int)
+@[expose] def ZPoly.isolateComplexRoots? (p : ZPoly) (_h : HasOnlySimpleRoots p) (atom_prec : Int)
     (strategy : AtomStrategy := .nkThenPellet) :
     Option (Array (DyadicRootIsolation p)) :=
   if hd : 0 < p.natDegree then
@@ -73,7 +73,7 @@ emission condition was not reached within that fuel bound. -/
 /-- Start a local search for one simple root from a caller-selected square and
     refine its atom to at
     least `max atomPrec (mahlerPrec p)`. This is a deliberately local search:
-    unlike {name}`Hex.isolate?`, it neither certifies every root nor establishes
+    unlike {name}`Hex.ZPoly.isolateComplexRoots?`, it neither certifies every root nor establishes
     pairwise disjointness against roots outside the returned atom. The
     self-contained {name}`Hex.AtomCertificate` is exactly the weaker fact
     needed by {name}`Hex.SimpleRoot.mk`. The returned atom is not promised to

--- a/HexRoots/README.md
+++ b/HexRoots/README.md
@@ -28,14 +28,14 @@ def p : ZPoly := DensePoly.ofCoeffs #[-1, -1, 0, 1]
 
 def roots : Option (Array (DyadicRootIsolation p)) :=
   if h : HasOnlySimpleRoots p then
-    isolate? p h 32 .nkThenPellet
+    ZPoly.isolateComplexRoots? p h 32 .nkThenPellet
   else
     none
 ```
 
 # Functionality
 
-- `Hex.isolate? p h precision strategy` returns pairwise-disjoint atoms for a
+- `Hex.ZPoly.isolateComplexRoots? p h precision strategy` returns pairwise-disjoint atoms for a
   polynomial whose roots are simple. A nonzero constant returns an empty
   array; the zero polynomial returns `none`.
 - `Hex.HasOnlySimpleRoots` is an executable, decidable precondition.

--- a/HexRoots/SPEC/hex-roots.md
+++ b/HexRoots/SPEC/hex-roots.md
@@ -422,7 +422,7 @@ def isolateAll? (p : ZPoly) (target : Int) (worklist : Array Component)
     positive degree, so the degenerate inputs are pinned here: a
     nonzero constant returns `some #[]` (no roots to isolate), and
     the zero polynomial returns `none`. -/
-def isolate? (p : ZPoly) (h : Hex.HasOnlySimpleRoots p) (atom_prec : Int)
+def ZPoly.isolateComplexRoots? (p : ZPoly) (h : Hex.HasOnlySimpleRoots p) (atom_prec : Int)
     (strategy : AtomStrategy := .nkThenPellet) :
     Option (Array (DyadicRootIsolation p))
 
@@ -544,7 +544,7 @@ already a target-ready atom with pairwise-disjoint discs. At the
 normalized depth, every component is
 root-bearing; the Mathlib companion proves that all three strategies
 certify it as an atom and that the atom discs are pairwise disjoint.
-Thus `isolate?` returns `some` for every nonzero squarefree input.
+Thus `ZPoly.isolateComplexRoots?` returns `some` for every nonzero squarefree input.
 `stopSlack` leaves three further rounds for the general driver and
 non-squarefree inputs. A `none` from a driver means only that its full
 emission condition was not reached within the fixed fuel bound; it does
@@ -620,7 +620,7 @@ one-square witness certifies. Roots on a grid *line* keep a two-square
 or four-square component under pure subdivision. Newton recentring is
 what turns those into single-square atoms.
 
-For polynomials with multiple roots there is no `isolate?` analogue.
+For polynomials with multiple roots there is no `ZPoly.isolateComplexRoots?` analogue.
 Use `isolateAll?` directly: a multiple root never atomizes (the `k = 1`
 witness requires `c₁` bounded away from 0, and `c₁ → 0` near a
 multiple root), so it appears in the output as a cluster with its
@@ -772,7 +772,7 @@ def RefinedIsolation.refineTo? (r : RefinedIsolation p) (target : Int)
 which floors the target at `mahlerPrec p` (so the subtype re-wrap
 always succeeds on a `some`) and derives the identity proof from the
 decidable `Intersects` re-check via `Quot.sound`; and
-`DyadicRootIsolation.toRefined?` records that an `isolate?` output
+`DyadicRootIsolation.toRefined?` records that an `ZPoly.isolateComplexRoots?` output
 meets the separation precision. `refineTo?` preserves the root
 (`sameRoot r r' = true`, proved meaningful in the companion), so
 callers can substitute the refined representative wherever the
@@ -852,7 +852,7 @@ is made here for pure Pellet refinement of a non-squarefree ambient polynomial.
   worklist, including the local first-refinable-atom search, `stopDepth`, the
   Φ termination measure discussion, and `DyadicRootIsolation.refineTo?` as a
   thin wrapper.
-- `HexRoots/IsolateAll.lean`: `isolateAll?`, `isolate?`, and the local
+- `HexRoots/IsolateAll.lean`: `isolateAll?`, `ZPoly.isolateComplexRoots?`, and the local
   `isolateOne?` entry point as thin wrappers over the shared driver loops, and
   the refined threading operation `RefinedIsolation.refineTo?` (below).
 - `HexRoots/SimpleRoot.lean`: `RefinedIsolation`, `Intersects`,
@@ -947,7 +947,7 @@ bit-length at precision `prec`.
   the two base squares are concentric. This does not change the
   asymptotic bound, but removes the repeated dominant `O(n²)` shift
   from those paths.
-- `isolate?` for degree `n`, well-separated roots, target precision
+- `ZPoly.isolateComplexRoots?` for degree `n`, well-separated roots, target precision
   `prec`: heuristically `O(n³ · B²)` bit operations. Tight root
   clusters add subdivision depth up to `O(mahlerPrec p)`.
 
@@ -956,7 +956,7 @@ bit-length at precision `prec`.
 Regression ceilings anchored to measured reality (`chungus2`, AMD EPYC 9455,
 96 logical CPUs with substantial idle capacity, Lean 4.32.0-rc1). Every pinned row runs the compiled expression
 `isolateAll? (seededPoly degree) target #[Component.cauchy ...]`; this avoids
-`isolate?`'s higher `separationDepth` target and makes the stated precision the
+`ZPoly.isolateComplexRoots?`'s higher `separationDepth` target and makes the stated precision the
 actual driver target. Degree 10 and 20 use three measured cold calls with no
 discarded warmup, degree 50 uses two, and degree 100 uses one. The direct
 driver prints and checks the returned atom count; unlike the canonical fixed

--- a/HexRoots/SimpleRoot.lean
+++ b/HexRoots/SimpleRoot.lean
@@ -141,7 +141,7 @@ theorem SimpleRoot.posDegree {p : ZPoly} (x : SimpleRoot p) :
   exact i.1.posDegree
 
 /-- Wrap an isolation as a `RefinedIsolation` when it meets the separation
-    precision, deciding the subtype bound. `isolate`'s output always
+    precision, deciding the subtype bound. `ZPoly.isolateComplexRoots?`'s output always
     qualifies (its target has a `separationDepth ≥ mahlerPrec` floor); this
     is the constructor consumers use to record that fact. -/
 @[expose]

--- a/HexRootsMathlib/Completeness/DriverCompleteness.lean
+++ b/HexRootsMathlib/Completeness/DriverCompleteness.lean
@@ -1282,9 +1282,9 @@ private theorem array_mapM_atoms {p : Hex.ZPoly}
 /-- Every nonzero squarefree executable polynomial is successfully isolated
 by each atom strategy. Nonzero constants take the explicit empty-output
 branch; positive-degree inputs use the complete Cauchy-started driver. -/
-theorem isolate?_exists (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolateComplexRoots?_exists (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (hp : p ≠ 0) (atomPrec : Int) (strategy : Hex.AtomStrategy) :
-    ∃ atoms, Hex.isolate? p h atomPrec strategy = some atoms := by
+    ∃ atoms, Hex.ZPoly.isolateComplexRoots? p h atomPrec strategy = some atoms := by
   have hpSize : p.size ≠ 0 := by
     intro hsize0
     apply hp
@@ -1308,38 +1308,38 @@ theorem isolate?_exists (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
       (le_max_right _ _) strategy hd
     obtain ⟨atoms, hmap⟩ := array_mapM_atoms rs hatoms
     refine ⟨atoms, ?_⟩
-    rw [Hex.isolate?, dite_eq_left hd]
+    rw [Hex.ZPoly.isolateComplexRoots?, dite_eq_left hd]
     change (Hex.isolateAll? p target #[Hex.Component.cauchy p hd] strategy).bind
       (fun rs => rs.mapM Hex.Certified.asAtom?) = some atoms
     rw [hall]
     exact hmap
   · refine ⟨#[], ?_⟩
-    rw [Hex.isolate?, dite_eq_right hd]
+    rw [Hex.ZPoly.isolateComplexRoots?, dite_eq_right hd]
     simp [hpSize]
 
 /-- A nonzero squarefree polynomial has a successful isolation whose atoms
 enumerate its complex roots exactly, without duplicates, at the requested
 precision.  This bundles driver completeness with the principal soundness
 contracts for proof-facing clients. -/
-theorem isolate?_spec (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolateComplexRoots?_spec (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (hp : p ≠ 0) (atomPrec : Int)
     (strategy : Hex.AtomStrategy := .nkThenPellet) :
     ∃ atoms : Array (Hex.DyadicRootIsolation p),
-      Hex.isolate? p h atomPrec strategy = some atoms ∧
+      Hex.ZPoly.isolateComplexRoots? p h atomPrec strategy = some atoms ∧
       atoms.size = (toPolyℂ p).natDegree ∧
       (atoms.toList.map HexRootsMathlib.DyadicRootIsolation.root).toFinset =
         (toPolyℂ p).roots.toFinset ∧
       ∀ iso ∈ atoms.toList, atomPrec ≤ iso.square.prec := by
-  obtain ⟨atoms, hrun⟩ := isolate?_exists p h hp atomPrec strategy
-  obtain ⟨hroots, hprec⟩ := isolate?_sound p h atomPrec strategy hrun
-  exact ⟨atoms, hrun, isolate?_count p h atomPrec strategy hrun,
+  obtain ⟨atoms, hrun⟩ := isolateComplexRoots?_exists p h hp atomPrec strategy
+  obtain ⟨hroots, hprec⟩ := isolateComplexRoots?_sound p h atomPrec strategy hrun
+  exact ⟨atoms, hrun, isolateComplexRoots?_count p h atomPrec strategy hrun,
     hroots, hprec⟩
 
 /-- Boolean `isSome` form of full driver completeness. -/
-theorem isolate?_isSome (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolateComplexRoots?_isSome (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (hp : p ≠ 0) (atomPrec : Int) (strategy : Hex.AtomStrategy) :
-    (Hex.isolate? p h atomPrec strategy).isSome = true := by
-  obtain ⟨atoms, hatoms⟩ := isolate?_exists p h hp atomPrec strategy
+    (Hex.ZPoly.isolateComplexRoots? p h atomPrec strategy).isSome = true := by
+  obtain ⟨atoms, hatoms⟩ := isolateComplexRoots?_exists p h hp atomPrec strategy
   rw [hatoms]
   rfl
 

--- a/HexRootsMathlib/Examples.lean
+++ b/HexRootsMathlib/Examples.lean
@@ -293,13 +293,13 @@ theorem pisot_roots :
 the three explicitly bounded roots above. -/
 theorem isolate_pisot :
     ∃ atoms : Array (DyadicRootIsolation pisot),
-      isolate? pisot pisot_simple 32 .nk = some atoms ∧
+      ZPoly.isolateComplexRoots? pisot pisot_simple 32 .nk = some atoms ∧
       atoms.size = 3 ∧
       (atoms.toList.map HexRootsMathlib.DyadicRootIsolation.root).toFinset =
         {pisotRealRoot, pisotLowerRoot, pisotUpperRoot} ∧
       ∀ iso ∈ atoms.toList, 32 ≤ iso.square.prec := by
   obtain ⟨atoms, hrun, hcount, hroots, hprec⟩ :=
-    isolate?_spec pisot pisot_simple pisot_ne_zero 32 .nk
+    isolateComplexRoots?_spec pisot pisot_simple pisot_ne_zero 32 .nk
   exact ⟨atoms, hrun, hcount.trans natDegree_pisot,
     hroots.trans pisot_roots, hprec⟩
 

--- a/HexRootsMathlib/Isolate.lean
+++ b/HexRootsMathlib/Isolate.lean
@@ -15,7 +15,7 @@ public section
 /-!
 # Exact atom enumeration
 
-Successful `Hex.isolate?` calls enumerate the complex roots exactly, for every
+Successful `Hex.ZPoly.isolateComplexRoots?` calls enumerate the complex roots exactly, for every
 atom strategy and including the executable zero and constant branches.
 -/
 
@@ -94,11 +94,11 @@ theorem array_mapM_isSome {α β : Type*} {f : α → Option β}
 /-- In the positive-degree branch, successful isolation is a successful
 Cauchy-started general driver run whose results correspond indexwise to the
 returned atoms. -/
-theorem isolate?_run (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolateComplexRoots?_run (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (atomPrec : Int) (strategy : Hex.AtomStrategy)
     (hdegree : 0 < p.natDegree)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate? p h atomPrec strategy = some atoms) :
+    (hrun : Hex.ZPoly.isolateComplexRoots? p h atomPrec strategy = some atoms) :
     ∃ rs : Array (Hex.Certified p),
       Hex.isolateAll? p (max atomPrec (Hex.separationDepth p : Int))
         #[Hex.Component.cauchy p hdegree] strategy = some rs ∧
@@ -106,7 +106,7 @@ theorem isolate?_run (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
       ∀ (i : Nat) (hi : i < rs.size) (hj : i < atoms.size),
         rs[i] = .atom atoms[i] := by
   have hrun' := hrun
-  rw [Hex.isolate?, dite_eq_left hdegree] at hrun'
+  rw [Hex.ZPoly.isolateComplexRoots?, dite_eq_left hdegree] at hrun'
   let target := max atomPrec (Hex.separationDepth p : Int)
   cases hall : Hex.isolateAll? p target
       #[Hex.Component.cauchy p hdegree] strategy with
@@ -130,15 +130,15 @@ theorem isolate?_run (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
 
 /-- Every root belongs to one of the atoms returned by successful
 positive-degree isolation. -/
-theorem isolate?_root_mem_of_pos (p : Hex.ZPoly)
+theorem isolateComplexRoots?_root_mem_of_pos (p : Hex.ZPoly)
     (h : Hex.HasOnlySimpleRoots p) (atomPrec : Int)
     (strategy : Hex.AtomStrategy) (hdegree : 0 < p.natDegree)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate? p h atomPrec strategy = some atoms)
+    (hrun : Hex.ZPoly.isolateComplexRoots? p h atomPrec strategy = some atoms)
     {z : ℂ} (hzroot : (toPolyℂ p).IsRoot z) :
     ∃ iso ∈ atoms.toList, DyadicRootIsolation.root iso = z := by
   obtain ⟨rs, hall, hsize, hrel⟩ :=
-    isolate?_run p h atomPrec strategy hdegree hrun
+    isolateComplexRoots?_run p h atomPrec strategy hdegree hrun
   obtain ⟨r, hr, hzr⟩ :=
     isolateAll_cauchy_covers p hdegree hall hzroot
   obtain ⟨i, hiList, hir⟩ := List.getElem_of_mem hr
@@ -156,14 +156,14 @@ theorem isolate?_root_mem_of_pos (p : Hex.ZPoly)
 
 /-- A successful non-positive-degree call is the nonzero constant branch and
 returns no atoms, independently of strategy. -/
-theorem isolate?_nonpositive (p : Hex.ZPoly)
+theorem isolateComplexRoots?_nonpositive (p : Hex.ZPoly)
     (h : Hex.HasOnlySimpleRoots p) (atomPrec : Int)
     (strategy : Hex.AtomStrategy) (hdegree : ¬0 < p.natDegree)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate? p h atomPrec strategy = some atoms) :
+    (hrun : Hex.ZPoly.isolateComplexRoots? p h atomPrec strategy = some atoms) :
     p.size ≠ 0 ∧ atoms = #[] := by
   have hrun' := hrun
-  rw [Hex.isolate?, dite_eq_right hdegree] at hrun'
+  rw [Hex.ZPoly.isolateComplexRoots?, dite_eq_right hdegree] at hrun'
   by_cases hp : p.size = 0
   · simp [hp] at hrun'
   · have hatoms : atoms = #[] := by
@@ -172,15 +172,15 @@ theorem isolate?_nonpositive (p : Hex.ZPoly)
 
 /-- Every returned atom meets the full driver target, not only the requested
 atom precision. -/
-theorem isolate?_prec (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolateComplexRoots?_prec (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (atomPrec : Int) (strategy : Hex.AtomStrategy)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate? p h atomPrec strategy = some atoms) :
+    (hrun : Hex.ZPoly.isolateComplexRoots? p h atomPrec strategy = some atoms) :
     ∀ iso ∈ atoms.toList,
       max atomPrec (Hex.separationDepth p : Int) ≤ iso.square.prec := by
   by_cases hdegree : 0 < p.natDegree
   · obtain ⟨rs, hall, hsize, hrel⟩ :=
-      isolate?_run p h atomPrec strategy hdegree hrun
+      isolateComplexRoots?_run p h atomPrec strategy hdegree hrun
     intro iso hiso
     obtain ⟨i, hiList, hir⟩ := List.getElem_of_mem hiso
     have hi : i < atoms.size := by simpa using hiList
@@ -192,16 +192,16 @@ theorem isolate?_prec (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     rw [← hir]
     exact hready.1
   · obtain ⟨-, hatoms⟩ :=
-      isolate?_nonpositive p h atomPrec strategy hdegree hrun
+      isolateComplexRoots?_nonpositive p h atomPrec strategy hdegree hrun
     subst atoms
     simp
 
 /-- Every successful isolation result can be wrapped as a
 `RefinedIsolation`: the driver's separation target dominates `mahlerPrec`. -/
-theorem isolate?_refined (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolateComplexRoots?_refined (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (atomPrec : Int) (strategy : Hex.AtomStrategy)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate? p h atomPrec strategy = some atoms) :
+    (hrun : Hex.ZPoly.isolateComplexRoots? p h atomPrec strategy = some atoms) :
     ∀ iso ∈ atoms.toList, (Hex.mahlerPrec p : Int) ≤ iso.square.prec := by
   have hsepNat : Hex.mahlerPrec p ≤ Hex.separationDepth p := by
     rw [Hex.separationDepth]
@@ -210,20 +210,20 @@ theorem isolate?_refined (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
       (Hex.separationDepth p : Int) := by exact_mod_cast hsepNat
   intro iso hiso
   exact hsep.trans <| (le_max_right atomPrec
-    (Hex.separationDepth p : Int)).trans <| isolate?_prec p h atomPrec
+    (Hex.separationDepth p : Int)).trans <| isolateComplexRoots?_prec p h atomPrec
       strategy hrun iso hiso
 
 /-- Distinct output indices select distinct semantic roots. -/
-theorem isolate?_roots_ne (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolateComplexRoots?_roots_ne (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (atomPrec : Int) (strategy : Hex.AtomStrategy)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate? p h atomPrec strategy = some atoms)
+    (hrun : Hex.ZPoly.isolateComplexRoots? p h atomPrec strategy = some atoms)
     {i j : Nat} (hi : i < atoms.size) (hj : j < atoms.size) (hij : i ≠ j) :
     DyadicRootIsolation.root atoms[i] ≠
       DyadicRootIsolation.root atoms[j] := by
   by_cases hdegree : 0 < p.natDegree
   · obtain ⟨rs, hall, hsize, hrel⟩ :=
-      isolate?_run p h atomPrec strategy hdegree hrun
+      isolateComplexRoots?_run p h atomPrec strategy hdegree hrun
     have hi' : i < rs.size := by simpa [hsize] using hi
     have hj' : j < rs.size := by simpa [hsize] using hj
     have hri := hrel i hi' hi
@@ -241,22 +241,22 @@ theorem isolate?_roots_ne (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     rw [heq] at hmemi
     exact (Set.disjoint_left.mp hdisj) hmemi hmemj
   · obtain ⟨-, hatoms⟩ :=
-      isolate?_nonpositive p h atomPrec strategy hdegree hrun
+      isolateComplexRoots?_nonpositive p h atomPrec strategy hdegree hrun
     subst atoms
     simp at hi
 
 /-- Distinct output atoms have disjoint closed circumscribed discs, for every
 strategy accepted by the general isolation driver. -/
-theorem isolate?_disjoint (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolateComplexRoots?_disjoint (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (atomPrec : Int) (strategy : Hex.AtomStrategy)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate? p h atomPrec strategy = some atoms)
+    (hrun : Hex.ZPoly.isolateComplexRoots? p h atomPrec strategy = some atoms)
     {i j : Nat} (hi : i < atoms.size) (hj : j < atoms.size) (hij : i ≠ j) :
     Disjoint (DyadicSquare.closedDisc atoms[i].square)
       (DyadicSquare.closedDisc atoms[j].square) := by
   by_cases hdegree : 0 < p.natDegree
   · obtain ⟨rs, hall, hsize, hrel⟩ :=
-      isolate?_run p h atomPrec strategy hdegree hrun
+      isolateComplexRoots?_run p h atomPrec strategy hdegree hrun
     have hi' : i < rs.size := by simpa [hsize] using hi
     have hj' : j < rs.size := by simpa [hsize] using hj
     have hri := hrel i hi' hi
@@ -265,22 +265,22 @@ theorem isolate?_disjoint (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     rw [hri, hrj] at hdisj
     exact hdisj
   · obtain ⟨-, hatoms⟩ :=
-      isolate?_nonpositive p h atomPrec strategy hdegree hrun
+      isolateComplexRoots?_nonpositive p h atomPrec strategy hdegree hrun
     subst atoms
     simp at hi
 
 /-- The number of returned atoms is the polynomial's complex natural degree.
-Together with `isolate?_roots_ne`, this records that the exact enumeration has
+Together with `isolateComplexRoots?_roots_ne`, this records that the exact enumeration has
 no duplicate representatives. -/
-theorem isolate?_count (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolateComplexRoots?_count (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (atomPrec : Int) (strategy : Hex.AtomStrategy)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate? p h atomPrec strategy = some atoms) :
+    (hrun : Hex.ZPoly.isolateComplexRoots? p h atomPrec strategy = some atoms) :
     atoms.size = (toPolyℂ p).natDegree := by
   classical
   by_cases hdegree : 0 < p.natDegree
   · obtain ⟨rs, hall, hsize, hrel⟩ :=
-      isolate?_run p h atomPrec strategy hdegree hrun
+      isolateComplexRoots?_run p h atomPrec strategy hdegree hrun
     calc
       atoms.size = rs.size := hsize.symm
       _ = ∑ _i : Fin rs.size, 1 := by simp
@@ -292,7 +292,7 @@ theorem isolate?_count (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
         rfl
       _ = (toPolyℂ p).natDegree := isolateAll_count p hdegree hall
   · obtain ⟨-, hatoms⟩ :=
-      isolate?_nonpositive p h atomPrec strategy hdegree hrun
+      isolateComplexRoots?_nonpositive p h atomPrec strategy hdegree hrun
     subst atoms
     rw [Array.size_empty, natDegree_toPolyℂ]
     exact Nat.eq_zero_of_not_pos hdegree |>.symm
@@ -300,10 +300,10 @@ theorem isolate?_count (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
 /-- Successful isolation enumerates exactly the distinct complex roots and
 meets the requested precision, for every strategy and every executable edge
 case. -/
-theorem isolate?_sound (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolateComplexRoots?_sound (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (atomPrec : Int) (strategy : Hex.AtomStrategy)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate? p h atomPrec strategy = some atoms) :
+    (hrun : Hex.ZPoly.isolateComplexRoots? p h atomPrec strategy = some atoms) :
     (atoms.toList.map DyadicRootIsolation.root).toFinset =
         (toPolyℂ p).roots.toFinset ∧
       ∀ iso ∈ atoms.toList, atomPrec ≤ iso.square.prec := by
@@ -326,14 +326,14 @@ theorem isolate?_sound (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
         have hzroot : (toPolyℂ p).IsRoot z :=
           (mem_roots hq).mp (Multiset.mem_toFinset.mp hz)
         obtain ⟨iso, hiso, hroot⟩ :=
-          isolate?_root_mem_of_pos p h atomPrec strategy hdegree hrun hzroot
+          isolateComplexRoots?_root_mem_of_pos p h atomPrec strategy hdegree hrun hzroot
         rw [List.mem_toFinset]
         exact List.mem_map.mpr ⟨iso, hiso, hroot⟩
     · intro iso hiso
       exact (le_max_left atomPrec (Hex.separationDepth p : Int)).trans <|
-        isolate?_prec p h atomPrec strategy hrun iso hiso
+        isolateComplexRoots?_prec p h atomPrec strategy hrun iso hiso
   · obtain ⟨hp, hatoms⟩ :=
-      isolate?_nonpositive p h atomPrec strategy hdegree hrun
+      isolateComplexRoots?_nonpositive p h atomPrec strategy hdegree hrun
     have hroots : (toPolyℂ p).roots = 0 := by
       apply Multiset.eq_zero_of_forall_notMem
       intro z hz

--- a/HexRootsMathlib/IsolateTotal.lean
+++ b/HexRootsMathlib/IsolateTotal.lean
@@ -24,63 +24,64 @@ noncomputable section
 
 /-- Isolate all complex roots of a nonzero squarefree integer polynomial.
 
-Unlike `Hex.isolate?`, this proof-facing wrapper cannot return `none`: its
+Unlike `Hex.ZPoly.isolateComplexRoots?`, this proof-facing wrapper cannot return `none`: its
 required hypotheses discharge the driver's completeness conditions. The
-result is characterized by `isolate_eq` as the successful executable output,
+result is characterized by `isolateComplexRoots_eq` as the successful executable output,
 with the same atom strategy and requested-precision parameters. -/
-def isolate (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p) (hp : p ≠ 0)
+def isolateComplexRoots (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p) (hp : p ≠ 0)
     (atomPrec : Int) (strategy : Hex.AtomStrategy := .nkThenPellet) :
     Array (Hex.DyadicRootIsolation p) :=
-  (isolate?_exists p h hp atomPrec strategy).choose
+  (isolateComplexRoots?_exists p h hp atomPrec strategy).choose
 
-/-- The total wrapper is exactly the successful result of `Hex.isolate?`. -/
-theorem isolate_eq (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+/-- The total wrapper is exactly the successful result of `Hex.ZPoly.isolateComplexRoots?`. -/
+theorem isolateComplexRoots_eq (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (hp : p ≠ 0) (atomPrec : Int)
     (strategy : Hex.AtomStrategy := .nkThenPellet) :
-    Hex.isolate? p h atomPrec strategy = some (isolate p h hp atomPrec strategy) :=
-  (isolate?_exists p h hp atomPrec strategy).choose_spec
+    Hex.ZPoly.isolateComplexRoots? p h atomPrec strategy =
+      some (isolateComplexRoots p h hp atomPrec strategy) :=
+  (isolateComplexRoots?_exists p h hp atomPrec strategy).choose_spec
 
 /-- The total wrapper returns one atom for each complex root, counted with
 multiplicity. -/
-theorem isolate_count (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolateComplexRoots_count (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (hp : p ≠ 0) (atomPrec : Int)
     (strategy : Hex.AtomStrategy := .nkThenPellet) :
-    (isolate p h hp atomPrec strategy).size =
+    (isolateComplexRoots p h hp atomPrec strategy).size =
       (HexRootsMathlib.toPolyℂ p).natDegree :=
-  isolate?_count p h atomPrec strategy (isolate_eq p h hp atomPrec strategy)
+  isolateComplexRoots?_count p h atomPrec strategy (isolateComplexRoots_eq p h hp atomPrec strategy)
 
 /-- The semantic roots selected by the returned atoms are exactly the roots of
 the input polynomial. -/
-theorem isolate_roots (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolateComplexRoots_roots (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (hp : p ≠ 0) (atomPrec : Int)
     (strategy : Hex.AtomStrategy := .nkThenPellet) :
-    ((isolate p h hp atomPrec strategy).toList.map
+    ((isolateComplexRoots p h hp atomPrec strategy).toList.map
       HexRootsMathlib.DyadicRootIsolation.root).toFinset =
         (HexRootsMathlib.toPolyℂ p).roots.toFinset :=
-  (isolate?_sound p h atomPrec strategy
-    (isolate_eq p h hp atomPrec strategy)).1
+  (isolateComplexRoots?_sound p h atomPrec strategy
+    (isolateComplexRoots_eq p h hp atomPrec strategy)).1
 
 /-- Every returned atom meets the requested precision. -/
-theorem isolate_prec (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolateComplexRoots_prec (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (hp : p ≠ 0) (atomPrec : Int)
     (strategy : Hex.AtomStrategy := .nkThenPellet) :
-    ∀ iso ∈ (isolate p h hp atomPrec strategy).toList,
+    ∀ iso ∈ (isolateComplexRoots p h hp atomPrec strategy).toList,
       atomPrec ≤ iso.square.prec :=
-  (isolate?_sound p h atomPrec strategy
-    (isolate_eq p h hp atomPrec strategy)).2
+  (isolateComplexRoots?_sound p h atomPrec strategy
+    (isolateComplexRoots_eq p h hp atomPrec strategy)).2
 
 /-- Distinct atoms returned by the total wrapper have disjoint closed
 circumscribed discs. -/
-theorem isolate_disjoint (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+theorem isolateComplexRoots_disjoint (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (hp : p ≠ 0) (atomPrec : Int)
     (strategy : Hex.AtomStrategy := .nkThenPellet)
-    {i j : Nat} (hi : i < (isolate p h hp atomPrec strategy).size)
-    (hj : j < (isolate p h hp atomPrec strategy).size) (hij : i ≠ j) :
+    {i j : Nat} (hi : i < (isolateComplexRoots p h hp atomPrec strategy).size)
+    (hj : j < (isolateComplexRoots p h hp atomPrec strategy).size) (hij : i ≠ j) :
     Disjoint
-      (DyadicSquare.closedDisc (isolate p h hp atomPrec strategy)[i].square)
-      (DyadicSquare.closedDisc (isolate p h hp atomPrec strategy)[j].square) :=
-  isolate?_disjoint p h atomPrec strategy
-    (isolate_eq p h hp atomPrec strategy) hi hj hij
+      (DyadicSquare.closedDisc (isolateComplexRoots p h hp atomPrec strategy)[i].square)
+      (DyadicSquare.closedDisc (isolateComplexRoots p h hp atomPrec strategy)[j].square) :=
+  isolateComplexRoots?_disjoint p h atomPrec strategy
+    (isolateComplexRoots_eq p h hp atomPrec strategy) hi hj hij
 
 end
 

--- a/HexRootsMathlib/NKDriver.lean
+++ b/HexRootsMathlib/NKDriver.lean
@@ -137,13 +137,13 @@ theorem isolateAll_nk_simple {p : Hex.ZPoly} {target : Int}
     (Array.getElem_mem_toList hi)
   exact ⟨iso, hiso, NKData.sound hnk⟩
 
-/-- In the positive-degree branch, successful `isolate` execution is a
+/-- In the positive-degree branch, successful `ZPoly.isolateComplexRoots?` execution is a
 successful Cauchy-started `isolateAll?` run whose result indices correspond
 exactly to the returned NK atoms. -/
 theorem isolate_nk_run (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (atomPrec : Int) (hdegree : 0 < p.natDegree)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate? p h atomPrec .nk = some atoms) :
+    (hrun : Hex.ZPoly.isolateComplexRoots? p h atomPrec .nk = some atoms) :
     ∃ rs : Array (Hex.Certified p),
       Hex.isolateAll? p (max atomPrec (Hex.separationDepth p : Int))
         #[Hex.Component.cauchy p hdegree] .nk = some rs ∧
@@ -152,7 +152,7 @@ theorem isolate_nk_run (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
         rs[i] = .atom atoms[i] ∧ Hex.nkWitness p atoms[i].square ∧
           atoms[i].witness.isNK = true := by
   have hrun' := hrun
-  rw [Hex.isolate?, dite_eq_left hdegree] at hrun'
+  rw [Hex.ZPoly.isolateComplexRoots?, dite_eq_left hdegree] at hrun'
   let target := max atomPrec (Hex.separationDepth p : Int)
   cases hall : Hex.isolateAll? p target
       #[Hex.Component.cauchy p hdegree] .nk with
@@ -186,7 +186,7 @@ requested precision and contains a unique interior simple root. -/
 theorem isolate_nk_simple (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (atomPrec : Int) (hdegree : 0 < p.natDegree)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate? p h atomPrec .nk = some atoms)
+    (hrun : Hex.ZPoly.isolateComplexRoots? p h atomPrec .nk = some atoms)
     {i : Nat} (hi : i < atoms.size) :
     atomPrec ≤ atoms[i].square.prec ∧
       Hex.nkWitness p atoms[i].square ∧
@@ -210,7 +210,7 @@ disjoint closed circumscribed discs. -/
 theorem isolate_nk_disjoint (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     (atomPrec : Int) (hdegree : 0 < p.natDegree)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate? p h atomPrec .nk = some atoms)
+    (hrun : Hex.ZPoly.isolateComplexRoots? p h atomPrec .nk = some atoms)
     {i j : Nat} (hi : i < atoms.size) (hj : j < atoms.size) (hij : i ≠ j) :
     Disjoint (DyadicSquare.closedDisc atoms[i].square)
       (DyadicSquare.closedDisc atoms[j].square) := by
@@ -229,7 +229,7 @@ theorem isolate_nk_covers_once_of_pos (p : Hex.ZPoly)
     (h : Hex.HasOnlySimpleRoots p) (atomPrec : Int)
     (hdegree : 0 < p.natDegree)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate? p h atomPrec .nk = some atoms)
+    (hrun : Hex.ZPoly.isolateComplexRoots? p h atomPrec .nk = some atoms)
     {z : ℂ} (hzroot : (toPolyℂ p).IsRoot z) :
     ∃! i : Fin atoms.size,
       z ∈ DyadicSquare.closedSquare atoms[i].square := by
@@ -282,28 +282,28 @@ theorem not_isRoot_of_degree_not_pos (p : Hex.ZPoly) (hp : p.size ≠ 0)
   apply hdegree
   simpa only [natDegree_toPolyℂ] using hpos
 
-/-- A successful non-positive-degree `isolate` call is exactly the nonzero
+/-- A successful non-positive-degree `ZPoly.isolateComplexRoots?` call is exactly the nonzero
 constant branch and returns the empty atom array. -/
 theorem isolate_nk_nonpositive (p : Hex.ZPoly)
     (h : Hex.HasOnlySimpleRoots p) (atomPrec : Int)
     (hdegree : ¬0 < p.natDegree)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate? p h atomPrec .nk = some atoms) :
+    (hrun : Hex.ZPoly.isolateComplexRoots? p h atomPrec .nk = some atoms) :
     p.size ≠ 0 ∧ atoms = #[] := by
   have hrun' := hrun
-  rw [Hex.isolate?, dite_eq_right hdegree] at hrun'
+  rw [Hex.ZPoly.isolateComplexRoots?, dite_eq_right hdegree] at hrun'
   by_cases hp : p.size = 0
   · simp [hp] at hrun'
   · have hatoms : atoms = #[] := by
       simpa only [hp, ↓reduceIte, Option.some.injEq] using hrun'.symm
     exact ⟨hp, hatoms⟩
 
-/-- Every successful NK-only `isolate` call assigns each complex root to
+/-- Every successful NK-only `ZPoly.isolateComplexRoots?` call assigns each complex root to
 exactly one returned atom, including the vacuous nonzero-constant branch. -/
 theorem isolate_nk_covers_once (p : Hex.ZPoly)
     (h : Hex.HasOnlySimpleRoots p) (atomPrec : Int)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate? p h atomPrec .nk = some atoms)
+    (hrun : Hex.ZPoly.isolateComplexRoots? p h atomPrec .nk = some atoms)
     {z : ℂ} (hzroot : (toPolyℂ p).IsRoot z) :
     ∃! i : Fin atoms.size,
       z ∈ DyadicSquare.closedSquare atoms[i].square := by
@@ -313,11 +313,11 @@ theorem isolate_nk_covers_once (p : Hex.ZPoly)
     exact (not_isRoot_of_degree_not_pos p hp hdegree z hzroot).elim
 
 /-- Any two differently indexed atoms returned by successful NK-only
-`isolate` execution have disjoint closed circumscribed discs. -/
+`ZPoly.isolateComplexRoots?` execution have disjoint closed circumscribed discs. -/
 theorem isolate_nk_pairwise (p : Hex.ZPoly)
     (h : Hex.HasOnlySimpleRoots p) (atomPrec : Int)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate? p h atomPrec .nk = some atoms)
+    (hrun : Hex.ZPoly.isolateComplexRoots? p h atomPrec .nk = some atoms)
     {i j : Nat} (hi : i < atoms.size) (hj : j < atoms.size) (hij : i ≠ j) :
     Disjoint (DyadicSquare.closedDisc atoms[i].square)
       (DyadicSquare.closedDisc atoms[j].square) := by
@@ -332,7 +332,7 @@ precision and has the unique interior simple-root contract. -/
 theorem isolate_nk_atom_sound (p : Hex.ZPoly)
     (h : Hex.HasOnlySimpleRoots p) (atomPrec : Int)
     {atoms : Array (Hex.DyadicRootIsolation p)}
-    (hrun : Hex.isolate? p h atomPrec .nk = some atoms)
+    (hrun : Hex.ZPoly.isolateComplexRoots? p h atomPrec .nk = some atoms)
     {i : Nat} (hi : i < atoms.size) :
     atomPrec ≤ atoms[i].square.prec ∧
       Hex.nkWitness p atoms[i].square ∧

--- a/HexRootsMathlib/README.md
+++ b/HexRootsMathlib/README.md
@@ -27,7 +27,7 @@ import HexRootsMathlib
 
 # Functionality
 
-`HexRootsMathlib.isolate` removes the executable `Option` when the caller has
+`HexRootsMathlib.isolateComplexRoots` removes the executable `Option` when the caller has
 the hypotheses required by completeness:
 
 ```lean
@@ -39,21 +39,21 @@ def p : ZPoly := DensePoly.ofCoeffs #[-1, -1, 0, 1]
 variable (hsimple : HasOnlySimpleRoots p) (hnonzero : p ≠ 0)
 
 noncomputable def roots : Array (DyadicRootIsolation p) :=
-  isolate? p hsimple hnonzero 32
+  ZPoly.isolateComplexRoots? p hsimple hnonzero 32
 ```
 
 The associated theorems are the main consumption surface:
 
 ```lean
-isolate_eq     -- the array is the successful Hex.isolate? result
-isolate?_count  -- one atom per complex root
-isolate_roots  -- selected semantic roots equal p.roots.toFinset
-isolate?_prec   -- every square meets the requested precision
-isolate?_disjoint -- distinct squares have disjoint circumscribed discs
+isolateComplexRoots_eq     -- the array is the successful Hex.ZPoly.isolateComplexRoots? result
+isolateComplexRoots?_count  -- one atom per complex root
+isolateComplexRoots_roots  -- selected semantic roots equal p.roots.toFinset
+isolateComplexRoots?_prec   -- every square meets the requested precision
+isolateComplexRoots?_disjoint -- distinct squares have disjoint circumscribed discs
 ```
 
-Clients that already have a successful `Hex.isolate?` call can instead use
-`isolate?_sound`, `isolate?_count`, `isolate?_disjoint`, and the atom-level
+Clients that already have a successful `Hex.ZPoly.isolateComplexRoots?` call can instead use
+`isolateComplexRoots?_sound`, `isolateComplexRoots?_count`, `isolateComplexRoots?_disjoint`, and the atom-level
 semantic root API.
 
 # Verification

--- a/HexRootsMathlib/SPEC/hex-roots-mathlib.md
+++ b/HexRootsMathlib/SPEC/hex-roots-mathlib.md
@@ -20,7 +20,7 @@ its separation contract. **Completeness** proves that the actual driver either
 uses its verified Pellet-bearing all-atoms local finisher, directly emits an
 already-ready NK-only atom array, or reaches a normalized depth where every
 retained component certifies as one atom, so
-`isolate?` never returns `none` on nonzero squarefree input under any atom
+`ZPoly.isolateComplexRoots?` never returns `none` on nonzero squarefree input under any atom
 strategy. One-atom refinement is additionally total under the default mixed
 strategy whenever the selected atom has reached `mahlerPrec`; this local result
 allows repeated roots elsewhere in the ambient polynomial. The soundness
@@ -85,7 +85,7 @@ third candidate-contribution slice
 experiment in hex-roots settles on Newton-Kantorovich atoms, the
 Rouché-on-circles development below is needed only for `k ≥ 2`
 cluster soundness and the Pellet atom disjunct, and drops off the
-critical path for `isolate?` on squarefree inputs (whose soundness
+critical path for `ZPoly.isolateComplexRoots?` on squarefree inputs (whose soundness
 then rests on `T_0` coverage, a triangle inequality, plus
 Newton-Kantorovich and the Mahler separation bound).
 
@@ -363,7 +363,7 @@ developments above.
   soundness. Retained squares cover every root, output discs are pairwise
   disjoint, and each certificate has its asserted multiplicity count. Thus
   the general driver's certificate counts sum to the polynomial degree; when
-  `isolate?` successfully extracts only atoms, their distinct semantic roots
+  `ZPoly.isolateComplexRoots?` successfully extracts only atoms, their distinct semantic roots
   enumerate the root finset exactly.
   ```lean
   theorem isolateAll_count (p : ZPoly)
@@ -371,15 +371,15 @@ developments above.
       (hr : isolateAll? p target #[Component.cauchy p h] strategy = some result) :
       ∑ i : Fin result.size, Certified.count result[i] = (toPolyℂ p).natDegree
 
-  theorem isolate?_sound (p : ZPoly) (h : Hex.HasOnlySimpleRoots p)
+  theorem isolateComplexRoots?_sound (p : ZPoly) (h : Hex.HasOnlySimpleRoots p)
       (atom_prec : Int) (strategy : AtomStrategy) {atoms}
-      (ha : isolate? p h atom_prec strategy = some atoms) :
+      (ha : ZPoly.isolateComplexRoots? p h atom_prec strategy = some atoms) :
       (atoms.toList.map (·.root)).toFinset = (toPolyℂ p).roots.toFinset ∧
       ∀ a ∈ atoms, atom_prec ≤ a.square.prec
   ```
   (`HasOnlySimpleRoots p` does *not* rule out `p = 0` (the
   executable gcd of `0` and `0` is `0`, of size `0 ≤ 1`), but
-  `isolate? 0 _ _ = none` by definition, so the `ha` hypothesis
+  `ZPoly.isolateComplexRoots? 0 _ _ = none` by definition, so the `ha` hypothesis
   supplies nonzeroness; a nonzero constant returns `some #[]` and
   both sides are empty. The rational-separability correspondence in
   `HasOnlySimpleRoots.lean` carries a `p ≠ 0` hypothesis for the same reason.)
@@ -395,18 +395,18 @@ developments above.
       (strategy : Hex.AtomStrategy := .nkThenPellet) :
       Array (Hex.DyadicRootIsolation p)
   ```
-  Unlike `Hex.isolate?`, this proof-facing wrapper cannot return `none`:
+  Unlike `Hex.ZPoly.isolateComplexRoots?`, this proof-facing wrapper cannot return `none`:
   its hypotheses discharge the driver's completeness conditions and the
-  result is extracted from `isolate?_exists`. It is characterized by
-  `isolate_eq` (it is exactly the successful executable output), and
-  its behaviour is packaged by `isolate?_count` (one atom per root,
-  with multiplicity), `isolate_roots` (the selected semantic roots are
-  exactly the root finset), `isolate?_prec` (every atom meets the
-  requested precision), and `isolate?_disjoint` (distinct atoms have
+  result is extracted from `isolateComplexRoots?_exists`. It is characterized by
+  `isolateComplexRoots_eq` (it is exactly the successful executable output), and
+  its behaviour is packaged by `isolateComplexRoots?_count` (one atom per root,
+  with multiplicity), `isolateComplexRoots_roots` (the selected semantic roots are
+  exactly the root finset), `isolateComplexRoots?_prec` (every atom meets the
+  requested precision), and `isolateComplexRoots?_disjoint` (distinct atoms have
   disjoint closed circumscribed discs).
 - `HexRootsMathlib/Examples.lean`: compiled regression examples for the
   public surface (kernel-`decide` witness checks on committed dyadic
-  fixtures and `isolate?`-based root extraction). Deliberately excluded
+  fixtures and `ZPoly.isolateComplexRoots?`-based root extraction). Deliberately excluded
   from the umbrella and built through the release-tests target so CI
   cannot silently lose it.
 
@@ -490,9 +490,9 @@ and it is the analytically hardest part:
     induction for `isolateLoop`/`isolateAll?`, and proves:
 
     ```lean
-    theorem isolate?_isSome (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+    theorem isolateComplexRoots?_isSome (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
         (hp : p ≠ 0) (atomPrec : Int) (strategy : Hex.AtomStrategy) :
-        (Hex.isolate? p h atomPrec strategy).isSome = true
+        (Hex.ZPoly.isolateComplexRoots? p h atomPrec strategy).isSome = true
     ```
 
     Nonzero constants take the executable empty-output branch. Positive-degree
@@ -591,14 +591,14 @@ dimensions. Polynomial and executable-witness specialization belongs in
 
 ## Headline correctness theorem
 
-`HexRootsMathlib.isolate?_sound`: a successful run of the executable
+`HexRootsMathlib.isolateComplexRoots?_sound`: a successful run of the executable
 isolator on a nonzero polynomial with only simple roots returns atoms
 whose semantic roots enumerate the root finset of the polynomial
 exactly, every atom meeting the requested precision. This is the
 end-to-end post-condition of the public API. Totality under the same
-hypotheses is `isolate?_isSome` (the completeness development's
-terminal theorem), packaged for consumers as the none-free `isolate`
-wrapper with its characterisation family (`isolate_eq`, `_count`,
+hypotheses is `isolateComplexRoots?_isSome` (the completeness development's
+terminal theorem), packaged for consumers as the none-free
+`isolateComplexRoots` wrapper with its characterisation family (`isolateComplexRoots_eq`, `_count`,
 `_roots`, `_prec`, `_disjoint`); the general-multiplicity count
 identity is `isolateAll_count`. Those are independently justified
 public API, and the correspondence and completeness theorems above are

--- a/PLAN/Releases.md
+++ b/PLAN/Releases.md
@@ -72,7 +72,7 @@ example that exercises the advertised user story end-to-end.
   integer polynomial. Results carry checked coverage, uniqueness,
   disjointness, count, and precision guarantees.
 - **Integration example:** `Examples/Release5.lean` — use the none-free
-  `HexRootsMathlib.isolate` wrapper for complex roots and the
+  `HexRootsMathlib.isolateComplexRoots` wrapper for complex roots and the
   `isolate_roots` elaborator for repeated real roots.
 
 ## Release readiness predicate

--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -88,8 +88,8 @@ Mathlib, and supplies correspondence proofs or Mathlib-facing APIs):
 - **hex-invariant-factors-mathlib**: the characteristic-matrix module correspondence, product agreement with the independently computed characteristic polynomial, and largest-factor agreement with the independently computed minimal polynomial
 - **hex-gram-schmidt-mathlib**: `GramSchmidt.Int.basis` = Mathlib's `gramSchmidt`
 - **hex-poly-z-mathlib**: `DensePoly Int ≃+* Polynomial ℤ`, Mignotte bound (via Mathlib's Mahler measure)
-- **hex-roots-mathlib**: Pellet's test on circles (built from `circleIntegral`), the Mahler separation bound, soundness of refinement and `isolate`
-- **hex-real-roots-mathlib**: Sturm's theorem (counting form over `Polynomial ℝ`), chain correspondence, soundness and completeness of `ZPoly.isolate?`
+- **hex-roots-mathlib**: Pellet's test on circles (built from `circleIntegral`), the Mahler separation bound, soundness of refinement and `ZPoly.isolateComplexRoots?`
+- **hex-real-roots-mathlib**: Sturm's theorem (counting form over `Polynomial ℝ`), chain correspondence, soundness and completeness of `ZPoly.isolateRealRoots?`
 - **hex-interval-mathlib**: real semantics, verified arithmetic and elementary-function propagators, certificate replay, and the `interval` tactic
 - **hex-resultant-mathlib**: executable resultant agreement with `Polynomial.resultant`, specialization, root-product, and discriminant theorems
 - **hex-number-field-mathlib**: fixed-field correspondence, exactification, lazy arithmetic, and algebraic-coefficient root completeness
@@ -680,9 +680,9 @@ for developments whose source-local move has not happened yet.
 - [hex-poly-z-gcd.md](../../HexPolyZGcd/SPEC/hex-poly-z-gcd.md): modular gcd for `Z[x]` with cofactors, a coprimality witness, and exact division (the Mathlib companion is specified in the same file)
 - [hex-cyclotomic.md](hex-cyclotomic.md): dense integer cyclotomic polynomials indexed by a checked factorization, the squarefree-kernel and divisor-recursion routes, the divisor family, and the factorization of `x^n - 1` (the Mathlib companion is specified in the same file)
 - [hex-roots.md](../../HexRoots/SPEC/hex-roots.md): certified complex root isolation for `Z[x]`
-- [hex-roots-mathlib](../../HexRootsMathlib/SPEC/hex-roots-mathlib.md): Pellet's test on circles, the Mahler separation bound, soundness of refinement and `isolate`
+- [hex-roots-mathlib](../../HexRootsMathlib/SPEC/hex-roots-mathlib.md): Pellet's test on circles, the Mahler separation bound, soundness of refinement and `ZPoly.isolateComplexRoots?`
 - [hex-real-roots.md](../../HexRealRoots/SPEC/hex-real-roots.md): certified real root isolation for `Z[x]`, Sturm-count witnesses, Descartes search with Sturm fallback
-- [hex-real-roots-mathlib.md](../../HexRealRootsMathlib/SPEC/hex-real-roots-mathlib.md): Sturm's theorem, chain correspondence, soundness and completeness of `ZPoly.isolate?`
+- [hex-real-roots-mathlib.md](../../HexRealRootsMathlib/SPEC/hex-real-roots-mathlib.md): Sturm's theorem, chain correspondence, soundness and completeness of `ZPoly.isolateRealRoots?`
 - [hex-interval.md](../../HexInterval/SPEC/hex-interval.md): exact interval data, shared programs, and budgeted propagation search
 - [hex-interval-mathlib.md](hex-interval-mathlib.md): real semantics, verified propagators, proof replay, and the `interval` tactic
 - **hex-interval-algebraic** (planned): Mathlib-facing interval providers backed by certified real and complex polynomial root isolation; its provider contract is specified in [hex-interval.md](../../HexInterval/SPEC/hex-interval.md#specialized-algebraic-solvers-before-generic-propagation)

--- a/bench/HexNumberField/Bench.lean
+++ b/bench/HexNumberField/Bench.lean
@@ -248,7 +248,7 @@ def runAddEliminant : Unit → IO UInt64 := fun _ => do
 def runIsolateAdd : Unit → IO UInt64 := fun _ => do
   let input ← requireSome "lazy/isolate-add" (← isolateInputRef.get)
   let isolations ← requireSome "lazy/isolate-add"
-    (isolate? input.polynomial input.simple (input.depth : Int))
+    (ZPoly.isolateComplexRoots? input.polynomial input.simple (input.depth : Int))
   return isolations.foldl
     (fun checksum isolation =>
       mixHash checksum (squareChecksum isolation.square))
@@ -836,7 +836,7 @@ general constructor remains the fixture for ladders whose polynomial is not
 the binomial used to choose `ladderRootSeed`. -/
 private def refinedOf? (p : ZPoly) (h : HasOnlySimpleRoots p) :
     Option (RefinedIsolation p) := do
-  let isolations ← isolate? p h (separationDepth p : Int)
+  let isolations ← ZPoly.isolateComplexRoots? p h (separationDepth p : Int)
   let iso ← isolations[0]?
   iso.toRefined?
 
@@ -845,9 +845,9 @@ candidate factor. This pins exactification fixtures to the intended factor
 rather than to the enclosing isolator's emission order. -/
 private def refinedFactor? (p q : ZPoly) (hp : HasOnlySimpleRoots p)
     (hq : HasOnlySimpleRoots q) : Option (RefinedIsolation p) := do
-  let pIsolations ← isolate? p hp (separationDepth p : Int)
+  let pIsolations ← ZPoly.isolateComplexRoots? p hp (separationDepth p : Int)
   let pRefined ← pIsolations.mapM DyadicRootIsolation.toRefined?
-  let qIsolations ← isolate? q hq (separationDepth q : Int)
+  let qIsolations ← ZPoly.isolateComplexRoots? q hq (separationDepth q : Int)
   let qIsolation ← qIsolations[0]?
   let qRefined ← qIsolation.toRefined?
   pRefined.toList.find? fun rep =>
@@ -2212,7 +2212,7 @@ setup_benchmark runMergeRootListLadder n => n ^ 2 * (Nat.log2 (n + 2) + 1)
 `g^2 * (X - 1)` over `ℚ(√2)`, constructs the degree-12 norm eliminant of the
 dense degree-6 repeated component, isolates it at separation depth, and
 disambiguates its six roots. The repaired inclusive profile puts 92.94% of the
-profiled process in `componentRoots?` and 85.01% in `isolate`. No tight
+profiled process in `componentRoots?` and 85.01% in `ZPoly.isolateComplexRoots?`. No tight
 scaling of the HexRoots executable on this family has been derived independently of timing,
 and BSSY's `Õ(d³ + d²·tau)` result analyzes `CIsolate`, not HexRoots' distinct
 driver. The former `n⁵ log² n` declaration instead composed HexRoots'

--- a/bench/HexRealRoots/Bench.lean
+++ b/bench/HexRealRoots/Bench.lean
@@ -11,7 +11,7 @@ import LeanBench
 Benchmark registrations for `hex-real-roots`.
 
 This Phase 4 slice measures the certified real-root isolation surface: the
-two isolation engines through the public `ZPoly.isolate?`/`ZPoly.isolateSturm?` drivers,
+two isolation engines through the public `ZPoly.isolateRealRoots?`/`ZPoly.isolateSturm?` drivers,
 the Sturm-chain and sign-variation primitives, the Möbius transform, the
 `rootBound`/`sepPrec` closed forms, and the `refineTo` refinement loop.
 
@@ -21,7 +21,7 @@ the scalar result, so the harness's hash column doubles as a
 cross-implementation conformance check.
 
 Input families (per `HexRealRoots/SPEC/hex-real-roots.md` §"Time budgets" and the
-conformance §"local" tier). `ZPoly.isolate?` is deliberately exercised on three
+conformance §"local" tier). `ZPoly.isolateRealRoots?` is deliberately exercised on three
 structurally different families, never a single happy-path shape:
 
 * `well-separated-products`: `∏_{k=1}^{n} (x − k)`, `n` unit-separated integer
@@ -38,7 +38,7 @@ structurally different families, never a single happy-path shape:
 
 `compare runIsolateDescartesFirst runIsolateSturm` (shared
 `well-separated-products` domain) is the intentional cross-engine equivalence
-check: `ZPoly.isolate?` runs Descartes-first, `ZPoly.isolateSturm?` is the certified
+check: `ZPoly.isolateRealRoots?` runs Descartes-first, `ZPoly.isolateSturm?` is the certified
 fallback, and both must hash-agree on the isolation endpoints at every common
 degree.
 
@@ -176,17 +176,17 @@ def refineP : ZPoly := DensePoly.ofCoeffs #[(-5 : Int), 1]
 
 /-! # Timed targets. -/
 
-/-- `ZPoly.isolate?` on the well-separated integer-root product. -/
-def runIsolateWellSep (p : ZPoly) : Int := isolationsChecksum (ZPoly.isolate? p)
+/-- `ZPoly.isolateRealRoots?` on the well-separated integer-root product. -/
+def runIsolateWellSep (p : ZPoly) : Int := isolationsChecksum (ZPoly.isolateRealRoots? p)
 
-/-- `ZPoly.isolate?` on the Chebyshev-clustered polynomial. -/
-def runIsolateChebyshev (p : ZPoly) : Int := isolationsChecksum (ZPoly.isolate? p)
+/-- `ZPoly.isolateRealRoots?` on the Chebyshev-clustered polynomial. -/
+def runIsolateChebyshev (p : ZPoly) : Int := isolationsChecksum (ZPoly.isolateRealRoots? p)
 
-/-- `ZPoly.isolate?` on the Mignotte worst-case polynomial. -/
-def runIsolateMignotte (p : ZPoly) : Int := isolationsChecksum (ZPoly.isolate? p)
+/-- `ZPoly.isolateRealRoots?` on the Mignotte worst-case polynomial. -/
+def runIsolateMignotte (p : ZPoly) : Int := isolationsChecksum (ZPoly.isolateRealRoots? p)
 
-/-- `ZPoly.isolate?` (Descartes-first) on the shared compare domain. -/
-def runIsolateDescartesFirst (p : ZPoly) : Int := isolationsChecksum (ZPoly.isolate? p)
+/-- `ZPoly.isolateRealRoots?` (Descartes-first) on the shared compare domain. -/
+def runIsolateDescartesFirst (p : ZPoly) : Int := isolationsChecksum (ZPoly.isolateRealRoots? p)
 
 /-- `ZPoly.isolateSturm?` (certified engine) on the shared compare domain. -/
 def runIsolateSturm (p : ZPoly) : Int := isolationsChecksum (ZPoly.isolateSturm? p)
@@ -216,7 +216,7 @@ def runSepPrec (p : ZPoly) : Int := Int.ofNat (sepPrec p)
 /-- Refine the first isolation of `x − 5` to precision `8·(n + 1)`; the
 escalating target drives a bisection depth linear in `n`. -/
 def runRefineTo (n : Nat) : Int :=
-  match ZPoly.isolate? refineP with
+  match ZPoly.isolateRealRoots? refineP with
   | none => -1
   | some rs =>
     match rs.isolations[0]? with
@@ -232,7 +232,7 @@ step and how the fixture parameter maps onto that step's input size, per
 `SPEC/benchmarking.md`.
 -/
 
-/- `ZPoly.isolate?` on `∏(x−k)`. SPEC §"Complexity contract": well-separated roots
+/- `ZPoly.isolateRealRoots?` on `∏(x−k)`. SPEC §"Complexity contract": well-separated roots
 resolve in `O(n + log(rootBound/gap))` bisection levels; with `O(n)` unresolved
 intervals per level that is `O(n²)` Möbius transforms, each an `O(n²)` integer
 Taylor shift, so `O(n⁴)` integer operations. Coefficient growth of `∏(x−k)`
@@ -249,7 +249,7 @@ setup_benchmark runIsolateWellSep n => n ^ 4
     signalFloorMultiplier := 1.0
   }
 
-/- `ZPoly.isolate?` on `T_n`. The clustered roots near `±1` (gaps `~1/n²`) force
+/- `ZPoly.isolateRealRoots?` on `T_n`. The clustered roots near `±1` (gaps `~1/n²`) force
 `O(log n)` extra bisection levels versus the well-separated family, but the
 dominant asymptotic is still `O(n²)` Möbius transforms of `O(n²)` cost each,
 i.e. `O(n⁴)`; coefficient magnitude `~2^n` (`h ~ n`) is the bignum factor. -/
@@ -265,7 +265,7 @@ setup_benchmark runIsolateChebyshev n => n ^ 4
     signalFloorMultiplier := 1.0
   }
 
-/- `ZPoly.isolate?` on the Mignotte worst case. SPEC §"Complexity contract": bisection
+/- `ZPoly.isolateRealRoots?` on the Mignotte worst case. SPEC §"Complexity contract": bisection
 depth is `O(n·(h + log n))` and each node is one `O(n²)` Möbius transform. The
 Mignotte polynomial has `O(1)` real roots (the close pair), so the bisection
 tree width is `O(1)` and the node count is `O(depth) = O(n)` at fixed `a`
@@ -285,7 +285,7 @@ setup_benchmark runIsolateMignotte n => n ^ 3
     signalFloorMultiplier := 1.0
   }
 
-/- Compare leg (Descartes-first `ZPoly.isolate?`). Shared `well-separated-products`
+/- Compare leg (Descartes-first `ZPoly.isolateRealRoots?`). Shared `well-separated-products`
 domain with `runIsolateSturm`; same `O(n⁴)` textbook model as
 `runIsolateWellSep` since it is the same driver on the same inputs. -/
 -- Declared cost-model: worst-case O(n^4) integer operations, textbook Descartes bisection.
@@ -306,7 +306,7 @@ total degree `O(n²)` — and the primitive chain's coefficients grow to `O(n·h
 bits (SPEC §"Complexity contract"), so each node's bignum evaluation carries an
 extra factor of `O(n)` over the Descartes engine's bounded-coefficient Möbius
 transform: `O(n²)` nodes × `O(n²)` Horner × `O(n)` bit-growth = `O(n⁵)`. This
-super-`O(n⁴)` cost is exactly why `ZPoly.isolate?` runs Descartes first; the compare's
+super-`O(n⁴)` cost is exactly why `ZPoly.isolateRealRoots?` runs Descartes first; the compare's
 relative-timing summary makes the gap concrete. -/
 -- Declared cost-model: O(n^5) bit-operations, full-chain-per-node Sturm bisection with O(n·h) coefficient growth.
 setup_benchmark runIsolateSturm n => n ^ 5

--- a/bench/HexRoots/Bench.lean
+++ b/bench/HexRoots/Bench.lean
@@ -14,7 +14,7 @@ This module is the Phase 4 benchmark root for the certified complex-root
 isolation API. It covers the exact Gaussian-dyadic primitives (`taylor`, the
 two atom-witness checks, the speculative Newton step), the separation-precision
 helper (`mahlerPrec`), the refinement primitives (`Component.refine1`,
-`Component.certify?`), the end-to-end drivers (`isolateAll?`, `isolate`), the
+`Component.certify?`), the end-to-end drivers (`isolateAll?`, `ZPoly.isolateComplexRoots?`), the
 refined-threading operation (`DyadicRootIsolation.refineTo?`), and the
 root-identity test (`RefinedIsolation.sameRoot`). It also registers the
 dual-route atom-certificate experiment on one shared canonical input, joined
@@ -35,7 +35,7 @@ The deterministic inputs include:
   three strategies (the atoms' stored squares differ, but the integer-grid
   projection of their centres does not).
 * `separatedPoly d = ∏(2X−(2j+1))` — uniformly separated half-integer roots,
-  used by canonical fixed `isolate`/`isolateAll?`/`refine1` cases and the
+  used by canonical fixed `ZPoly.isolateComplexRoots?`/`isolateAll?`/`refine1` cases and the
   historical unregistered isolation diagnostic ladder.
 * `boundedRootPoly 128` — bounded-height with exact root `1`, used by the
   canonical witness, Newton, and pinned-NK certification cases.
@@ -75,7 +75,7 @@ canonical or parametric case):
   component; `runCertify` — one pinned-NK certification attempt on the
   bounded-root fixture. Both are fixed `O(n²)` operation shapes.
 * `runIsolateAll` — fixed `isolateAll?` at target `32` on separated degree 12.
-* `runIsolate` — fixed `isolate` to the `separationDepth` floor on separated
+* `runIsolate` — fixed `ZPoly.isolateComplexRoots?` to the `separationDepth` floor on separated
   degree 8.
 * `runRefineTo` — achieved-precision ladder, `O(t²)` in the quadratic GMP
   regime.
@@ -286,7 +286,7 @@ def refinePoly : ZPoly := DensePoly.ofCoeffs #[6, -7, 0, 1]
 refined form against itself. `none` never occurs for this squarefree fixture. -/
 def refineAtom? : Option (DyadicRootIsolation refinePoly) :=
   if h : HasOnlySimpleRoots refinePoly then
-    match isolate? refinePoly h 0 with
+    match ZPoly.isolateComplexRoots? refinePoly h 0 with
     | some atoms => atoms[0]?
     | none => none
   else none
@@ -338,24 +338,26 @@ def isolateAllChecksum (p : ZPoly) : UInt64 :=
 strategy-invariant projection; `0` for non-squarefree or degenerate inputs. -/
 def isolateDigest (strategy : AtomStrategy) (p : ZPoly) : UInt64 :=
   if h : HasOnlySimpleRoots p then
-    match isolate? p h 0 strategy with
+    match ZPoly.isolateComplexRoots? p h 0 strategy with
     | some atoms => rootsDigest atoms
     | none => 0
   else 0
 
-/-- Benchmark target: `isolate` to the `separationDepth` floor (`atom_prec = 0`). -/
+/-- Benchmark target: `ZPoly.isolateComplexRoots?` to the `separationDepth`
+floor (`atom_prec = 0`). -/
 def runIsolateParam (p : ZPoly) : UInt64 :=
   isolateDigest .nkThenPellet p
 
-/-- Compare-group target: `isolate` under the Newton-Kantorovich-only strategy. -/
+/-- Compare-group target: `ZPoly.isolateComplexRoots?` under the
+Newton-Kantorovich-only strategy. -/
 def isolateNkChecksum (p : ZPoly) : UInt64 :=
   isolateDigest .nk p
 
-/-- Compare-group target: `isolate` under the Pellet-only strategy. -/
+/-- Compare-group target: `ZPoly.isolateComplexRoots?` under the Pellet-only strategy. -/
 def isolatePelletChecksum (p : ZPoly) : UInt64 :=
   isolateDigest .pellet p
 
-/-- Compare-group target: `isolate` under the default `nkThenPellet` strategy. -/
+/-- Compare-group target: `ZPoly.isolateComplexRoots?` under the default `nkThenPellet` strategy. -/
 def isolateNkThenPelletChecksum (p : ZPoly) : UInt64 :=
   isolateDigest .nkThenPellet p
 
@@ -577,7 +579,7 @@ setup_fixed_benchmark runIsolateAll where {
   repeats := 5, maxSecondsPerCall := 90.0, expectedHash := some 0x5e4b3fd1d798497a }
 
 /-
-Cost model. `isolate` runs `isolateAll?` from the Cauchy component to
+Cost model. `ZPoly.isolateComplexRoots?` runs `isolateAll?` from the Cauchy component to
 `max atom_prec (separationDepth p)` and requires every result to be an atom.
 With `atom_prec = 0` the target is the `separationDepth` floor, which grows
 with the degree, so this is the deeper of the two whole-polynomial drivers.
@@ -629,7 +631,7 @@ The independently derived wall model is `~n⁷`; its current attempted schedule
 is recorded at each registration below. -/
 
 /-
-Cost model: one `isolate` run over `linProdPoly n`; the SPEC supplies the `n³`
+Cost model: one `ZPoly.isolateComplexRoots?` run over `linProdPoly n`; the SPEC supplies the `n³`
 driver factor. Since `log ‖p‖∞ = Θ(n·log n)`, its working length
 `B = separationDepth + n·log ‖p‖∞` is `Θ(n²·log n)`. Thus
 `O(n³·B²)` gives the `~n⁷` wall model (polylogarithms suppressed); the NK-only

--- a/conformance/HexRealRoots/Conformance.lean
+++ b/conformance/HexRealRoots/Conformance.lean
@@ -26,7 +26,7 @@ Covered operations:
 - `Hex.mobiusTransform`, `Hex.descartesVar`
 - `Hex.twoPow`, `Hex.ceilLog2Nat`, `Hex.ceilLog2Dyadic`
 - `Hex.rootBound`, `Hex.sepPrec`, `Hex.isolationDepth`
-- `Hex.ZPoly.isolateSturm?`, `Hex.ZPoly.isolateDescartes?`, `Hex.ZPoly.isolate?`
+- `Hex.ZPoly.isolateSturm?`, `Hex.ZPoly.isolateDescartes?`, `Hex.ZPoly.isolateRealRoots?`
 - `Hex.RealRootIsolation.refine1`, `Hex.RealRootIsolation.refineTo`
 - `Hex.RealRootIsolation.refined`
 - `Hex.RefinedRealIsolation.sameRoot` (and the `Overlaps` decidability instance)
@@ -39,12 +39,12 @@ Covered properties:
 - `ZPoly.sturmCount` is additive across a split point:
   `count (a, c] = count (a, b] + count (b, c]`.
 - `ZPoly.rootCount` equals the number of real roots and equals the isolation count of
-  `ZPoly.isolate?` (completeness certificate).
+  `ZPoly.isolateRealRoots?` (completeness certificate).
 - Every emitted isolation brackets a genuine sign change of `evalDyadic` (or a
   root exactly at the included upper endpoint), so a real root sits in each
   half-open interval.
 - Emitted isolations are ordered and pairwise disjoint (`upperᵢ ≤ lowerᵢ₊₁`).
-- The Sturm engine returns `some` and agrees with `ZPoly.isolate?` on the isolation
+- The Sturm engine returns `some` and agrees with `ZPoly.isolateRealRoots?` on the isolation
   *count* (the intervals themselves need not coincide, and do not for
   `x³ − x − 1`).
 - `mobiusTransform` produces the literal SPEC numerator on committed intervals,
@@ -62,8 +62,8 @@ Covered properties:
   square-free primitive inputs and strips repeated factors otherwise.
 
 Covered edge cases:
-- the zero polynomial (`ZPoly.isolate? = none`) and a nonzero constant
-  (`ZPoly.isolate?` is `some` with an empty isolation array).
+- the zero polynomial (`ZPoly.isolateRealRoots? = none`) and a nonzero constant
+  (`ZPoly.isolateRealRoots?` is `some` with an empty isolation array).
 - a linear polynomial whose single root is captured by the whole initial
   interval without any bisection.
 - a dyadic root that a bisection midpoint hits exactly (`2x² − 5x + 2`, and the
@@ -189,7 +189,7 @@ private def refinedSubinterval {p : ZPoly} (i : RealRootIsolation p) : Option Bo
 
 /-! # Whole-run isolation, per fixture.
 
-For each fixture: the exact interval endpoints of `ZPoly.isolate?` (a human-readable
+For each fixture: the exact interval endpoints of `ZPoly.isolateRealRoots?` (a human-readable
 regression pin, cross-checked against `python-flint` in the oracle PR); the
 independent teeth that make the pin more than a determinism check — the emitted
 count equals the mathematically known real-root count `ZPoly.rootCount`, every
@@ -203,16 +203,17 @@ re-testing it here is noise. The zero / non-square-free `ZPoly.isolateDescartes?
 none` rejections below stay: they test the engine's input-contract
 classification, not the termination theorem. -/
 
-/-- Assert the shared per-fixture invariants, given the expected `ZPoly.isolate?`
+/-- Assert the shared per-fixture invariants, given the expected `ZPoly.isolateRealRoots?`
 endpoints and the known real-root count `n`. Bundled so each fixture is one
 `#guard` block with no copy-pasted body. -/
 private def isolatesAs (p : ZPoly) (expected : Array (Dyadic × Dyadic)) (n : Nat) : Bool :=
-  -- `ZPoly.isolate?` yields the committed endpoints (oracle-verified in the oracle PR).
-  (endpoints (ZPoly.isolate? p) == some expected) &&
+  -- `ZPoly.isolateRealRoots?` yields the committed endpoints (oracle-verified in the oracle PR).
+  (endpoints (ZPoly.isolateRealRoots? p) == some expected) &&
   -- Completeness: one isolation per real root, matching the independent count.
-  (isoCount (ZPoly.isolate? p) == some n) && (ZPoly.rootCount p == n) &&
+  (isoCount (ZPoly.isolateRealRoots? p) == some n) && (ZPoly.rootCount p == n) &&
   -- Each interval brackets a real root; the whole run is ordered and disjoint.
-  allBracket (ZPoly.isolate? p) && ((endpoints (ZPoly.isolate? p)).elim false sortedDisjoint) &&
+  allBracket (ZPoly.isolateRealRoots? p) &&
+    ((endpoints (ZPoly.isolateRealRoots? p)).elim false sortedDisjoint) &&
   -- Sturm engine: returns `some` and agrees on the isolation count.
   (ZPoly.isolateSturm? p).isSome && (isoCount (ZPoly.isolateSturm? p) == some n)
 
@@ -233,16 +234,16 @@ private def isolatesAs (p : ZPoly) (expected : Array (Dyadic × Dyadic)) (n : Na
 
 -- The Sturm engine's intervals need NOT coincide with the driver's: for
 -- `x³ − x − 1` the Sturm search emits the whole initial interval `(−4, 4]` (the
--- count is already `1`, so it never bisects) while `ZPoly.isolate?` (Descartes-first)
+-- count is already `1`, so it never bisects) while `ZPoly.isolateRealRoots?` (Descartes-first)
 -- narrows to `(0, 4]`. Only the count is invariant across engines.
 #guard endpoints (ZPoly.isolateSturm? cubicSingle) = some #[(di (-4), di 4)]
-#guard endpoints (ZPoly.isolate? cubicSingle) = some #[(di 0, di 4)]
+#guard endpoints (ZPoly.isolateRealRoots? cubicSingle) = some #[(di 0, di 4)]
 
 /-! # Edge cases: zero, constant, non-square-free. -/
 
 -- The zero polynomial is rejected by every engine (input-contract classification,
 -- independent of the termination theorem).
-#guard ZPoly.isolate? zeroPoly = none
+#guard ZPoly.isolateRealRoots? zeroPoly = none
 #guard ZPoly.isolateSturm? zeroPoly = none
 #guard ZPoly.isolateDescartes? zeroPoly = none
 
@@ -253,7 +254,7 @@ private def isolatesAs (p : ZPoly) (expected : Array (Dyadic × Dyadic)) (n : Na
 -- Non-square-free rejection: both engines and the driver decline (input-contract
 -- classification), and the square-free core (`x² − 1`, from `(x − 1)²(x + 1)`)
 -- isolates its two roots through the full bundle.
-#guard ZPoly.isolate? nonSquareFree = none
+#guard ZPoly.isolateRealRoots? nonSquareFree = none
 #guard ZPoly.isolateSturm? nonSquareFree = none
 #guard ZPoly.isolateDescartes? nonSquareFree = none
 #guard (ZPoly.squareFreeCore nonSquareFree).toArray = #[(-1 : Int), 0, 1]

--- a/conformance/HexRealRoots/EmitFixtures.lean
+++ b/conformance/HexRealRoots/EmitFixtures.lean
@@ -22,18 +22,18 @@ Operations covered:
 
 * `root_count`   — `Hex.ZPoly.rootCount p`, the total number of real roots,
   value an `Int`.
-* `isolations`   — the isolating intervals from `Hex.ZPoly.isolate? p`,
+* `isolations`   — the isolating intervals from `Hex.ZPoly.isolateRealRoots? p`,
   value a matrix of rows `[lo_num, lo_exp, hi_num, hi_exp]`.  Each
   dyadic endpoint is encoded as `[num, exp]` with value `num · 2^(−exp)`
   (`Dyadic.zero` as `[0, 0]`, `Dyadic.ofOdd n k _` as `[n, k]`).
 * `isolate_none` — value `true` for the rejection cases (the zero
   polynomial and non-square-free inputs), where the driver declines.
 
-Records are emitted from the single top-level driver `Hex.ZPoly.isolate? p`.
+Records are emitted from the single top-level driver `Hex.ZPoly.isolateRealRoots? p`.
 The Descartes/Sturm cross-engine agreement check this driver once
 carried (the executable stand-in for the termination theorem) is
 retired now that `HexRealRootsMathlib.isolateDescartes?_isSome` is
-proven; `ZPoly.isolate?` is Descartes-first, so on a square-free input its
+proven; `ZPoly.isolateRealRoots?` is Descartes-first, so on a square-free input its
 output is exactly the Descartes engine's, and the emitted stream is
 unchanged.
 
@@ -68,27 +68,29 @@ private def isoRows {p : ZPoly} (res : RealRootIsolations p) : List (List Int) :
   res.isolations.toList.map fun iso =>
     dyadicPair iso.interval.lower ++ dyadicPair iso.interval.upper
 
-/-- Emit one case from the top-level driver `ZPoly.isolate? p`.  When
-`squarefree`, `ZPoly.isolate?` must return `some` (guaranteed by
-`isolate?_isSome`); the run is emitted from its output.  Otherwise it
+/-- Emit one case from the top-level driver `ZPoly.isolateRealRoots? p`.  When
+`squarefree`, `ZPoly.isolateRealRoots?` must return `some` (guaranteed by
+`isolateRealRoots?_isSome`); the run is emitted from its output.  Otherwise it
 must return `none` and the case is a rejection.  Any deviation `throw`s,
 exiting non-zero. -/
 private def emitCase (id : String) (coeffs : List Int) (squarefree : Bool) : IO Unit := do
   emitPolyFixture lib id coeffs
   let p : ZPoly := DensePoly.ofCoeffs coeffs.toArray
   if squarefree then
-    match ZPoly.isolate? p with
+    match ZPoly.isolateRealRoots? p with
     | some r =>
       emitResult lib id "root_count" (toString (ZPoly.rootCount p))
       emitResult lib id "isolations" (intMatrixValue (isoRows r))
     | none =>
-      throw <| IO.userError s!"{lib}/{id}: ZPoly.isolate? fell back to none on a square-free input"
+      throw <| IO.userError
+        s!"{lib}/{id}: ZPoly.isolateRealRoots? fell back to none on a square-free input"
   else
-    match ZPoly.isolate? p with
+    match ZPoly.isolateRealRoots? p with
     | none =>
       emitResult lib id "isolate_none" "true"
     | some _ =>
-      throw <| IO.userError s!"{lib}/{id}: expected ZPoly.isolate? to reject a non-square-free input"
+      throw <| IO.userError
+        s!"{lib}/{id}: expected ZPoly.isolateRealRoots? to reject a non-square-free input"
 
 /-! # SPEC core fixtures. -/
 

--- a/conformance/HexRoots/Conformance.lean
+++ b/conformance/HexRoots/Conformance.lean
@@ -21,7 +21,7 @@ Disc containment and geometry are checked in exact `Rat` arithmetic via
 `Dyadic.toRat` of the stored centres and radii.
 
 Covered operations:
-- `isolate` — all-atoms driver for squarefree inputs.
+- `ZPoly.isolateComplexRoots?` — all-atoms driver for squarefree inputs.
 - `isolateAll?` — worklist driver returning atoms and clusters.
 - `isolateOne?` — local single-atom certification from a selected square.
 - `DyadicRootIsolation.refineTo?` — precision refinement of one atom.
@@ -61,15 +61,15 @@ Covered properties:
 - `mahlerPrec` and `cauchyExp` equal their closed forms.
 
 Covered edge cases:
-- the zero polynomial (`isolate` returns `none`);
-- a nonzero constant (`isolate` returns `some #[]`);
+- the zero polynomial (`ZPoly.isolateComplexRoots?` returns `none`);
+- a nonzero constant (`ZPoly.isolateComplexRoots?` returns `some #[]`);
 - the linear polynomial `x` (one atom at the origin);
 - the non-squarefree `(x²+1)(x−5)²` (a `k = 2` cluster survives);
 - components far from every root (`refine1` empties them, `certify?` returns
   `none`, `rootFree` is `true`).
 
 The degree-10 Chebyshev fixture `T₁₀` is exercised only on its cheap
-operations because full `isolate` runs far past this module's
+operations because full `ZPoly.isolateComplexRoots?` runs far past this module's
 elaboration-time budget. The small Mignotte polynomial
 `x⁵ − (100x − 1)²` now pins full five-root isolation under every strategy.
 -/
@@ -181,13 +181,13 @@ private def matchAcross {p : ZPoly} (a b : Array (DyadicRootIsolation p)) : Bool
 instance (an `if h : …`), not by kernel `decide`: the instance routes through a
 rational-gcd computation whose well-founded recursion the kernel cannot unfold. -/
 
-/-- `isolate` under a chosen strategy, obtaining the squarefreeness hypothesis
+/-- `ZPoly.isolateComplexRoots?` under a chosen strategy, obtaining the squarefreeness hypothesis
     from the runtime decision procedure. -/
 private def isoAtoms (p : ZPoly) (prec : Int) (strat : AtomStrategy) :
     Option (Array (DyadicRootIsolation p)) :=
-  if h : HasOnlySimpleRoots p then isolate? p h prec strat else none
+  if h : HasOnlySimpleRoots p then ZPoly.isolateComplexRoots? p h prec strat else none
 
-/-! # `isolate?`: atom count, root coverage, geometry, strategy agreement.
+/-! # `ZPoly.isolateComplexRoots?`: atom count, root coverage, geometry, strategy agreement.
 
 Each squarefree fixture is isolated under all three strategies once; the single
 check per fixture asserts the atom count (its degree), the cross-strategy
@@ -242,14 +242,15 @@ under `nkThenPellet` alone for the same budget reason. -/
     | some ax => ax.size == 6 && ax.all fun i => onUnitCircle i.square
     | none => false)
 
-/-! # `isolate?`: degenerate inputs.
+/-! # `ZPoly.isolateComplexRoots?`: degenerate inputs.
 
 `HasOnlySimpleRoots 0` holds (the gcd of `0` and its derivative is `0`, whose
-stored size is `0 ≤ 1`), so the zero polynomial reaches `isolate`, which pins it
+stored size is `0 ≤ 1`), so the zero polynomial reaches `ZPoly.isolateComplexRoots?`, which pins it
 to `none`; a nonzero constant yields `some #[]`; the linear `x` yields a single
 atom whose disc covers the origin. -/
 
-#guard (if h : HasOnlySimpleRoots (0 : ZPoly) then (isolate? (0 : ZPoly) h 8).isSome else true) == false
+#guard (if h : HasOnlySimpleRoots (0 : ZPoly) then
+    (ZPoly.isolateComplexRoots? (0 : ZPoly) h 8).isSome else true) == false
 #guard (isoAtoms constant 8 .nkThenPellet).map (·.size) == some 0
 #guard
   (match isoAtoms linear 8 .nkThenPellet with
@@ -311,7 +312,7 @@ squarefree fixtures return all atoms. -/
 /-! # `refineTo?` and `sameRoot`.
 
 A coarse atom is built by hand at an exact integer root of `rat1` (its centre is
-the root, so both witnesses certify) — `isolate` itself always overshoots to a
+the root, so both witnesses certify) — `ZPoly.isolateComplexRoots?` itself always overshoots to a
 much finer precision via speculative Newton, so a hand-built coarse atom is the
 only way to exercise the refinement path. Its `atomWitness` is discharged by
 kernel `decide` (degree 3), and the `RefinedIsolation` precision side-condition
@@ -515,7 +516,7 @@ non-squarefree input certifies as a `k = 2` cluster. -/
 
 The runtime squarefreeness decision confirms `mignotte` has only simple
 roots, and its coefficient array is re-derived by `taylor` at `0` above.
-`isolate` must find all five roots: the close real pair straddling `1/100`
+`ZPoly.isolateComplexRoots?` must find all five roots: the close real pair straddling `1/100`
 (separation about `2^{−16.4}`), the real root near `21.5377`, and the
 complex pair near `−10.78 ± 18.66i`. It checks that worklist re-entry retains
 only squares covering the certified disc and that all three large-magnitude
@@ -524,7 +525,7 @@ roots are preserved under every atom strategy. -/
 #guard (if HasOnlySimpleRoots mignotte then true else false)
 
 #guard (if h : HasOnlySimpleRoots mignotte then
-    match isolate? mignotte h 8 with
+    match ZPoly.isolateComplexRoots? mignotte h 8 with
     | some ax =>
         ax.size == 5 &&
           -- the close pair: exactly two atom centres within 10⁻³ of 1/100
@@ -539,7 +540,8 @@ roots are preserved under every atom strategy. -/
   else false)
 
 #guard (if h : HasOnlySimpleRoots mignotte then
-    match isolate? mignotte h 8 .nk, isolate? mignotte h 8 .pellet with
+    match ZPoly.isolateComplexRoots? mignotte h 8 .nk,
+        ZPoly.isolateComplexRoots? mignotte h 8 .pellet with
     | some a, some b => a.size == 5 && b.size == 5
     | _, _ => false
   else false)

--- a/conformance/HexRoots/EmitFixtures.lean
+++ b/conformance/HexRoots/EmitFixtures.lean
@@ -18,8 +18,8 @@ python-flint's `fmpz_poly.complex_roots()` (certified Arb balls with
 multiplicities) and cross-checks that the Lean certification discs
 cover the flint roots with matching multiplicities.
 
-The driver uses `isolateAll?` at target `32` rather than `isolate`: the oracle
-needs root *locations*, not the separation precision `isolate` forces.
+The driver uses `isolateAll?` at target `32` rather than `ZPoly.isolateComplexRoots?`: the oracle
+needs root *locations*, not the separation precision `ZPoly.isolateComplexRoots?` forces.
 
 **Fixture set.** The CI tier contains 50 degree-20 dense
 polynomials from the seed-`0xC0FFEE` LCG, plus the small curated rational and

--- a/examples/HexRootsDemo.lean
+++ b/examples/HexRootsDemo.lean
@@ -62,7 +62,7 @@ def showAtoms {q : ZPoly}
 def main : IO Unit := do
   IO.println "Certified isolation for p(x) = x^3 - x - 1"
   if h : HasOnlySimpleRoots p then
-    match isolate? p h 32 .nk with
+    match ZPoly.isolateComplexRoots? p h 32 .nk with
     | none =>
         IO.eprintln "isolation unexpectedly exhausted its certified fuel"
     | some atoms =>

--- a/reports/hex-number-field-performance.md
+++ b/reports/hex-number-field-performance.md
@@ -73,7 +73,7 @@ from `CIsolate` in its bounded-precision front end with exact-dyadic fallback,
 speculative Newton acceptance, dual certificate routes, and conservative
 global completeness depth. No proof transfers BSSY's amortised complexity
 analysis across those changes. Profiling does show that this unmatched phase
-dominates: `isolate` accounts for 91.87% of the profiled algebraic-roots
+dominates: `ZPoly.isolateComplexRoots?` accounts for 91.87% of the profiled algebraic-roots
 process, 92% of the lazy-addition process, and 85.01% of the repaired
 fixed-field-roots process; the latter spends 92.94% of the profiled process in
 the enclosing `componentRoots?` phase.
@@ -99,7 +99,7 @@ The per-library SPEC retains the HexRoots isolation ceiling as its worst-case
 contract; changing the benchmark mode does not weaken that contract.
 
 The compiled `isolation-stats` command reproduces the input characterisation.
-`isolation target` is the exact `separationDepth` passed to `isolate`, not the
+`isolation target` is the exact `separationDepth` passed to `ZPoly.isolateComplexRoots?`, not the
 adaptive working precision eventually reached by the isolator:
 
 | family | fixture parameter | degree after `squareFreeCore` | `coeffAbsMax` | `ceilLog2 coeffAbsMax` | isolation target |
@@ -1244,14 +1244,14 @@ fail mode 1 and reopen the finding. The raw local profile is
 | share | function |
 |---:|---|
 | 92.11% | `Hex.AlgebraicRoot.ofEliminant?` |
-| 92.11% | `Hex.isolate?` / `isolateLoop` |
+| 92.11% | `Hex.ZPoly.isolateComplexRoots?` / `isolateLoop` |
 | 86.32% | `Hex.Component.refineAll` / `IsolationLoop.next` |
 | 84.83% | `Hex.taylor` |
 
 The former parametric `runLazyAddLadder` derivation correctly identified
 isolation at separation depth as dominant, although its scaling model was not
 supported. Eliminant construction is the 5.754 us `runAddEliminant` fixed case
-against a 46 s call, and 92% of the call is inside `isolate`. The replacement
+against a 46 s call, and 92% of the call is inside `ZPoly.isolateComplexRoots?`. The replacement
 fixed registration keeps this phase covered without making an asymptotic claim.
 
 ### `exactification-selection` — certification, not factorization evidence
@@ -1260,7 +1260,7 @@ fixed registration keeps this phase covered without making an asymptotic claim.
 |---:|---|
 | 95.63% | `Hex.AlgebraicRoot.exact?` |
 | 95.58% | `Hex.AlgebraicRoot.exactFactor?` |
-| 95.28% | `Hex.isolate?` / `isolateLoop` |
+| 95.28% | `Hex.ZPoly.isolateComplexRoots?` / `isolateLoop` |
 | 47.39% | `Hex.AlgebraicNumber.canonicalRep?` / `ofNormalized?` |
 
 The former `runExactLadder` declared the classical BHKS factorization bound
@@ -1277,7 +1277,7 @@ the declared envelope over-predicts by `n^4.14`. This family is now the fixed
 | share | function |
 |---:|---|
 | 83.01% | `Hex.AlgebraicRoot.exactFactor?` |
-| 77.19% | `Hex.isolate?` / `isolateLoop` |
+| 77.19% | `Hex.ZPoly.isolateComplexRoots?` / `isolateLoop` |
 | 38.53% | `Hex.AlgebraicNumber.canonicalRep?` |
 | **18.04%** | `Hex.ZPoly.factorize` |
 
@@ -1292,7 +1292,7 @@ BHKS factorization bound cannot support mode 2 for this end-to-end family.
 | share | `runExactFactorLadder` | `runCanonicalRepLadder` |
 |---:|---:|---:|
 | registered operation | 95.77% | 96.27% |
-| `Hex.isolate?` / `isolateLoop` | 95.46% | 96.27% |
+| `Hex.ZPoly.isolateComplexRoots?` / `isolateLoop` | 95.46% | 96.27% |
 | `Hex.Component.refineAll` | 87.10% | 87.88% |
 | `Hex.exactRootFree` | 84.34% | 85.20% |
 | `Hex.taylor` | 77.35% | 78.18% |
@@ -1339,7 +1339,7 @@ this ladder's slower-than-declared verdict.
 
 | share | function |
 |---:|---|
-| 91.87% | `Hex.isolate?` / `isolateLoop` |
+| 91.87% | `Hex.ZPoly.isolateComplexRoots?` / `isolateLoop` |
 | 91.45% | `Hex.QAdjoin.roots?` |
 | 91.45% | `Hex.QAdjoin.Roots.componentRoots?` |
 | 82.90% | `Hex.taylor` |
@@ -1362,7 +1362,7 @@ resultants even though neither entered the dominant inclusive ranking.
 |---:|---|
 | 92.96% | `Hex.QAdjoin.roots?` |
 | 92.94% | `Hex.QAdjoin.Roots.componentRoots?` |
-| 85.01% | `Hex.isolate?` / `isolateLoop` |
+| 85.01% | `Hex.ZPoly.isolateComplexRoots?` / `isolateLoop` |
 | 78.37% | `Hex.taylor` |
 | 7.52% | `Hex.retainZero?` |
 | 7.43% | `Hex.QAdjoin.Roots.evalBall?` |

--- a/reports/hex-number-field-tower-performance.md
+++ b/reports/hex-number-field-tower-performance.md
@@ -816,7 +816,7 @@ these whole-capture shares is promoted to an exact within-target percentage.
 95.71% of the raw capture is inside `Hex.NumberTower.adjoin?`. The dominant
 phase is candidate-factor disambiguation under the fixed embedding:
 `RawEvaluation.vanishesAt?` 95.46% → `Hex.AlgebraicRoot.ofEliminant?`
-94.92% → the upstream isolation kernel `Hex.isolate?`/`isolateLoop` 95.15%,
+94.92% → the upstream isolation kernel `Hex.ZPoly.isolateComplexRoots?`/`isolateLoop` 95.15%,
 with `Hex.taylor` 69.37% and dyadic Gauss arithmetic (`GaussDyadic.mul`
 46.63%) as the leaf work; `Internal.extend?` (level validation) is 31.88%
 and factor selection `selectFactor?` 63.62%. The factorization step itself
@@ -824,7 +824,7 @@ is not visible at this input because the quartic factors immediately; the
 cost is the SPEC's embedding invariant being enforced (`adjoin?` "selects
 the unique irreducible factor that vanishes at the requested AlgebraicRoot
 under the current embedding"). The isolation kernel that dominates is the
-same `Hex.isolate?` measured by HexNumberField's and HexRoots' registered
+same `Hex.ZPoly.isolateComplexRoots?` measured by HexNumberField's and HexRoots' registered
 isolation ladders; its asymptotic evidence lives in those upstream reports,
 and the tower-level boundary is measured end to end by the registered
 `runAdjoin`/`runAdjoinIdentity` cases.
@@ -833,14 +833,14 @@ and the tower-level boundary is measured end to end by the registered
 
 `runSplit`: 99.90% inside `Hex.NumberTower.splitAux`; root retention and
 adjoining dominate through the same disambiguation path
-(`RawEvaluation.vanishesAt?` 66.97%, `Hex.isolate?` 64.55%), with the
+(`RawEvaluation.vanishesAt?` 66.97%, `Hex.ZPoly.isolateComplexRoots?` 64.55%), with the
 remainder in the tower factorization it repeats after each extension.
 `runFlatten`: 97.93% inside the target, 97.36% in
 `Hex.NumberTower.flatten?`, dominated by the primitive-element candidate
 search `Flatten.searchRecoveredAux` 90.20% whose cost is
 `Flatten.candidateAt?` → `Hex.AlgebraicPoly.Common.shift?` 83.22% (the
 integer eliminant of `θ + cα`) and the canonical exactification
-`Hex.AlgebraicRoot.exact?` 61.83%, both running the upstream `Hex.isolate?`
+`Hex.AlgebraicRoot.exact?` 61.83%, both running the upstream `Hex.ZPoly.isolateComplexRoots?`
 kernel (94.99%). The flattening components the search feeds are the
 registered `runBasisImages`, `runCertifies`, `runCoordinateMaps`,
 `runRecoverPair`, and `runRecoverSearch` cases; the eliminant/exactification

--- a/reports/hex-real-roots-performance.md
+++ b/reports/hex-real-roots-performance.md
@@ -17,7 +17,7 @@ sites in `bench/HexRealRoots/Bench.lean`:
 - `Hex.RealRootsBench.runSepPrec`: `n`
 - `Hex.RealRootsBench.runRefineTo`: `n`
 
-The `ZPoly.isolate?` surface is exercised on three structurally different input
+The `ZPoly.isolateRealRoots?` surface is exercised on three structurally different input
 families, never a single happy-path shape:
 `well-separated-products` (∏(x−k)), `chebyshev-clustered` (integer `T_n`), and
 `mignotte-worst-case` (`xⁿ−(a·x−1)²`, `a = 1000`). The Sturm-chain,
@@ -97,13 +97,13 @@ lake exe hexrealroots_bench compare \
 
 reports `agreement: all functions agree on common params` over the shared
 `well-separated-products` domain (`4, 8, 12, 16, 20`): the Descartes-first
-`ZPoly.isolate?` and the certified `ZPoly.isolateSturm?` engines produce identical
+`ZPoly.isolateRealRoots?` and the certified `ZPoly.isolateSturm?` engines produce identical
 isolation-endpoint hashes (both `0x88e69732f982a9a0` at `n = 20`), the
 cross-implementation conformance check the compare group is for. The
 relative-timing summary quantifies the engine gap the declared models predict:
-`ZPoly.isolate?` (Descartes-first) is `O(n⁴)` while the Sturm-only engine is `O(n⁵)`
+`ZPoly.isolateRealRoots?` (Descartes-first) is `O(n⁴)` while the Sturm-only engine is `O(n⁵)`
 (full Sturm-chain evaluation per node with `O(n·h)` coefficient growth), which
-is why `ZPoly.isolate?` runs Descartes first.
+is why `ZPoly.isolateRealRoots?` runs Descartes first.
 
 ### SPEC time budgets
 
@@ -170,7 +170,7 @@ are developer-local under `/tmp` and are not committed.
 `lean_dec_ref`), Hex/Lean own code 9.9% (`Array.ofFn`, the Möbius
 `compose`/`mul` folds). The huge `∏(x−k)` coefficients (`~n!`, `O(n log n)`
 bits) make GMP arithmetic and its allocation traffic dominate; the inclusive
-cost flows through `ZPoly.isolate?` → `ZPoly.isolateDescartes?` → `mobiusTransform`, both
+cost flows through `ZPoly.isolateRealRoots?` → `ZPoly.isolateDescartes?` → `mobiusTransform`, both
 of which carry their own registrations.
 
 ### `chebyshev-clustered`
@@ -188,7 +188,7 @@ the deeper bisection the clustering forces.
 allocation 40.2%, GMP 32.5% (`realloc`/`__gmp_default_reallocate`-heavy), Lean
 runtime 13.2%, own code 11.1%. The large `a = 1000` coefficients and the
 close-pair bisection depth make reallocation of growing GMP limbs the dominant
-leaf cost; inclusive cost is the registered `ZPoly.isolate?` path.
+leaf cost; inclusive cost is the registered `ZPoly.isolateRealRoots?` path.
 
 ### `dense-primitive`
 
@@ -202,7 +202,7 @@ pseudo-division with `O(n·h)`-bit operands — and the inclusive cost is the
 registered `runSturmChain` (`ZPoly.sturmChain`) target itself.
 
 No unregistered dominant inclusive helper appears in any of the four profiles:
-every dominant path terminates in a registered bench target (`ZPoly.isolate?`,
+every dominant path terminates in a registered bench target (`ZPoly.isolateRealRoots?`,
 `mobiusTransform`, or `sturmChain`), so the Attribution rule is satisfied and
 no new target is required.
 

--- a/reports/hex-roots-performance.md
+++ b/reports/hex-roots-performance.md
@@ -614,7 +614,7 @@ bottleneck, inclusively terminating in registered `refineTo?`. Artefact:
 developer-local `/tmp/hexroots-9794-refineto.perf`.
 
 **Attribution rule.** Every dominant inclusive path terminates in a registered
-bench target (`isolateAll?`/`isolate`, `taylor`, `witnessCheck`/
+bench target (`isolateAll?`/`ZPoly.isolateComplexRoots?`, `taylor`, `witnessCheck`/
 `nkWitnessCheck`, `newtonSquare`, `refine1`/`certify`, `refineTo?`), so no
 unregistered helper dominates and no new target is required. (Lean's
 closure-call unwinding fragments some inclusive attribution into an unresolved


### PR DESCRIPTION
This PR renames the two root isolators to say which roots they find. `Hex.ZPoly.isolate?` becomes `Hex.ZPoly.isolateRealRoots?` and `Hex.isolate?` becomes `Hex.ZPoly.isolateComplexRoots?`, with the complex one moving into `Hex.ZPoly` beside its sibling so dot notation works on both. Before this the two differed only by a namespace qualifier while doing quite different things over different fields, which is easy to misread at a call site.

The total wrapper follows as `HexRootsMathlib.isolateComplexRoots` with its characterisation family `isolateComplexRoots_{eq,count,roots,prec,disjoint}`, and the lemmas about the executable form become `isolateComplexRoots?_*`. On the real side only `isolate?_isSome` needed the matching `isolateRealRoots?_isSome`.

`isolateSturm?`, `isolateDescartes?`, `isolateAll?`, `isolateOne?` and the `isolate_nk_*` family keep their names. The engine names already say which roots they find, and the rest are lower-level drivers, so renaming them would have doubled the diff for no clarity gain.

One name to be careful with in review: `isolate_roots` belongs to the `HexRealRootsMathlib` elaborator *and* was the name of a total-wrapper lemma. Only the lemma is renamed; the elaborator, its syntax and its error strings are untouched.

`lake build` over all 53 bench executables, `HexConformance`, `HexReleaseTests` and `HexManual` (11586 jobs) is green, as are `check_dag.py`, `check_phase4.py`, `check_phase7.py`, `check_released_manifest.py`, `check_manual_split.py`, `check_trust_surface.py` and `check_factor_sweep_freshness.py`.

🤖 Prepared with Claude Code