### PR TITLE
refactor(real-roots): narrow the basic polynomial import

### DIFF
--- a/HexRealRoots/Basic.lean
+++ b/HexRealRoots/Basic.lean
@@ -6,7 +6,7 @@ Authors: Kim Morrison
 
 module
 
-public import HexPolyZ
+public import HexPolyZ.IntegerPolynomial
 
 public section
 


### PR DESCRIPTION
`HexRealRoots.Basic` only uses the integer-polynomial core, but imported the full `HexPolyZ` umbrella. The umbrella also exposes NTT multiplication, pulling `HexModArith` and its native build into every basic real-root consumer.

Import `HexPolyZ.IntegerPolynomial` directly. This keeps `HexRealRoots.Chain` and its Mathlib root-count consumer in the pure Lean dependency closure.

Validation:

- `lake build HexRealRoots`
- `lake build` (11,224 jobs)
- cold targeted build of `Mathlib.Tactic.RealRootCount` and `MathlibTest.RealRootCount` with all Hex build directories absent; only the required pure Lean modules were built

:robot: Prepared with Codex
