### PR TITLE
feat(number-field): give QAdjoin its own Repr, naming the number not a square

### DIFF
--- a/HexManual/Chapters/HexNumberField.lean
+++ b/HexManual/Chapters/HexNumberField.lean
@@ -220,25 +220,23 @@ def c : QAdjoin cbrt2 := cbrt2.toQAdjoin
 #guard c.toAlgebraicNumber = cbrt2
 ```
 
-An element prints as the expression that rebuilds it: the coordinates, here
-`c⁵ = 2c²`, together with the polynomial and the isolating square that name
-the field and pick out the root. Pasting the output back reproduces the
-element, and the two side conditions on the square are discharged by
-`decide`:
+An element prints as the expression that rebuilds it: the generating number,
+which prints round-trippably itself, and the coordinates, here `c⁵ = 2c²`.
+Pasting the output back reproduces the element:
 
 ```lean (name := cbrt2Pow)
 #eval c ^ 5
 ```
 ```leanOutput cbrt2Pow
-PolyQuot.ofSquare #p[-2, 0, 0, 1] ⟨((1385297844439 : Dyadic) >>> 40), 0, 37⟩ #p[0, 0, 2]
+QAdjoin.ofCoeffs (ZPoly.rootNear #p[-2, 0, 0, 1] 1.25992) #p[0, 0, 2]
 ```
 ```lean (name := pasted)
 -- the printed form, pasted back
-#eval PolyQuot.ofSquare #p[-2, 0, 0, 1]
-  ⟨((1385297844439 : Dyadic) >>> 40), 0, 37⟩ #p[0, 0, 2]
+#eval QAdjoin.ofCoeffs
+  (ZPoly.rootNear #p[-2, 0, 0, 1] 1.25992) #p[0, 0, 2]
 ```
 ```leanOutput pasted
-PolyQuot.ofSquare #p[-2, 0, 0, 1] ⟨((1385297844439 : Dyadic) >>> 40), 0, 37⟩ #p[0, 0, 2]
+QAdjoin.ofCoeffs (ZPoly.rootNear #p[-2, 0, 0, 1] 1.25992) #p[0, 0, 2]
 ```
 ```lean
 #guard (c ^ 5).coeffs = #p[0, 0, 2]

--- a/HexNumberField/Convert.lean
+++ b/HexNumberField/Convert.lean
@@ -40,7 +40,45 @@ end AlgebraicNumber
 ring on its minimal polynomial, with the embedding fixed by the root it
 denotes. Reducible, so every `PolyQuot` operation, instance and theorem
 applies unchanged. -/
-abbrev QAdjoin (a : AlgebraicNumber) : Type := PolyQuot a.p a.x
+@[expose, implicit_reducible]
+def QAdjoin (a : AlgebraicNumber) : Type := PolyQuot a.p a.x
+
+section Instances
+variable {a : AlgebraicNumber}
+
+/-! `QAdjoin` is a `def`, not an `abbrev`, so it carries its own head symbol
+and can hold instances `PolyQuot` must not have -- notably `Repr`, which
+names the generating number rather than an isolating square. The price is
+that the presentation-ring instances no longer arrive by unfolding, so they
+are re-exported here. Each is the `PolyQuot` instance unchanged. -/
+
+instance : DecidableEq (QAdjoin a) := inferInstanceAs (DecidableEq (PolyQuot a.p a.x))
+instance : Zero (QAdjoin a) := inferInstanceAs (Zero (PolyQuot a.p a.x))
+instance : One (QAdjoin a) := inferInstanceAs (One (PolyQuot a.p a.x))
+instance : Add (QAdjoin a) := inferInstanceAs (Add (PolyQuot a.p a.x))
+instance : Sub (QAdjoin a) := inferInstanceAs (Sub (PolyQuot a.p a.x))
+instance : Neg (QAdjoin a) := inferInstanceAs (Neg (PolyQuot a.p a.x))
+instance : Mul (QAdjoin a) := inferInstanceAs (Mul (PolyQuot a.p a.x))
+instance : SMul Rat (QAdjoin a) := inferInstanceAs (SMul Rat (PolyQuot a.p a.x))
+instance : Coe (DensePoly Rat) (QAdjoin a) := inferInstanceAs (Coe _ (PolyQuot a.p a.x))
+instance : NatCast (QAdjoin a) := inferInstanceAs (NatCast (PolyQuot a.p a.x))
+instance : IntCast (QAdjoin a) := inferInstanceAs (IntCast (PolyQuot a.p a.x))
+instance (priority := 90) (n : Nat) : OfNat (QAdjoin a) (n + 2) :=
+  inferInstanceAs (OfNat (PolyQuot a.p a.x) (n + 2))
+instance : Inv (QAdjoin a) := inferInstanceAs (Inv (PolyQuot a.p a.x))
+instance : Div (QAdjoin a) := inferInstanceAs (Div (PolyQuot a.p a.x))
+instance : Pow (QAdjoin a) Nat := inferInstanceAs (Pow (PolyQuot a.p a.x) Nat)
+instance : Pow (QAdjoin a) Int := inferInstanceAs (Pow (PolyQuot a.p a.x) Int)
+
+/-- The element of `ℚ(a)` with coordinates `f` in the power basis of `a`.
+Unlike `PolyQuot.ofSquare` this needs no square and no side conditions: the
+generating number already carries its own root. -/
+@[expose]
+def QAdjoin.ofCoeffs (a : AlgebraicNumber) (f : DensePoly Rat) : QAdjoin a :=
+  PolyQuot.reduce a.p a.x f
+
+end Instances
+
 
 namespace AlgebraicNumber
 

--- a/HexNumberField/Nearest.lean
+++ b/HexNumberField/Nearest.lean
@@ -210,4 +210,15 @@ instance : Repr AlgebraicNumber where
 
 end AlgebraicNumber
 
+/-- An element of `ℚ(a)` prints as the expression that rebuilds it: the
+generating number, which prints round-trippably itself, and the reduced
+coordinates. This is why `QAdjoin` is a `def` rather than an `abbrev`: the
+`PolyQuot` instance would otherwise win, and that one can only name the root
+by its isolating square. Carrying the number instead of a square, this form
+also leaves no `decide` side conditions to discharge when it is pasted back. -/
+instance (a : AlgebraicNumber) : Repr (QAdjoin a) where
+  reprPrec e _ :=
+    Std.Format.text
+      s!"QAdjoin.ofCoeffs ({repr a}) {repr (e : PolyQuot a.p a.x).coeffs}"
+
 end Hex

--- a/HexNumberField/SPEC/hex-number-field.md
+++ b/HexNumberField/SPEC/hex-number-field.md
@@ -51,7 +51,7 @@ structure PolyQuot (p : ZPoly) (x : SimpleRoot p) where
 instance : DecidableEq (PolyQuot p x)
 
 /-- The fixed field `ℚ(a)` of a canonical number. -/
-abbrev QAdjoin (a : AlgebraicNumber) : Type := PolyQuot a.p a.x
+def QAdjoin (a : AlgebraicNumber) : Type := PolyQuot a.p a.x  -- implicit_reducible
 
 /-- A factorization-lazy algebraic number. -/
 structure AlgebraicRoot where
@@ -239,6 +239,22 @@ canonical number induces, that evidence is an instance:
 ```lean
 instance (a : AlgebraicNumber) : ZPoly.CheckedIrreducible a.p
 ```
+
+`QAdjoin` is `implicit_reducible` rather than an abbreviation, so it keeps its
+own head symbol for instance search while still unfolding to `PolyQuot a.p a.x`
+everywhere else. That buys it one instance `PolyQuot` cannot have:
+
+```lean
+def QAdjoin.ofCoeffs (a : AlgebraicNumber) (f : DensePoly Rat) : QAdjoin a
+instance (a : AlgebraicNumber) : Repr (QAdjoin a)
+```
+
+An element of `ℚ(a)` prints as `QAdjoin.ofCoeffs (a) f`, naming the generating
+number -- which prints round-trippably itself -- instead of an isolating
+square, and so leaves no `decide` side conditions to discharge when it is
+pasted back. The presentation-ring instances are re-exported for the new head
+symbol, each `inferInstanceAs` of the `PolyQuot` one. The type of a pasted
+value is still only propositionally the original.
 
 so `a.toQAdjoin : QAdjoin a` inverts and divides without any evidence
 registered by hand. `QAdjoin a` abbreviates `PolyQuot a.p a.x` reducibly, so

--- a/HexNumberFieldTower/Flatten.lean
+++ b/HexNumberFieldTower/Flatten.lean
@@ -159,7 +159,7 @@ def recoverPairFast? (theta alpha gamma : AlgebraicNumber) (shift : Int) :
     Option (PolyQuot gamma.p gamma.x × PolyQuot gamma.p gamma.x) := do
   if shift = 0 then none else
   letI : ZPoly.CheckedIrreducible gamma.p := gamma.checked
-  let gammaCoordinate := gamma.toQAdjoin
+  let gammaCoordinate : PolyQuot gamma.p gamma.x := gamma.toQAdjoin
   let affine : DensePoly (PolyQuot gamma.p gamma.x) :=
     DensePoly.ofList
       [gammaCoordinate, (-(shift : Rat)) • (1 : PolyQuot gamma.p gamma.x)]


### PR DESCRIPTION
Stacked on #10129; review that first.

`QAdjoin a` was a reducible abbreviation for `PolyQuot a.p a.x`, so it shared a head symbol and could not hold an instance of its own — which is why #10129 has to name the root by its isolating square even when the value is a `QAdjoin`. Marking it `implicit_reducible` gives instance search a distinct head while it keeps unfolding everywhere else, exactly as core uses the attribute for `PosFin` and `ExceptConds`, and as this repo already does in `HexMvPolyMathlib/Equiv.lean`.

That buys the instance that matters. A `QAdjoin` value knows its generating `AlgebraicNumber`, which already prints round-trippably, so

```
QAdjoin.ofCoeffs (ZPoly.rootNear #p[-2, 0, 0, 1] 1.25992) #p[0, 0, 2]
```

replaces

```
PolyQuot.ofSquare #p[-2, 0, 0, 1] ⟨((1385297844439 : Dyadic) >>> 40), 0, 37⟩ #p[0, 0, 2]
```

69 characters against 88, verified as an exact fixed point in the manual. Three gains beyond the length: it says *which number* generates the field rather than showing a 41-bit square; `QAdjoin.ofCoeffs` has no side conditions, so pasting costs no kernel `decide`; and the general `PolyQuot` form from #10129 still covers presentations that have no `AlgebraicNumber` behind them.

No wrapper field and no unwrapping — values are unchanged, and `QAdjoin a` stays defeq to `PolyQuot a.p a.x` outside instance search. The cost is that the presentation-ring instances no longer arrive by unfolding, so sixteen are re-exported, each `inferInstanceAs` of the `PolyQuot` one. I checked these are genuinely required by deleting them and watching `OfNat (QAdjoin cbrt2) 2` fail; that is the same property that makes the new `Repr` win, and I confirmed it is selected rather than merely accepted.

The limit is unchanged and stated in the SPEC: a pasted value's type is propositionally but not definitionally the original, so comparing spellings needs a transport. That is inherent to printing a value that occurs in a type, and no arrangement of `QAdjoin` — including a wrapper structure — closes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)