### PR TITLE
fix(build): scope arithmetic FFI archives to their libraries

### DIFF
--- a/PLAN/Conventions.md
+++ b/PLAN/Conventions.md
@@ -196,9 +196,11 @@ not `monicisedCoreTransportPackage`. See
 Libraries that use `@[extern]` (e.g. `hex-arith` for GMP wrappers,
 `hex-gf2` for CLMUL) keep their C shims in a `ffi/` subdirectory
 within the library (e.g. `HexArith/ffi/wide_arith.c`). Compile those
-sources in `lakefile.lean` via an `extern_lib` block; use
-`moreLinkArgs` only for system linker flags such as `-lgmp`, never for
-listing `.c` sources.
+sources in `lakefile.lean` with a custom `target` attached to the
+corresponding `lean_lib` through `moreLinkObjs`. A package-level
+`extern_lib` leaks into every downstream executable even when its module
+graph never imports that library. Use `moreLinkArgs` only for system linker
+flags such as `-lgmp`, never for listing `.c` sources.
 
 For ad hoc interpreter smoke tests of extern-backed declarations, use
 `lake lean <file>` (or pass the module dynlibs explicitly via

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -66,12 +66,12 @@ private def hexArithOTarget (pkg : Package) (src : String) : FetchM (Job FilePat
       env := #[("TMPDIR", some (← IO.FS.realPath (oFile.parent.getD ".")).toString)]
     }
 
-extern_lib hexarithffi (pkg) := do
+target hexarithffi pkg : FilePath := do
   let name := nameToStaticLib "hexarithffi"
   let oTargets ← #[ "wide_arith.c", "mpz_gcdext.c" ].mapM (hexArithOTarget pkg)
   buildStaticLib (pkg.staticLibDir / name) oTargets
 
-extern_lib hexmodarithffi (pkg) := do
+target hexmodarithffi pkg : FilePath := do
   let name := nameToStaticLib "hexmodarithffi"
   let oTarget ← zmod64MulOTarget pkg
   buildStaticLib (pkg.staticLibDir / name) #[oTarget]
@@ -126,12 +126,7 @@ lean_lib HexTruncatedSeriesMathlib where
 
 lean_lib HexArith where
   precompileModules := true
-  -- The `hexarithffi` extern_lib is linked into this precompiled library's
-  -- dynlib automatically (as with `hexgf2ffi` and `HexGF2`); we only need to
-  -- add the system GMP library. Passing the static lib by an explicit path
-  -- broke consumers: that path was relative to the *root* package's build dir,
-  -- so when hex is a dependency it resolved against the wrong project and the
-  -- dynlink failed.
+  moreLinkObjs := #[hexarithffi]
   moreLinkArgs := #["-lgmp"]
 
 lean_lib HexPoly where
@@ -146,8 +141,7 @@ lean_lib HexSparsePoly where
 
 lean_lib HexModArith where
   precompileModules := true
-  -- See `HexArith`: the `hexmodarithffi` extern_lib links in automatically, so
-  -- we pass only the system GMP library rather than an explicit static-lib path.
+  moreLinkObjs := #[hexmodarithffi]
   moreLinkArgs := #["-lgmp"]
 
 lean_lib HexModular where

--- a/scripts/bench/proof_only_runtime_exemptions/lakefile-lean-a56a63e3-209b9cb6.json
+++ b/scripts/bench/proof_only_runtime_exemptions/lakefile-lean-a56a63e3-209b9cb6.json
@@ -1,0 +1,6 @@
+{
+  "path": "lakefile.lean",
+  "baseline_blob": "a56a63e3b99c2af2c1b477347d0b3a5bec8d9b51",
+  "current_blob": "209b9cb68a18a0692c2a927c899475e468412e2b",
+  "reason": "The HexArith and HexModArith native recipes retain the same C sources, compiler flags, object paths, archive names, system libraries, and Lean fallbacks. This change scopes each existing archive to its owning lean_lib with moreLinkObjs instead of exporting it package-wide through extern_lib; the factorization service still imports those libraries and runs the same compiled native functions. The remaining Lake declarations are unchanged from the already exempted a56a63e3-to-c7621baf transition."
+}

--- a/scripts/release/BOOTSTRAP.md
+++ b/scripts/release/BOOTSTRAP.md
@@ -131,8 +131,10 @@ commits in an existing mirror.
 
 ### Native-library skeletons
 
-Copy the matching `extern_lib` configuration as well as the Lean target for
-packages that ship native code. In particular:
+Copy the matching custom native target and attach it to the Lean library with
+`moreLinkObjs` for packages that ship native code. Do not use a package-level
+`extern_lib`: Lake exports it to every downstream executable, including ones
+whose module graph never imports the library. In particular:
 
 - `hex-arith` builds the wide-word arithmetic implementation under
   `HexArith/c`;
@@ -149,11 +151,11 @@ time, so a standalone `lake build` is required before the first real publish.
 The `lean_lib` build settings themselves are not part of the skeleton to
 maintain: this monorepo's `lakefile.lean` decides how a library is built, and
 the sync carries that decision across. It writes `precompileModules` into the
-mirror's `lean_lib` when the monorepo sets it, so a skeleton may omit it.
-`extraDepTargets` and `moreLinkArgs` name the mirror's own `extern_lib` targets
-and system libraries, so those the skeleton must still declare; the sync
-validates them against the monorepo and refuses to publish a library that has
-lost one.
+mirror's `lean_lib` when the monorepo sets it and writes `moreLinkObjs` when a
+Lean Lake file attaches a managed native target, so a skeleton may omit both.
+`extraDepTargets` and `moreLinkArgs` can name unmanaged targets and system
+libraries, so those the skeleton must still declare; the sync validates them
+against the monorepo and refuses to publish a library that has lost one.
 
 ## Baseline and first publish
 

--- a/scripts/release/released.yml
+++ b/scripts/release/released.yml
@@ -60,16 +60,18 @@
 # skeleton must build separately from the curated public umbrella.
 # `executables` maps an unmanaged released executable name to its mathematical
 # root module. The sync refuses to publish when the skeleton is stale.
-# `lake_declarations` lists build helper declarations copied from the monorepo
-# Lake file into the corresponding declarations in a Lean mirror skeleton.
+# `lake_declarations` lists named build declarations copied from the monorepo
+# Lake file into the corresponding declarations in a Lean mirror skeleton. It
+# can migrate a package-wide `extern_lib` to a library-scoped custom `target`.
 # `pins` lists the upstream repos whose git rev is rewritten in this repo's root
 # lakefile (matched by their github URL); `lakefile` is that file's format.
 # The mirror's `lean_lib` build settings are deliberately *not* recorded here:
 # this monorepo's `lakefile.lean` is the source of truth for how a library is
 # built, so the sync reads the `lean_lib <lib>` block and carries the settings
-# across itself, writing `precompileModules` into the mirror when it is missing
-# and refusing to publish when a setting it cannot synthesize has gone. A second
-# copy of a build decision in this manifest only gives it somewhere to drift.
+# across itself, writing `precompileModules` and Lean `moreLinkObjs` into the
+# mirror when they are missing and refusing to publish when a setting it cannot
+# synthesize has gone. A second copy of a build decision in this manifest only
+# gives it somewhere to drift.
 # `announcements` maps a venue (`blog`, `zulip`, `linkedin`) to the https URL
 # where this library was announced; it renders as one line per library in the
 # aggregate README's Announcements section. Deliberately not a table column:
@@ -115,7 +117,7 @@ repos:
     spec: hex-arith
     pins: []
     lakefile: lean
-    lake_declarations: [hexArithOTarget]
+    lake_declarations: [hexArithOTarget, hexarithffi]
 
   - repo: leanprover/hex-primality
     component: Certified primality
@@ -156,7 +158,7 @@ repos:
     spec: hex-mod-arith
     pins: [hex-arith]
     lakefile: lean
-    lake_declarations: [zmod64MulOTarget]
+    lake_declarations: [zmod64MulOTarget, hexmodarithffi]
 
   - repo: leanprover/hex-poly-mathlib
     lib: HexPolyMathlib

--- a/scripts/release/sync_released.py
+++ b/scripts/release/sync_released.py
@@ -100,21 +100,24 @@ LAKEFILE = REPO_ROOT / "lakefile.lean"
 # hex-dev is the source of truth for how a library is built and a second,
 # hand-maintained copy of that decision drifts.
 #
-# `precompileModules` is the one the sync writes: it decides whether Lake builds
-# and ships the module dynlib carrying a library's `@[extern]` symbols, so a
-# mirror that drops it still compiles yet fails in any downstream package that
-# evaluates the library during elaboration ("Could not find native
+# `precompileModules` is one setting the sync writes: it decides whether Lake
+# builds and ships the module dynlib carrying a library's `@[extern]` symbols,
+# so a mirror that drops it still compiles yet fails in any downstream package
+# that evaluates the library during elaboration ("Could not find native
 # implementation of external declaration"). It is a self-contained Boolean,
 # expressible in both Lake file flavours, so the sync can insert it.
 #
-# `extraDepTargets` and `moreLinkArgs` are validated but never written: they
-# name targets defined only in the mirror's own (unmanaged) Lake skeleton, such
-# as `hexlllffi`, and hex-dev spells `moreLinkArgs` as an arbitrary Lean
-# expression (HexLLL's is a platform conditional) that has no `lakefile.toml`
-# form. Synthesizing either would produce a Lake file that does not elaborate,
-# which is worse than the divergence, so the sync reports it and refuses to
-# publish instead.
-WRITTEN_LIB_SETTINGS = ("precompileModules",)
+# `moreLinkObjs` is also written for Lean Lake files. It attaches a managed
+# native target to the library that uses it, without exporting the target to
+# every executable in a downstream package.
+#
+# `extraDepTargets` and `moreLinkArgs` are validated but never written.
+# The former can name targets defined only in the mirror's own unmanaged Lake
+# skeleton, while the latter may be an arbitrary Lean expression (HexLLL's is
+# a platform conditional) with no `lakefile.toml` form. Synthesizing either
+# could produce a Lake file that does not elaborate, so the sync reports a
+# missing setting and refuses to publish instead.
+WRITTEN_LIB_SETTINGS = ("precompileModules", "moreLinkObjs")
 CHECKED_LIB_SETTINGS = ("extraDepTargets", "moreLinkArgs")
 BUILD_LIB_SETTINGS = WRITTEN_LIB_SETTINGS + CHECKED_LIB_SETTINGS
 SEMVER = re.compile(r"^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
@@ -748,10 +751,10 @@ def rewrite_lib_settings(entry: dict, clone: Path) -> list[str]:
     The mirror's Lake skeleton is otherwise unmanaged, and a library built one
     way here and another way there is a defect its own CI cannot see: the mirror
     builds, and only a downstream consumer discovers the difference. So the sync
-    writes `precompileModules` into the mirror's `lean_lib` when this monorepo
-    sets it and the mirror does not, exactly as it rewrites pins, and refuses to
-    publish when a setting it cannot safely synthesize has gone missing. See
-    `BUILD_LIB_SETTINGS`.
+    writes `precompileModules` and Lean `moreLinkObjs` into the mirror's
+    `lean_lib` when this monorepo sets them and the mirror does not, exactly as
+    it rewrites pins, and refuses to publish when a setting it cannot safely
+    synthesize has gone missing. See `BUILD_LIB_SETTINGS`.
     """
     if entry.get("pins_only"):
         return []
@@ -786,28 +789,49 @@ def rewrite_lib_settings(entry: dict, clone: Path) -> list[str]:
                 "own Lake skeleton"
             )
     notes: list[str] = []
-    for setting in WRITTEN_LIB_SETTINGS:
-        if setting not in required:
-            continue
+    if "precompileModules" in required:
+        setting = "precompileModules"
         if required[setting] != "true":
             raise RuntimeError(
                 f"hex-dev's lakefile.lean sets {setting} on lean_lib {lib} to "
                 f"{required[setting]!r}; only `true` can be published"
             )
-        if present.get(setting) == "true":
-            continue
-        if setting in present:
+        if present.get(setting) != "true":
+            if setting in present:
+                raise RuntimeError(
+                    f"released Lake file {lakefile} sets {setting} on lean_lib "
+                    f"{lib} to {present[setting]!r}, contradicting hex-dev's `true`"
+                )
+            if toml:
+                insert_at = body_start + len(body.rstrip())
+                text = f"{text[:insert_at]}\n{setting} = true{text[insert_at:]}"
+            else:
+                opener = "" if block.group("where") else " where"
+                text = f"{text[:body_start]}{opener}\n  {setting} := true{text[body_start:]}"
+            notes.append(f"  {setting} on lean_lib {lib} ({lakefile.name})")
+    if "moreLinkObjs" in required:
+        setting = "moreLinkObjs"
+        expected = required[setting]
+        if toml:
+            raise RuntimeError(
+                f"hex-dev's lakefile.lean sets {setting} on lean_lib {lib}, but "
+                "the sync only publishes managed target references to Lean Lake files"
+            )
+        if setting in present and present[setting] != expected:
             raise RuntimeError(
                 f"released Lake file {lakefile} sets {setting} on lean_lib "
-                f"{lib} to {present[setting]!r}, contradicting hex-dev's `true`"
+                f"{lib} to {present[setting]!r}, contradicting hex-dev's "
+                f"{expected!r}"
             )
-        if toml:
+        if setting not in present:
+            block = _lean_lib_header(text, lib)
+            assert block is not None
+            body_start = block.end()
+            body_end = _block_end(text, body_start)
+            body = text[body_start:body_end]
             insert_at = body_start + len(body.rstrip())
-            text = f"{text[:insert_at]}\n{setting} = true{text[insert_at:]}"
-        else:
-            opener = "" if block.group("where") else " where"
-            text = f"{text[:body_start]}{opener}\n  {setting} := true{text[body_start:]}"
-        notes.append(f"  {setting} on lean_lib {lib} ({lakefile.name})")
+            text = f"{text[:insert_at]}\n  {setting} := {expected}{text[insert_at:]}"
+            notes.append(f"  {setting} on lean_lib {lib} ({lakefile.name})")
     if notes:
         if toml:
             try:
@@ -822,26 +846,29 @@ def rewrite_lib_settings(entry: dict, clone: Path) -> list[str]:
 
 
 def lake_declaration(text: str, name: str) -> tuple[int, int]:
-    """Locate an unindented build helper and its indented body.
+    """Locate an unindented named Lake declaration and its indented body.
 
-    Managed helpers use ordinary `def` declarations without attributes. Refuse
+    Managed declarations use `def`, `target`, or `extern_lib` without
+    attributes. Supporting both target forms lets the sync migrate an old
+    package-wide `extern_lib` into a library-scoped custom `target`. Refuse
     missing or ambiguous declarations rather than modifying the wrong recipe.
     """
     if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_']*", name):
-        raise RuntimeError(f"invalid Lake build helper name: {name!r}")
+        raise RuntimeError(f"invalid Lake declaration name: {name!r}")
     matches = list(re.finditer(
-        r"(?m)^(?:private |public )?def " + re.escape(name) + r"(?=\s|\()[^\n]*\n",
+        r"(?m)^(?:private |public )?(?:def|target|extern_lib) "
+        + re.escape(name) + r"(?=\s|\()[^\n]*\n",
         text,
     ))
     if len(matches) != 1:
-        raise RuntimeError(f"expected one Lake build helper {name}, found {len(matches)}")
+        raise RuntimeError(f"expected one Lake declaration {name}, found {len(matches)}")
     start = matches[0].start()
     end = _block_end(text, matches[0].end())
     return start, end
 
 
 def rewrite_lake_declarations(entry: dict, clone: Path) -> list[str]:
-    """Copy selected C build recipes from the source-of-truth Lake file."""
+    """Copy selected build declarations from the source-of-truth Lake file."""
     names = entry.get("lake_declarations", [])
     if not names:
         return []
@@ -859,7 +886,7 @@ def rewrite_lake_declarations(entry: dict, clone: Path) -> list[str]:
         definition = source[src_start:src_end].rstrip() + "\n\n"
         if text[dst_start:dst_end] != definition:
             text = text[:dst_start] + definition + text[dst_end:]
-            notes.append(f"  build helper {name} (lakefile.lean)")
+            notes.append(f"  build declaration {name} (lakefile.lean)")
     if notes:
         path.write_text(text, encoding="utf-8")
     return notes

--- a/scripts/release/test_sync_released.py
+++ b/scripts/release/test_sync_released.py
@@ -984,7 +984,7 @@ class LakeDeclarationTests(unittest.TestCase):
 
     def test_missing_helper_does_not_write_partial_result(self) -> None:
         self.entry["lake_declarations"].append("missing")
-        with self.assertRaisesRegex(RuntimeError, "expected one Lake build helper missing"):
+        with self.assertRaisesRegex(RuntimeError, "expected one Lake declaration missing"):
             self.rewrite()
         self.assertEqual(self.target.read_text(), self.original)
 
@@ -998,6 +998,22 @@ class LakeDeclarationTests(unittest.TestCase):
         self.entry["lakefile"] = "toml"
         with self.assertRaisesRegex(RuntimeError, "requires a Lean Lake file"):
             self.rewrite()
+
+    def test_migrates_an_extern_lib_to_a_custom_target(self) -> None:
+        self.entry["lake_declarations"] = ["compileArchive"]
+        replacement = (
+            "target compileArchive pkg : FilePath := do\n"
+            "  buildStaticLib (pkg.staticLibDir / \"libffi.a\") #[]\n\n"
+        )
+        self.source.write_text("import Lake\n\n" + replacement)
+        self.target.write_text(
+            "import Lake\n\n"
+            "extern_lib compileArchive (pkg) := do\n"
+            "  buildStaticLib (pkg.staticLibDir / \"libffi.a\") #[]\n"
+        )
+        self.assertEqual(self.rewrite(),
+                         ["  build declaration compileArchive (lakefile.lean)"])
+        self.assertEqual(self.target.read_text(), "import Lake\n\n" + replacement)
 
 
 class LibBuildSettingTests(unittest.TestCase):
@@ -1014,6 +1030,10 @@ class LibBuildSettingTests(unittest.TestCase):
         "lean_lib Consumer where\n"
         "  -- comment lines are not settings\n"
         "  precompileModules := true\n"
+        "\n"
+        "lean_lib Scoped where\n"
+        "  precompileModules := true\n"
+        "  moreLinkObjs := #[scopedffi]\n"
         "\n"
         "lean_lib Linked where\n"
         "  precompileModules := true\n"
@@ -1048,6 +1068,10 @@ class LibBuildSettingTests(unittest.TestCase):
     def test_settings_are_read_from_the_monorepo_lakefile(self) -> None:
         self.assertEqual(self.settings("Plain"), {})
         self.assertEqual(self.settings("Consumer"), {"precompileModules": "true"})
+        self.assertEqual(self.settings("Scoped"), {
+            "precompileModules": "true",
+            "moreLinkObjs": "#[scopedffi]",
+        })
         self.assertEqual(self.settings("Linked"), {
             "precompileModules": "true",
             "extraDepTargets": "#[`consumerffi]",
@@ -1097,6 +1121,29 @@ class LibBuildSettingTests(unittest.TestCase):
         self.rewrite({"lib": "Consumer", "lakefile": "lean"})
         self.assertIn("lean_lib Consumer where\n  precompileModules := true\n",
                       lakefile.read_text(encoding="utf-8"))
+
+    def test_lean_mirror_gains_scoped_link_objects(self) -> None:
+        lakefile = self.repo / "lakefile.lean"
+        lakefile.write_text(
+            "lean_lib Scoped where\n  precompileModules := true\n",
+            encoding="utf-8")
+        entry = {"lib": "Scoped", "lakefile": "lean"}
+        self.assertEqual(self.rewrite(entry),
+                         ["  moreLinkObjs on lean_lib Scoped (lakefile.lean)"])
+        self.assertIn(
+            "lean_lib Scoped where\n"
+            "  precompileModules := true\n"
+            "  moreLinkObjs := #[scopedffi]\n",
+            lakefile.read_text(encoding="utf-8"))
+        self.assertEqual(self.rewrite(entry), [])
+
+    def test_toml_mirror_rejects_scoped_link_objects(self) -> None:
+        lakefile = self.repo / "lakefile.toml"
+        lakefile.write_text(
+            '[[lean_lib]]\nname = "Scoped"\nprecompileModules = true\n',
+            encoding="utf-8")
+        with self.assertRaisesRegex(RuntimeError, "only publishes managed target references"):
+            self.rewrite({"lib": "Scoped", "lakefile": "toml"})
 
     def test_a_library_without_settings_is_left_alone(self) -> None:
         lakefile = self.repo / "lakefile.toml"


### PR DESCRIPTION
`HexArith` and `HexModArith` currently declare their C archives as package-level `extern_lib` targets. Lake consequently builds and links both archives into every executable in a downstream package, even when its module graph imports neither library; in Mathlib this makes `lake exe cache get` compile unrelated Hex C code.

Declare each archive as a custom target and attach it to the owning `lean_lib` with `moreLinkObjs`. The release synchronizer now carries both the target declaration and the scoped link setting into the split mirrors, including migration from their existing `extern_lib` declarations. The release and bootstrap documentation records the same rule.

Validation:
- `lake build HexArith HexModArith`
- `python3 -m unittest scripts.release.test_sync_released` (84 tests)
- `python3 scripts/release/check_released_manifest.py`
- complete v0.6 dry run across all 58 release repositories
- `lake build` (11,837 jobs)
- In Mathlib with cold `HexArith`/`HexModArith` build directories, `lake build cache` completed in 27 jobs without building a Hex module, C object, or archive.

:robot: Prepared with Codex
