### PR TITLE
feat(release): publish one shared semantic version

### DIFF
--- a/.github/workflows/sync-released.yml
+++ b/.github/workflows/sync-released.yml
@@ -4,9 +4,10 @@ name: Sync released repos
 # (scripts/release/released.yml + scripts/release/sync_released.py).
 #
 # Manual dispatch, defaulting to a dry run. A real sync (dry_run=false) overwrites
-# each released repo's managed paths, rewrites their cross-repo Lake pins, pushes
-# to their `main`, and advances the baseline — one dispatch drives it all the way
-# through. The uncoordinated-commit guard skips any released repo whose `main` has
+# each released repo's managed paths, publishes one shared semantic-version tag,
+# and advances the baseline — one dispatch drives it all the way through. A
+# completed real sync increments the minor version. The uncoordinated-commit
+# guard skips any released repo whose `main` has
 # moved off the baseline, so out-of-band commits are never clobbered. Needs the
 # `RELEASED_SYNC_PAT` and `RELEASED_SYNC_PAT_2` secrets (Contents and Workflows:
 # read/write on the released repos; Workflows is required for managed CI files.
@@ -76,7 +77,7 @@ jobs:
             --baseline /tmp/baseline.json "${args[@]}"
       - name: Publish advanced baseline
         # A later mirror can fail after earlier mirrors were pushed. Preserve
-        # those exact heads even when the sync step reports that failure.
+        # their heads and the pending shared version so a retry resumes it.
         if: ${{ always() && inputs.dry_run == false }}
         env:
           GH_TOKEN: ${{ github.token }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,8 @@
 
 `hex-dev` is the development monorepo where new Hex sublibraries are
 incubated before they are split out for release. `hex` is the released
-aggregate repo; it depends on released split libraries at exact Lake
-revisions.
+aggregate repo; it depends on one shared semantic version of the released
+split libraries.
 
 The authoritative list of split repos published from `hex-dev` is
 [`scripts/release/released.yml`](scripts/release/released.yml), which
@@ -17,7 +17,7 @@ Two structural things the manifest encodes:
 - `hex-test-kit` is the shared conformance/bench helper library
   (source: `Hex/`), not user-facing Hex API.
 - `leanprover/hex` is `pins_only`: it publishes no library source and is
-  re-pinned to the SHAs synced each run, so it is listed last. Its README
+  re-pinned to the shared version synced each run, so it is listed last. Its README
   is generated from `scripts/release/hex-README.md` plus the manifest's
   `component:` labels (see [SPEC/readme.md](SPEC/readme.md)).
 
@@ -32,7 +32,8 @@ development happens in this one tree; a single `lake build` (plus the
 `bench/` and `conformance/` sub-projects) builds everything together.
 The split repos are **published mirrors**: a dispatchable CI
 workflow regenerates each one from the matching content in `hex-dev`,
-rewriting their cross-repo Lake pins and committing to their `main`.
+rewriting their cross-repo Lake requirements, committing to their `main`, and
+tagging every mirror with the same release version.
 Never hand-edit a released repo; change it here and let the sync publish.
 
 Every library uses the same per-library layout (so the publish step is a
@@ -51,10 +52,11 @@ The publish mechanism is `scripts/release/released.yml` (the per-repo
 managed-path + pin manifest), `scripts/release/released-ci.yml` (the managed
 mirror CI workflows), `scripts/release/sync_released.py` (the
 driver; supports `--dry-run`), `scripts/release/synced.json` (the
-per-repo `main` baseline this monorepo corresponds to), and
+per-repo `main` baseline and shared release version), and
 `.github/workflows/sync-released.yml` (manual dispatch, dry by default).
-A real sync overwrites each released repo's managed paths and rewrites
-its Lake pins, so it must only run once this monorepo is at or ahead of
+A real sync overwrites each released repo's managed paths, rewrites its Hex
+requirements to the next shared minor version, and tags the resulting commit,
+so it must only run once this monorepo is at or ahead of
 every released repo's `main`. Run `--dry-run` first.
 
 **Uncoordinated-commit guard.** The sync refuses to overwrite a released
@@ -70,7 +72,9 @@ that), then re-run the sync.
 The baseline lives on a dedicated, unprotected `release-sync-baseline`
 branch that the workflow reads and advances on every real run, so a single
 `workflow_dispatch` (dry-run first, then `dry_run=false`) drives the whole
-publish through with no follow-up. `scripts/release/synced.json` is the
+publish through with no follow-up. A partial failure leaves a pending release
+bound to its source commit, and the retry completes that version rather than
+incrementing again. `scripts/release/synced.json` is the
 bootstrap seed used only before that branch exists.
 
 # hex — agent-specific conventions

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 Verified computational algebra in Lean 4.
 
 **If you want to *use* Hex, you want https://github.com/leanprover/hex, not
-this repository.** That is the released aggregate: it depends on the split
-Hex libraries at exact Lake revisions and is what downstream projects should
-add as a dependency.
+this repository.** That is the released aggregate: it depends on one shared
+semantic version of the split Hex libraries and is what downstream projects
+should add as a dependency.
 
 **Documentation: https://kim-em.github.io/hex-dev/** is the Hex manual,
 rendered from `HexManual/` and published on every push to `main`.
@@ -19,7 +19,8 @@ a change that breaks a downstream library shows up immediately.
 
 The released repositories are **published mirrors**, not places to work: a
 dispatchable CI workflow regenerates each one from the matching content
-here, rewrites its cross-repo Lake pins, and commits to its `main`. Never
+here, rewrites its cross-repo Lake requirements, and publishes the same version
+tag in every repository. Never
 hand-edit a released repo; change it here and let the sync publish it.
 
 The authoritative list of published libraries, in topological order and with

--- a/scripts/release/BOOTSTRAP.md
+++ b/scripts/release/BOOTSTRAP.md
@@ -175,7 +175,8 @@ required because the sync publishes `.github/workflows/ci.yml`. Then:
 5. Watch each mirror's own CI on the sync push; a build-only workflow on the
    published tree is what establishes that the mirror is coherent.
 
-The first complete real workflow tags every released repository `v0.1.0`.
+Some libraries used `v0.1.0` before releases were coordinated, so the first
+shared release is `v0.2.0` across every released repository.
 Each later complete release increments the shared minor version and resets its
 patch component to zero. Lake files use that tag as their cross-Hex input
 revision; manifests record both the tag and its exact resolved commit.

--- a/scripts/release/BOOTSTRAP.md
+++ b/scripts/release/BOOTSTRAP.md
@@ -98,20 +98,21 @@ on the closest already released package. The initial `main` must contain:
 - one Lake project, at the root: a mirror has no sidecar projects, and a
   skeleton that still declares a `lean_lib` reading from `bench/` or
   `conformance/` should drop it;
-- a non-public regression-test `lean_lib` containing every module named by the
-  manifest entry's `test_modules` list. These modules are intentionally absent
-  from the public umbrella, and the released repository's CI must build this
-  target explicitly;
+- the public library target. The sync creates and maintains the conventional
+  non-public `<Lib>Tests` target from the manifest entry's `test_modules` list;
+  these modules remain absent from the public umbrella, and the released
+  repository's CI builds that target explicitly;
 - a separate `lean_lib` for every complete development umbrella in
   `build_modules`, so a curated public umbrella cannot hide a broken proof
   module; and
 - every executable in the manifest's `executables` map, with exactly the named
   root module.
 
-Publication validates these declarations in the unmanaged Lake skeleton before
-copying source. It also validates that every `scripts/ci` helper named by the
-managed workflow exists in the mirror. A stale target or missing helper
-therefore stops the sync before it can partially update that repository.
+Publication updates the release-test target, then validates the remaining
+declarations in the unmanaged Lake skeleton before copying source. It also
+validates that every `scripts/ci` helper named by the managed workflow exists
+in the mirror. A stale target or missing helper therefore stops the sync before
+it can partially update that repository.
 
 Source, the umbrella module, README, SPEC, and `.github/workflows/ci.yml` are
 managed by the sync. Do not duplicate or hand-edit those files in a released
@@ -174,7 +175,17 @@ required because the sync publishes `.github/workflows/ci.yml`. Then:
 5. Watch each mirror's own CI on the sync push; a build-only workflow on the
    published tree is what establishes that the mirror is coherent.
 
+The first complete real workflow tags every released repository `v0.1.0`.
+Each later complete release increments the shared minor version and resets its
+patch component to zero. Lake files use that tag as their cross-Hex input
+revision; manifests record both the tag and its exact resolved commit.
+
 The real workflow advances the `release-sync-baseline` branch in the same run.
