### PR TITLE
doc: close out Cloudflare cache migration

### DIFF
--- a/docs/cache-infrastructure.md
+++ b/docs/cache-infrastructure.md
@@ -4,10 +4,10 @@ Where the build cache lives, who owns it, and which knob feeds which workflow.
 
 ## Cloudflare account
 
-This table records the required destination. During the 2026 account migration,
-the live cache and repository variables remain on the older personal account
-until the destination copy has passed verification and both the upload and
-newly allocated `r2.dev` endpoints are changed together.
+The 2026 account migration is complete. The live bucket, repository variables,
+public endpoint, and publisher credential are all in the dedicated Hex account.
+The source bucket in the personal account was deleted after anonymous reads and
+an authenticated trusted publication succeeded.
 
 | | |
 |---|---|
@@ -35,6 +35,20 @@ to sign them, so the read host must be public; only uploads use a key.
 | `LAKE_CACHE_KEY` (secret) | `<ACCESS_KEY_ID>:<SECRET>`, read-write | `ci.yml` upload only |
 
 Lake service names: `hex-public` for reads, `hex-r2` for uploads.
+
+## Publisher credential
+
+The GitHub Actions secret `LAKE_CACHE_KEY` contains the S3 access-key pair for
+the non-expiring Cloudflare token named **Hex Lake cache R2 publisher**. The
+token belongs to the `hex` account and is restricted to object read/write/list
+access in `hex-cache`; it has no bucket-administration, Worker, DNS, Registrar,
+or billing authority.
+
+When rotating it, create the replacement in the `hex` account, install the new
+`<ACCESS_KEY_ID>:<SECRET_ACCESS_KEY>` pair as `LAKE_CACHE_KEY`, and let a fully
+verified `main` run publish an exact revision before revoking the old token. Do
+not put the token value in a repository variable or expose it to pull-request
+code.
 
 ## Read path and the interim `r2.dev` host
 

--- a/progress/20260907T234430Z_cloudflare_documentation_closeout.md
+++ b/progress/20260907T234430Z_cloudflare_documentation_closeout.md
@@ -1,0 +1,36 @@
+# Cloudflare documentation closeout
+
+## Accomplished
+
+- Reconciled the durable cache documentation with the completed account
+  migration. `hex-cache`, both endpoint pairs, and the least-privilege
+  publisher credential are in the dedicated `hex` account; the personal-account
+  source bucket has been deleted.
+- Documented the publisher credential's ownership, scope, GitHub secret format,
+  and safe rotation sequence without recording any credential value or local
+  recovery location.
+- Closed out the acceptance work left by the earlier migration and cache-cleanup
+  sessions. PRs #9440 and #9441 moved and verified the R2 cache. PR #9491 then
+  made GitHub's dependency-scoped cache primary and R2 the fallback: main run
+  `32696632216` restored and republished 1,205 R2 artifacts and saved the first
+  trusted GitHub snapshot; Pages run `32696632192` deployed successfully. Later
+  CI run `32725120481` and Pages run `32725881966` both restored a compatible
+  GitHub snapshot, with CI correctly skipping the R2 fallback.
+
+## Current frontier
+
+The account migration and cache-policy acceptance are complete. The durable
+documentation now describes the live account, endpoints, credential boundary,
+and two-level restore path.
+
+## Next step
+
+Continue observing GitHub cache eviction and R2 usage under normal traffic. If
+the `hex` account later owns a suitable Cloudflare zone, replace both public
+`r2.dev` endpoint variables together with an R2 custom domain and exercise an
+anonymous restore before disabling the development endpoint.
+
+## Blockers
+
+The custom-domain improvement requires a zone in the `hex` account. It does not
+block the current GitHub-primary, R2-fallback cache path.


### PR DESCRIPTION
## Summary

- record the completed move of `hex-cache` to the dedicated Hex account
- document the least-privilege publisher credential and safe rotation sequence
- close out the earlier migration and cache-policy acceptance work in a new progress record

## Verification

- reconciled the endpoint table with live repository variables
- recorded the successful cold R2 fallback/publication and later warm GitHub cache restores
- `git diff --check`

Progress: `progress/20260907T234430Z_cloudflare_documentation_closeout.md`