### PR TITLE
prove multivariate content multiplicativity

### DIFF
--- a/HexMvGcd/Content.lean
+++ b/HexMvGcd/Content.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexMvGcd.Cert
+public import HexMvGcd.Gauss
 
 @[expose] public section
 set_option backward.proofsInPublic true
@@ -315,9 +316,213 @@ theorem content_primPart [LawfulGcdOps R] {p : MvPoly n R cmp} (hp : p ≠ 0) :
     _ = normalize d := hnorm.symm
     _ = 1 := LawfulGcdOps.normalize_unit d hisUnit
 
+omit [Dvd R] [GcdOps R] in
+private theorem C_mul (a b : R) :
+    (C (a * b) : MvPoly n R cmp) = C a * C b := by
+  unfold C
+  rw [monomial_mul_monomial, Mono.zero_mul]
+
+private theorem C_dvd_of_dvd_content [LawfulGcdOps R]
+    {p : MvPoly n R cmp} {d : R} (hd : d ∣ content p) : C d ∣ p := by
+  rcases (LawfulGcdOps.dvd_iff d (content p)).mp hd with ⟨x, hx⟩
+  refine ⟨C x * primPart p, ?_⟩
+  calc
+    p = C (content p) * primPart p := (content_mul_primPart p).symm
+    _ = C (d * x) * primPart p := by rw [hx]
+    _ = (C d * C x) * primPart p := by rw [C_mul]
+    _ = (C x * primPart p) * C d := by grind
+
+private theorem scalar_dvd_coeff_of_C_dvd [LawfulGcdOps R]
+    {p : MvPoly n R cmp} {d : R} (hd : C d ∣ p) (m : Mono n) :
+    d ∣ coeff m p := by
+  rcases hd with ⟨q, hq⟩
+  apply (LawfulGcdOps.dvd_iff d (coeff m p)).mpr
+  refine ⟨coeff m q, ?_⟩
+  calc
+    coeff m p = coeff m (q * C d) := congrArg (coeff m) hq
+    _ = coeff m (C d * q) := by rw [MvPoly.mul_comm]
+    _ = d * coeff m q := coeff_C_mul d q m
+
+private theorem dvd_polyNormalize [LawfulGcdOps R]
+    [IsMonomialOrder cmp] (p : MvPoly n R cmp) : p ∣ polyNormalize p := by
+  refine ⟨polyNormUnit p, ?_⟩
+  unfold polyNormalize
+  exact MvPoly.mul_comm p (polyNormUnit p)
+
+private theorem polyNormalize_dvd [LawfulGcdOps R]
+    [IsMonomialOrder cmp] (p : MvPoly n R cmp) : polyNormalize p ∣ p := by
+  rcases (polyIsUnit_iff (polyNormUnit p)).mp (polyNormUnit_isUnit p) with
+    ⟨v, hv⟩
+  refine ⟨v, ?_⟩
+  unfold polyNormalize
+  grind
+
+private theorem eq_normalize_of_dvd [LawfulGcdOps R]
+    (a b : R) (ha : normalize a = a) (hab : a ∣ b) (hba : b ∣ a) :
+    a = normalize b := by
+  rcases (LawfulGcdOps.dvd_iff a b).mp hab with ⟨q, hbq⟩
+  by_cases hazero : a = 0
+  · have hbzero : b = 0 := by rw [hbq, hazero, Lean.Grind.Semiring.zero_mul]
+    rw [hazero, hbzero]
+    unfold normalize
+    rw [Lean.Grind.Semiring.zero_mul]
+  · rcases (LawfulGcdOps.dvd_iff b a).mp hba with ⟨r, har⟩
+    have hqr : q * r = 1 := by
+      have hzero : a * (1 - q * r) = 0 := by
+        rw [har, hbq]
+        grind
+      rcases LawfulGcdOps.no_zero_div a (1 - q * r) hzero with
+        haz | hrest
+      · exact False.elim (hazero haz)
+      · grind
+    have hqunit : GcdOps.isUnit q = true :=
+      (LawfulGcdOps.isUnit_iff q).mpr ⟨r, hqr⟩
+    symm
+    calc
+      normalize b = normalize (a * q) := congrArg normalize hbq
+      _ = normalize a * normalize q := LawfulGcdOps.normalize_mul a q
+      _ = a * 1 := by rw [ha, LawfulGcdOps.normalize_unit q hqunit]
+      _ = a := Lean.Grind.Semiring.mul_one a
+
+private theorem scalarContent_view_assoc
+    {sourceCmp : Mono (n + 1) → Mono (n + 1) → Ordering}
+    [Std.TransCmp sourceCmp] [Std.LawfulEqCmp sourceCmp] [LawfulGcdOps R]
+    (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
+    [Std.TransCmp cmp'] [Std.LawfulEqCmp cmp']
+    (p : MvPoly (n + 1) R sourceCmp)
+    (g : MvPoly n R cmp')
+    (hdiv : ∀ k, g ∣ (toUnivariate i cmp' p).coeff k)
+    (hgreat : ∀ d, (∀ k, d ∣ (toUnivariate i cmp' p).coeff k) → d ∣ g) :
+    content p ∣ content g ∧ content g ∣ content p := by
+  have hCleft : C (content p) ∣ g := by
+    apply hgreat
+    intro k
+    apply C_dvd_of_dvd_content
+    apply dvd_scalarContent
+    intro m
+    rw [toUnivariate_coeff]
+    exact scalarContent_dvd_coeff p (insertVar i k m)
+  have hleft : content p ∣ content g := by
+    apply dvd_scalarContent
+    intro m
+    exact scalar_dvd_coeff_of_C_dvd hCleft m
+  have hCright : C (content g) ∣ g := by
+    apply C_dvd_of_dvd_content
+    apply (LawfulGcdOps.dvd_iff (content g) (content g)).mpr
+    exact ⟨1, (Lean.Grind.Semiring.mul_one _).symm⟩
+  have hright : content g ∣ content p := by
+    apply dvd_scalarContent
+    intro m
+    have hslice : C (content g) ∣
+        (toUnivariate i cmp' p).coeff (Mono.degreeOf i m) :=
+      Hex.dvdTrans hCright (hdiv (Mono.degreeOf i m))
+    have hcoeff := scalar_dvd_coeff_of_C_dvd hslice (removeVar i m)
+    rw [toUnivariate_coeff, insertVar_removeVar] at hcoeff
+    exact hcoeff
+  exact ⟨hleft, hright⟩
+
+omit [DecidableEq R] [BEq R] [LawfulBEq R] [Dvd R] [GcdOps R] in
+private theorem vars_eq_nil
+    {cmp0 : Mono 0 → Mono 0 → Ordering}
+    [Std.TransCmp cmp0] [Std.LawfulEqCmp cmp0]
+    (p : MvPoly 0 R cmp0) : p.vars = [] := by
+  cases h : p.vars with
+  | nil => rfl
+  | cons i is => exact Fin.elim0 i
+
+/-- Content of a constant is its normalized coefficient. -/
+theorem content_C [LawfulGcdOps R] (a : R) :
+    content (C a : MvPoly n R cmp) = normalize a := by
+  unfold content scalarContent
+  rw [termsList_C]
+  by_cases ha : a = 0
+  · rw [ite_eq_left ha, ha, normalize]
+    exact (Lean.Grind.Semiring.zero_mul _).symm
+  · rw [ite_eq_right ha]
+    rfl
+
 theorem content_mul [LawfulGcdOps R] (p q : MvPoly n R cmp) :
     content (p * q) = content p * content q := by
-  sorry
+  induction n with
+  | zero =>
+      have hp : p = C (coeff Mono.zero p) :=
+        eq_C_of_vars_eq_nil p (vars_eq_nil p)
+      have hq : q = C (coeff Mono.zero q) :=
+        eq_C_of_vars_eq_nil q (vars_eq_nil q)
+      rw [hp, hq, ← C_mul, content_C, content_C, content_C,
+        LawfulGcdOps.normalize_mul]
+  | succ n ih =>
+      let pv := toUnivariate 0 Mono.lex p
+      let qv := toUnivariate 0 Mono.lex q
+      let pqv := toUnivariate 0 Mono.lex (p * q)
+      let rp := denseContent pv
+      let rq := denseContent qv
+      let rpq := denseContent pqv
+      let dp := polyNormalize rp
+      let dq := polyNormalize rq
+      let dpq := polyNormalize rpq
+      have hdpDiv : ∀ k, dp ∣ pv.coeff k := by
+        intro k
+        exact Hex.dvdTrans (polyNormalize_dvd rp)
+          (denseContent_dvd_coeff pv k)
+      have hdpGreat : ∀ d, (∀ k, d ∣ pv.coeff k) → d ∣ dp := by
+        intro d hd
+        exact Hex.dvdTrans (dvd_denseContent pv d hd)
+          (dvd_polyNormalize rp)
+      have hdqDiv : ∀ k, dq ∣ qv.coeff k := by
+        intro k
+        exact Hex.dvdTrans (polyNormalize_dvd rq)
+          (denseContent_dvd_coeff qv k)
+      have hdqGreat : ∀ d, (∀ k, d ∣ qv.coeff k) → d ∣ dq := by
+        intro d hd
+        exact Hex.dvdTrans (dvd_denseContent qv d hd)
+          (dvd_polyNormalize rq)
+      have hdpqDiv : ∀ k, dpq ∣ pqv.coeff k := by
+        intro k
+        exact Hex.dvdTrans (polyNormalize_dvd rpq)
+          (denseContent_dvd_coeff pqv k)
+      have hdpqGreat : ∀ d, (∀ k, d ∣ pqv.coeff k) → d ∣ dpq := by
+        intro d hd
+        exact Hex.dvdTrans (dvd_denseContent pqv d hd)
+          (dvd_polyNormalize rpq)
+      have hpAssoc := scalarContent_view_assoc 0 Mono.lex p dp hdpDiv hdpGreat
+      have hqAssoc := scalarContent_view_assoc 0 Mono.lex q dq hdqDiv hdqGreat
+      have hpqAssoc := scalarContent_view_assoc 0 Mono.lex (p * q) dpq
+        hdpqDiv hdpqGreat
+      have hview : pqv = pv * qv := toUnivariate_mul 0 p q
+      have hraw := denseContent_mul_assoc pv qv
+      rw [← hview] at hraw
+      have hnorm : dpq = dp * dq := by
+        have hforward : dpq ∣ rp * rq :=
+          Hex.dvdTrans (polyNormalize_dvd rpq) hraw.1
+        have hback : rp * rq ∣ dpq :=
+          Hex.dvdTrans hraw.2 (dvd_polyNormalize rpq)
+        have hcanon := eq_polyNormalize_of_dvd dpq (rp * rq)
+          (polyNormalize_idem rpq) hforward hback
+        calc
+          dpq = polyNormalize (rp * rq) := hcanon
+          _ = polyNormalize rp * polyNormalize rq := polyNormalize_mul rp rq
+          _ = dp * dq := rfl
+      have hlower : content dpq = content dp * content dq := by
+        rw [hnorm]
+        exact ih (cmp := Mono.lex) dp dq
+      have hforward : content (p * q) ∣ content p * content q :=
+        Hex.dvdTrans hpqAssoc.1 (by
+          rw [hlower]
+          exact Hex.dvdMul hpAssoc.2 hqAssoc.2)
+      have hback : content p * content q ∣ content (p * q) :=
+        Hex.dvdTrans (Hex.dvdMul hpAssoc.1 hqAssoc.1) (by
+          rw [← hlower]
+          exact hpqAssoc.2)
+      have hcanon := eq_normalize_of_dvd
+        (content (p * q)) (content p * content q)
+        (normalize_scalarContent (p * q)) hforward hback
+      have hpNorm : normalize (content p) = content p :=
+        normalize_scalarContent p
+      have hqNorm : normalize (content q) = content q :=
+        normalize_scalarContent q
+      rw [LawfulGcdOps.normalize_mul, hpNorm, hqNorm] at hcanon
+      exact hcanon
 
 theorem primPart_mul [LawfulGcdOps R] (p q : MvPoly n R cmp) :
     primPart (p * q) = primPart p * primPart q := by
@@ -347,9 +552,7 @@ theorem primPart_mul [LawfulGcdOps R] (p q : MvPoly n R cmp) :
     · exact hcp hzero
     · exact hcq hzero
   have hC :
-      (C (cp * cq) : MvPoly n R cmp) = C cp * C cq := by
-    unfold C
-    rw [monomial_mul_monomial, Mono.zero_mul]
+      (C (cp * cq) : MvPoly n R cmp) = C cp * C cq := C_mul cp cq
   have hleft :
       (C cp * C cq) * primPart (p * q) = p * q := by
     calc

--- a/HexMvGcd/Gauss.lean
+++ b/HexMvGcd/Gauss.lean
@@ -254,6 +254,16 @@ theorem dvdTrans [GcdDomainLaws R] {a b c : R}
     _ = (a * x) * y := by rw [hb]
     _ = a * (x * y) := Lean.Grind.Semiring.mul_assoc a x y
 
+/-- Divisibility is preserved by multiplying two divisible pairs. -/
+theorem dvdMul [GcdDomainLaws R] {a b c d : R}
+    (hac : a ∣ c) (hbd : b ∣ d) : a * b ∣ c * d := by
+  rcases (GcdDomainLaws.dvd_iff a c).mp hac with ⟨x, hx⟩
+  rcases (GcdDomainLaws.dvd_iff b d).mp hbd with ⟨y, hy⟩
+  apply (GcdDomainLaws.dvd_iff (a * b) (c * d)).mpr
+  refine ⟨x * y, ?_⟩
+  rw [hx, hy]
+  grind
+
 /-- Every finite coefficient list admits a greatest common divisor, including
 the empty list whose gcd is chosen as zero. -/
 theorem coeffGcd_nonempty [GcdDomainLaws R] (xs : List R) :
@@ -1852,7 +1862,7 @@ private theorem toUnivariate_dvd_zero
   calc
     toUnivariate 0 cmp' q = toUnivariate 0 cmp' (r * p) := by rw [hr]
     _ = toUnivariate 0 cmp' r * toUnivariate 0 cmp' p :=
-      toUnivariate_mul r p
+      toUnivariate_mul 0 r p
     _ = toUnivariate 0 cmp' p * toUnivariate 0 cmp' r :=
       DensePoly.mul_comm_poly _ _
 
@@ -1963,6 +1973,42 @@ theorem cancelCommonFactor
   exact CoprimeCancelLaws.cancel_coprime g a b d hcop hda hdb
 
 end Lift
+
+section NormalizeAssoc
+
+variable [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
+  [Dvd R] [GcdOps R] [LawfulGcdOps R] [IsMonomialOrder cmp]
+
+/-- Mutually divisible polynomials have the same canonical normalization. -/
+theorem eq_polyNormalize_of_dvd (a b : MvPoly n R cmp)
+    (ha : polyNormalize a = a) (hab : a ∣ b) (hba : b ∣ a) :
+    a = polyNormalize b := by
+  rcases hab with ⟨q, hbq⟩
+  by_cases hazero : a = 0
+  · have hbzero : b = 0 := by
+      calc
+        b = q * a := hbq
+        _ = 0 := by rw [hazero, MvPoly.mul_zero]
+    rw [hazero, hbzero, polyNormalize_zero]
+  · rcases hba with ⟨r, har⟩
+    have hqr : q * r = 1 := by
+      have hzero : (q * r - 1) * a = 0 := by
+        rw [har, hbq]
+        grind
+      rcases GcdDomainLaws.no_zero_div (q * r - 1) a hzero with
+        hrest | haz
+      · grind
+      · exact False.elim (hazero haz)
+    have hqunit : polyIsUnit q = true :=
+      (polyIsUnit_iff q).mpr ⟨r, hqr⟩
+    symm
+    calc
+      polyNormalize b = polyNormalize (q * a) := congrArg polyNormalize hbq
+      _ = polyNormalize q * polyNormalize a := polyNormalize_mul q a
+      _ = 1 * a := by rw [polyNormalize_unit q hqunit, ha]
+      _ = a := MvPoly.one_mul a
+
+end NormalizeAssoc
 
 end MvPoly
 

--- a/HexMvGcd/Gcd.lean
+++ b/HexMvGcd/Gcd.lean
@@ -336,7 +336,50 @@ theorem contentIn_mul
     (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
     [IsMonomialOrder cmp'] (p q : MvPoly (n + 1) R cmp) :
     contentIn i cmp' (p * q) = contentIn i cmp' p * contentIn i cmp' q := by
-  sorry
+  let pv := toUnivariate i cmp' p
+  let qv := toUnivariate i cmp' q
+  let pqv := toUnivariate i cmp' (p * q)
+  let cp := contentIn i cmp' p
+  let cq := contentIn i cmp' q
+  let cpq := contentIn i cmp' (p * q)
+  let dp := denseContent pv
+  let dq := denseContent qv
+  let dpq := denseContent pqv
+  have hcpdp : cp ∣ dp := by
+    apply dvd_denseContent pv cp
+    intro k
+    exact contentIn_dvd_coeff i cmp' p k
+  have hdpcp : dp ∣ cp := by
+    apply dvd_contentIn i cmp' p dp
+    intro k
+    exact denseContent_dvd_coeff pv k
+  have hcqdq : cq ∣ dq := by
+    apply dvd_denseContent qv cq
+    intro k
+    exact contentIn_dvd_coeff i cmp' q k
+  have hdqcq : dq ∣ cq := by
+    apply dvd_contentIn i cmp' q dq
+    intro k
+    exact denseContent_dvd_coeff qv k
+  have hcpqdpq : cpq ∣ dpq := by
+    apply dvd_denseContent pqv cpq
+    intro k
+    exact contentIn_dvd_coeff i cmp' (p * q) k
+  have hdpqcpq : dpq ∣ cpq := by
+    apply dvd_contentIn i cmp' (p * q) dpq
+    intro k
+    exact denseContent_dvd_coeff pqv k
+  have hview : pqv = pv * qv := toUnivariate_mul i p q
+  have hdense := denseContent_mul_assoc pv qv
+  rw [← hview] at hdense
+  have hforward : cpq ∣ cp * cq :=
+    dvdTrans (dvdTrans hcpqdpq hdense.1) (Hex.dvdMul hdpcp hdqcq)
+  have hback : cp * cq ∣ cpq :=
+    dvdTrans (Hex.dvdMul hcpdp hcqdq) (dvdTrans hdense.2 hdpqcpq)
+  have hcanon := eq_polyNormalize_of_dvd cpq (cp * cq)
+    (contentIn_normalized i cmp' (p * q)) hforward hback
+  rw [polyNormalize_mul, contentIn_normalized, contentIn_normalized] at hcanon
+  exact hcanon
 
 theorem primPartIn_mul
     {cmp : Mono (n + 1) → Mono (n + 1) → Ordering}
@@ -937,37 +980,6 @@ private theorem reorder_dvd
     reorder cmp' q = reorder cmp' (a * p) := congrArg (reorder cmp') ha
     _ = reorder cmp' a * reorder cmp' p := reorder_mul a p
 
-private theorem eq_normalize_of_dvd [IsMonomialOrder cmp]
-    [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R]
-    [Dvd R] [GcdOps R] [LawfulGcdOps R]
-    (a b : MvPoly n R cmp) (ha : polyNormalize a = a)
-    (hab : a ∣ b) (hba : b ∣ a) : a = polyNormalize b := by
-  rcases hab with ⟨q, hbq⟩
-  by_cases hazero : a = 0
-  · have hbzero : b = 0 := by
-      calc
-        b = q * a := hbq
-        _ = 0 := by rw [hazero, MvPoly.mul_zero]
-    rw [hazero, hbzero, polyNormalize_zero]
-  · rcases hba with ⟨r, har⟩
-    have hqr : q * r = 1 := by
-      have hzero : (q * r - 1) * a = 0 := by
-        rw [har, hbq]
-        grind
-      rcases GcdDomainLaws.no_zero_div (q * r - 1) a hzero with
-        hrest | haz
-      · grind
-      · exact False.elim (hazero haz)
-    have hqunit : polyIsUnit q = true :=
-      (polyIsUnit_iff q).mpr ⟨r, hqr⟩
-    symm
-    calc
-      polyNormalize b = polyNormalize (q * a) :=
-        congrArg polyNormalize hbq
-      _ = polyNormalize q * polyNormalize a := polyNormalize_mul q a
-      _ = 1 * a := by rw [polyNormalize_unit q hqunit, ha]
-      _ = a := MvPoly.one_mul a
-
 theorem gcd_reorder
     {cmp' : Mono n → Mono n → Ordering}
     [IsMonomialOrder cmp] [IsMonomialOrder cmp']
@@ -998,7 +1010,7 @@ theorem gcd_reorder
     have := reorder_dvd (cmp := cmp) (cmp' := cmp') hback
     simpa [reorder_reorder] using this
   have hcanon : g' = polyNormalize r :=
-    eq_normalize_of_dvd g' r (gcd_normalized _ _) hg'dvd hrdvd
+    eq_polyNormalize_of_dvd g' r (gcd_normalized _ _) hg'dvd hrdvd
   cases hlead : r.leadingTerm with
   | none =>
       refine ⟨1, 1, Lean.Grind.Semiring.mul_one 1, ?_⟩

--- a/HexMvGcd/View.lean
+++ b/HexMvGcd/View.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 import HexBasic.Fold
+import HexBasic.List
 public import HexMvGcd.Divide
 public import HexMvPoly.Recursive
 
@@ -138,11 +139,6 @@ private theorem insertVar_mul (i : Fin (n + 1)) (ea eb : Nat)
   · by_cases hlt : j < i.val <;>
       simp [insertVar, Mono.mul, heq, hlt]
 
-private theorem insertVar_mul_zero (i : Fin (n + 1)) (a b : Mono n) :
-    insertVar i 0 (Mono.mul a b) =
-      Mono.mul (insertVar i 0 a) (insertVar i 0 b) := by
-  simpa using insertVar_mul i 0 0 a b
-
 private theorem removeVar_mul (i : Fin (n + 1)) (a b : Mono (n + 1)) :
     removeVar i (Mono.mul a b) =
       Mono.mul (removeVar i a) (removeVar i b) := by
@@ -150,52 +146,72 @@ private theorem removeVar_mul (i : Fin (n + 1)) (a b : Mono (n + 1)) :
   intro j hj
   by_cases hlt : j < i.val <;> simp [removeVar, Mono.mul, hlt]
 
+private theorem splits_insertVar_perm (i : Fin (n + 1)) (e : Nat)
+    (m : Mono n) :
+    ((List.range (e + 1)).flatMap fun d =>
+      (Mono.splits m).map fun ab =>
+        (insertVar i d ab.1, insertVar i (e - d) ab.2)).Perm
+      (Mono.splits (insertVar i e m)) := by
+  have hleft :
+      ((List.range (e + 1)).flatMap fun d =>
+        (Mono.splits m).map fun ab =>
+          (insertVar i d ab.1, insertVar i (e - d) ab.2)).Nodup := by
+    apply List.nodup_flatMap_of_disjoint List.nodup_range
+    · intro d _
+      apply (Mono.splits_nodup m).map
+      intro ab cd hne heq
+      apply hne
+      apply Prod.ext
+      · exact ((insertVar_inj i d d ab.1 cd.1).mp
+          (congrArg Prod.fst heq)).2
+      · exact ((insertVar_inj i (e - d) (e - d) ab.2 cd.2).mp
+          (congrArg Prod.snd heq)).2
+    · intro d _ k _ hdk z hzd hzk
+      rcases List.mem_map.mp hzd with ⟨ab, _, hab⟩
+      rcases List.mem_map.mp hzk with ⟨cd, _, hcd⟩
+      have hfirst : insertVar i d ab.1 = insertVar i k cd.1 := by
+        exact (congrArg Prod.fst hab).trans (congrArg Prod.fst hcd).symm
+      have hdegree := congrArg (Mono.degreeOf i) hfirst
+      rw [degreeOf_insertVar, degreeOf_insertVar] at hdegree
+      exact hdk hdegree
+  apply (List.perm_ext_iff_of_nodup hleft
+    (Mono.splits_nodup (insertVar i e m))).mpr
+  intro z
+  constructor
+  · intro hz
+    rcases List.mem_flatMap.mp hz with ⟨d, hd, hrow⟩
+    rcases List.mem_map.mp hrow with ⟨ab, hab, rfl⟩
+    have hde : d ≤ e := Nat.le_of_lt_succ (List.mem_range.mp hd)
+    apply (Mono.splits_mem_iff ..).mpr
+    rw [← insertVar_mul, (Mono.splits_mem_iff ..).mp hab,
+      Nat.add_sub_of_le hde]
+  · intro hz
+    have hmul : Mono.mul z.1 z.2 = insertVar i e m :=
+      (Mono.splits_mem_iff ..).mp hz
+    let d := Mono.degreeOf i z.1
+    have hsum : d + Mono.degreeOf i z.2 = e := by
+      have hdegree := congrArg (Mono.degreeOf i) hmul
+      rw [degreeOf_mul, degreeOf_insertVar] at hdegree
+      exact hdegree
+    have hde : d ≤ e := by omega
+    apply List.mem_flatMap.mpr
+    refine ⟨d, List.mem_range.mpr (Nat.lt_succ_of_le hde), ?_⟩
+    apply List.mem_map.mpr
+    refine ⟨(removeVar i z.1, removeVar i z.2), ?_, ?_⟩
+    · apply (Mono.splits_mem_iff ..).mpr
+      rw [← removeVar_mul, hmul, removeVar_insertVar]
+    · apply Prod.ext
+      · exact insertVar_removeVar i z.1
+      · have hrest : e - d = Mono.degreeOf i z.2 := by omega
+        rw [hrest]
+        exact insertVar_removeVar i z.2
+
+
 private theorem splits_insertVar_zero_perm (i : Fin (n + 1)) (m : Mono n) :
     ((Mono.splits m).map fun ab =>
       (insertVar i 0 ab.1, insertVar i 0 ab.2)).Perm
         (Mono.splits (insertVar i 0 m)) := by
-  let lift : Mono n × Mono n → Mono (n + 1) × Mono (n + 1) :=
-    fun ab => (insertVar i 0 ab.1, insertVar i 0 ab.2)
-  have hinj : Function.Injective lift := by
-    rintro ⟨a, b⟩ ⟨c, d⟩ h
-    apply Prod.ext
-    · exact ((insertVar_inj i 0 0 a c).mp (congrArg Prod.fst h)).2
-    · exact ((insertVar_inj i 0 0 b d).mp (congrArg Prod.snd h)).2
-  have hnodup : ((Mono.splits m).map lift).Nodup := by
-    apply (Mono.splits_nodup m).map
-    intro a b hne heq
-    exact hne (hinj heq)
-  apply (List.perm_ext_iff_of_nodup hnodup
-    (Mono.splits_nodup (insertVar i 0 m))).mpr
-  rintro ⟨a, b⟩
-  constructor
-  · intro hmem
-    rcases List.mem_map.mp hmem with ⟨⟨c, d⟩, hcd, hab⟩
-    cases hab
-    apply (Mono.splits_mem_iff ..).mpr
-    rw [← insertVar_mul_zero, (Mono.splits_mem_iff ..).mp hcd]
-  · intro hmem
-    have hmul : Mono.mul a b = insertVar i 0 m :=
-      (Mono.splits_mem_iff ..).mp hmem
-    have hdegree : Mono.degreeOf i a + Mono.degreeOf i b = 0 := by
-      calc
-        Mono.degreeOf i a + Mono.degreeOf i b =
-            Mono.degreeOf i (Mono.mul a b) := (degreeOf_mul i a b).symm
-        _ = Mono.degreeOf i (insertVar i 0 m) := by rw [hmul]
-        _ = 0 := degreeOf_insertVar i 0 m
-    have ha0 : Mono.degreeOf i a = 0 := by omega
-    have hb0 : Mono.degreeOf i b = 0 := by omega
-    have ha : insertVar i 0 (removeVar i a) = a := by
-      rw [← ha0]
-      exact insertVar_removeVar i a
-    have hb : insertVar i 0 (removeVar i b) = b := by
-      rw [← hb0]
-      exact insertVar_removeVar i b
-    apply List.mem_map.mpr
-    refine ⟨(removeVar i a, removeVar i b), ?_, ?_⟩
-    · apply (Mono.splits_mem_iff ..).mpr
-      rw [← removeVar_mul, hmul, removeVar_insertVar]
-    · exact Prod.ext ha hb
+  simpa using splits_insertVar_perm i 0 m
 
 /-- The full coefficient of a constant embedding is supported exactly on
 monomials having selected-variable degree zero. -/
@@ -455,10 +471,11 @@ private theorem coeff_foldl_add_term
       simp only [List.foldl_cons]
       rw [ih, coeff_add]
 
-/-- The recursive view at the first variable preserves multiplication. -/
-theorem toUnivariate_mul (p q : MvPoly (n + 1) R cmp) :
-    toUnivariate 0 cmp' (p * q) =
-      toUnivariate 0 cmp' p * toUnivariate 0 cmp' q := by
+/-- The recursive view at a selected variable preserves multiplication. -/
+theorem toUnivariate_mul (i : Fin (n + 1))
+    (p q : MvPoly (n + 1) R cmp) :
+    toUnivariate i cmp' (p * q) =
+      toUnivariate i cmp' p * toUnivariate i cmp' q := by
   apply DensePoly.ext_coeff
   intro e
   apply MvPoly.ext
@@ -466,16 +483,16 @@ theorem toUnivariate_mul (p q : MvPoly (n + 1) R cmp) :
   rw [toUnivariate_coeff, DensePoly.coeff_mul]
   have hdiag := DensePoly.mulCoeffSum_eq_diagonal
     (S := MvPoly n R cmp')
-    (toUnivariate 0 cmp' p) (toUnivariate 0 cmp' q) e
+    (toUnivariate i cmp' p) (toUnivariate i cmp' q) e
   have hdegree := DensePoly.diagonalSum_eq_degree_bound
     (S := MvPoly n R cmp')
-    (toUnivariate 0 cmp' p) (toUnivariate 0 cmp' q) e
+    (toUnivariate i cmp' p) (toUnivariate i cmp' q) e
   have hdiagCoeff := congrArg (coeff m) (hdiag.trans hdegree)
   rw [hdiagCoeff]
-  rw [MvPoly.coeff_mul, insertVar_zero_eq_prepend]
-  have hhead : (Mono.prepend e m).head = e := by
-    exact Mono.getElem_prepend_zero e m
-  simp only [Mono.splits, Mono.dropHead_prepend, hhead]
+  rw [MvPoly.coeff_mul]
+  let term : Mono (n + 1) × Mono (n + 1) → R := fun ab =>
+    coeff ab.1 p * coeff ab.2 q
+  rw [← List.foldl_add_perm term (splits_insertVar_perm i e m) 0]
   rw [List.foldl_add_flatMap]
   rw [coeff_foldl_add_term, coeff_zero]
   apply List.foldl_congr
@@ -490,19 +507,18 @@ theorem toUnivariate_mul (p q : MvPoly (n + 1) R cmp) :
   calc
     m.splits.foldl
         (fun acc x => acc +
-          coeff (Mono.prepend d x.1) p *
-            coeff (Mono.prepend (e - d) x.2) q) 0 =
+          coeff (insertVar i d x.1) p *
+            coeff (insertVar i (e - d) x.2) q) 0 =
         m.splits.foldl
           (fun acc x => acc +
-            coeff x.1 ((toUnivariate 0 cmp' p).coeff d) *
-              coeff x.2 ((toUnivariate 0 cmp' q).coeff (e - d))) 0 := by
+            coeff x.1 ((toUnivariate i cmp' p).coeff d) *
+              coeff x.2 ((toUnivariate i cmp' q).coeff (e - d))) 0 := by
       apply List.foldl_congr
       intro z x _
-      rw [toUnivariate_coeff, toUnivariate_coeff,
-        insertVar_zero_eq_prepend, insertVar_zero_eq_prepend]
+      rw [toUnivariate_coeff, toUnivariate_coeff]
     _ = coeff m
-          ((toUnivariate 0 cmp' p).coeff d *
-            (toUnivariate 0 cmp' q).coeff (e - d)) :=
+          ((toUnivariate i cmp' p).coeff d *
+            (toUnivariate i cmp' q).coeff (e - d)) :=
       (MvPoly.coeff_mul _ _ _).symm
 
 omit [BEq R] [LawfulBEq R] in


### PR DESCRIPTION
`contentIn` and scalar `content` could be computed, but their multiplicativity contracts were still admitted. This proves both from the executable recursive views and the proof-side Gauss content theorem, and generalizes recursive-view multiplication from variable zero to any selected variable.

The proof keeps certificate production unchanged. It identifies each recursive content with the scalar content up to normalized associates, applies lower-arity multiplicativity, and uses canonical normalization to obtain equality.

Validation:
- `lake build HexMvGcd.View`
- `lake build HexMvGcd.Gauss`
- `lake build HexMvGcd.Gcd`
- `lake build HexMvGcd.Content`
- `git diff --check`

Part of #10082.
