### PR TITLE
Prove gcd-domain cancellation and primitive descent

### DIFF
--- a/HexMvGcd/Divide.lean
+++ b/HexMvGcd/Divide.lean
@@ -184,9 +184,11 @@ private theorem leadingTerm_monomial_mul {g : MvPoly n R cmp}
       ← IsMonomialOrder.mul_mono (cmp := cmp) b mg m]
     exact le_leadingTerm hg b hb
 
-/-- The leading term of a product is the product of the leading terms over a
-coefficient domain. -/
-theorem leadingTerm_mul [LawfulGcdOps R]
+omit [Dvd R] [GcdOps R] in
+/-- The leading term of a product is the product of the leading terms when
+the coefficient ring has no zero divisors. -/
+theorem leadingTerm_mul_of_no_zero_div
+    (noZeroDiv : ∀ a b : R, a * b = 0 → a = 0 ∨ b = 0)
     {p q : MvPoly n R cmp} {mp mq : Mono n} {cp cq : R}
     (hp : p.leadingTerm = some (mp, cp))
     (hq : q.leadingTerm = some (mq, cq)) :
@@ -201,7 +203,7 @@ theorem leadingTerm_mul [LawfulGcdOps R]
     exact q.coeff?_ne_zero mq (hqc.trans (congrArg some hzero))
   have hprod : cp * cq ≠ 0 := by
     intro hzero
-    rcases LawfulGcdOps.no_zero_div cp cq hzero with hzero | hzero
+    rcases noZeroDiv cp cq hzero with hzero | hzero
     · exact hcp hzero
     · exact hcq hzero
   have hcoeff : coeff (Mono.mul mp mq) (p * q) = cp * cq := by
@@ -263,6 +265,14 @@ theorem leadingTerm_mul [LawfulGcdOps R]
   · intro m hm
     rcases exists_mul_of_mem hm with ⟨a, ha, b, hb, rfl⟩
     exact mul_isLE (le_leadingTerm hp a ha) (le_leadingTerm hq b hb)
+
+/-- The leading-term product law specialized to executable gcd domains. -/
+theorem leadingTerm_mul [LawfulGcdOps R]
+    {p q : MvPoly n R cmp} {mp mq : Mono n} {cp cq : R}
+    (hp : p.leadingTerm = some (mp, cp))
+    (hq : q.leadingTerm = some (mq, cq)) :
+    (p * q).leadingTerm = some (Mono.mul mp mq, cp * cq) :=
+  leadingTerm_mul_of_no_zero_div LawfulGcdOps.no_zero_div hp hq
 
 omit [DecidableEq R] [Dvd R] [GcdOps R] in
 private theorem leadRel_sub_of_cancel {r s : MvPoly n R cmp}

--- a/HexMvGcd/Gauss.lean
+++ b/HexMvGcd/Gauss.lean
@@ -54,10 +54,98 @@ section Cancel
 variable {R : Type u} [Lean.Grind.CommRing R] [Dvd R]
   [GcdDomainLaws R]
 
