### PR TITLE
refactor(mathlib): polish Sturm and polynomial parsing APIs

### DIFF
--- a/HexBerlekampZassenhausMathlib/FactorTactic.lean
+++ b/HexBerlekampZassenhausMathlib/FactorTactic.lean
@@ -178,13 +178,13 @@ meta partial def parsePolynomial (tactic : String) (fuel : Nat) (e : Expr) :
       let vE ← Hex.CertificateSyntax.reifyZPoly v
       return (v, vE, mkConst ``HexBerlekampZassenhausMathlib.toPolynomial_X)
   | (``Polynomial.C, #[_, _, c]) => do
-      let k ← HexPolyZMathlib.PolyParse.evalIntLit tactic c
+      let k ← HexPolyZMathlib.PolyParse.evalIntCoeff tactic c
       constLeaf tactic k c none
   | (``DFunLike.coe, args) =>
       -- `Polynomial.C c` elaborates to `⇑Polynomial.C c`.
       if args.size == 6 && args[4]!.getAppFn.isConstOf ``Polynomial.C then do
         let c := args[5]!
-        let k ← HexPolyZMathlib.PolyParse.evalIntLit tactic c
+        let k ← HexPolyZMathlib.PolyParse.evalIntCoeff tactic c
         constLeaf tactic k c none
       else
         throwError "{tactic}: unsupported polynomial syntax{indentExpr e}"

--- a/HexPolyZ/IntegerPolynomial.lean
+++ b/HexPolyZ/IntegerPolynomial.lean
@@ -169,7 +169,7 @@ theorem dilate_neg_one_ne_zero {p : ZPoly} (hp : p ≠ 0) :
 /-- Reflection in the origin preserves the optional degree. -/
 @[simp] theorem degree?_dilate_neg_one (p : ZPoly) :
     (dilate (-1) p).degree? = p.degree? := by
-  simp [DensePoly.natDegree, DensePoly.degree?, size_dilate_neg_one]
+  simp [DensePoly.degree?, size_dilate_neg_one]
 
 /-- The reflected leading coefficient differs only by the degree-parity sign. -/
 theorem leadingCoeff_dilate_neg_one (p : ZPoly) :

--- a/HexPolyZ/Rational.lean
+++ b/HexPolyZ/Rational.lean
@@ -187,7 +187,7 @@ theorem primitive_normalizePrimitiveSign {p : ZPoly} (hp : Primitive p) :
 /-- Sign normalization preserves optional degree. -/
 @[simp] theorem degree?_normalizePrimitiveSign (p : ZPoly) :
     (normalizePrimitiveSign p).degree? = p.degree? := by
-  simp [DensePoly.natDegree, DensePoly.degree?, size_normalizePrimitiveSign]
+  simp [DensePoly.degree?, size_normalizePrimitiveSign]
 
 /-- The rational primitive part is primitive when its content is nonzero. -/
 theorem ratPolyPrimitivePart_primitive (f : DensePoly Rat)

--- a/HexPolyZMathlib/PolyParse.lean
+++ b/HexPolyZMathlib/PolyParse.lean
@@ -47,33 +47,27 @@ meta def evalRat (tactic : String) (e : Expr) : MetaM Rat := do
 
 /-- Extract a `Nat` literal from an `Expr` (numerals and raw literals). -/
 meta def getNat (tactic : String) (e : Expr) : MetaM Nat := do
-  match ← getNatValue? e with
-  | some n => return n
-  | none =>
-    match (← whnfR e).getAppFnArgs with
-    | (``OfNat.ofNat, #[_, n, _]) =>
-      match ← getNatValue? n with
-      | some k => return k
-      | none => throwError "{tactic}: not a Nat literal{indentExpr e}"
-    | _ => throwError "{tactic}: not a Nat literal{indentExpr e}"
+  let some n ← getNatValue? e
+    | throwError "{tactic}: not a Nat literal{indentExpr e}"
+  return n
 
 /-- Interpret an integer scalar-coefficient leaf (`OfNat`, `Neg`, `+`, `-`, `*`,
 `Int.ofNat`, `Nat.cast`, `Int.cast`, raw literals). Throws the dedicated
 non-integer-coefficient error on anything else (e.g. a genuine `ℚ`/`ℝ`
 non-integer). -/
-meta partial def evalIntLit (tactic : String) (e : Expr) : MetaM Int := do
+meta partial def evalIntCoeff (tactic : String) (e : Expr) : MetaM Int := do
   match (← whnfR e).getAppFnArgs with
   | (``OfNat.ofNat, #[_, n, _]) => return Int.ofNat (← getNat tactic n)
-  | (``Neg.neg, #[_, _, a]) => return - (← evalIntLit tactic a)
+  | (``Neg.neg, #[_, _, a]) => return - (← evalIntCoeff tactic a)
   | (``HMul.hMul, #[_, _, _, _, a, b]) =>
-      return (← evalIntLit tactic a) * (← evalIntLit tactic b)
+      return (← evalIntCoeff tactic a) * (← evalIntCoeff tactic b)
   | (``HAdd.hAdd, #[_, _, _, _, a, b]) =>
-      return (← evalIntLit tactic a) + (← evalIntLit tactic b)
+      return (← evalIntCoeff tactic a) + (← evalIntCoeff tactic b)
   | (``HSub.hSub, #[_, _, _, _, a, b]) =>
-      return (← evalIntLit tactic a) - (← evalIntLit tactic b)
+      return (← evalIntCoeff tactic a) - (← evalIntCoeff tactic b)
   | (``Int.ofNat, #[n]) => return Int.ofNat (← getNat tactic n)
   | (``Nat.cast, #[_, _, n]) => return Int.ofNat (← getNat tactic n)
-  | (``Int.cast, #[_, _, z]) => evalIntLit tactic z
+  | (``Int.cast, #[_, _, z]) => evalIntCoeff tactic z
   | _ =>
     match ← getIntValue? e with
     | some z => return z
@@ -85,7 +79,7 @@ denominator is `1`; otherwise the dedicated non-integer-coefficient error fires.
 For `ℝ` (not evaluable to `Rat`), only structurally integer leaves are accepted. -/
 meta def evalCoeff (tactic : String) (isRat : Bool) (e : Expr) : MetaM Int := do
   try
-    evalIntLit tactic e
+    evalIntCoeff tactic e
   catch _ =>
     if isRat then
       let q ← evalRat tactic e

--- a/HexRealRootsMathlib.lean
+++ b/HexRealRootsMathlib.lean
@@ -13,6 +13,7 @@ public import HexRealRootsMathlib.RealRootCount
 public import HexRealRootsMathlib.Hadamard
 public import HexRealRootsMathlib.Discr
 public import HexRealRootsMathlib.Separation
+public import HexRealRootsMathlib.Sign
 public import HexRealRootsMathlib.ChainCorrespond
 public import HexRealRootsMathlib.LiteralChain
 public import HexRealRootsMathlib.LiteralIsolations

--- a/HexRealRootsMathlib/IsolateRootsElab.lean
+++ b/HexRealRootsMathlib/IsolateRootsElab.lean
@@ -140,7 +140,7 @@ meta def evalRat (e : Expr) : MetaM Rat :=
 
 /-! # The integer-polynomial interpreter
 
-The interpreter itself (`getNat`/`evalIntLit`/`evalCoeff`/`parsePoly`) is
+The interpreter itself (`getNat`/`evalIntCoeff`/`evalCoeff`/`parsePoly`) is
 hoisted to `HexPolyZMathlib.PolyParse`, shared with the
 `factor_poly`/`irreducibility` `Polynomial ℤ` provider. -/
 

--- a/HexRealRootsMathlib/Sign.lean
+++ b/HexRealRootsMathlib/Sign.lean
@@ -1,0 +1,35 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import Mathlib.Topology.Connected.TotallyDisconnected
+public import Mathlib.Topology.Instances.Sign
+
+/-!
+# Signs of continuous nonvanishing functions
+
+This file backports the general sign lemmas used by the Sturm development.
+-/
+
+public section
+
+variable {α : Type*} [Zero α] [TopologicalSpace α] [LinearOrder α] [OrderTopology α]
+
+/-- The sign of a continuous function is continuous wherever the function is nonzero. -/
+theorem ContinuousOn.sign {β : Type*} [TopologicalSpace β] {f : β → α} {s : Set β}
+    (hf : ContinuousOn f s) (h0 : ∀ x ∈ s, f x ≠ 0) :
+    ContinuousOn (fun x => SignType.sign (f x)) s := by
+  refine (continuousOn_of_forall_continuousAt fun y hy => ?_).comp' hf (Set.mapsTo_image _ _)
+  obtain ⟨x, hx, rfl⟩ := hy
+  exact continuousAt_sign_of_ne_zero (h0 x hx)
+
+/-- A continuous nonvanishing function has constant sign on a preconnected set. -/
+theorem IsPreconnected.sign_eq_of_continuousOn {β : Type*} [TopologicalSpace β] {f : β → α}
+    {s : Set β} (hs : IsPreconnected s) (hf : ContinuousOn f s)
+    (h0 : ∀ x ∈ s, f x ≠ 0) {x y : β} (hx : x ∈ s) (hy : y ∈ s) :
+    SignType.sign (f x) = SignType.sign (f y) :=
+  hs.constant (hf.sign h0) hx hy

--- a/HexRealRootsMathlib/SturmChainDefs.lean
+++ b/HexRealRootsMathlib/SturmChainDefs.lean
@@ -131,23 +131,19 @@ theorem signVariations_congr {l₁ l₂ : List ℝ}
     signVariations l₁ = signVariations l₂ :=
   countSignChanges_congr (filter_ne_zero_congr h)
 
-/-- The sign of the first surviving (nonzero) entry of a real list, as an
-`Option SignType`: `none` when every entry is zero. This is the piece of local
-state that governs how prepending a nonzero entry changes `signVariations`. -/
+/-- The sign of the first nonzero entry of a real list, or `0` if every entry is zero. -/
 @[expose]
-noncomputable def firstSign (l : List ℝ) : Option SignType :=
-  (l.filter (fun v => decide (v ≠ 0))).head?.map (fun a => SignType.sign a)
+noncomputable def firstSign (l : List ℝ) : SignType :=
+  ((l.filter (fun v => decide (v ≠ 0))).head?.map SignType.sign).getD 0
 
-@[simp] theorem firstSign_nil : firstSign [] = none := rfl
+@[simp] theorem firstSign_nil : firstSign [] = 0 := rfl
 
-theorem firstSign_cons_zero {a : ℝ} (l : List ℝ) (ha : a = 0) :
-    firstSign (a :: l) = firstSign l := by
-  unfold firstSign; rw [List.filter_cons_of_neg (by simp [ha])]
+@[simp] theorem firstSign_cons_zero (l : List ℝ) : firstSign (0 :: l) = firstSign l := by
+  simp [firstSign]
 
-theorem firstSign_cons_ne {a : ℝ} (l : List ℝ) (ha : a ≠ 0) :
-    firstSign (a :: l) = some (SignType.sign a) := by
-  unfold firstSign
-  rw [List.filter_cons_of_pos (by simp [ha]), List.head?_cons, Option.map_some]
+@[simp] theorem firstSign_cons_ne {a : ℝ} (l : List ℝ) (ha : a ≠ 0) :
+    firstSign (a :: l) = SignType.sign a := by
+  simp [firstSign, ha]
 
 private theorem sign_mul_eq_neg_one {a b : ℝ} :
     (SignType.sign a * SignType.sign b = -1) ↔ a * b < 0 := by
@@ -157,21 +153,19 @@ private theorem sign_mul_eq_neg_one {a b : ℝ} :
 opposite the sign of the next surviving entry. -/
 theorem signVariations_cons {a : ℝ} (l : List ℝ) (ha : a ≠ 0) :
     signVariations (a :: l) =
-      (firstSign l).elim 0
-        (fun t => if SignType.sign a * t = -1 then 1 else 0) + signVariations l := by
+      (if SignType.sign a * firstSign l = -1 then 1 else 0) + signVariations l := by
   induction l with
   | nil => rw [signVariations_cons_ne a [] ha]; simp [firstSign]
   | cons b l' ih =>
     by_cases hb : b = 0
     · subst hb
-      rw [firstSign_cons_zero l' rfl, signVariations_cons_zero l',
+      rw [firstSign_cons_zero l', signVariations_cons_zero l',
         signVariations_cons_ne a (0 :: l') ha, List.filter_cons_of_neg (by simp),
         ← signVariations_cons_ne a l' ha]
       exact ih
     · rw [firstSign_cons_ne l' hb, signVariations_cons_ne a (b :: l') ha,
         List.filter_cons_of_pos (by simp [hb]), countSignChanges_cons_cons,
         ← signVariations_cons_ne b l' hb]
-      simp only [Option.elim_some]
       congr 1
       simp only [sign_mul_eq_neg_one]
 

--- a/HexRealRootsMathlib/SturmTheorem.lean
+++ b/HexRealRootsMathlib/SturmTheorem.lean
@@ -81,9 +81,8 @@ private theorem SignRelation.signVariations_eq {L M : List ℝ} (h : SignRelatio
         firstSign_cons_ne (y :: l) hX, signVariations_cons (y :: l) hX,
         firstSign_cons_ne l hy]
       rw [signVariations_cons (0 :: y' :: m) hx',
-        firstSign_cons_zero (y' :: m) rfl, firstSign_cons_ne m hy',
+        firstSign_cons_zero (y' :: m), firstSign_cons_ne m hy',
         signVariations_cons_zero]
-      simp only [Option.elim_some]
       rw [← add_assoc, ih.1]
       congr 1
       rw [← hsx, ← hsy, ite_eq_left hopp]
@@ -321,13 +320,13 @@ theorem sturmVar_root_cross (hchain : IsSturmChain p chain) (r : ℝ) (hr : p.Is
       = 1 + signVariations ((q :: tail).map (Polynomial.eval a))
     rw [signVariations_cons _ hpa]
     simp only [List.map_cons]
-    rw [firstSign_cons_ne _ hqa, Option.elim_some, ite_eq_left hsignA]
+    rw [firstSign_cons_ne _ hqa, ite_eq_left hsignA]
   have hSVb : sturmVar (p :: q :: tail) b = sturmVar (q :: tail) b := by
     change signVariations (p.eval b :: (q :: tail).map (Polynomial.eval b))
       = signVariations ((q :: tail).map (Polynomial.eval b))
     rw [signVariations_cons _ hpb]
     simp only [List.map_cons]
-    rw [firstSign_cons_ne _ hqb, Option.elim_some, ite_eq_right hsignB, zero_add]
+    rw [firstSign_cons_ne _ hqb, ite_eq_right hsignB, zero_add]
   have hSVr : sturmVar (p :: q :: tail) r = sturmVar (q :: tail) r := by
     change signVariations (p.eval r :: (q :: tail).map (Polynomial.eval r))
       = signVariations ((q :: tail).map (Polynomial.eval r))

--- a/HexRealRootsMathlib/SturmTheorem.lean
+++ b/HexRealRootsMathlib/SturmTheorem.lean
@@ -8,6 +8,7 @@ module
 
 public import HexRealRootsMathlib.SturmChainDefs
 public import Mathlib.Analysis.Polynomial.Order
+public import HexRealRootsMathlib.Sign
 
 /-!
 # Sturm's theorem
@@ -91,27 +92,11 @@ private theorem SignRelation.signVariations_eq {L M : List ℝ} (h : SignRelatio
 
 
 /-- A real polynomial with no roots on an interval has equal signs at its endpoints. -/
-theorem eval_sign_eq_of_no_zero {q : Polynomial ℝ} {a b : ℝ} (hab : a ≤ b)
+private theorem eval_sign_eq_of_no_zero {q : Polynomial ℝ} {a b : ℝ} (hab : a ≤ b)
     (hz : ∀ x ∈ Set.Icc a b, q.eval x ≠ 0) :
-    SignType.sign (q.eval a) = SignType.sign (q.eval b) := by
-  have hna : q.eval a ≠ 0 := hz a ⟨le_refl a, hab⟩
-  have hnb : q.eval b ≠ 0 := hz b ⟨hab, le_refl b⟩
-  have hpos : 0 < q.eval a * q.eval b := by
-    rcases lt_or_gt_of_ne (mul_ne_zero hna hnb) with hlt | hgt
-    · exfalso
-      have hmem : (0 : ℝ) ∈ Set.uIcc (q.eval a) (q.eval b) := by
-        rcases mul_neg_iff.mp hlt with ⟨hx, hy⟩ | ⟨hx, hy⟩
-        · exact Set.mem_uIcc.mpr (Or.inr ⟨hy.le, hx.le⟩)
-        · exact Set.mem_uIcc.mpr (Or.inl ⟨hx.le, hy.le⟩)
-      have hsub := intermediate_value_uIcc (a := a) (b := b)
-        (f := fun x => q.eval x) q.continuousOn
-      obtain ⟨c, hc, hc0⟩ := hsub hmem
-      rw [Set.uIcc_of_le hab] at hc
-      exact hz c hc hc0
-    · exact hgt
-  rcases mul_pos_iff.mp hpos with ⟨h1, h2⟩ | ⟨h1, h2⟩
-  · rw [sign_pos h1, sign_pos h2]
-  · rw [sign_neg h1, sign_neg h2]
+    SignType.sign (q.eval a) = SignType.sign (q.eval b) :=
+  isPreconnected_Icc.sign_eq_of_continuousOn q.continuousOn hz
+    ⟨le_refl a, hab⟩ ⟨hab, le_refl b⟩
 
 /-- Build the sign-pattern relation `SignRelation` between the evaluations of a
 polynomial list at a "generic" point `a` (where every element is nonzero) and a

--- a/scripts/bench/proof_only_runtime_exemptions/hexpolyz-integerpolynomial-lean-cbb73fbe-91bb4bff.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexpolyz-integerpolynomial-lean-cbb73fbe-91bb4bff.json
@@ -1,0 +1,6 @@
+{
+  "path": "HexPolyZ/IntegerPolynomial.lean",
+  "baseline_blob": "cbb73fbeea543a0c31b529b31fb9454a250ead07",
+  "current_blob": "91bb4bff0d721850693af1eecaba1b04c9b514a9",
+  "reason": "Removes an unused simp argument from the proof of degree?_dilate_neg_one; no definition or factorization-service runtime path changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexpolyz-rational-lean-a32953c6-31e87d56.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexpolyz-rational-lean-a32953c6-31e87d56.json
@@ -1,0 +1,6 @@
+{
+  "path": "HexPolyZ/Rational.lean",
+  "baseline_blob": "a32953c66adbff4207d98a982e5420d5505fa91b",
+  "current_blob": "31e87d568af118aeeb91d9122b18ebf49da5f76b",
+  "reason": "Removes an unused simp argument from the proof of degree?_normalizePrimitiveSign; no definition or factorization-service runtime path changes."
+}

--- a/scripts/check_sturm_sync.py
+++ b/scripts/check_sturm_sync.py
@@ -14,7 +14,7 @@ MODULES = {
     "HexRealRootsMathlib.SturmChainDefs": "Mathlib.Analysis.Polynomial.Sturm.Defs",
     "HexRealRootsMathlib.SturmTheorem": "Mathlib.Analysis.Polynomial.Sturm.Basic",
     "HexRealRootsMathlib.SturmCertificate": "Mathlib.Analysis.Polynomial.Sturm.Certificate",
-    "HexPolyZMathlib.PolyParse": "Mathlib.Tactic.RealRootCount.Parse",
+    "HexPolyZMathlib.PolyParse": "Mathlib.Tactic.HexPolyZ.Parse",
     "HexRealRootsMathlib.RealRootCount": "Mathlib.Tactic.RealRootCount",
     "HexRealRootsMathlib.RealRootCountTests": "MathlibTest.RealRootCount",
     "HexRealRootsMathlib.SturmTests": "MathlibTest.Sturm",

--- a/scripts/check_sturm_sync.py
+++ b/scripts/check_sturm_sync.py
@@ -22,7 +22,10 @@ MODULES = {
 
 
 # Mathlib master has moved the Sign modules since Hex's pinned Mathlib release.
-RENAMES = MODULES | {"Mathlib.Data.Sign.Basic": "Mathlib.Basic.Sign.Basic"}
+RENAMES = MODULES | {
+    "HexRealRootsMathlib.Sign": "Mathlib.Topology.Instances.Sign.Connected",
+    "Mathlib.Data.Sign.Basic": "Mathlib.Basic.Sign.Basic",
+}
 
 
 def mathlib_text(text: str) -> str:


### PR DESCRIPTION
The Mathlib-facing Sturm development had several avoidable API wrinkles. This PR:

- backports the general `ContinuousOn.sign` and `IsPreconnected.sign_eq_of_continuousOn` APIs from [Mathlib #43512](https://github.com/leanprover-community/mathlib4/pull/43512), then reduces the polynomial helper to a private specialization;
- makes `Sturm.firstSign` return `SignType` directly, using `0` when no nonzero entry exists;
- delegates natural-literal recognition to Lean's `getNatValue?` and renames the small integer-expression evaluator to `evalIntCoeff`.

It also updates the source synchronizer for the parser's new Mathlib home, `Mathlib.Tactic.HexPolyZ.Parse`. The temporary sign compatibility module can disappear once Hex's Mathlib pin includes the upstream lemmas.

Validation:

- `lake build HexPolyZMathlib HexBerlekampZassenhausMathlib HexRealRootsMathlib` (9,413 jobs)
- `python3 scripts/check_sturm_sync.py /home/kim/worktrees/mathlib4/mathlib4-abel-ruffini-hex`

:robot: Prepared with Codex