+It records a pending version before the first push and each repository as its
+tag is published. If a later mirror fails, rerun the workflow at the same
+hex-dev commit: it resumes that version, and only marks the release complete
+after every mirror carries the tag. A staged `--only` publish likewise remains
+pending until all repositories have joined the release.
 Future out-of-band changes to a released `main` must be re-seeded into this
 monorepo before publication continues; never bypass that reconciliation with
 `--force` merely to make a release proceed.

--- a/scripts/release/check_released_manifest.py
+++ b/scripts/release/check_released_manifest.py
@@ -132,7 +132,7 @@ def parse_sync_baseline(text: str, source: str) -> set[str]:
         fail(f"{source}: sync baseline must be a JSON object")
     published: set[str] = set()
     for repo, revision in document.items():
-        if repo == "_comment":
+        if isinstance(repo, str) and repo.startswith("_"):
             continue
         if (
             not isinstance(repo, str)

--- a/scripts/release/released.yml
+++ b/scripts/release/released.yml
@@ -6,8 +6,9 @@
 # and its unmanaged skeleton, overwrites the managed paths from here, enables
 # native Verso docstrings in each managed-source repo's lakefile, copies the
 # monorepo's Lean toolchain, synchronizes exact external dependency locks,
-# rewrites cross-repo Hex pins to the commits just synced, and commits to the
-# released repo's `main`.
+# rewrites cross-repo Hex requirements to the shared release version, commits
+# to the released repo's `main`, and tags that commit. The lockfiles retain the
+# exact commits resolved by those tags.
 #
 # A released repo ships the library and nothing else: its Lean source, umbrella,
 # SPEC and README. Benchmarks, conformance drivers, fixtures and oracles are
@@ -25,8 +26,8 @@
 # a second workflow beside its build-only one; nor do `reports/` or `.claude/`,
 # beyond the figures an entry names below.
 #
-# Order is topological (upstream first) so each repo's freshly-pushed SHA is
-# known before its downstream consumers are processed.
+# Order is topological (upstream first) so each version tag exists and its exact
+# commit is known before downstream consumers are processed.
 #
 # ADDING A REPO HERE IS ONLY HALF THE JOB. Each publishing token is scoped to
 # an explicit list of repositories (and a fine-grained token caps that list,
@@ -48,8 +49,8 @@
 # the library and nothing else, and the driver applies the same divergence guard
 # as every other managed path.
 # `test_modules` lists verification-only modules copied with the source but
-# intentionally absent from the public umbrella; released CI builds them via a
-# non-public `lean_lib` target.
+# intentionally absent from the public umbrella; the sync maintains their
+# non-public `<Lib>Tests` target and released CI builds it.
 # `keep_paths` is the escape hatch out of that sweep: explicit relative paths a
 # mirror owns that are neither managed nor part of the common skeleton. One
 # entry uses it, for `hex-test-kit`'s fixed `HexTestKit.lean` umbrella. It can

--- a/scripts/release/sync_released.py
+++ b/scripts/release/sync_released.py
@@ -121,9 +121,11 @@ SEMVER = re.compile(r"^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
 
 
 def next_release_version(current: object = None) -> str:
-    """Increment the shared minor version, starting with ``v0.1.0``."""
+    """Increment the shared minor version, starting with ``v0.2.0``."""
     if current is None:
-        return "v0.1.0"
+        # A few libraries published independent v0.1.0 tags before releases
+        # were coordinated. Treat that version as the historical floor.
+        return "v0.2.0"
     if not isinstance(current, str) or (match := SEMVER.fullmatch(current)) is None:
         raise ValueError(f"invalid completed release version: {current!r}")
     major, minor, _patch = map(int, match.groups())

--- a/scripts/release/sync_released.py
+++ b/scripts/release/sync_released.py
@@ -9,14 +9,16 @@ For each repo in scripts/release/released.yml (topological order), this:
   3. for managed-source repos, enables native Verso docstrings and carries the
      `lean_lib` build settings this monorepo's lakefile gives the library,
   4. copies the stable Lean toolchain and exact external dependency pins,
-  5. rewrites cross-repo Hex pins in the repo's Lake files,
-  6. commits `chore: sync from hex-dev@<sha>` and pushes to `main`
+  5. rewrites cross-repo Hex requirements to one shared semantic version,
+  6. commits `chore: sync from hex-dev@<sha>`, pushes to `main`, and tags the
+     resulting commit with that version
      (unless --dry-run, which prints the planned changes and pin rewrites).
 
 A `pins_only` entry (the `leanprover/hex` aggregate) receives the managed CI
 workflow but no library source or Verso rewrite from the monorepo. The sync
-re-pins it to the SHAs published this run. Listed last, after its upstreams, its
-pins resolve to the freshly-pushed commits. Its other managed artifact is the
+re-pins it to the version published this run. Listed last, after its upstreams,
+its lockfile resolves those requirements to the freshly-pushed commits. Its
+other managed artifact is the
 README, rendered by `aggregate_readme.py` from a template plus the manifest's
 `component:` labels so the published library table cannot fall behind.
 
@@ -115,6 +117,59 @@ LAKEFILE = REPO_ROOT / "lakefile.lean"
 WRITTEN_LIB_SETTINGS = ("precompileModules",)
 CHECKED_LIB_SETTINGS = ("extraDepTargets", "moreLinkArgs")
 BUILD_LIB_SETTINGS = WRITTEN_LIB_SETTINGS + CHECKED_LIB_SETTINGS
+SEMVER = re.compile(r"^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+
+
+def next_release_version(current: object = None) -> str:
+    """Increment the shared minor version, starting with ``v0.1.0``."""
+    if current is None:
+        return "v0.1.0"
+    if not isinstance(current, str) or (match := SEMVER.fullmatch(current)) is None:
+        raise ValueError(f"invalid completed release version: {current!r}")
+    major, minor, _patch = map(int, match.groups())
+    return f"v{major}.{minor + 1}.0"
+
+
+def release_transaction(document: dict, source_sha: str) -> tuple[str, set[str], bool]:
+    """Return ``(version, completed repos, resumed)`` for the next publication.
+
+    A pending transaction is deliberately tied to one hex-dev commit. This
+    prevents a retry from placing the same version on different source states
+    after main has advanced.
+    """
+    pending = document.get("_pending_release")
+    if pending is None:
+        return next_release_version(document.get("_version")), set(), False
+    if not isinstance(pending, dict):
+        raise ValueError("_pending_release must be an object")
+    version = pending.get("version")
+    source = pending.get("source")
+    repos = pending.get("repos")
+    if (not isinstance(version, str) or SEMVER.fullmatch(version) is None
+            or not isinstance(source, str)
+            or not isinstance(repos, list)
+            or not all(isinstance(repo, str) for repo in repos)
+            or len(repos) != len(set(repos))):
+        raise ValueError("invalid _pending_release record")
+    expected = next_release_version(document.get("_version"))
+    if version != expected:
+        raise ValueError(
+            f"pending release is {version}, but {expected} must follow the "
+            "completed release"
+        )
+    if source != source_sha:
+        raise RuntimeError(
+            f"release {version} is pending from hex-dev@{source[:12]}; rerun "
+            "the sync at that commit before starting another release"
+        )
+    return version, set(repos), True
+
+
+def write_baseline(path: Path, document: dict) -> None:
+    """Atomically replace the live release baseline."""
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+    temporary.replace(path)
 
 
 def run(cmd: list[str], cwd: Path | None = None, capture: bool = False) -> str:
@@ -808,6 +863,72 @@ def rewrite_lake_declarations(entry: dict, clone: Path) -> list[str]:
     return notes
 
 
+def rewrite_test_target(entry: dict, clone: Path) -> list[str]:
+    """Build exactly the release regressions declared by the manifest.
+
+    Test modules live in the managed library tree, so requiring a hand-edited
+    mirror target whenever that list changes defeats publish-out synchronization.
+    The mirror's conventional ``<Lib>Tests`` target is therefore generated from
+    ``test_modules`` while the rest of its Lake skeleton remains local.
+    """
+    modules = entry.get("test_modules") or []
+    if entry.get("pins_only") or not modules:
+        return []
+    lib = entry["lib"]
+    target = f"{lib}Tests"
+    lakefile = clone / f"lakefile.{entry['lakefile']}"
+    text = lakefile.read_text(encoding="utf-8")
+    original = text
+    if entry["lakefile"] == "toml":
+        rendered = "globs = " + json.dumps(modules)
+        block = _toml_lib_block(text, target)
+        if block is None:
+            text = text.rstrip() + (
+                f'\n\n[[lean_lib]]\nname = "{target}"\n{rendered}\n'
+            )
+        else:
+            body = block.group(1)
+            rewritten, count = re.subn(
+                r"(?m)^[ \t]*globs[ \t]*=[ \t]*\[[^\]]*\][ \t]*$",
+                rendered,
+                body,
+                count=1,
+            )
+            if count == 0:
+                rewritten = body.rstrip() + f"\n{rendered}\n"
+            text = text[:block.start(1)] + rewritten + text[block.end(1):]
+        try:
+            tomllib.loads(text)
+        except tomllib.TOMLDecodeError as exc:
+            raise RuntimeError(
+                f"release-test rewrite produced invalid TOML in {lakefile}: {exc}"
+            ) from exc
+    else:
+        rendered = "  globs := #[" + ", ".join(f"`{module}" for module in modules) + "]"
+        header = _lean_lib_header(text, target)
+        if header is None:
+            text = text.rstrip() + f"\n\nlean_lib {target} where\n{rendered}\n"
+        else:
+            body_start = header.end()
+            body_end = _block_end(text, body_start)
+            body = text[body_start:body_end]
+            rewritten, count = re.subn(
+                r"(?m)^[ \t]+globs[ \t]*:=[ \t]*#\[[^\]]*\][ \t]*$",
+                rendered,
+                body,
+                count=1,
+            )
+            if count == 0:
+                opener = "" if header.group("where") else " where"
+                text = text[:body_start] + opener + "\n" + rendered + text[body_start:]
+            else:
+                text = text[:body_start] + rewritten + text[body_end:]
+    if text == original:
+        return []
+    lakefile.write_text(text, encoding="utf-8")
+    return [f"  release tests on lean_lib {target} ({lakefile.name})"]
+
+
 def validate_skeleton(entry: dict, clone: Path) -> None:
     """Check the unmanaged Lake file carries every release build root.
 
@@ -1131,8 +1252,8 @@ def rewrite_doc_verso(clone: Path) -> list[str]:
 
 
 def rewrite_pins(entry: dict, clone: Path, synced: dict[str, str],
-                 dep_owner: dict[str, str]) -> list[str]:
-    """Rewrite every synced-repo git pin in the released repo's lakefiles."""
+                 dep_owner: dict[str, str], version: str) -> list[str]:
+    """Rewrite every published Hex requirement to the shared release tag."""
     notes: list[str] = []
     match_owner = r'(?:kim-em|leanprover)'
     for lf in _lake_files(clone, ["lakefile.toml", "lakefile.lean"]):
@@ -1148,15 +1269,16 @@ def rewrite_pins(entry: dict, clone: Path, synced: dict[str, str],
             # toml: `git = "https://github.com/<owner>/<dep>.git"\n  rev = "..."`
             text, n1 = re.subn(
                 r'(git\s*=\s*"https://github\.com/)' + match_owner
-                + r'(/' + tail + r'"\s*\n\s*rev\s*=\s*")[0-9a-f]{7,40}(")',
-                lambda m, t=target, s=sha: m.group(1) + t + m.group(2) + s + m.group(3), text)
-            # lean: `"https://github.com/<owner>/<dep>.git" @ "<sha>"`
+                + r'(/' + tail + r'"\s*\n\s*rev\s*=\s*")[^"]+(")',
+                lambda m, t=target: m.group(1) + t + m.group(2) + version + m.group(3), text)
+            # lean: `"https://github.com/<owner>/<dep>.git" @ "<version>"`
             text, n2 = re.subn(
                 r'("https://github\.com/)' + match_owner
-                + r'(/' + tail + r'"\s*@\s*")[0-9a-f]{7,40}(")',
-                lambda m, t=target, s=sha: m.group(1) + t + m.group(2) + s + m.group(3), text)
+                + r'(/' + tail + r'"\s*@\s*")[^"]+(")',
+                lambda m, t=target: m.group(1) + t + m.group(2) + version + m.group(3), text)
             if n1 or n2:
-                notes.append(f"  pin {dep} -> {sha[:12]} ({lf.relative_to(clone)})")
+                notes.append(
+                    f"  pin {dep} -> {version} ({sha[:12]}; {lf.relative_to(clone)})")
         if text != orig:
             lf.write_text(text, encoding="utf-8")
     return notes
@@ -1165,11 +1287,9 @@ def rewrite_pins(entry: dict, clone: Path, synced: dict[str, str],
 def rewrite_manifest(entry: dict, clone: Path, synced: dict[str, str],
                      dep_owner: dict[str, str],
                      pins: dict[str, dict[str, str]],
+                     version: str,
                      catalog: dict[str, dict[str, str]] | None = None) -> list[str]:
-    """Pin the synced SHAs in every lake-manifest.json, so Lake's lockfile points
-    at the new revisions, not a stale checkout: Lake trusts the manifest, and a
-    lockfile left alone keeps resolving the upstream commit it was written
-    against."""
+    """Resolve Hex release tags to exact SHAs in every Lake manifest."""
     notes: list[str] = []
     import json as _json
     # Match either owner so a manifest still carrying the pre-transfer URL is
@@ -1197,13 +1317,12 @@ def rewrite_manifest(entry: dict, clone: Path, synced: dict[str, str],
                     pkg["url"] = re.sub(r'(github\.com/)(?:kim-em|leanprover)(/)',
                                         rf'\g<1>{target}\g<2>', url)
                     pkg["rev"] = synced[dep]
-                    if pkg.get("inputRev") and len(pkg["inputRev"]) >= 7:
-                        pkg["inputRev"] = synced[dep]
+                    pkg["inputRev"] = version
                     changed += 1
                     notes.append(f"  manifest {dep} -> {synced[dep][:12]} ({mf.relative_to(clone)})")
         if mf == clone / "lake-manifest.json":
             changed += _synthesize_manifest_packages(
-                entry, clone, doc, synced, dep_owner, catalog, notes)
+                entry, clone, doc, synced, dep_owner, version, catalog, notes)
         if changed:
             mf.write_text(_json.dumps(doc, indent=2) + "\n", encoding="utf-8")
     return notes
@@ -1220,6 +1339,7 @@ def _manifest_catalog() -> dict[str, dict[str, str]]:
 def _synthesize_manifest_packages(entry: dict, clone: Path, doc: dict,
                                   synced: dict[str, str],
                                   dep_owner: dict[str, str],
+                                  version: str,
                                   catalog: dict[str, dict[str, str]] | None,
                                   notes: list[str]) -> int:
     """Add lockfile entries for pinned published dependencies the mirror's
@@ -1263,7 +1383,7 @@ def _synthesize_manifest_packages(entry: dict, clone: Path, doc: dict,
             "rev": synced[dep],
             "name": spec["lib"],
             "manifestFile": "lake-manifest.json",
-            "inputRev": synced[dep],
+            "inputRev": version,
             "inherited": f"{dep}.git" not in lake_text,
             "configFile": f"lakefile.{spec['lakefile']}",
         })
@@ -1293,6 +1413,7 @@ def _hex_import_roots(entry: dict, clone: Path) -> set[str]:
 
 def rewrite_requires(entry: dict, clone: Path, synced: dict[str, str],
                      dep_owner: dict[str, str],
+                     version: str,
                      catalog: dict[str, dict[str, str]] | None = None) -> list[str]:
     """Require directly every published library the sources import directly.
 
@@ -1303,7 +1424,7 @@ def rewrite_requires(entry: dict, clone: Path, synced: dict[str, str],
     hex-bareiss) or a dependency stops requiring it, the mirror fails with
     "unknown module prefix". A direct require for each direct import is
     always correct and never redundant enough to matter, so the sync appends
-    the missing ones at the synced revision: a `[[require]]` block before the
+    the missing ones at the shared release version: a `[[require]]` block before the
     first target in `lakefile.toml`, or a `require ... from git` after the
     last one in `lakefile.lean`.
     """
@@ -1331,7 +1452,7 @@ def rewrite_requires(entry: dict, clone: Path, synced: dict[str, str],
         return notes
     if entry["lakefile"] == "toml":
         block = "".join(
-            f'[[require]]\nname = "{lib}"\ngit = "{url}"\nrev = "{synced[dep]}"\n\n'
+            f'[[require]]\nname = "{lib}"\ngit = "{url}"\nrev = "{version}"\n\n'
             for dep, lib, url in additions)
         anchor = re.search(r"(?m)^\[\[(?:lean_lib|lean_exe)\]\]", text)
         if anchor:
@@ -1340,7 +1461,7 @@ def rewrite_requires(entry: dict, clone: Path, synced: dict[str, str],
             text = text.rstrip("\n") + "\n\n" + block
     else:
         block = "".join(
-            f'\nrequire {lib} from git\n  "{url}" @ "{synced[dep]}"\n'
+            f'\nrequire {lib} from git\n  "{url}" @ "{version}"\n'
             for dep, lib, url in additions)
         requires = list(re.finditer(r"(?m)^require\b.*(?:\n[ \t]+.*)*\n", text))
         if requires:
@@ -1351,7 +1472,7 @@ def rewrite_requires(entry: dict, clone: Path, synced: dict[str, str],
         text = text[:end] + block + text[end:]
     lakefile.write_text(text, encoding="utf-8")
     for dep, lib, _url in additions:
-        notes.append(f"  require + {dep} ({lib}) -> {synced[dep][:12]} ({lakefile.name})")
+        notes.append(f"  require + {dep} ({lib}) -> {version} ({lakefile.name})")
     return notes
 
 
@@ -1394,11 +1515,47 @@ def validate_external_imports(entry: dict, clone: Path) -> None:
             + f" but {lakefile.name} requires no package providing it")
 
 
+def remote_tag_target(clone: Path, version: str) -> str | None:
+    """Return the commit named by a remote lightweight tag, if it exists."""
+    output = run(
+        ["git", "ls-remote", "--refs", "origin", f"refs/tags/{version}"],
+        cwd=clone,
+        capture=True,
+    )
+    if not output:
+        return None
+    lines = output.splitlines()
+    if len(lines) != 1 or len(lines[0].split()) != 2:
+        raise RuntimeError(f"unexpected remote tag response for {version!r}")
+    return lines[0].split()[0]
+
+
+def version_tag_collisions(entries: list[dict], version: str) -> dict[str, str]:
+    """Existing tags that prevent allocating a new shared version."""
+    collisions: dict[str, str] = {}
+    for entry in entries:
+        repo = entry["repo"]
+        output = run(
+            ["git", "ls-remote", "--refs", clone_url(repo, None),
+             f"refs/tags/{version}"],
+            capture=True,
+        )
+        if output:
+            fields = output.split()
+            if len(fields) != 2:
+                raise RuntimeError(
+                    f"unexpected remote tag response for {repo}@{version}"
+                )
+            collisions[repo] = fields[0]
+    return collisions
+
+
 def sync_repo(entry: dict, source_sha: str, token: str | None, dry_run: bool,
               synced: dict[str, str], baseline: dict[str, str], force: bool,
               dep_owner: dict[str, str],
-              pins: dict[str, dict[str, str]]) -> bool:
-    """Sync one repo. Returns True if the baseline SHA changed (a push happened)."""
+              pins: dict[str, dict[str, str]], version: str,
+              resuming: bool) -> bool:
+    """Sync and tag one repo; return whether it belongs to this release."""
     repo = entry["repo"]
     short = repo.split("/")[-1]
     print(f"\n=== {repo} ===")
@@ -1406,10 +1563,18 @@ def sync_repo(entry: dict, source_sha: str, token: str | None, dry_run: bool,
         clone = Path(td) / short
         run(["git", "clone", "--depth", "1", clone_url(repo, token), str(clone)], capture=True)
         head = run(["git", "rev-parse", "HEAD"], cwd=clone, capture=True)
+        tagged = remote_tag_target(clone, version)
         # Compare-and-swap guard: refuse to overwrite a repo whose main has moved
         # off the baseline this monorepo was synced from (an uncoordinated commit).
         expected = baseline.get(short)
         if expected and head != expected:
+            # The process may have been interrupted after its atomic main+tag
+            # push and before the baseline write. A recorded pending transaction
+            # makes that exact tag a sufficient, immutable recovery marker.
+            if resuming and tagged == head:
+                print(f"  resumed {repo}@{version} ({head[:12]})")
+                synced[short] = head
+                return True
             msg = (f"  UNCOORDINATED: {repo} main is {head[:12]}, baseline expects "
                    f"{expected[:12]}. Reconcile (re-seed from main) before syncing.")
             if not force:
@@ -1417,6 +1582,8 @@ def sync_repo(entry: dict, source_sha: str, token: str | None, dry_run: bool,
                 synced[short] = expected
                 return False
             print(msg + " Overriding (--force).")
+        for line in rewrite_test_target(entry, clone):
+            print(line)
         validate_skeleton(entry, clone)
         validate_ci_helpers(entry, clone)
         for line in apply_paths(entry, clone):
@@ -1433,17 +1600,31 @@ def sync_repo(entry: dict, source_sha: str, token: str | None, dry_run: bool,
             print(line)
         for line in rewrite_external_pins(clone, pins):
             print(line)
-        for line in rewrite_requires(entry, clone, synced, dep_owner):
+        for line in rewrite_requires(entry, clone, synced, dep_owner, version):
             print(line)
-        for line in rewrite_pins(entry, clone, synced, dep_owner):
+        for line in rewrite_pins(entry, clone, synced, dep_owner, version):
             print(line)
-        for line in rewrite_manifest(entry, clone, synced, dep_owner, pins):
+        for line in rewrite_manifest(entry, clone, synced, dep_owner, pins, version):
             print(line)
         status = run(["git", "status", "--porcelain"], cwd=clone, capture=True)
         if not status:
             print("  (no changes)")
             synced[short] = head
-            return False
+            if dry_run:
+                print(f"  DRY-RUN: would tag current main as {version}")
+                return False
+            if tagged is not None:
+                if tagged != head:
+                    raise RuntimeError(
+                        f"{repo} already has {version} at {tagged[:12]}, not "
+                        f"current main {head[:12]}"
+                    )
+                print(f"  {version} already tags {repo}@{head[:12]}")
+                return True
+            run(["git", "tag", version, head], cwd=clone)
+            run(["git", "push", "origin", f"refs/tags/{version}"], cwd=clone)
+            print(f"  tagged {repo}@{version} ({head[:12]})")
+            return True
         print("  changed files:")
         for l in status.splitlines():
             print(f"    {l}")
@@ -1458,15 +1639,22 @@ def sync_repo(entry: dict, source_sha: str, token: str | None, dry_run: bool,
                 for line in workflow_diff.splitlines():
                     print(f"    {line}")
             synced[short] = head  # stand-in so downstream pin previews resolve
-            print("  DRY-RUN: not committing or pushing")
+            print(f"  DRY-RUN: would commit, push, and tag {version}")
             return False
+        if tagged is not None:
+            raise RuntimeError(
+                f"{repo} already has {version} at {tagged[:12]}, but this sync "
+                "would change its contents"
+            )
         run(["git", "add", "-A"], cwd=clone)
         run(["git", "-c", "user.name=hex-dev sync",
              "-c", "user.email=noreply@anthropic.com",
              "commit", "-q", "-m", f"chore: sync from hex-dev@{source_sha[:12]}"], cwd=clone)
-        run(["git", "push", "origin", "HEAD:main"], cwd=clone)
         synced[short] = run(["git", "rev-parse", "HEAD"], cwd=clone, capture=True)
-        print(f"  pushed {synced[short][:12]} to {repo}@main")
+        run(["git", "tag", version, synced[short]], cwd=clone)
+        run(["git", "push", "--atomic", "origin", "HEAD:main",
+             f"refs/tags/{version}"], cwd=clone)
+        print(f"  pushed {synced[short][:12]} to {repo}@main and tagged {version}")
         return True
 
 
@@ -1517,6 +1705,20 @@ def main() -> int:
     baseline_doc = json.loads(args.baseline.read_text(encoding="utf-8")) if args.baseline.exists() else {}
     baseline = {k: v for k, v in baseline_doc.items() if not k.startswith("_")}
     source_sha = run(["git", "rev-parse", "HEAD"], cwd=REPO_ROOT, capture=True)
+    try:
+        version, completed, resuming = release_transaction(baseline_doc, source_sha)
+    except (RuntimeError, ValueError) as exc:
+        print(f"release sync: {exc}", file=sys.stderr)
+        return 1
+    all_repos = {entry["repo"].split("/")[-1] for entry in manifest["repos"]}
+    unknown_completed = completed - all_repos
+    if unknown_completed:
+        print(
+            "release sync: pending release names repositories absent from "
+            f"released.yml: {', '.join(sorted(unknown_completed))}",
+            file=sys.stderr,
+        )
+        return 1
     # Owner each dep is published under, per released.yml — the single source of
     # truth the pin/manifest rewrites target (kim-em pre-cutover, leanprover after).
     dep_owner = {e["repo"].split("/")[-1]: e["repo"].split("/")[0]
@@ -1536,6 +1738,21 @@ def main() -> int:
         print(f"release sync: --only {args.only} matches {len(targets)} manifest "
               "entries; expected exactly one", file=sys.stderr)
         return 1
+    if not resuming:
+        try:
+            collisions = version_tag_collisions(manifest["repos"], version)
+        except (RuntimeError, subprocess.CalledProcessError) as exc:
+            print(f"release sync: version-tag preflight failed: {exc}", file=sys.stderr)
+            return 1
+        if collisions:
+            print(
+                f"release sync: cannot allocate shared version {version}; "
+                "the tag already exists:",
+                file=sys.stderr,
+            )
+            for repo, revision in collisions.items():
+                print(f"  {repo}@{version} -> {revision[:12]}", file=sys.stderr)
+            return 1
     repo_token: dict[str, str] = {}
     if not args.dry_run:
         repo_token, blocked = route_tokens(targets, tokens)
@@ -1554,6 +1771,19 @@ def main() -> int:
               f"({per_slot}; Contents grants verified; Workflows grants are "
               "checked by GitHub when workflow changes are pushed)")
 
+        # Allocate the version before the first push. The workflow publishes
+        # this file even if a later repository fails, so retries resume rather
+        # than minting a new version halfway through the repository graph.
+        baseline_doc["_pending_release"] = {
+            "version": version,
+            "source": source_sha,
+            "repos": sorted(completed),
+        }
+        write_baseline(args.baseline, baseline_doc)
+        print(f"release {version}: " + ("resuming" if resuming else "started"))
+    else:
+        print(f"release {version}: preview")
+
     failed_repo: str | None = None
     current_repo = "<manifest>"
     try:
@@ -1564,8 +1794,15 @@ def main() -> int:
             # Dry runs skip routing and clone over public https; real runs index
             # the routed map so a repository routing ever missed fails closed.
             token = None if args.dry_run else repo_token[entry["repo"]]
-            sync_repo(entry, source_sha, token, args.dry_run,
-                      synced, baseline, args.force, dep_owner, pins)
+            released = sync_repo(entry, source_sha, token, args.dry_run,
+                                 synced, baseline, args.force, dep_owner, pins,
+                                 version, resuming)
+            if not args.dry_run:
+                if released:
+                    completed.add(entry["repo"].split("/")[-1])
+                baseline_doc.update(synced)
+                baseline_doc["_pending_release"]["repos"] = sorted(completed)
+                write_baseline(args.baseline, baseline_doc)
     except Exception as exc:
         failed_repo = current_repo
         message = str(exc)
@@ -1581,15 +1818,21 @@ def main() -> int:
         # skeleton or network operation fails. Persist those exact new heads so
         # the workflow can advance its guard branch even while reporting the
         # failed publication.
-        if not args.dry_run and synced:
+        if not args.dry_run:
             baseline_doc.update(synced)
-            args.baseline.write_text(
-                json.dumps(baseline_doc, indent=2) + "\n",
-                encoding="utf-8",
-            )
+            baseline_doc["_pending_release"]["repos"] = sorted(completed)
+            if failed_repo is None and completed == all_repos:
+                baseline_doc["_version"] = version
+                del baseline_doc["_pending_release"]
+                print(f"\ncompleted release {version} across {len(all_repos)} repositories")
+            write_baseline(args.baseline, baseline_doc)
             print(f"\nadvanced baseline -> {args.baseline}")
+    if not args.dry_run and failed_repo is None and completed != all_repos and not args.only:
+        missing = ", ".join(sorted(all_repos - completed))
+        failed_repo = "<release>"
+        print(f"\nrelease {version} remains incomplete: {missing}", file=sys.stderr)
     print(f"\nsynced {len(synced)} repo(s) from hex-dev@{source_sha[:12]}"
-          + (" (dry-run)" if args.dry_run else ""))
+          + (f" for {version} (dry-run)" if args.dry_run else f" for {version}"))
     return 1 if failed_repo else 0
 
 

--- a/scripts/release/synced.json
+++ b/scripts/release/synced.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Bootstrap release ledger used only until the dedicated `release-sync-baseline` branch exists. _version is the last shared release; per-repo values are main HEADs. A real sync records a pending release before publishing and advances the ledger after every repository so retries are safe.",
-  "_version": "v0.0.0",
+  "_version": "v0.1.0",
   "hex-test-kit": "610207eec0ca214928eec42a6dd2084d859bf94d",
   "hex-matrix": "42c865718206dc1c2e63e3fc0ebb94db8174bd12",
   "hex-matrix-mathlib": "a0ae2639613d29f73a5fe5abccd7749af8f9a67c",

--- a/scripts/release/synced.json
+++ b/scripts/release/synced.json
@@ -1,5 +1,6 @@
 {
-  "_comment": "Bootstrap per-repo `main` HEADs used only until the dedicated `release-sync-baseline` branch exists. The publish sync refuses to overwrite a released repo whose main has moved off the live baseline, and every real workflow run advances that branch even when a later mirror fails.",
+  "_comment": "Bootstrap release ledger used only until the dedicated `release-sync-baseline` branch exists. _version is the last shared release; per-repo values are main HEADs. A real sync records a pending release before publishing and advances the ledger after every repository so retries are safe.",
+  "_version": "v0.0.0",
   "hex-test-kit": "610207eec0ca214928eec42a6dd2084d859bf94d",
   "hex-matrix": "42c865718206dc1c2e63e3fc0ebb94db8174bd12",
   "hex-matrix-mathlib": "a0ae2639613d29f73a5fe5abccd7749af8f9a67c",

--- a/scripts/release/test_sync_released.py
+++ b/scripts/release/test_sync_released.py
@@ -35,7 +35,7 @@ class SyncReleasedTests(unittest.TestCase):
         self.temporary.cleanup()
 
     def test_release_versions_start_at_point_one_and_increment_minor(self) -> None:
-        self.assertEqual(sync_released.next_release_version(), "v0.1.0")
+        self.assertEqual(sync_released.next_release_version(), "v0.2.0")
         self.assertEqual(sync_released.next_release_version("v0.1.0"), "v0.2.0")
         self.assertEqual(sync_released.next_release_version("v2.9.7"), "v2.10.0")
         with self.assertRaisesRegex(ValueError, "invalid completed release"):
@@ -732,7 +732,7 @@ class SyncReleasedTests(unittest.TestCase):
 
         def publish(entry, _source_sha, _token, _dry_run, synced,
                     _baseline, _force, _dep_owner, _pins, version, resuming):
-            self.assertEqual(version, "v0.1.0")
+            self.assertEqual(version, "v0.2.0")
             self.assertFalse(resuming)
             if entry["repo"].endswith("/first"):
                 synced["first"] = "new-first"
@@ -761,7 +761,7 @@ class SyncReleasedTests(unittest.TestCase):
         self.assertEqual(advanced["first"], "new-first")
         self.assertEqual(advanced["second"], "old-second")
         self.assertEqual(advanced["_pending_release"], {
-            "version": "v0.1.0", "source": "source-sha", "repos": ["first"]})
+            "version": "v0.2.0", "source": "source-sha", "repos": ["first"]})
         self.assertNotIn("_version", advanced)
 
     def test_completed_publication_advances_the_shared_version(self) -> None:
@@ -818,8 +818,9 @@ class SyncReleasedTests(unittest.TestCase):
         baseline.write_text(json.dumps({
             "first": "new-first",
             "second": "old-second",
+            "_version": "v0.1.0",
             "_pending_release": {
-                "version": "v0.1.0",
+                "version": "v0.2.0",
                 "source": "source-sha",
                 "repos": ["first"],
             },
@@ -827,7 +828,7 @@ class SyncReleasedTests(unittest.TestCase):
 
         def publish(entry, _source_sha, _token, _dry_run, synced,
                     _baseline, _force, _dep_owner, _pins, version, resuming):
-            self.assertEqual(version, "v0.1.0")
+            self.assertEqual(version, "v0.2.0")
             self.assertTrue(resuming)
             short = entry["repo"].split("/")[-1]
             synced[short] = f"new-{short}"
@@ -847,7 +848,7 @@ class SyncReleasedTests(unittest.TestCase):
             self.assertEqual(sync_released.main(), 0)
 
         advanced = json.loads(baseline.read_text(encoding="utf-8"))
-        self.assertEqual(advanced["_version"], "v0.1.0")
+        self.assertEqual(advanced["_version"], "v0.2.0")
         self.assertNotIn("_pending_release", advanced)
 
     def test_only_sync_seeds_dependency_pins_from_baseline(self) -> None:
@@ -866,7 +867,7 @@ class SyncReleasedTests(unittest.TestCase):
 
         def publish(entry, _source_sha, _token, _dry_run, synced,
                     _baseline, _force, _dep_owner, _pins, version, resuming):
-            self.assertEqual(version, "v0.1.0")
+            self.assertEqual(version, "v0.2.0")
             self.assertFalse(resuming)
             self.assertEqual(entry["repo"], "leanprover/downstream")
             self.assertEqual(synced["upstream"], "new-upstream")
@@ -934,13 +935,13 @@ class SyncReleasedTests(unittest.TestCase):
         ):
             self.assertTrue(sync_released.sync_repo(
                 entry, "source-sha", None, False, synced, {"probe": old}, False,
-                {}, {}, "v0.1.0", False))
+                {}, {}, "v0.2.0", False))
 
         main = subprocess.run(
             ["git", "-C", str(remote), "rev-parse", "refs/heads/main"], check=True,
             capture_output=True, text=True).stdout.strip()
         tag = subprocess.run(
-            ["git", "-C", str(remote), "rev-parse", "refs/tags/v0.1.0"], check=True,
+            ["git", "-C", str(remote), "rev-parse", "refs/tags/v0.2.0"], check=True,
             capture_output=True, text=True).stdout.strip()
         self.assertEqual(main, tag)
         self.assertEqual(synced["probe"], main)
@@ -1218,7 +1219,7 @@ class TokenPreflightTests(unittest.TestCase):
         def publish(entry, _source_sha, token, _dry_run, synced,
                     _baseline, _force, _dep_owner, _pins, version, resuming):
             seen_tokens.append(token)
-            self.assertEqual(version, "v0.1.0")
+            self.assertEqual(version, "v0.2.0")
             self.assertFalse(resuming)
             return False
 

--- a/scripts/release/test_sync_released.py
+++ b/scripts/release/test_sync_released.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -32,6 +33,23 @@ class SyncReleasedTests(unittest.TestCase):
 
     def tearDown(self) -> None:
         self.temporary.cleanup()
+
+    def test_release_versions_start_at_point_one_and_increment_minor(self) -> None:
+        self.assertEqual(sync_released.next_release_version(), "v0.1.0")
+        self.assertEqual(sync_released.next_release_version("v0.1.0"), "v0.2.0")
+        self.assertEqual(sync_released.next_release_version("v2.9.7"), "v2.10.0")
+        with self.assertRaisesRegex(ValueError, "invalid completed release"):
+            sync_released.next_release_version("0.1.0")
+
+    def test_pending_release_is_bound_to_its_source_commit(self) -> None:
+        document = {"_version": "v0.2.0", "_pending_release": {
+            "version": "v0.3.0", "source": "abc", "repos": ["hex-basic"]}}
+        self.assertEqual(
+            sync_released.release_transaction(document, "abc"),
+            ("v0.3.0", {"hex-basic"}, True),
+        )
+        with self.assertRaisesRegex(RuntimeError, "rerun the sync at that commit"):
+            sync_released.release_transaction(document, "def")
 
     def test_toolchain_reaches_side_projects(self) -> None:
         notes = sync_released.rewrite_toolchains(self.repo)
@@ -410,6 +428,33 @@ class SyncReleasedTests(unittest.TestCase):
             (self.repo / "bench" / "lakefile.lean").read_text(),
         )
 
+    def test_hex_pins_use_one_release_version(self) -> None:
+        sha = "a" * 40
+        (self.repo / "lakefile.toml").write_text(
+            '[[require]]\nname = "HexBasic"\n'
+            'git = "https://github.com/kim-em/hex-basic.git"\n'
+            f'rev = "{sha}"\n',
+            encoding="utf-8",
+        )
+        (self.repo / "bench" / "lakefile.lean").write_text(
+            'require HexBasic from git\n'
+            '  "https://github.com/kim-em/hex-basic.git" @ "v0.1.0"\n',
+            encoding="utf-8",
+        )
+        notes = sync_released.rewrite_pins(
+            {}, self.repo, {"hex-basic": sha},
+            {"hex-basic": "leanprover"}, "v0.2.0")
+        self.assertEqual(len(notes), 2)
+        self.assertIn(
+            'git = "https://github.com/leanprover/hex-basic.git"\n'
+            'rev = "v0.2.0"',
+            (self.repo / "lakefile.toml").read_text(),
+        )
+        self.assertIn(
+            '"https://github.com/leanprover/hex-basic.git" @ "v0.2.0"',
+            (self.repo / "bench" / "lakefile.lean").read_text(),
+        )
+
     def test_reservoir_toml_pin_rewrites_by_package_name(self) -> None:
         (self.repo / "lakefile.toml").write_text(
             'name = "consumer"\n'
@@ -474,6 +519,37 @@ class SyncReleasedTests(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "lakefile.toml"):
             sync_released.validate_skeleton({"lakefile": "toml"}, self.repo)
 
+    def test_release_test_target_tracks_manifest_in_toml(self) -> None:
+        lakefile = self.repo / "lakefile.toml"
+        lakefile.write_text(
+            '[[lean_lib]]\nname = "HexProbe"\n\n'
+            '[[lean_lib]]\nname = "HexProbeTests"\n'
+            'globs = ["HexProbe.OldTest"]\n',
+            encoding="utf-8",
+        )
+        entry = {"lib": "HexProbe", "lakefile": "toml",
+                 "test_modules": ["HexProbe.FirstTest", "HexProbe.SecondTest"]}
+        self.assertEqual(sync_released.rewrite_test_target(entry, self.repo),
+                         ["  release tests on lean_lib HexProbeTests (lakefile.toml)"])
+        self.assertIn(
+            'globs = ["HexProbe.FirstTest", "HexProbe.SecondTest"]',
+            lakefile.read_text(encoding="utf-8"),
+        )
+        self.assertEqual(sync_released.rewrite_test_target(entry, self.repo), [])
+
+    def test_release_test_target_is_created_in_lean(self) -> None:
+        lakefile = self.repo / "lakefile.lean"
+        lakefile.write_text("import Lake\n\nlean_lib HexProbe\n", encoding="utf-8")
+        entry = {"lib": "HexProbe", "lakefile": "lean",
+                 "test_modules": ["HexProbe.FirstTest", "HexProbe.SecondTest"]}
+        sync_released.rewrite_test_target(entry, self.repo)
+        self.assertIn(
+            "lean_lib HexProbeTests where\n"
+            "  globs := #[`HexProbe.FirstTest, `HexProbe.SecondTest]\n",
+            lakefile.read_text(encoding="utf-8"),
+        )
+        sync_released.validate_skeleton(entry, self.repo)
+
     def test_manifest_uses_exact_external_commit(self) -> None:
         manifest = {
             "version": "1.1.0",
@@ -487,7 +563,7 @@ class SyncReleasedTests(unittest.TestCase):
         path = self.repo / "lake-manifest.json"
         path.write_text(json.dumps(manifest), encoding="utf-8")
         sync_released.rewrite_manifest(
-            {}, self.repo, {}, {}, self.pins)
+            {}, self.repo, {}, {}, self.pins, "v0.1.0")
         package = json.loads(path.read_text())["packages"][0]
         self.assertEqual(package["rev"], self.mathlib["rev"])
         self.assertEqual(package["inputRev"], self.mathlib["inputRev"])
@@ -515,15 +591,16 @@ class SyncReleasedTests(unittest.TestCase):
                    "hex-arith": {"lib": "HexArith", "lakefile": "lean"}}
         notes = sync_released.rewrite_manifest(
             {"pins": ["hex-basic", "hex-arith", "hex-poly"]}, self.repo,
-            synced, {}, self.pins, catalog)
+            synced, {}, self.pins, "v0.1.0", catalog)
         packages = {pkg["name"]: pkg
                     for pkg in json.loads(path.read_text())["packages"]}
         self.assertEqual(set(packages), {"HexPoly", "HexBasic", "HexArith"})
         self.assertEqual(packages["HexPoly"]["rev"], "b" * 40)
+        self.assertEqual(packages["HexPoly"]["inputRev"], "v0.1.0")
         basic = packages["HexBasic"]
         self.assertEqual(basic["url"], "https://github.com/leanprover/hex-basic.git")
         self.assertEqual(basic["rev"], "a" * 40)
-        self.assertEqual(basic["inputRev"], "a" * 40)
+        self.assertEqual(basic["inputRev"], "v0.1.0")
         self.assertTrue(basic["inherited"])
         self.assertEqual(basic["configFile"], "lakefile.toml")
         self.assertEqual(packages["HexArith"]["configFile"], "lakefile.lean")
@@ -531,7 +608,7 @@ class SyncReleasedTests(unittest.TestCase):
         # A second pass finds everything present and adds nothing.
         again = sync_released.rewrite_manifest(
             {"pins": ["hex-basic", "hex-arith", "hex-poly"]}, self.repo,
-            synced, {}, self.pins, catalog)
+            synced, {}, self.pins, "v0.1.0", catalog)
         self.assertFalse(any("manifest +" in note for note in again))
 
     def test_manifest_records_direct_pins_as_not_inherited(self) -> None:
@@ -547,7 +624,8 @@ class SyncReleasedTests(unittest.TestCase):
                         encoding="utf-8")
         sync_released.rewrite_manifest(
             {"pins": ["hex-basic"]}, self.repo, {"hex-basic": "a" * 40}, {},
-            self.pins, {"hex-basic": {"lib": "HexBasic", "lakefile": "toml"}})
+            self.pins, "v0.1.0",
+            {"hex-basic": {"lib": "HexBasic", "lakefile": "toml"}})
         package = json.loads(path.read_text())["packages"][0]
         self.assertFalse(package["inherited"])
 
@@ -594,18 +672,19 @@ class SyncReleasedTests(unittest.TestCase):
                    "hex-arith": {"lib": "HexArith", "lakefile": "lean"},
                    "hex-matrix": {"lib": "HexMatrix", "lakefile": "toml"}}
         notes = sync_released.rewrite_requires(
-            entry, self.repo, synced, {}, catalog)
+            entry, self.repo, synced, {}, "v0.1.0", catalog)
         text = (self.repo / "lakefile.toml").read_text()
         self.assertEqual(notes, [
-            f'  require + hex-arith (HexArith) -> {"b" * 12} (lakefile.toml)'])
+            '  require + hex-arith (HexArith) -> v0.1.0 (lakefile.toml)'])
         self.assertNotIn("hex-basic.git", text)
         block = ('[[require]]\nname = "HexArith"\n'
                  'git = "https://github.com/leanprover/hex-arith.git"\n'
-                 f'rev = "{"b" * 40}"\n\n[[lean_lib]]')
+                 'rev = "v0.1.0"\n\n[[lean_lib]]')
         self.assertIn(block, text)
         self.assertEqual(text.count("[[require]]"), 2)
         self.assertEqual(
-            sync_released.rewrite_requires(entry, self.repo, synced, {}, catalog),
+            sync_released.rewrite_requires(
+                entry, self.repo, synced, {}, "v0.1.0", catalog),
             [])
 
     def test_direct_imports_gain_direct_requires_in_lean(self) -> None:
@@ -623,12 +702,13 @@ class SyncReleasedTests(unittest.TestCase):
                  "pins": ["hex-basic", "hex-arith"]}
         sync_released.rewrite_requires(
             entry, self.repo, {"hex-basic": "a" * 40, "hex-arith": "b" * 40}, {},
+            "v0.1.0",
             {"hex-basic": {"lib": "HexBasic", "lakefile": "toml"},
              "hex-arith": {"lib": "HexArith", "lakefile": "lean"}})
         text = (self.repo / "lakefile.lean").read_text()
         self.assertIn(
             '@ "0"\n\nrequire HexBasic from git\n'
-            f'  "https://github.com/leanprover/hex-basic.git" @ "{"a" * 40}"\n\n'
+            '  "https://github.com/leanprover/hex-basic.git" @ "v0.1.0"\n\n'
             "@[default_target]", text)
 
     def test_missing_root_toolchain_fails_closed(self) -> None:
@@ -651,7 +731,9 @@ class SyncReleasedTests(unittest.TestCase):
         )
 
         def publish(entry, _source_sha, _token, _dry_run, synced,
-                    _baseline, _force, _dep_owner, _pins):
+                    _baseline, _force, _dep_owner, _pins, version, resuming):
+            self.assertEqual(version, "v0.1.0")
+            self.assertFalse(resuming)
             if entry["repo"].endswith("/first"):
                 synced["first"] = "new-first"
                 return True
@@ -667,6 +749,7 @@ class SyncReleasedTests(unittest.TestCase):
         with (
             patch.object(sync_released, "MANIFEST", manifest),
             patch.object(sync_released, "external_pins", return_value={}),
+            patch.object(sync_released, "version_tag_collisions", return_value={}),
             patch.object(sync_released, "run", return_value="source-sha"),
             patch.object(sync_released, "selection_check", return_value=None),
             patch.object(sync_released, "sync_repo", side_effect=publish),
@@ -677,6 +760,95 @@ class SyncReleasedTests(unittest.TestCase):
         advanced = json.loads(baseline.read_text(encoding="utf-8"))
         self.assertEqual(advanced["first"], "new-first")
         self.assertEqual(advanced["second"], "old-second")
+        self.assertEqual(advanced["_pending_release"], {
+            "version": "v0.1.0", "source": "source-sha", "repos": ["first"]})
+        self.assertNotIn("_version", advanced)
+
+    def test_completed_publication_advances_the_shared_version(self) -> None:
+        manifest = self.repo / "released.yml"
+        manifest.write_text(
+            "repos:\n"
+            "  - repo: leanprover/first\n"
+            "  - repo: leanprover/second\n",
+            encoding="utf-8",
+        )
+        baseline = self.repo / "baseline.json"
+        baseline.write_text(json.dumps({
+            "_version": "v0.1.0",
+            "first": "old-first",
+            "second": "old-second",
+        }), encoding="utf-8")
+
+        def publish(entry, _source_sha, _token, _dry_run, synced,
+                    _baseline, _force, _dep_owner, _pins, version, resuming):
+            self.assertEqual(version, "v0.2.0")
+            self.assertFalse(resuming)
+            short = entry["repo"].split("/")[-1]
+            synced[short] = f"new-{short}"
+            return True
+
+        argv = ["sync_released.py", "--token", "secret-token",
+                "--baseline", str(baseline)]
+        with (
+            patch.object(sync_released, "MANIFEST", manifest),
+            patch.object(sync_released, "external_pins", return_value={}),
+            patch.object(sync_released, "version_tag_collisions", return_value={}),
+            patch.object(sync_released, "run", return_value="source-sha"),
+            patch.object(sync_released, "selection_check", return_value=None),
+            patch.object(sync_released, "sync_repo", side_effect=publish),
+            patch("sys.argv", argv),
+        ):
+            self.assertEqual(sync_released.main(), 0)
+
+        advanced = json.loads(baseline.read_text(encoding="utf-8"))
+        self.assertEqual(advanced["_version"], "v0.2.0")
+        self.assertNotIn("_pending_release", advanced)
+        self.assertEqual(advanced["first"], "new-first")
+        self.assertEqual(advanced["second"], "new-second")
+
+    def test_pending_publication_resumes_same_version(self) -> None:
+        manifest = self.repo / "released.yml"
+        manifest.write_text(
+            "repos:\n"
+            "  - repo: leanprover/first\n"
+            "  - repo: leanprover/second\n",
+            encoding="utf-8",
+        )
+        baseline = self.repo / "baseline.json"
+        baseline.write_text(json.dumps({
+            "first": "new-first",
+            "second": "old-second",
+            "_pending_release": {
+                "version": "v0.1.0",
+                "source": "source-sha",
+                "repos": ["first"],
+            },
+        }), encoding="utf-8")
+
+        def publish(entry, _source_sha, _token, _dry_run, synced,
+                    _baseline, _force, _dep_owner, _pins, version, resuming):
+            self.assertEqual(version, "v0.1.0")
+            self.assertTrue(resuming)
+            short = entry["repo"].split("/")[-1]
+            synced[short] = f"new-{short}"
+            return True
+
+        argv = ["sync_released.py", "--token", "secret-token",
+                "--baseline", str(baseline)]
+        with (
+            patch.object(sync_released, "MANIFEST", manifest),
+            patch.object(sync_released, "external_pins", return_value={}),
+            patch.object(sync_released, "version_tag_collisions", return_value={}),
+            patch.object(sync_released, "run", return_value="source-sha"),
+            patch.object(sync_released, "selection_check", return_value=None),
+            patch.object(sync_released, "sync_repo", side_effect=publish),
+            patch("sys.argv", argv),
+        ):
+            self.assertEqual(sync_released.main(), 0)
+
+        advanced = json.loads(baseline.read_text(encoding="utf-8"))
+        self.assertEqual(advanced["_version"], "v0.1.0")
+        self.assertNotIn("_pending_release", advanced)
 
     def test_only_sync_seeds_dependency_pins_from_baseline(self) -> None:
         manifest = self.repo / "released.yml"
@@ -693,7 +865,9 @@ class SyncReleasedTests(unittest.TestCase):
         )
 
         def publish(entry, _source_sha, _token, _dry_run, synced,
-                    _baseline, _force, _dep_owner, _pins):
+                    _baseline, _force, _dep_owner, _pins, version, resuming):
+            self.assertEqual(version, "v0.1.0")
+            self.assertFalse(resuming)
             self.assertEqual(entry["repo"], "leanprover/downstream")
             self.assertEqual(synced["upstream"], "new-upstream")
             self.assertEqual(synced["downstream"], "old-downstream")
@@ -712,6 +886,7 @@ class SyncReleasedTests(unittest.TestCase):
         with (
             patch.object(sync_released, "MANIFEST", manifest),
             patch.object(sync_released, "external_pins", return_value={}),
+            patch.object(sync_released, "version_tag_collisions", return_value={}),
             patch.object(sync_released, "run", return_value="source-sha"),
             patch.object(sync_released, "selection_check", return_value=None),
             patch.object(sync_released, "sync_repo", side_effect=publish),
@@ -722,6 +897,53 @@ class SyncReleasedTests(unittest.TestCase):
         advanced = json.loads(baseline.read_text(encoding="utf-8"))
         self.assertEqual(advanced["upstream"], "new-upstream")
         self.assertEqual(advanced["downstream"], "new-downstream")
+        self.assertEqual(advanced["_pending_release"]["repos"], ["downstream"])
+
+    def test_repo_push_updates_main_and_tag_atomically(self) -> None:
+        remote = self.repo / "remote.git"
+        seed = self.repo / "seed"
+        subprocess.run(["git", "init", "-q", "--bare", str(remote)], check=True)
+        subprocess.run(["git", "clone", "-q", str(remote), str(seed)], check=True)
+        (seed / "managed.txt").write_text("old\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(seed), "add", "managed.txt"], check=True)
+        subprocess.run([
+            "git", "-C", str(seed), "-c", "user.name=Test",
+            "-c", "user.email=test@example.com", "commit", "-qm", "seed",
+        ], check=True)
+        subprocess.run(["git", "-C", str(seed), "push", "-q", "origin", "HEAD:main"],
+                       check=True)
+        subprocess.run(["git", "-C", str(remote), "symbolic-ref", "HEAD",
+                        "refs/heads/main"], check=True)
+        old = subprocess.run(
+            ["git", "-C", str(seed), "rev-parse", "HEAD"], check=True,
+            capture_output=True, text=True).stdout.strip()
+
+        def apply(_entry, clone):
+            (clone / "managed.txt").write_text("new\n", encoding="utf-8")
+            return ["  managed.txt"]
+
+        synced: dict[str, str] = {}
+        entry = {"repo": "leanprover/probe", "pins_only": True,
+                 "lakefile": "toml"}
+        with (
+            patch.object(sync_released, "clone_url", return_value=str(remote)),
+            patch.object(sync_released, "validate_skeleton"),
+            patch.object(sync_released, "validate_ci_helpers"),
+            patch.object(sync_released, "apply_paths", side_effect=apply),
+            patch.object(sync_released, "rewrite_toolchains", return_value=[]),
+        ):
+            self.assertTrue(sync_released.sync_repo(
+                entry, "source-sha", None, False, synced, {"probe": old}, False,
+                {}, {}, "v0.1.0", False))
+
+        main = subprocess.run(
+            ["git", "-C", str(remote), "rev-parse", "refs/heads/main"], check=True,
+            capture_output=True, text=True).stdout.strip()
+        tag = subprocess.run(
+            ["git", "-C", str(remote), "rev-parse", "refs/tags/v0.1.0"], check=True,
+            capture_output=True, text=True).stdout.strip()
+        self.assertEqual(main, tag)
+        self.assertEqual(synced["probe"], main)
 
 
 class LakeDeclarationTests(unittest.TestCase):
@@ -994,8 +1216,10 @@ class TokenPreflightTests(unittest.TestCase):
         seen_tokens: list = []
 
         def publish(entry, _source_sha, token, _dry_run, synced,
-                    _baseline, _force, _dep_owner, _pins):
+                    _baseline, _force, _dep_owner, _pins, version, resuming):
             seen_tokens.append(token)
+            self.assertEqual(version, "v0.1.0")
+            self.assertFalse(resuming)
             return False
 
         argv = ["sync_released.py", "--dry-run", "--baseline", str(baseline)]
@@ -1003,6 +1227,7 @@ class TokenPreflightTests(unittest.TestCase):
         with (
             patch.object(sync_released, "MANIFEST", manifest),
             patch.object(sync_released, "external_pins", return_value={}),
+            patch.object(sync_released, "version_tag_collisions", return_value={}),
             patch.object(sync_released, "run", return_value="source-sha"),
             patch.object(sync_released, "sync_repo", side_effect=publish),
             patch.dict(sync_released.os.environ, env),
@@ -1073,7 +1298,28 @@ class TokenPreflightTests(unittest.TestCase):
         with (
             patch.object(sync_released, "MANIFEST", manifest),
             patch.object(sync_released, "external_pins", return_value={}),
+            patch.object(sync_released, "version_tag_collisions", return_value={}),
             patch.object(sync_released, "run", return_value="source-sha"),
+            patch.object(sync_released, "sync_repo") as publish,
+            patch("sys.argv", argv),
+        ):
+            self.assertEqual(sync_released.main(), 1)
+        publish.assert_not_called()
+
+    def test_existing_tag_stops_a_new_release_before_publication(self) -> None:
+        manifest = self.repo / "released.yml"
+        manifest.write_text(
+            "repos:\n  - repo: leanprover/hex-basic\n", encoding="utf-8")
+        baseline = self.repo / "baseline.json"
+        baseline.write_text(
+            json.dumps({"hex-basic": "a" * 40}), encoding="utf-8")
+        argv = ["sync_released.py", "--dry-run", "--baseline", str(baseline)]
+        with (
+            patch.object(sync_released, "MANIFEST", manifest),
+            patch.object(sync_released, "external_pins", return_value={}),
+            patch.object(sync_released, "run", return_value="source-sha"),
+            patch.object(sync_released, "version_tag_collisions", return_value={
+                "leanprover/hex-basic": "b" * 40}),
             patch.object(sync_released, "sync_repo") as publish,
             patch("sys.argv", argv),
         ):
@@ -1091,6 +1337,7 @@ class TokenPreflightTests(unittest.TestCase):
         with (
             patch.object(sync_released, "MANIFEST", manifest),
             patch.object(sync_released, "external_pins", return_value={}),
+            patch.object(sync_released, "version_tag_collisions", return_value={}),
             patch.object(sync_released, "run", return_value="source-sha"),
             patch.object(sync_released, "selection_check", return_value="HTTP 404"),
             patch.object(sync_released, "sync_repo") as publish,


### PR DESCRIPTION
Hex’s released mirrors currently pin one another by commit SHA, so a downstream package inherits non-semver `inputRev` values. Mathlib rejects those transitive manifest inputs, which means consumers must list every Hex dependency directly even when Lake could resolve them transitively.

Publish one shared semantic version across the complete released repository graph. Three libraries already used `v0.1.0` independently, so the first coordinated release is `v0.2.0`; each later complete release increments the minor component and resets the patch component to zero. Released Lake files use the shared tag, while `lake-manifest.json` retains both the semantic `inputRev` and its exact resolved commit.

The release is a resumable transaction:

- the live baseline records the version and source commit before the first push;
- each repository atomically pushes its `main` update and immutable lightweight tag;
- partial failures and staged `--only` runs resume the same version at the same source commit;
- the global version advances only after every split repository and the aggregate carry the tag;
- a preflight rejects existing tags before any mutation.

The sync now also generates each manifest-declared `<Lib>Tests` target. This closes the release blocker introduced when `HexRealRootsMathlib.SturmTests` joined the source of truth but the released mirror’s local Lake skeleton did not know about it.

Validation: 105 release-tooling unit tests; release-manifest validation; `lake build HexReleaseTests` (10,027 jobs); a complete 56-repository `v0.2.0` dry-run against the live baseline; an actual local bare-repository test proving `main` and the release tag are pushed atomically; and `git diff --check`.

:robot: Prepared with Codex
