### PR TITLE
Prepare the Mathlib-free polynomial gcd-domain lift

### DIFF
--- a/HexMvGcd/Gauss.lean
+++ b/HexMvGcd/Gauss.lean
@@ -451,7 +451,24 @@ variable [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
 /-- Gauss's lemma lifts proof-only gcd-domain structure through every finite
 multivariate arity. -/
 theorem gcdDomainLaws : GcdDomainLaws (MvPoly n R cmp) := by
-  sorry
+  refine {
+    dvd_iff := ?_
+    one_ne_zero := ?_
+    no_zero_div := ?_
+    gcd_exists := ?_ }
+  · intro a b
+    constructor
+    · rintro ⟨q, hq⟩
+      exact ⟨q, hq.trans (MvPoly.mul_comm q a)⟩
+    · rintro ⟨q, hq⟩
+      exact ⟨q, hq.trans (MvPoly.mul_comm a q)⟩
+  · intro hone
+    have hcoeff := congrArg (coeff (Mono.zero : Mono n)) hone
+    rw [coeff_one, coeff_zero, ite_eq_left rfl] at hcoeff
+    exact GcdDomainLaws.one_ne_zero hcoeff
+  · intro a b hab
+    exact MvPoly.zero_product GcdDomainLaws.no_zero_div hab
+  · sorry
 
 instance (priority := 100) instGcdDomainLawsMvPoly :
     GcdDomainLaws (MvPoly n R cmp) :=

--- a/HexMvGcd/Gcd.lean
+++ b/HexMvGcd/Gcd.lean
@@ -1060,7 +1060,7 @@ instance instLawfulGcdOpsMvPoly [IsMonomialOrder cmp]
     rw [coeff_one, coeff_zero, ite_eq_left rfl] at hcoeff
     exact LawfulGcdOps.one_ne_zero hcoeff
   · intro a b hab
-    exact GcdDomainLaws.no_zero_div a b hab
+    exact MvPoly.zero_product LawfulGcdOps.no_zero_div hab
   · intro a b hb
     change quotient (a * b) b = a
     unfold quotient

--- a/HexMvGcd/Normalize.lean
+++ b/HexMvGcd/Normalize.lean
@@ -324,6 +324,59 @@ theorem unit_eq_C
             _ = if m = Mono.zero then cp else 0 := by rw [hpC', coeff_C]
             _ = coeff m (C cp : MvPoly n R cmp) := (coeff_C m cp).symm
 
+omit [Dvd R] [GcdOps R] in
+/-- A coefficient domain makes the polynomial ring a domain for every storage
+comparator. -/
+theorem zero_product
+    (noZeroDiv : ∀ a b : R, a * b = 0 → a = 0 ∨ b = 0)
+    {p q : MvPoly n R cmp} (hpq : p * q = 0) : p = 0 ∨ q = 0 := by
+  by_cases hp : p = 0
+  · exact Or.inl hp
+  by_cases hq : q = 0
+  · exact Or.inr hq
+  let p' : MvPoly n R Mono.lex := reorder Mono.lex p
+  let q' : MvPoly n R Mono.lex := reorder Mono.lex q
+  have hp' : p' ≠ 0 := by
+    intro hzero
+    apply hp
+    apply ext
+    intro m
+    calc
+      coeff m p = coeff m p' := (coeff_reorder Mono.lex m p).symm
+      _ = 0 := by rw [hzero, coeff_zero]
+      _ = coeff m (0 : MvPoly n R cmp) := (coeff_zero m).symm
+  have hq' : q' ≠ 0 := by
+    intro hzero
+    apply hq
+    apply ext
+    intro m
+    calc
+      coeff m q = coeff m q' := (coeff_reorder Mono.lex m q).symm
+      _ = 0 := by rw [hzero, coeff_zero]
+      _ = coeff m (0 : MvPoly n R cmp) := (coeff_zero m).symm
+  have hpq' : p' * q' = 0 := by
+    calc
+      p' * q' = reorder Mono.lex (p * q) :=
+        (reorder_mul (R := R) (cmp := cmp) (cmp' := Mono.lex) p q).symm
+      _ = reorder Mono.lex (0 : MvPoly n R cmp) := by rw [hpq]
+      _ = 0 := by
+        apply ext
+        intro m
+        rw [coeff_reorder, coeff_zero, coeff_zero]
+  cases hpLead : p'.leadingTerm with
+  | none => exact False.elim (hp' ((leadingTerm_eq_none_iff p').mp hpLead))
+  | some pterm =>
+      rcases pterm with ⟨mp, cp⟩
+      cases hqLead : q'.leadingTerm with
+      | none => exact False.elim (hq' ((leadingTerm_eq_none_iff q').mp hqLead))
+      | some qterm =>
+          rcases qterm with ⟨mq, cq⟩
+          have hlead := leadingTerm_mul_of_no_zero_div noZeroDiv hpLead hqLead
+          have hnone : (p' * q').leadingTerm = none :=
+            (leadingTerm_eq_none_iff (p' * q')).mpr hpq'
+          rw [hlead] at hnone
+          cases hnone
+
 /-- Unit recognition is sound and complete under the coefficient gcd laws. -/
 theorem polyIsUnit_iff [IsMonomialOrder cmp] [LawfulGcdOps R]
     (p : MvPoly n R cmp) :

