### PR TITLE
fix(mv-gcd): bind squarefree casts to coefficient ring

### DIFF
--- a/HexMvGcd/README.md
+++ b/HexMvGcd/README.md
@@ -43,6 +43,8 @@ def y : P := X 1
 - Deterministic PRS fallback plus heuristic and Brown modular producers.
 - Named-variable content through `contentIn` and `primPartIn`.
 - Square-free decomposition, radical, and square-freeness tests.
+  Differentiation uses the coefficient ring's natural-number cast;
+  decomposition and radical require characteristic zero for that ring.
 
 # Verification
 

--- a/HexMvGcd/SPEC/hex-mv-gcd.md
+++ b/HexMvGcd/SPEC/hex-mv-gcd.md
@@ -1237,9 +1237,11 @@ deliberately so. -/
 def Squarefree (p : MvPoly n R cmp) : Prop :=
   p ≠ 0 ∧ ∀ d, d * d ∣ p → IsConst d
 
+attribute [local instance] Lean.Grind.Semiring.natCast
+
 /-- Mathlib-free characteristic zero: every positive natural remains
-nonzero after casting to `R`. -/
-class NatNoZero (R : Type u) [Zero R] [NatCast R] : Prop where
+nonzero under the coefficient ring's own cast. -/
+class NatNoZero (R : Type u) [Lean.Grind.CommRing R] : Prop where
   natCast_ne_zero : ∀ m : Nat, 0 < m → (m : R) ≠ 0
 
 /-- The fraction field used to interpret the relative squarefree predicate