+/-- Multiplication transports a chosen gcd to a gcd of the two products. -/
+private theorem mulGcd
+    (m a b c : R) (hca : c ∣ a) (hcb : c ∣ b)
+    (hc : ∀ d, d ∣ a → d ∣ b → d ∣ c) :
+    m * c ∣ m * a ∧ m * c ∣ m * b ∧
+      ∀ d, d ∣ m * a → d ∣ m * b → d ∣ m * c := by
+  have hleft : m * c ∣ m * a := by
+    rcases (GcdDomainLaws.dvd_iff c a).mp hca with ⟨q, hq⟩
+    apply (GcdDomainLaws.dvd_iff (m * c) (m * a)).mpr
+    refine ⟨q, ?_⟩
+    rw [hq]
+    grind
+  have hright : m * c ∣ m * b := by
+    rcases (GcdDomainLaws.dvd_iff c b).mp hcb with ⟨q, hq⟩
+    apply (GcdDomainLaws.dvd_iff (m * c) (m * b)).mpr
+    refine ⟨q, ?_⟩
+    rw [hq]
+    grind
+  refine ⟨hleft, hright, ?_⟩
+  intro d hdma hdmb
+  by_cases hm : m = 0
+  · apply (GcdDomainLaws.dvd_iff d (m * c)).mpr
+    refine ⟨0, ?_⟩
+    rw [hm, Lean.Grind.Semiring.zero_mul, Lean.Grind.Semiring.mul_zero]
+  rcases GcdDomainLaws.gcd_exists (m * a) (m * b) with
+    ⟨x, hxa, hxb, hxgreat⟩
+  have hmcx : m * c ∣ x := hxgreat (m * c) hleft hright
+  rcases (GcdDomainLaws.dvd_iff (m * c) x).mp hmcx with ⟨t, hxt⟩
+  let n := c * t
+  have hxn : x = m * n := by
+    change x = m * (c * t)
+    rw [hxt]
+    grind
+  have hna : n ∣ a := by
+    rcases (GcdDomainLaws.dvd_iff x (m * a)).mp hxa with ⟨q, hq⟩
+    apply (GcdDomainLaws.dvd_iff n a).mpr
+    refine ⟨q, ?_⟩
+    have heq : m * a = m * (n * q) := by
+      calc
+        m * a = x * q := hq
+        _ = (m * n) * q := by rw [hxn]
+        _ = m * (n * q) := by grind
+    have hzero : m * (a - n * q) = 0 := by grind
+    rcases GcdDomainLaws.no_zero_div m (a - n * q) hzero with hz | hz
+    · exact False.elim (hm hz)
+    · grind
+  have hnb : n ∣ b := by
+    rcases (GcdDomainLaws.dvd_iff x (m * b)).mp hxb with ⟨q, hq⟩
+    apply (GcdDomainLaws.dvd_iff n b).mpr
+    refine ⟨q, ?_⟩
+    have heq : m * b = m * (n * q) := by
+      calc
+        m * b = x * q := hq
+        _ = (m * n) * q := by rw [hxn]
+        _ = m * (n * q) := by grind
+    have hzero : m * (b - n * q) = 0 := by grind
+    rcases GcdDomainLaws.no_zero_div m (b - n * q) hzero with hz | hz
+    · exact False.elim (hm hz)
+    · grind
+  have hnc : n ∣ c := hc n hna hnb
+  rcases (GcdDomainLaws.dvd_iff n c).mp hnc with ⟨q, hq⟩
+  have hxmc : x ∣ m * c := by
+    apply (GcdDomainLaws.dvd_iff x (m * c)).mpr
+    refine ⟨q, ?_⟩
+    rw [hq, hxn]
+    grind
+  rcases (GcdDomainLaws.dvd_iff d x).mp (hxgreat d hdma hdmb) with ⟨r, hr⟩
+  rcases (GcdDomainLaws.dvd_iff x (m * c)).mp hxmc with ⟨s, hs⟩
+  apply (GcdDomainLaws.dvd_iff d (m * c)).mpr
+  refine ⟨r * s, ?_⟩
+  calc
+    m * c = x * s := hs
+    _ = (d * r) * s := by rw [hr]
+    _ = d * (r * s) := by grind
+
 /-- Ordinary gcd-domain arithmetic gives Euclid cancellation in the exact
 form consumed by certificate maximality. -/
 theorem coprimeCancelOfGcdDomain : CoprimeCancelLaws R := by
-  sorry
+  constructor
+  intro g a b d hcop hda hdb
+  rcases GcdDomainLaws.gcd_exists a b with ⟨c, hca, hcb, hc⟩
+  rcases hcop c hca hcb with ⟨u, hcu⟩
+  have hdgc : d ∣ g * c := (mulGcd g a b c hca hcb hc).2.2 d hda hdb
+  rcases (GcdDomainLaws.dvd_iff d (g * c)).mp hdgc with ⟨q, hq⟩
+  apply (GcdDomainLaws.dvd_iff d g).mpr
+  refine ⟨q * u, ?_⟩
+  calc
+    g = g * 1 := (Lean.Grind.Semiring.mul_one g).symm
+    _ = g * (c * u) := by rw [hcu]
+    _ = (g * c) * u := by grind
+    _ = (d * q) * u := by rw [hq]
+    _ = d * (q * u) := by grind
 
 instance (priority := 100) instCoprimeCancelLawsOfGcdDomain :
     CoprimeCancelLaws R :=