--- a/HexMvGcd/View.lean
+++ b/HexMvGcd/View.lean
@@ -23,7 +23,7 @@ by applying `ofUnivariate` to a dense constant polynomial.
 
 namespace Hex.MvPoly
 
-universe u
+universe u v
 
 variable {n : Nat} {R : Type u}
   {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
@@ -437,6 +437,73 @@ theorem constIn_mul (i : Fin (n + 1)) (a b : MvPoly n R cmp') :
           DensePoly.coeff_C, ite_eq_right hright]
         exact coeff_zero _
       rw [hz, Lean.Grind.Semiring.mul_zero]
+
+private theorem insertVar_zero_eq_prepend (e : Nat) (m : Mono n) :
+    insertVar (0 : Fin (n + 1)) e m = Mono.prepend e m := by
+  rfl
+
+private theorem coeff_foldl_add_term
+    {cmp0 : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp0] [Std.LawfulEqCmp cmp0]
+    {A : Type v} (m : Mono n) (xs : List A)
+    (f : A → MvPoly n R cmp0) (z : MvPoly n R cmp0) :
+    coeff m (xs.foldl (fun acc x => acc + f x) z) =
+      xs.foldl (fun acc x => acc + coeff m (f x)) (coeff m z) := by
+  induction xs generalizing z with
+  | nil => rfl
+  | cons x xs ih =>
+      simp only [List.foldl_cons]
+      rw [ih, coeff_add]
+
+/-- The recursive view at the first variable preserves multiplication. -/
+theorem toUnivariate_mul (p q : MvPoly (n + 1) R cmp) :
+    toUnivariate 0 cmp' (p * q) =
+      toUnivariate 0 cmp' p * toUnivariate 0 cmp' q := by
+  apply DensePoly.ext_coeff
+  intro e
+  apply MvPoly.ext
+  intro m
+  rw [toUnivariate_coeff, DensePoly.coeff_mul]
+  have hdiag := DensePoly.mulCoeffSum_eq_diagonal
+    (S := MvPoly n R cmp')
+    (toUnivariate 0 cmp' p) (toUnivariate 0 cmp' q) e
+  have hdegree := DensePoly.diagonalSum_eq_degree_bound
+    (S := MvPoly n R cmp')
+    (toUnivariate 0 cmp' p) (toUnivariate 0 cmp' q) e
+  have hdiagCoeff := congrArg (coeff m) (hdiag.trans hdegree)
+  rw [hdiagCoeff]
+  rw [MvPoly.coeff_mul, insertVar_zero_eq_prepend]
+  have hhead : (Mono.prepend e m).head = e := by
+    exact Mono.getElem_prepend_zero e m
+  simp only [Mono.splits, Mono.dropHead_prepend, hhead]
+  rw [List.foldl_add_flatMap]
+  rw [coeff_foldl_add_term, coeff_zero]
+  apply List.foldl_congr
+  intro acc d hd
+  rw [List.foldl_map]
+  simp only [DensePoly.diagonalMulCoeffTerm]
+  have hde : ¬ e < d := by
+    exact Nat.not_lt_of_ge (Nat.le_of_lt_succ (List.mem_range.mp hd))
+  rw [ite_eq_right hde]
+  rw [List.foldl_add_eq_add_foldl]
+  apply congrArg (fun x => acc + x)
+  calc
+    m.splits.foldl
+        (fun acc x => acc +
+          coeff (Mono.prepend d x.1) p *
+            coeff (Mono.prepend (e - d) x.2) q) 0 =
+        m.splits.foldl
+          (fun acc x => acc +
+            coeff x.1 ((toUnivariate 0 cmp' p).coeff d) *
+              coeff x.2 ((toUnivariate 0 cmp' q).coeff (e - d))) 0 := by
+      apply List.foldl_congr
+      intro z x _
+      rw [toUnivariate_coeff, toUnivariate_coeff,
+        insertVar_zero_eq_prepend, insertVar_zero_eq_prepend]
+    _ = coeff m
+          ((toUnivariate 0 cmp' p).coeff d *
+            (toUnivariate 0 cmp' q).coeff (e - d)) :=
+      (MvPoly.coeff_mul _ _ _).symm
 
 omit [BEq R] [LawfulBEq R] in
 /-- Constant embedding is injective. -/

--- a/HexPoly/Euclid/MulRing.lean
+++ b/HexPoly/Euclid/MulRing.lean
@@ -193,7 +193,7 @@ private theorem fold_diagonal_truncate_degree {S : Type _}
 /-- The diagonal sum over `List.range p.size` equals the sum over
 `List.range (n + 1)`; the canonical degree-`n` truncation of the convolution,
 independent of `p.size`. -/
-private theorem diagonalSum_eq_degree_bound {S : Type _}
+theorem diagonalSum_eq_degree_bound {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S]
     (p q : DensePoly S) (n : Nat) :
     (List.range p.size).foldl (fun acc i => acc + diagonalMulCoeffTerm p q n i) 0 =

--- a/scripts/bench/proof_only_runtime_exemptions/hexpoly-euclid-mulring-lean-ac64178b-ccc4934e.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexpoly-euclid-mulring-lean-ac64178b-ccc4934e.json
@@ -1,0 +1,6 @@
+{
+  "path": "HexPoly/Euclid/MulRing.lean",
+  "baseline_blob": "ac64178be71e2a335ca904cef0b9510751c7562d",
+  "current_blob": "ccc4934e98c5f244cf2385cd5a6770eaeb68be63",
+  "reason": "Covers the already exempted import and proof-script cleanup from ac64178b to 166ec622, then removes `private` from the existing `diagonalSum_eq_degree_bound` proof so the GCD library can reuse it. No executable definition body changes."
+}


### PR DESCRIPTION
The proof-only polynomial gcd-domain lift was using its single `sorry` for all four class fields, and the SPEC's intended arity induction lacked a Mathlib-free multiplicative recursive view. This slice proves the divisibility, nontriviality, and zero-product fields directly, adds `toUnivariate_mul` at the first variable, and leaves only `gcd_exists` inside the existing gap.

It also makes the executable `LawfulGcdOps` domain proof independent of the remaining gcd-existence gap. Exporting an existing `HexPoly` convolution proof changes its source fingerprint but no executable definition, so the PR records the exact proof-only blob transition required by the benchmark freshness guard. This is an incremental prerequisite for #10082; it does not close the tracker or reduce the remaining literal `sorry` count.

Validation:
- `lake build HexMvGcd HexMvHensel HexMvFactor HexMvFactorizationTests` (619 jobs)
- `lake build HexMvGcd.Normalize HexMvGcd.Gauss HexMvGcd.Gcd` after review cleanup
- `python3 scripts/bench/check_factor_sweep_freshness.py`
- 75 benchmark-freshness unit tests
- `git diff --check`
- `#print axioms Hex.MvPoly.toUnivariate_mul`
- `#print axioms Hex.MvPoly.zero_product`

Both audited theorems depend only on `propext`, `Classical.choice`, and `Quot.sound`.
