### PR TITLE
doc(number-field-tower): refresh the factoring figures after the speed-ups

### DIFF
--- a/HexManual/Chapters/HexNumberFieldTower.lean
+++ b/HexManual/Chapters/HexNumberFieldTower.lean
@@ -226,7 +226,7 @@ on fixed inputs rather than as asymptotics.
   * 7.9 ms
 * * `factor?`
   * `X²⁴ − X − 1` over `ℚ(√2)`
-  * 250 ms
+  * 34 ms
 * * `split?`
   * `(X² − 2)(X² − 3)` over `ℚ`
   * 68 ms
@@ -242,9 +242,10 @@ Per-call medians on chungus2 from the exports recorded in
 `reports/hex-number-field-tower-performance.md` in the `hex-dev` repository;
 regenerate with `.lake/build/bin/hexnumberfieldtower_bench run
 Hex.NumberTowerBench.<target>`. Factoring over a number field is far slower
-than PARI's `nffactor` on the same inputs (fifty to three hundred times on
-the Selmer family `Xⁿ − X − 1` over `ℚ(√2)`); the report records the
-comparison and its provenance.
+than PARI's `nffactor` on the same inputs (thirty to a hundred and twenty
+times on the Selmer family `Xⁿ − X − 1` over `ℚ(√2)`, at `n = 2` and
+`n = 12` respectively); the report records the comparison and its
+provenance.
 
 # The Mathlib correspondence
 %%%


### PR DESCRIPTION
This PR brings the `HexNumberFieldTower` chapter's performance section into line with the measurements recorded by #10085. The degree-24 Selmer factorization row goes from 250 ms to 34 ms, and the sentence comparing the library to PARI goes from "fifty to three hundred times" to "thirty to a hundred and twenty times", naming the rungs those endpoints come from.

Both numbers are read off the integrated-executable section of `reports/hex-number-field-tower-performance.md`: the paired median for degree-24 factoring is 33.540–33.691 ms, and the fresh comparator table gives raw PARI/Hex ratios of 0.03028 at `n = 2` and 0.00848 at `n = 12`.

The other six rows in the table are left alone. Several of them run through the same Trager path and have very likely improved as well, but the registered canonical export still carries the pre-improvement medians for them, so refreshing those figures needs a re-run of that export rather than a guess.

🤖 Prepared with Claude Code