@@ -1327,7 +1329,17 @@ theorem radical_zero [NatNoZero R] : radical (0 : MvPoly n R cmp) = 0
 ```
 
 `NatNoZero R` asserts `(m : R) ≠ 0` for `0 < m`, which is characteristic
-zero stated Mathlib-free, with instances for `Int` and `Rat`.
+zero stated Mathlib-free, with instances for `Int` and `Rat`. The cast in
+this assertion is `Lean.Grind.Semiring.natCast` from the same
+`Lean.Grind.CommRing R` used for coefficient arithmetic. `derivatives`,
+`yunLoop`, `sqfStep`, `sqfOps`, `isSquarefree`, `radical`, `sqfDecomp`, and
+their correctness theorems take no independent `[NatCast R]` argument.
+Every differentiation in this pipeline uses that ring cast, including the
+recursive content and Yun steps. A local cast supplied by a caller cannot
+change the decision or multiplicities, or certify characteristic zero for
+a positive-characteristic ring. The general `MvPoly.derivative` retains
+its explicit cast argument; these ring-based consumers fix it internally.
+
 `PerfectFrac R` asserts that the fraction field of `R` is perfect, which
 holds in characteristic zero and for finite fields, and fails for
 `F_p(t)`.

--- a/HexMvGcd/SPEC/hex-mv-gcd.md
+++ b/HexMvGcd/SPEC/hex-mv-gcd.md
@@ -1334,6 +1334,10 @@ this assertion is `Lean.Grind.Semiring.natCast` from the same
 `Lean.Grind.CommRing R` used for coefficient arithmetic. `derivatives`,
 `yunLoop`, `sqfStep`, `sqfOps`, `isSquarefree`, `radical`, `sqfDecomp`, and
 their correctness theorems take no independent `[NatCast R]` argument.
+The public decomposition helpers `yunLoop`, `sqfStep`, and `sqfOps` also
+require `[NatNoZero R]`; calling them directly does not bypass the
+characteristic-zero requirement of `sqfDecomp`. The arity-zero helper
+`sqfBase` only extracts a scalar and works in any coefficient characteristic.
 Every differentiation in this pipeline uses that ring cast, including the
 recursive content and Yun steps. A local cast supplied by a caller cannot
 change the decision or multiplicities, or certify characteristic zero for

--- a/HexMvGcd/Squarefree.lean
+++ b/HexMvGcd/Squarefree.lean
@@ -282,7 +282,7 @@ private theorem sorted_merge_fold (entries acc : List (SqfFactor n R cmp))
 /-- One decreasing Yun layer in the selected main variable.  The fuel is the
 total degree of the primitive input plus one; in characteristic zero every
 nonterminal layer removes at least one degree from `b`. -/
-def yunLoop [IsMonomialOrder cmp] (i : Fin n) (fuel k : Nat)
+def yunLoop [NatNoZero R] [IsMonomialOrder cmp] (i : Fin n) (fuel k : Nat)
     (b d : MvPoly n R cmp) (acc : List (SqfFactor n R cmp)) :
     List (SqfFactor n R cmp) :=
   match fuel with
@@ -298,7 +298,7 @@ def yunLoop [IsMonomialOrder cmp] (i : Fin n) (fuel k : Nat)
         yunLoop i fuel (k + 1) nextB nextD acc
 
 omit [LawfulGcdOps R] [LawfulBezoutOps R] in
-private theorem positive_yunLoop [IsMonomialOrder cmp]
+private theorem positive_yunLoop [NatNoZero R] [IsMonomialOrder cmp]
     (i : Fin n) (fuel k : Nat) (b d : MvPoly n R cmp)
     (acc : List (SqfFactor n R cmp)) (hk : 0 < k)
     (hacc : PositiveMultiplicities acc) :
@@ -324,7 +324,7 @@ private def ReverseSortedMultiplicities
   factors.Pairwise fun left right => right.multiplicity < left.multiplicity
 
 omit [LawfulGcdOps R] [LawfulBezoutOps R] in
-private theorem sorted_yunLoop [IsMonomialOrder cmp]
+private theorem sorted_yunLoop [NatNoZero R] [IsMonomialOrder cmp]
     (i : Fin n) (fuel k : Nat) (b d : MvPoly n R cmp)
     (acc : List (SqfFactor n R cmp))
     (hbelow : MultiplicitiesBelow k acc)
@@ -523,7 +523,7 @@ def sqfBase : SqfOpsAt R 0 where
 
 /-- One recursive content split followed by Yun in a variable which occurs in
 the normalized primitive part. -/
-def sqfStep {m : Nat} (lower : SqfOpsAt R m) :
+def sqfStep [NatNoZero R] {m : Nat} (lower : SqfOpsAt R m) :
     SqfOpsAt R (m + 1) where
   decomp := fun cmp _ p =>
     let split := sqfPrimitiveSplit p
@@ -553,12 +553,12 @@ def sqfStep {m : Nat} (lower : SqfOpsAt R m) :
           ⟨scalar * coefficientDecomp.content, factors⟩
 
 /-- Construct squarefree decomposition recursively in the arity. -/
-def sqfOps : (m : Nat) → SqfOpsAt R m
+def sqfOps [NatNoZero R] : (m : Nat) → SqfOpsAt R m
   | 0 => sqfBase
   | m + 1 => sqfStep (sqfOps m)
 
 omit [LawfulGcdOps R] [LawfulBezoutOps R] in
-private theorem positive_sqfOps (m : Nat)
+private theorem positive_sqfOps [NatNoZero R] (m : Nat)
     (order : Mono m → Mono m → Ordering) [IsMonomialOrder order]
     (p : MvPoly m R order) :
     PositiveMultiplicities ((sqfOps (R := R) m).decomp order p).factors := by
@@ -580,7 +580,7 @@ private theorem positive_sqfOps (m : Nat)
               · simp [PositiveMultiplicities]
 
 omit [LawfulGcdOps R] [LawfulBezoutOps R] in
-private theorem sorted_sqfOps (m : Nat)
+private theorem sorted_sqfOps [NatNoZero R] (m : Nat)
     (order : Mono m → Mono m → Ordering) [IsMonomialOrder order]
     (p : MvPoly m R order) :
     SortedMultiplicities ((sqfOps (R := R) m).decomp order p).factors := by

--- a/HexMvGcd/Squarefree.lean
+++ b/HexMvGcd/Squarefree.lean
@@ -27,8 +27,10 @@ namespace Hex.MvPoly
 
 universe u
 
-/-- Mathlib-free characteristic zero. -/
-class NatNoZero (R : Type u) [Zero R] [NatCast R] : Prop where
+attribute [local instance] Lean.Grind.Semiring.natCast
+
+/-- Mathlib-free characteristic zero for the coefficient ring's own natural cast. -/
+class NatNoZero (R : Type u) [Lean.Grind.CommRing R] : Prop where
   natCast_ne_zero : ∀ m : Nat, 0 < m → (m : R) ≠ 0
 
 instance instNatNoZeroInt : NatNoZero Int := by
@@ -153,8 +155,9 @@ variable {n : Nat} {R : Type u} {cmp : Mono n → Mono n → Ordering}
   [Dvd R] [BezoutOps R] [LawfulGcdOps R] [LawfulBezoutOps R]
   [GcdProducer R]
 
-/-- All partial derivatives, in variable-index order. -/
-def derivatives [NatCast R] (p : MvPoly n R cmp) : List (MvPoly n R cmp) :=
+/-- All partial derivatives, in variable-index order, using the coefficient
+ring's natural cast. -/
+def derivatives (p : MvPoly n R cmp) : List (MvPoly n R cmp) :=
   (List.finRange n).map fun i => derivative i p
 
 /-- Merge one factor into the multiplicity-sorted accumulator, multiplying
@@ -279,7 +282,7 @@ private theorem sorted_merge_fold (entries acc : List (SqfFactor n R cmp))
 /-- One decreasing Yun layer in the selected main variable.  The fuel is the
 total degree of the primitive input plus one; in characteristic zero every
 nonterminal layer removes at least one degree from `b`. -/
-def yunLoop [NatCast R] [IsMonomialOrder cmp] (i : Fin n) (fuel k : Nat)
+def yunLoop [IsMonomialOrder cmp] (i : Fin n) (fuel k : Nat)
     (b d : MvPoly n R cmp) (acc : List (SqfFactor n R cmp)) :
     List (SqfFactor n R cmp) :=
   match fuel with
@@ -295,7 +298,7 @@ def yunLoop [NatCast R] [IsMonomialOrder cmp] (i : Fin n) (fuel k : Nat)
         yunLoop i fuel (k + 1) nextB nextD acc
 
 omit [LawfulGcdOps R] [LawfulBezoutOps R] in
-private theorem positive_yunLoop [NatCast R] [IsMonomialOrder cmp]
+private theorem positive_yunLoop [IsMonomialOrder cmp]
     (i : Fin n) (fuel k : Nat) (b d : MvPoly n R cmp)
     (acc : List (SqfFactor n R cmp)) (hk : 0 < k)
     (hacc : PositiveMultiplicities acc) :
@@ -321,7 +324,7 @@ private def ReverseSortedMultiplicities
   factors.Pairwise fun left right => right.multiplicity < left.multiplicity
 
 omit [LawfulGcdOps R] [LawfulBezoutOps R] in
-private theorem sorted_yunLoop [NatCast R] [IsMonomialOrder cmp]
+private theorem sorted_yunLoop [IsMonomialOrder cmp]
     (i : Fin n) (fuel k : Nat) (b d : MvPoly n R cmp)
     (acc : List (SqfFactor n R cmp))
     (hbelow : MultiplicitiesBelow k acc)
@@ -520,7 +523,7 @@ def sqfBase : SqfOpsAt R 0 where
 
 /-- One recursive content split followed by Yun in a variable which occurs in
 the normalized primitive part. -/
-def sqfStep [NatCast R] {m : Nat} (lower : SqfOpsAt R m) :
+def sqfStep {m : Nat} (lower : SqfOpsAt R m) :
     SqfOpsAt R (m + 1) where
   decomp := fun cmp _ p =>
     let split := sqfPrimitiveSplit p
@@ -550,12 +553,12 @@ def sqfStep [NatCast R] {m : Nat} (lower : SqfOpsAt R m) :
           ⟨scalar * coefficientDecomp.content, factors⟩
 
 /-- Construct squarefree decomposition recursively in the arity. -/
-def sqfOps [NatCast R] : (m : Nat) → SqfOpsAt R m
+def sqfOps : (m : Nat) → SqfOpsAt R m
   | 0 => sqfBase
   | m + 1 => sqfStep (sqfOps m)
 
 omit [LawfulGcdOps R] [LawfulBezoutOps R] in
-private theorem positive_sqfOps [NatCast R] (m : Nat)
+private theorem positive_sqfOps (m : Nat)
     (order : Mono m → Mono m → Ordering) [IsMonomialOrder order]
     (p : MvPoly m R order) :
     PositiveMultiplicities ((sqfOps (R := R) m).decomp order p).factors := by
@@ -577,7 +580,7 @@ private theorem positive_sqfOps [NatCast R] (m : Nat)
               · simp [PositiveMultiplicities]
 
 omit [LawfulGcdOps R] [LawfulBezoutOps R] in
-private theorem sorted_sqfOps [NatCast R] (m : Nat)
+private theorem sorted_sqfOps (m : Nat)
     (order : Mono m → Mono m → Ordering) [IsMonomialOrder order]
     (p : MvPoly m R order) :
     SortedMultiplicities ((sqfOps (R := R) m).decomp order p).factors := by
@@ -597,36 +600,36 @@ private theorem sorted_sqfOps [NatCast R] (m : Nat)
 
 /-- Characteristic-zero squarefree decomposition with recursive content and
 scalar content split off. -/
-def sqfDecomp [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
+def sqfDecomp [IsMonomialOrder cmp] [NatNoZero R]
     (p : MvPoly n R cmp) : SqfDecomp n R cmp :=
   (sqfOps (R := R) n).decomp cmp p
 
 /-- Product of the distinct polynomial factors; scalar content is omitted. -/
-def radical [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
+def radical [IsMonomialOrder cmp] [NatNoZero R]
     (p : MvPoly n R cmp) : MvPoly n R cmp :=
   let q := polyNormalize (primPart p)
   if q == 0 then 0
   else quotient q (gcdList (q :: derivatives q))
 
 /-- Exact Boolean squarefree decision under the relative CAS convention. -/
-def isSquarefree [IsMonomialOrder cmp] [NatCast R]
+def isSquarefree [IsMonomialOrder cmp]
     (p : MvPoly n R cmp) : Bool :=
   let q := primPart p
   polyIsUnit (gcdList (q :: derivatives q))
 
-theorem isSquarefree_iff [IsMonomialOrder cmp] [NatCast R]
+theorem isSquarefree_iff [IsMonomialOrder cmp]
     [Div R] [ExactDivLaws R] [Hex.Fraction.NonzeroOne R] [PerfectFrac R]
     (p : MvPoly n R cmp) :
     isSquarefree p = true ↔ Squarefree p := by
   sorry
 
-theorem radical_squarefree [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
+theorem radical_squarefree [IsMonomialOrder cmp] [NatNoZero R]
     (p : MvPoly n R cmp) (hp : p ≠ 0) : Squarefree (radical p) := by
   sorry
 
 /-- The radical divides the original input, including its scalar content
 and normalization unit. -/
-theorem radical_dvd [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
+theorem radical_dvd [IsMonomialOrder cmp] [NatNoZero R]
     (p : MvPoly n R cmp) : radical p ∣ p := by
   let q := polyNormalize (primPart p)
   have hrestore : C (sqfPrimitiveSplit p).1 * q = p :=
@@ -655,12 +658,12 @@ theorem radical_dvd [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
           mul_comm (gcdList _) (quotient ..), hquot]
 
 omit [LawfulGcdOps R] [LawfulBezoutOps R] in
-@[simp] theorem radical_zero [IsMonomialOrder cmp] [NatCast R] [NatNoZero R] :
+@[simp] theorem radical_zero [IsMonomialOrder cmp] [NatNoZero R] :
     radical (0 : MvPoly n R cmp) = 0 := by
   simp [radical]
 
 /-- Multiplying the scalar and factor powers reconstructs the input. -/
-theorem sqfDecomp_prod [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
+theorem sqfDecomp_prod [IsMonomialOrder cmp] [NatNoZero R]
     (p : MvPoly n R cmp) :
     (sqfDecomp p).factors.foldl
       (fun acc f => acc * f.factor ^ f.multiplicity)
@@ -668,17 +671,17 @@ theorem sqfDecomp_prod [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
   sorry
 
 /-- Every polynomial returned by square-free decomposition is square-free. -/
-theorem sqfDecomp_squarefree [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
+theorem sqfDecomp_squarefree [IsMonomialOrder cmp] [NatNoZero R]
     (p : MvPoly n R cmp) :
     ∀ f ∈ (sqfDecomp p).factors, Squarefree f.factor := by
   sorry
 
-theorem sqfDecomp_primitive [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
+theorem sqfDecomp_primitive [IsMonomialOrder cmp] [NatNoZero R]
     (p : MvPoly n R cmp) :
     ∀ f ∈ (sqfDecomp p).factors, content f.factor = 1 := by
   sorry
 
-theorem sqfDecomp_coprime [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
+theorem sqfDecomp_coprime [IsMonomialOrder cmp] [NatNoZero R]
     (p : MvPoly n R cmp) :
     ∀ f ∈ (sqfDecomp p).factors, ∀ g ∈ (sqfDecomp p).factors,
       f.multiplicity ≠ g.multiplicity →
@@ -687,21 +690,21 @@ theorem sqfDecomp_coprime [IsMonomialOrder cmp] [NatCast R] [NatNoZero R]
 
 omit [LawfulGcdOps R] [LawfulBezoutOps R] in
 theorem sqfDecomp_multiplicity_pos [IsMonomialOrder cmp]
-    [NatCast R] [NatNoZero R] (p : MvPoly n R cmp) :
+    [NatNoZero R] (p : MvPoly n R cmp) :
     ∀ f ∈ (sqfDecomp p).factors, 0 < f.multiplicity := by
   simpa [sqfDecomp, PositiveMultiplicities] using
     positive_sqfOps (R := R) n cmp p
 
 omit [LawfulGcdOps R] [LawfulBezoutOps R] in
 theorem sqfDecomp_multiplicity_sorted [IsMonomialOrder cmp]
-    [NatCast R] [NatNoZero R] (p : MvPoly n R cmp) :
+    [NatNoZero R] (p : MvPoly n R cmp) :
     List.Pairwise (fun f g => f.multiplicity < g.multiplicity)
       (sqfDecomp p).factors := by
   simpa [sqfDecomp, SortedMultiplicities] using
     sorted_sqfOps (R := R) n cmp p
 
 theorem sqfDecomp_nonconstant [IsMonomialOrder cmp]
-    [NatCast R] [NatNoZero R] (p : MvPoly n R cmp) :
+    [NatNoZero R] (p : MvPoly n R cmp) :
     ∀ f ∈ (sqfDecomp p).factors, ¬ IsConst f.factor := by
   sorry
 

--- a/HexMvGcd/SquarefreeTests.lean
+++ b/HexMvGcd/SquarefreeTests.lean
@@ -11,10 +11,15 @@ public meta import HexMvGcd.Prs
 public meta import HexMvGcd.Squarefree
 public meta import HexMvPoly.Ring
 public import HexMvGcd.Squarefree
+import all HexMvGcd.Squarefree
+import all HexMvPoly.Structural
+import all HexMvPoly.Basic
+import all HexMvPoly.Ring
+import all HexMvPoly.Query
 
 public section
 
-/-! Focused finite-field squarefree decision regressions. -/
+/-! Squarefree decisions and coefficient-cast coherence regressions. -/
 
 namespace Hex.MvPoly
 
@@ -60,5 +65,120 @@ example (p : F3P1) : isSquarefree p = true ↔ Squarefree p :=
 #guard
   let x : F3P1 := X 0
   !isSquarefree (x ^ 3 + 1)
+
+namespace CastTests
+
+section Generic
+
+variable {R : Type u} [Lean.Grind.CommRing R] [DecidableEq R]
+  [BEq R] [LawfulBEq R] [Dvd R] [BezoutOps R] [GcdProducer R]
+  {n : Nat} {cmp : Mono n → Mono n → Ordering} [IsMonomialOrder cmp]
+
+omit [BEq R] [LawfulBEq R] [Dvd R] [BezoutOps R] [GcdProducer R] in
+/-- An unrelated cast in the caller's scope cannot change differentiation. -/
+theorem derivatives_cast (cast : NatCast R) (p : MvPoly n R cmp) :
+    (letI : NatCast R := cast; derivatives p) = derivatives p := by
+  rfl
+
+/-- An unrelated cast cannot change the decision, radical, or decomposition. -/
+theorem squarefree_cast [NatNoZero R] (cast : NatCast R) (p : MvPoly n R cmp) :
+    (letI : NatCast R := cast; (isSquarefree p, radical p, sqfDecomp p)) =
+      (isSquarefree p, radical p, sqfDecomp p) := by
+  rfl
+
+omit [DecidableEq R] [BEq R] [LawfulBEq R] [Dvd R] [BezoutOps R]
+    [GcdProducer R] in
+/-- Characteristic zero refers to the ring's cast even under local shadowing. -/
+theorem characteristic_cast [NatNoZero R] (cast : NatCast R) :
+    letI : NatCast R := cast
+    NatNoZero R := by
+  infer_instance
+
+end Generic
+
+@[expose, instance_reducible] def badIntCast : NatCast Int := ⟨fun _ => 1⟩
+@[expose, instance_reducible] def badRatCast : NatCast Rat := ⟨fun _ => 1⟩
+
+abbrev P := MvPoly 1 Int Mono.lex
+abbrev Q := MvPoly 1 Rat Mono.lex
+
+@[expose] def repeated : P := (X 0 + 1) * (X 0 + 1)
+
+/-- The low-level derivative accepts a caller-selected cast. -/
+theorem explicit_derivative :
+    (letI : NatCast Int := badIntCast; derivative 0 repeated) = (X 0 + C 2 : P) := by
+  decide +kernel
+
+/-- Squarefree replay fixes the derivative's cast to the ring operations. -/
+theorem ring_derivatives :
+    (letI : NatCast Int := badIntCast; derivatives repeated) =
+      [C 2 * X 0 + C 2] := by
+  decide +kernel
+
+/-- The repeated nonconstant divisor witnesses semantic failure of squarefreeness. -/
+theorem not_squarefree : ¬ Squarefree repeated := by
+  intro h
+  have hd : (X 0 + 1 : P) * (X 0 + 1) ∣ repeated :=
+    ⟨1, by simp only [repeated, one_mul]⟩
+  have hc := h.2 (X 0 + 1) hd
+  have hn : ¬ IsConst (X 0 + 1 : P) := by
+    change (X 0 + 1 : P).vars ≠ []
+    decide +kernel
+  exact hn hc
+
+#guard
+  letI : NatCast Int := badIntCast
+  !isSquarefree repeated && radical repeated == (X 0 + 1 : P)
+
+#guard
+  letI : NatCast Int := badIntCast
+  let decomp := sqfDecomp repeated
+  decomp.content == 1 && decomp.factors.length == 1 &&
+    decomp.factors.all (fun f => f.factor == (X 0 + 1 : P) && f.multiplicity == 2)
+
+#guard
+  letI : NatCast Rat := badRatCast
+  let p : Q := C (3 / 2) * ((X 0 + 1 : Q) ^ 3)
+  let decomp := sqfDecomp p
+  !isSquarefree p && radical p == (X 0 + 1 : Q) &&
+    decomp.content == 3 / 2 && decomp.factors.length == 1 &&
+    decomp.factors.all (fun f => f.factor == (X 0 + 1 : Q) && f.multiplicity == 3)
+
+#guard
+  letI : NatCast Int := badIntCast
+  !isSquarefree (0 : P) && radical (0 : P) == 0 &&
+    isSquarefree (C 6 : P) && radical (C 6 : P) == 1 &&
+    (sqfDecomp (C 6 : P)).content == 6 && (sqfDecomp (C 6 : P)).factors.isEmpty
+
+#guard
+  letI : NatCast (ZMod64 3) := ⟨fun _ => 1⟩
+  let x : F3P1 := X 0
+  !isSquarefree (x ^ 3 + 1) && isSquarefree (x * (x + 1))
+
+/-- A nonzero but unrelated cast cannot certify characteristic zero in F₃. -/
+theorem no_characteristic_zero [ZMod64.Bounds 3] [ZMod64.PrimeModulus 3] :
+    letI : NatCast (ZMod64 3) := ⟨fun _ => 1⟩
+    ¬ NatNoZero (ZMod64 3) := by
+  intro h
+  have hn := h.natCast_ne_zero 3 (by decide)
+  exact hn (ZMod64.natCast_self (p := 3))
+
+/-- info: 'Hex.MvPoly.CastTests.squarefree_cast' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms squarefree_cast
+
+/-- info: 'Hex.MvPoly.CastTests.ring_derivatives' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms ring_derivatives
+
+/-- info: 'Hex.MvPoly.CastTests.not_squarefree' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms not_squarefree
+
+/-- info: 'Hex.MvPoly.CastTests.no_characteristic_zero' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms no_characteristic_zero
+
+end CastTests
 
 end Hex.MvPoly

--- a/HexMvGcd/SquarefreeTests.lean
+++ b/HexMvGcd/SquarefreeTests.lean
@@ -96,6 +96,8 @@ theorem characteristic_cast [NatNoZero R] (cast : NatCast R) :
 
 end Generic
 
+/- The shadowing casts below are deliberately inert for the squarefree API.
+These checks must keep compiling and evaluating identically with them in scope. -/
 @[expose, instance_reducible] def badIntCast : NatCast Int := ⟨fun _ => 1⟩
 @[expose, instance_reducible] def badRatCast : NatCast Rat := ⟨fun _ => 1⟩
 
@@ -162,6 +164,15 @@ theorem no_characteristic_zero [ZMod64.Bounds 3] [ZMod64.PrimeModulus 3] :
   intro h
   have hn := h.natCast_ne_zero 3 (by decide)
   exact hn (ZMod64.natCast_self (p := 3))
+
+-- Direct decomposition helpers also reject positive characteristic, even
+-- when an unrelated cast sends every natural to a nonzero coefficient.
+example : True := by
+  letI : NatCast (ZMod64 3) := ⟨fun _ => 1⟩
+  fail_if_success have _ := sqfOps (R := ZMod64 3) 1
+  fail_if_success have _ := sqfStep (R := ZMod64 3) sqfBase
+  fail_if_success have _ := yunLoop (R := ZMod64 3) (cmp := Mono.lex) (n := 1) 0 1 1 1 0 []
+  trivial
 
 /-- info: 'Hex.MvPoly.CastTests.squarefree_cast' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in

--- a/HexMvPoly/SPEC/hex-mv-poly.md
+++ b/HexMvPoly/SPEC/hex-mv-poly.md
@@ -416,6 +416,9 @@ matching the shape of `Hex.DensePoly.derivative` while retaining
 canonical zero deletion. Its coefficient law uses
 `[Lean.Grind.Semiring R] [DecidableEq R]`; the theorem module may expose
 `Lean.Grind.Semiring.natCast` as a default-priority local instance.
+That law concerns the semiring’s own natural cast, not an arbitrary
+caller-selected `NatCast`. Consumers that need mathematical differentiation
+must bind the computational cast to the coefficient semiring’s cast.
 Mathlib's `CommSemiring` already supplies `Zero`, `NatCast`, `Add`, and
 `Mul`, so the companion needs no Mathlib-to-Grind adapter merely to call
 the definition.


### PR DESCRIPTION
A caller-supplied `NatCast` could change squarefree differentiation: with every natural cast to `1`, `(x + 1)^2` was reported squarefree and its repeated factor received multiplicity one. The same disconnected cast could also supply a false `NatNoZero` witness for a positive-characteristic ring.

Bind differentiation throughout the squarefree pipeline to the coefficient ring’s own natural cast, and make `NatNoZero` refer to that same ring. Require characteristic zero on the public Yun/decomposition helpers as well, so direct calls cannot bypass that precondition. Update both relevant SPECs and the README to state these contracts. The lower-level derivative API retains its explicit cast parameter.

Regressions cover shadowed casts over integers, rationals, and F₃, repeated factors and multiplicities, zero and constants, the impossibility of forging characteristic zero for F₃, and rejection of direct decomposition-helper calls over F₃. Kernel proofs audit the cast boundary without `sorryAx`.

Validation:
- Whole-graph `lake build`, including `HexManual` (10,762 jobs); focused GCD/Hensel/factorization, conformance, and kernel-probe targets.
- Fresh fixtures match committed data; all 86 SymPy oracle cases pass.
- All 19 GCD benchmark replay checks pass with Singular and FLINT.
- DAG, file length, copyright, phase 4/7, release-manifest checks, and `git diff --check` pass.

Repairs the counterexample reported in #10082 (https://github.com/kim-em/hex-dev/issues/10082#issuecomment-5567406579). This is an incremental contract repair: existing general correctness proofs remain unfinished, and no phase counters or release readiness claims advance. The tracker stays open.