@@ -136,8 +224,6 @@ theorem dvd_chooseCoeffGcd [GcdDomainLaws R] (xs : List R) (d : R)
 end CoeffFold
 
 namespace MvPoly
-
-universe v
 
 variable {n : Nat} {R : Type u} {cmp : Mono n → Mono n → Ordering}
   [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
@@ -292,11 +378,68 @@ theorem fractionPolyGcd_nonempty
 out every nonunit common divisor back in the coefficient ring. -/
 theorem primitive_descent [GcdDomainLaws R]
     {f g d : MvPoly n R cmp}
-    (hf : Primitive f) (hg : Primitive g)
+    (hf : Primitive f)
     (hcop : CoprimeOverFraction f g)
     (hdf : d ∣ f) (hdg : d ∣ g) :
     ∃ u, d * u = 1 := by
-  sorry
+  have hmapDvdF : fractionMap d ∣ fractionMap f := by
+    rcases hdf with ⟨q, hq⟩
+    refine ⟨fractionMap q, ?_⟩
+    calc
+      fractionMap f = fractionMap (q * d) := congrArg fractionMap hq
+      _ = fractionMap q * fractionMap d := fractionMap_mul q d
+  have hmapDvdG : fractionMap d ∣ fractionMap g := by
+    rcases hdg with ⟨q, hq⟩
+    refine ⟨fractionMap q, ?_⟩
+    calc
+      fractionMap g = fractionMap (q * d) := congrArg fractionMap hq
+      _ = fractionMap q * fractionMap d := fractionMap_mul q d
+  rcases hcop (fractionMap d) hmapDvdF hmapDvdG with ⟨q, hdq⟩
+  have hFracOne : (1 : Hex.Fraction R) ≠ 0 :=
+    fun h => Hex.Fraction.zero_ne_one h.symm
+  have hFracNoZero : ∀ a b : Hex.Fraction R,
+      a * b = 0 → a = 0 ∨ b = 0 := by
+    intro a b hab
+    by_cases ha : a = 0
+    · exact Or.inl ha
+    · right
+      by_cases hb : b = 0
+      · exact hb
+      · exact False.elim ((ExactDivLaws.mul_ne_zero ha hb) hab)
+  rcases unit_eq_C hFracOne hFracNoZero hdq with ⟨_, _, hdConst, _⟩
+  let c := coeff Mono.zero d
+  have hdc : d = C c := by
+    apply ext
+    intro m
+    by_cases hm : m = Mono.zero
+    · subst m
+      rw [coeff_C]
+      simp only [ite_true]
+      rfl
+    · rw [coeff_C, ite_eq_right hm]
+      have hcoeff := congrArg (coeff m) hdConst
+      rw [fractionMap, coeff_mapCoeffs Hex.Fraction.ofCoeff_zero,
+        coeff_C, ite_eq_right hm] at hcoeff
+      exact (Hex.Fraction.ofCoeff_eq_zero_iff (coeff m d)).mp hcoeff
+  rcases hdf with ⟨a, ha⟩
+  have hcommon : ∀ x, x ∈ coefficientList f → c ∣ x := by
+    intro x hx
+    rcases List.mem_map.mp hx with ⟨term, hterm, rfl⟩
+    rcases term with ⟨m, x⟩
+    have hcoeff : coeff m f = x := coeff_eq_of_mem_terms f hterm
+    apply (GcdDomainLaws.dvd_iff c x).mpr
+    refine ⟨coeff m a, ?_⟩
+    calc
+      x = coeff m f := hcoeff.symm
+      _ = coeff m (a * d) := congrArg (coeff m) ha
+      _ = coeff m (C c * a) := by rw [hdc, MvPoly.mul_comm]
+      _ = c * coeff m a := coeff_C_mul c a m
+  rcases hf c hcommon with ⟨u, hcu⟩
+  refine ⟨C u, ?_⟩
+  rw [hdc]
+  change monomial Mono.zero c * monomial Mono.zero u = 1
+  rw [monomial_mul_monomial, Mono.zero_mul, hcu]
+  rfl
 
 end Fraction
 

--- a/HexMvGcd/Gcd.lean
+++ b/HexMvGcd/Gcd.lean
@@ -916,19 +916,6 @@ theorem lcm_normalized [IsMonomialOrder cmp]
     (f h : MvPoly n R cmp) : polyNormalize (lcm f h) = lcm f h := by
   exact polyNormalize_idem _
 
-private theorem reorder_mul
-    {cmp' : Mono n → Mono n → Ordering}
-    [IsMonomialOrder cmp] [IsMonomialOrder cmp']
-    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    (p q : MvPoly n R cmp) :
-    reorder cmp' (p * q) = reorder cmp' p * reorder cmp' q := by
-  apply ext
-  intro m
-  rw [coeff_reorder, coeff_mul, coeff_mul]
-  apply List.foldl_add_congr (Mono.splits m)
-  intro ab _
-  rw [coeff_reorder, coeff_reorder]
-
 private theorem reorder_reorder
     {cmp' : Mono n → Mono n → Ordering}
     [IsMonomialOrder cmp] [IsMonomialOrder cmp']

--- a/HexMvGcd/Normalize.lean
+++ b/HexMvGcd/Normalize.lean
@@ -212,7 +212,7 @@ theorem normalize_scalarContent [LawfulGcdOps R] (p : MvPoly n R cmp) :
       simp only
       exact LawfulGcdOps.normalize_idem _
 
-private theorem eq_zero_of_mul_eq_zero {a b : Mono n}
+theorem eq_zero_of_mul_eq_zero {a b : Mono n}
     (h : Mono.mul a b = Mono.zero) : a = Mono.zero := by
   apply Vector.ext
   intro i hi
@@ -227,7 +227,7 @@ private theorem eq_zero_of_mul_eq_zero {a b : Mono n}
   rw [Mono.getElem_zero]
   exact (Nat.eq_zero_of_add_eq_zero hj').1
 
-private theorem eq_zero_of_isLE [IsMonomialOrder cmp] {m : Mono n}
+theorem eq_zero_of_isLE [IsMonomialOrder cmp] {m : Mono n}
     (h : (cmp m Mono.zero).isLE) : m = Mono.zero := by
   cases hcmp : cmp m Mono.zero with
   | lt =>
@@ -236,6 +236,93 @@ private theorem eq_zero_of_isLE [IsMonomialOrder cmp] {m : Mono n}
       exact False.elim (IsMonomialOrder.zero_le m hgt)
   | eq => exact Std.LawfulEqCmp.eq_of_compare hcmp
   | gt => simp [hcmp] at h
+
+omit [Dvd R] [GcdOps R] in
+/-- A polynomial with a multiplicative inverse is a constant, and its
+coefficient has the corresponding scalar inverse. The source comparator need
+not itself be a monomial order. -/
+theorem unit_eq_C
+    (one_ne_zero : (1 : R) ≠ 0)
+    (noZeroDiv : ∀ a b : R, a * b = 0 → a = 0 ∨ b = 0)
+    {p q : MvPoly n R cmp} (hpq : p * q = 1) :
+    ∃ c d : R, p = C c ∧ c * d = 1 := by
+  let p' : MvPoly n R Mono.lex := reorder Mono.lex p
+  let q' : MvPoly n R Mono.lex := reorder Mono.lex q
+  have hpq' : p' * q' = 1 := by
+    calc
+      p' * q' = reorder Mono.lex (p * q) :=
+        (reorder_mul (R := R) (cmp := cmp) (cmp' := Mono.lex) p q).symm
+      _ = reorder Mono.lex (1 : MvPoly n R cmp) := by rw [hpq]
+      _ = 1 := by
+        apply ext
+        intro m
+        rw [coeff_reorder, coeff_one, coeff_one]
+  have hpzero : p' ≠ 0 := by
+    intro hp
+    rw [hp, MvPoly.zero_mul] at hpq'
+    have hcoeff := congrArg (coeff (Mono.zero : Mono n)) hpq'
+    rw [coeff_zero, coeff_one, ite_eq_left rfl] at hcoeff
+    exact one_ne_zero hcoeff.symm
+  have hqzero : q' ≠ 0 := by
+    intro hq
+    rw [hq, MvPoly.mul_zero] at hpq'
+    have hcoeff := congrArg (coeff (Mono.zero : Mono n)) hpq'
+    rw [coeff_zero, coeff_one, ite_eq_left rfl] at hcoeff
+    exact one_ne_zero hcoeff.symm
+  cases hpLead : p'.leadingTerm with
+  | none => exact False.elim (hpzero ((leadingTerm_eq_none_iff p').mp hpLead))
+  | some pterm =>
+      rcases pterm with ⟨mp, cp⟩
+      cases hqLead : q'.leadingTerm with
+      | none => exact False.elim (hqzero ((leadingTerm_eq_none_iff q').mp hqLead))
+      | some qterm =>
+          rcases qterm with ⟨mq, cq⟩
+          have hlead := leadingTerm_mul_of_no_zero_div noZeroDiv hpLead hqLead
+          have hcoeff := coeff_eq_of_leadingTerm hlead
+          rw [hpq', coeff_one] at hcoeff
+          have hcp : cp ≠ 0 := by
+            intro hzero
+            have hopt := (leadingTerm_eq_some_iff p' mp cp).mp hpLead |>.1
+            exact p'.coeff?_ne_zero mp (hopt.trans (congrArg some hzero))
+          have hcq : cq ≠ 0 := by
+            intro hzero
+            have hopt := (leadingTerm_eq_some_iff q' mq cq).mp hqLead |>.1
+            exact q'.coeff?_ne_zero mq (hopt.trans (congrArg some hzero))
+          have hcprod : cp * cq ≠ 0 := by
+            intro hzero
+            rcases noZeroDiv cp cq hzero with hzero | hzero
+            · exact hcp hzero
+            · exact hcq hzero
+          have hmono : Mono.mul mp mq = Mono.zero := by
+            by_cases hmono : Mono.mul mp mq = Mono.zero
+            · exact hmono
+            · rw [ite_eq_right hmono] at hcoeff
+              exact False.elim (hcprod hcoeff.symm)
+          have hcoeffUnit : cp * cq = 1 := by
+            rw [ite_eq_left hmono] at hcoeff
+            exact hcoeff.symm
+          have hmp : mp = Mono.zero := eq_zero_of_mul_eq_zero hmono
+          have hpC' : p' = C cp := by
+            apply ext
+            intro m
+            rw [coeff_C]
+            by_cases hm : m = Mono.zero
+            · subst m
+              rw [← hmp, coeff_eq_of_leadingTerm hpLead]
+              simp
+            · rw [ite_eq_right hm]
+              apply coeff_eq_zero_of_not_mem m p'
+              intro hmem
+              have hle := le_leadingTerm hpLead m hmem
+              rw [hmp] at hle
+              exact hm (eq_zero_of_isLE hle)
+          refine ⟨cp, cq, ?_, hcoeffUnit⟩
+          apply ext
+          intro m
+          calc
+            coeff m p = coeff m p' := (coeff_reorder Mono.lex m p).symm
+            _ = if m = Mono.zero then cp else 0 := by rw [hpC', coeff_C]
+            _ = coeff m (C cp : MvPoly n R cmp) := (coeff_C m cp).symm
 
 /-- Unit recognition is sound and complete under the coefficient gcd laws. -/
 theorem polyIsUnit_iff [IsMonomialOrder cmp] [LawfulGcdOps R]
@@ -271,74 +358,17 @@ theorem polyIsUnit_iff [IsMonomialOrder cmp] [LawfulGcdOps R]
             rfl
         | cons next rest => simp [polyIsUnit, hterms] at hunit
   · rintro ⟨q, hpq⟩
-    have hpzero : p ≠ 0 := by
-      intro hp
-      subst p
-      rw [zero_mul] at hpq
-      have hcoeff := congrArg (coeff (Mono.zero : Mono n)) hpq
-      rw [coeff_zero, coeff_one, ite_eq_left rfl] at hcoeff
-      exact LawfulGcdOps.one_ne_zero hcoeff.symm
-    have hqzero : q ≠ 0 := by
-      intro hq
-      subst q
-      rw [mul_zero] at hpq
-      have hcoeff := congrArg (coeff (Mono.zero : Mono n)) hpq
-      rw [coeff_zero, coeff_one, ite_eq_left rfl] at hcoeff
-      exact LawfulGcdOps.one_ne_zero hcoeff.symm
-    cases hpLead : p.leadingTerm with
-    | none => exact False.elim (hpzero ((leadingTerm_eq_none_iff p).mp hpLead))
-    | some pterm =>
-        rcases pterm with ⟨mp, cp⟩
-        cases hqLead : q.leadingTerm with
-        | none => exact False.elim (hqzero ((leadingTerm_eq_none_iff q).mp hqLead))
-        | some qterm =>
-            rcases qterm with ⟨mq, cq⟩
-            have hlead := leadingTerm_mul hpLead hqLead
-            have hcoeff := coeff_eq_of_leadingTerm hlead
-            rw [hpq, coeff_one] at hcoeff
-            have hcp : cp ≠ 0 := by
-              intro hzero
-              have hopt := (leadingTerm_eq_some_iff p mp cp).mp hpLead |>.1
-              exact p.coeff?_ne_zero mp
-                (hopt.trans (congrArg some hzero))
-            have hcq : cq ≠ 0 := by
-              intro hzero
-              have hopt := (leadingTerm_eq_some_iff q mq cq).mp hqLead |>.1
-              exact q.coeff?_ne_zero mq
-                (hopt.trans (congrArg some hzero))
-            have hcprod : cp * cq ≠ 0 := by
-              intro hzero
-              rcases LawfulGcdOps.no_zero_div cp cq hzero with hzero | hzero
-              · exact hcp hzero
-              · exact hcq hzero
-            have hmono : Mono.mul mp mq = Mono.zero := by
-              by_cases hmono : Mono.mul mp mq = Mono.zero
-              · exact hmono
-              · rw [ite_eq_right hmono] at hcoeff
-                exact False.elim (hcprod hcoeff.symm)
-            have hcoeffUnit : cp * cq = 1 := by
-              rw [ite_eq_left hmono] at hcoeff
-              exact hcoeff.symm
-            have hmp : mp = Mono.zero := eq_zero_of_mul_eq_zero hmono
-            have hpC : p = C cp := by
-              apply ext
-              intro m
-              rw [coeff_C]
-              by_cases hm : m = Mono.zero
-              · subst m
-                rw [← hmp, coeff_eq_of_leadingTerm hpLead]
-                simp
-              · rw [ite_eq_right hm]
-                apply coeff_eq_zero_of_not_mem m p
-                intro hmem
-                have hle := le_leadingTerm hpLead m hmem
-                rw [hmp] at hle
-                exact hm (eq_zero_of_isLE hle)
-            have hisUnit : GcdOps.isUnit cp = true :=
-              (LawfulGcdOps.isUnit_iff cp).mpr ⟨cq, hcoeffUnit⟩
-            rw [hpC]
-            rw [polyIsUnit, termsList_C, ite_eq_right hcp]
-            simp [hisUnit]
+    rcases unit_eq_C LawfulGcdOps.one_ne_zero LawfulGcdOps.no_zero_div hpq with
+      ⟨cp, cq, hpC, hcoeffUnit⟩
+    have hcp : cp ≠ 0 := by
+      intro hzero
+      rw [hzero, Lean.Grind.Semiring.zero_mul] at hcoeffUnit
+      exact LawfulGcdOps.one_ne_zero hcoeffUnit.symm
+    have hisUnit : GcdOps.isUnit cp = true :=
+      (LawfulGcdOps.isUnit_iff cp).mpr ⟨cq, hcoeffUnit⟩
+    rw [hpC]
+    rw [polyIsUnit, termsList_C, ite_eq_right hcp]
+    simp [hisUnit]
 
 /-- The chosen normalization multiplier is a polynomial unit. -/
 theorem polyNormUnit_isUnit [IsMonomialOrder cmp] [LawfulGcdOps R]

--- a/HexMvPoly/Structural.lean
+++ b/HexMvPoly/Structural.lean
@@ -217,6 +217,30 @@ theorem coeff_reorder [Lean.Grind.Semiring R] [DecidableEq R]
   unfold reorder
   rw [coeff_ofTerms, coeff_terms]
 
+/-- Reordering preserves multiplication while changing only the term order. -/
+theorem reorder_mul [Lean.Grind.CommRing R] [DecidableEq R]
+    [BEq R] [LawfulBEq R]
+    {cmp' : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp'] [Std.LawfulEqCmp cmp']
+    (p q : MvPoly n R cmp) :
+    reorder cmp' (p * q) = reorder cmp' p * reorder cmp' q := by
+  apply ext
+  intro m
+  rw [coeff_reorder, coeff_mul, coeff_mul]
+  apply List.foldl_add_congr (Mono.splits m)
+  intro ab _
+  rw [coeff_reorder, coeff_reorder]
+
+/-- Reordering preserves the multiplicative identity. -/
+theorem reorder_one [Lean.Grind.CommRing R] [DecidableEq R]
+    [BEq R] [LawfulBEq R]
+    {cmp' : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp'] [Std.LawfulEqCmp cmp'] :
+    reorder cmp' (1 : MvPoly n R cmp) = 1 := by
+  apply ext
+  intro m
+  rw [coeff_reorder, coeff_one, coeff_one]
+
 /-- Renaming variables sums coefficients whose target monomials coincide. -/
 theorem coeff_rename [Lean.Grind.Semiring R] [DecidableEq R]
     (cmp' : Mono k → Mono k → Ordering)


### PR DESCRIPTION
The GCD checker needs coefficient-domain cancellation and a way to descend coprimality from the fraction field. Both foundational theorems were still axiomatized by `sorry`, so later multivariate maximality and rational-lift proofs inherited `sorryAx` before the polynomial arity lift was considered.

This proves `coprimeCancelOfGcdDomain` by transporting a chosen gcd through multiplication and cancelling in the coefficient domain. It also proves `primitive_descent`: an accepted fraction-field unit is shown to be constant, injectivity pulls that constant back to the coefficient ring, and primitiveness supplies its inverse. The leading-term product lemma now exposes a no-zero-divisors premise so the fraction-polynomial unit argument does not require executable `GcdOps`.

The review follow-up moves comparator-independent `reorder` multiplication laws beside `reorder`, shares the polynomial-unit-is-constant lemma with `polyIsUnit_iff`, reuses the existing monomial-zero lemmas, removes the unused second primitiveness premise, and uses `Fraction.zero_ne_one` directly.

This is a reviewable proof slice for #10082. It removes two of the 17 remaining `HexMvGcd` proof gaps. The `GcdDomainLaws (MvPoly ...)` arity lift and the other 15 gaps remain explicit, so the tracker stays open.

Validation:

- `lake build HexMvGcd.Gauss`
- `lake build HexMvGcd.Gcd`
- `lake build HexMvGcd HexMvHensel HexMvFactor HexMvFactorizationTests`
- kernel axiom audit of `Hex.coprimeCancelOfGcdDomain`, `Hex.MvPoly.unit_eq_C`, and `Hex.MvPoly.primitive_descent`: `[propext, Classical.choice, Quot.sound]`, with no `sorryAx`
- `git diff --check`
