### PR TITLE
doc: specify ordered real algebraic numbers

### DIFF
--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -158,7 +158,7 @@ Each library with its immediate dependencies:
 - **hex-rcf**: hex-real-roots, hex-real-roots-mathlib, hex-poly-z, hex-poly-z-mathlib (mathlib: true)
 - **hex-resultant**: hex-poly
 - **hex-number-field**: hex-poly-z, hex-roots, hex-resultant, hex-berlekamp-zassenhaus, hex-matrix, hex-row-reduce
-- **hex-real-algebraic** (planned): hex-number-field
+- **hex-real-algebraic** (planned): hex-number-field, plus its existing computational dependencies where directly imported (see the SPEC's library boundary)
 - **hex-number-field-tower**: hex-number-field, hex-resultant, hex-berlekamp-zassenhaus, hex-row-reduce
 - **hex-berlekamp**: hex-poly-fp, hex-matrix, hex-row-reduce, hex-gfq-ring, hex-basic, hex-finite-field
 - **hex-hensel**: hex-poly-fp, hex-poly-z, hex-basic

--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -44,6 +44,7 @@
 - **hex-rcf**: the `rcf` tactic, a complete decision procedure for univariate real-closed-field sentences (Boolean combinations of polynomial inequalities under one `∀`/`∃` over `ℝ`); `mathlib: true`, soundness theorem in the same library
 - **hex-resultant**: polynomial resultant and discriminant via the subresultant pseudo-remainder sequence
 - **hex-number-field**: fixed fields `QAdjoin p x`, factorization-lazy `AlgebraicRoot`, canonical `AlgebraicNumber`, and roots of polynomials with algebraic coefficients
+- **[hex-real-algebraic](hex-real-algebraic.md)** (planned): the real subtype of canonical algebraic numbers, exact ordered-field arithmetic, real roots, rounding, and dyadic approximation
 - **hex-number-field-tower**: successive number-field extensions, Trager factorization, adjoining roots, splitting fields, and primitive-element flattening
 - **hex-berlekamp**: Berlekamp factoring, distinct-degree and equal-degree factorization (Cantor-Zassenhaus), and the Rabin irreducibility test over any `F_q`; the `factor_poly` / `irreducibility` tactic drivers (native `FpPoly p` arms plus extensions for other input types)
 - **hex-hensel**: Hensel lifting from `mod p` to `mod p^k`
@@ -94,6 +95,7 @@ Mathlib, and supplies correspondence proofs or Mathlib-facing APIs):
 - **hex-interval-mathlib**: real semantics, verified arithmetic and elementary-function propagators, certificate replay, and the `interval` tactic
 - **hex-resultant-mathlib**: executable resultant agreement with `Polynomial.resultant`, specialization, root-product, and discriminant theorems
 - **hex-number-field-mathlib**: fixed-field correspondence, exactification, lazy arithmetic, and algebraic-coefficient root completeness
+- **[hex-real-algebraic-mathlib](hex-real-algebraic.md#companion-and-proof-inventory)** (planned): ordered-field structure, the embedding into the algebraic reals, operation correspondence, and `IsRealClosed`
 - **hex-number-field-tower-mathlib**: tower embeddings, Trager correctness, splitting fields, and primitive-element equivalence
 - **hex-poly-fp-mathlib**: `FpPoly p ≃+* Polynomial (ZMod p)`, and transport of coefficients, degree, leading coefficients, ring operations, coefficient-sum evaluation, composition, and divisibility
 - **hex-berlekamp-mathlib**: `Decidable (Irreducible f)` for `Polynomial (ZMod p)`; the `Polynomial (ZMod p)` extension for `factor_poly` / `irreducibility`
@@ -156,6 +158,7 @@ Each library with its immediate dependencies:
 - **hex-rcf**: hex-real-roots, hex-real-roots-mathlib, hex-poly-z, hex-poly-z-mathlib (mathlib: true)
 - **hex-resultant**: hex-poly
 - **hex-number-field**: hex-poly-z, hex-roots, hex-resultant, hex-berlekamp-zassenhaus, hex-matrix, hex-row-reduce
+- **hex-real-algebraic** (planned): hex-number-field
 - **hex-number-field-tower**: hex-number-field, hex-resultant, hex-berlekamp-zassenhaus, hex-row-reduce
 - **hex-berlekamp**: hex-poly-fp, hex-matrix, hex-row-reduce, hex-gfq-ring, hex-basic, hex-finite-field
 - **hex-hensel**: hex-poly-fp, hex-poly-z, hex-basic
@@ -193,6 +196,7 @@ Mathlib companion libraries (each also depends on Mathlib):
 - **hex-interval-mathlib**: hex-interval
 - **hex-resultant-mathlib**: hex-resultant, hex-poly-mathlib
 - **hex-number-field-mathlib**: hex-number-field, hex-resultant-mathlib, hex-berlekamp-zassenhaus-mathlib, hex-roots-mathlib, hex-poly-z-mathlib
+- **hex-real-algebraic-mathlib** (planned): hex-real-algebraic, hex-number-field-mathlib, Mathlib
 - **hex-number-field-tower-mathlib**: hex-number-field-tower, hex-number-field-mathlib, hex-resultant-mathlib, hex-berlekamp-zassenhaus-mathlib, hex-row-reduce-mathlib
 - **hex-matrix-mathlib**: hex-matrix
 - **hex-row-reduce-mathlib**: hex-row-reduce, hex-matrix-mathlib
@@ -640,7 +644,7 @@ for developments whose source-local move has not happened yet.
 - [hex-arith](../../HexArith/SPEC/hex-arith.md): extended GCD, Barrett/Montgomery reduction, binomial coefficients, Fermat's little theorem
 - [hex-primality.md](../../HexPrimality/SPEC/hex-primality.md): Miller-Rabin compositeness witnesses, Pocklington certificates, a kernel-reducible sieve and stored initial segment, and the Mathlib-free `primality` tactic
 - [hex-primality-mathlib.md](../../HexPrimalityMathlib/SPEC/hex-primality-mathlib.md): `Nat.Prime` correspondence and segment transports, bare-tactic registration, and the opt-in `norm_num` proof policy
-- [hex-int-factor.md](hex-int-factor.md): integer factorization with complete prime-exponent certificates, the divisor-function API, multiplicative order and primitive roots (the Mathlib companion is specified in the same file)
+- [hex-int-factor.md](../../HexIntFactor/SPEC/hex-int-factor.md): integer factorization with complete prime-exponent certificates, the divisor-function API, multiplicative order and primitive roots (the Mathlib companion is specified in the same file)
 - [hex-matrix](https://github.com/leanprover/hex-matrix/blob/main/SPEC/hex-matrix.md) (released): dense matrices, arithmetic, elementary row/column operations, submatrix slicing, the Gram matrix
 - [hex-row-reduce](https://github.com/leanprover/hex-row-reduce/blob/main/SPEC/hex-row-reduce.md) (released): row reduction, rank, span, nullspace
 - [hex-determinant](https://github.com/leanprover/hex-determinant/blob/main/SPEC/hex-determinant.md) (released): Leibniz determinant and cofactor/Cauchy-Binet/Plücker theory
@@ -694,6 +698,7 @@ for developments whose source-local move has not happened yet.
 - [hex-resultant-mathlib](../../HexResultantMathlib/SPEC/hex-resultant-mathlib.md): executable resultant agreement, specialization, root-product, and discriminant theorems
 - [hex-number-field](../../HexNumberField/SPEC/hex-number-field.md): `QAdjoin`, factorization-lazy `AlgebraicRoot`, canonical `AlgebraicNumber`, and algebraic-coefficient roots
 - [hex-number-field-mathlib](../../HexNumberFieldMathlib/SPEC/hex-number-field-mathlib.md): fixed-field correspondence, exactification, lazy arithmetic, and root completeness
+- [hex-real-algebraic](hex-real-algebraic.md) (planned): exact ordered real algebraic numbers, real roots, rounding, and approximation (the Mathlib companion is specified in the same file)
 - [hex-number-field-tower](../../HexNumberFieldTower/SPEC/hex-number-field-tower.md): successive extensions, Trager factorization, splitting fields, and flattening
 - [hex-number-field-tower-mathlib.md](../../HexNumberFieldTowerMathlib/SPEC/hex-number-field-tower-mathlib.md): semantic towers, factorization correctness, splitting, and primitive-element equivalence
 - [hex-berlekamp](../../HexBerlekamp/SPEC/hex-berlekamp.md): Berlekamp factoring, Rabin irreducibility test, and the `factor_poly` / `irreducibility` tactic drivers

--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -158,7 +158,7 @@ Each library with its immediate dependencies:
 - **hex-rcf**: hex-real-roots, hex-real-roots-mathlib, hex-poly-z, hex-poly-z-mathlib (mathlib: true)
 - **hex-resultant**: hex-poly
 - **hex-number-field**: hex-poly-z, hex-roots, hex-resultant, hex-berlekamp-zassenhaus, hex-matrix, hex-row-reduce
-- **hex-real-algebraic** (planned): hex-number-field, plus its existing computational dependencies where directly imported (see the SPEC's library boundary)
+- **hex-real-algebraic** (planned): hex-number-field; hex-poly, hex-poly-z, hex-roots where directly imported
 - **hex-number-field-tower**: hex-number-field, hex-resultant, hex-berlekamp-zassenhaus, hex-row-reduce
 - **hex-berlekamp**: hex-poly-fp, hex-matrix, hex-row-reduce, hex-gfq-ring, hex-basic, hex-finite-field
 - **hex-hensel**: hex-poly-fp, hex-poly-z, hex-basic

--- a/SPEC/Libraries/hex-real-algebraic.md
+++ b/SPEC/Libraries/hex-real-algebraic.md
@@ -1,0 +1,401 @@
+# hex-real-algebraic (exact ordered real algebraic numbers)
+
+`hex-real-algebraic` supplies `Hex.RealAlgebraicNumber`, the real subtype of
+canonical `AlgebraicNumber`, with executable field arithmetic and exact order.
+`hex-real-algebraic-mathlib` identifies its values with the algebraic reals and
+proves that it is a real closed ordered field. This document specifies both
+libraries; it does not introduce their implementation or release entries.
+
+## Library boundary
+
+Use a new library, depending on
+[hex-number-field](../../HexNumberField/SPEC/hex-number-field.md).
+That library has shipped and serves complex algebraic arithmetic independently
+of an order. The [release manifest](../../scripts/release/released.yml) manages
+each library separately. Develop both new libraries here and add them to the
+manifest only when ready for publication.
+
+The dependency arrows below point from a library to its dependencies:
+
+```text
+hex-real-algebraic         -> hex-number-field
+hex-real-algebraic-mathlib -> hex-real-algebraic
+                          -> hex-number-field-mathlib -> hex-number-field
+                          -> Mathlib
+```
+
+`hex-poly`, `hex-poly-z`, `hex-roots`, and dyadic arithmetic are already below
+`hex-number-field`; declare their pins too wherever the new library directly
+imports them. There is no dependency on `hex-number-field-tower`, `hex-rcf`,
+`hex-interval`, or either new library from `hex-number-field`. Both new nodes
+can therefore be appended after their existing dependencies without a cycle.
+Computational modules, including their core law instances, must have no
+transitive Mathlib import. Companion proofs never flow back into that graph.
+
+The public surface includes construction, arithmetic, comparison, `min`, `max`,
+`sign`, `abs`, nonnegative square roots, polynomial real roots, `floor`, `ceil`,
+dyadic approximation, and rational recognition. Comparison has the semantics
+of `AlgebraicNumber.realCompare`. Refine-on-overlap fast paths, lazy
+`AlgebraicRoot` comparison, Tarski queries, and quantifier elimination are
+separate work; replacement comparison algorithms must prove agreement with
+this reference and preserve the public theorems.
+
+## Carrier, construction, and closure
+
+The carrier is exactly the subtype, with no additional root representation:
+
+```lean
+def RealAlgebraicNumber := {a : AlgebraicNumber // a.isReal = true}
+```
+
+Use `RealAlgebraicNumber` as the namespace for the following proposed names.
+`toAlgebraic` projects the underlying canonical value. `ofAlgebraic?` performs
+one stored-precision `isReal` test, returning `some ⟨a, h⟩` precisely on success
+and `none` on nonreal input. A proof-taking `ofAlgebraic a h` packages an already
+known real value without retesting. `ofRoot? r` exactifies `r` through
+`AlgebraicRoot.exact` and then calls `ofAlgebraic?`. No implicit coercion from
+arbitrary complex algebraic numbers is provided.
+
+Equality is inherited from the canonical carrier: subtype equality is equality
+of `toAlgebraic`, and `BEq` delegates to its existing Boolean equality. Proof
+fields are erased. Do not introduce approximate equality or an additional
+quotient. The existing Boolean algorithm compares minimal polynomials and
+tests the stored discs; its agreement with structural Lean equality currently
+has its proof in the companion. Supplying Mathlib-free `LawfulBEq` and
+`DecidableEq` is an explicit proof obligation below.
+
+Provide `0`, `1`, natural and integer casts, `ofRat`, rational casts, negation,
+addition, subtraction, multiplication, inversion, division, natural and integer
+powers, and scalar multiplication by `Nat`, `Int`, and `Rat`. Each operation
+runs the corresponding `AlgebraicNumber` operation and rechecks `isReal` once
+on the canonical result. Powers reuse `natPow` and `intPow`, including repeated
+squaring, and check their final result. Inversion and division are total with
+`0⁻¹ = 0` and `a / 0 = 0`, as in the underlying field.
+
+The internal total packer uses `ofAlgebraic?` with
+`Hex.panicWith zero "RealAlgebraicNumber: nonreal operation result"` as the
+fallback. Construct subtype zero directly from the stored zero representative
+and its decidable reality test, so this fallback does not depend on itself.
+Classify it as **unreachable-by-pipeline-invariant** under
+[the fallback policy](../design-principles.md): its only callers are the field
+operations and casts on real inputs. Public checked construction propagates
+`none`; it never turns a rejected complex input into zero.
+
+Prove `ofAlgebraic?_isSome` from `a.isReal = true`. The companion supplies
+`zero_isReal`, `one_isReal`, `ofRat_isReal`, `neg_isReal`, `add_isReal`,
+`sub_isReal`, `mul_isReal`, `inv_isReal`, `div_isReal`, `natPow_isReal`,
+`intPow_isReal`, and `smul_isReal` for the underlying operations. Cast cases
+reduce to `ofRat_isReal`. Their hypotheses are reality of the operands, with
+no nonzero hypothesis for inversion. Together with the underlying arithmetic
+correspondence and `isReal_iff`, these prove every packer call succeeds and
+that `toAlgebraic` commutes with every operation. The analogous Mathlib-free
+closure laws are also needed for the core law instances; a companion theorem
+alone cannot inhabit an instance in a computational module.
+
+Threading closure proofs through each operation is an alternative. It would
+remove the runtime check but require all closure proofs in the computational
+dependency graph before even the arithmetic wrappers can be defined. Rechecking
+has a fixed extra disc test at the already stored precision and matches the
+existing `exact` / `exact?_isSome` design. It is the chosen implementation.
+
+Reuse `conj` on the underlying value and prove `conj_eq : a.conj = a`; its real
+branch already returns its argument. Reuse `AlgebraicNumber.approx` for complex
+balls. Delegate display to the canonical value. `Repr` emits a checked real
+constructor around the underlying round-trip representation, with no printed
+proof terms; elaborating it must recover the same subtype value. It must not
+use a decimal approximation or a partial `Option.get!` requiring a new
+unreachability assumption.
+
+## Order and core instances
+
+`compare a b` is `a.toAlgebraic.realCompare b.toAlgebraic`. The comparison first
+uses canonical equality; if unequal, it compares real ball centres at
+`AlgebraicNumber.separationPrec (a.p * b.p)`. Merely comparing the stored
+centres of two independently canonicalized numbers is insufficient.
+
+Define the operations with these exact conventions:
+
+| Operation | Definition |
+| --- | --- |
+| `a < b` | `compare a b = .lt` |
+| `a ≤ b` | `compare a b ≠ .gt` |
+| `DecidableLT`, `DecidableLE` | Decide these finite `Ordering` tests |
+| `Ord` | The comparison above |
+| `min a b` | `a` if `a ≤ b`, otherwise `b` |
+| `max a b` | `a` if `b ≤ a`, otherwise `b` |
+| `sign a : Int` | `-1`, `0`, or `1` according as `compare a 0` is `.lt`, `.eq`, or `.gt` |
+| `abs a` | `-a` if `a < 0`, otherwise `a` |
+
+Both extrema return their left argument on ties. Expose named `sign` and `abs`
+even without Mathlib; the companion's absolute-value notation must use the
+same executable operation. Do not define `LE` or `LT` on the ambient complex
+carrier. Nonreal input is rejected before any order operation is called.
+
+In the pinned Lean `v4.34.0-rc2`, the core law classes are in namespace `Std`.
+Provide `Std.IsLinearOrder` (and its preorder and partial-order parents),
+`Std.LawfulOrderLT`, `Std.LawfulOrderBEq`, `Std.LawfulOrderOrd`,
+`Std.LawfulEqOrd`, `Std.TransOrd`, `Std.LawfulOrderMin`, and
+`Std.LawfulOrderMax`, with the left-leaning min/max laws. They relate all the
+operations above to one order; a bare `Ord` instance is not enough.
+
+Provide `Lean.Grind.Field RealAlgebraicNumber` and
+`Lean.Grind.OrderedRing RealAlgebraicNumber` on those same arithmetic and order
+operations. `OrderedRing` requires ordered addition, `0 < 1`, and preservation
+of strict inequalities by positive multiplication on each side. The core
+field and linear-order packages together let `grind` use ordered-field laws.
+They must remain executable when passed as dictionaries to generic code.
+
+These are **new Mathlib-free proof obligations**, not automatic consequences
+of having Mathlib-free class definitions. The existing
+[field proof](../../HexNumberFieldMathlib/Field.lean) and
+[equality proof](../../HexNumberFieldMathlib/Basic.lean) import Mathlib;
+the `Field.toGrindField` bridge available there does not provide a
+Mathlib-free field instance. A computational `Laws` module must prove the
+closure, canonical equality, field, comparison transitivity, and arithmetic
+monotonicity laws from the executable algorithms and their certificates.
+Place reusable underlying laws in `hex-number-field` when appropriate. No
+axiom, assumed law typeclass, imported companion proof, or `native_decide`
+may stand in for these proofs. This work is required before claiming the
+Mathlib-free ordered-field interface complete.
+
+Keep the executable definitions independent of the law module. In the
+companion, build `LinearOrder`, `Field`, and `IsStrictOrderedRing` using the
+same data fields and the real interpretation. The pinned Mathlib expresses an
+ordered field with these separate classes. Its generic core bridges must
+agree with the explicit core instances. Regression examples must compile
+both with only the computational umbrella and after importing the companion;
+check arithmetic, numerals, comparisons, extrema, and small `grind` proofs.
+
+## Square roots and polynomial roots
+
+Use the following public square-root forms:
+
+```lean
+sqrt? : RealAlgebraicNumber → Option RealAlgebraicNumber
+sqrt (a : RealAlgebraicNumber) (h : 0 ≤ a) : RealAlgebraicNumber
+```
+
+`sqrt? a` returns `none` exactly when `a < 0`. Otherwise solve `X² - a` with
+the real-root API and select its unique nonnegative root. At zero it returns
+zero. The proof-taking total form uses the same computation; classify its
+fallback as unreachable by `sqrt?_isSome` under `0 ≤ a`. Also name and prove
+the internal root-selection success lemma `sqrtRoot?_isSome` under that
+hypothesis, so a failed root search cannot masquerade as a negative argument.
+Require `sqrt_nonneg`, `sqrt_sq` (`sqrt a h * sqrt a h = a`), uniqueness, and
+`sqrt_square` (`sqrt (a*a) h = abs a`, independent of the proof `h`).
+
+Represent `RealAlgebraicPoly` as an `AlgebraicPoly` with an erased proof that
+each stored coefficient passes `isReal`. Its array constructor accepts only
+real algebraic coefficients, projects them, and uses `AlgebraicPoly.ofArray`
+for trailing-zero normalization. A checked conversion from `AlgebraicPoly`
+rejects a nonreal coefficient. This reuses the existing normalizer without
+assuming `DensePoly AlgebraicNumber` has a Mathlib-free equality dictionary.
+
+`RealAlgebraicPoly.roots` returns a real root set with constructors `.all` and
+`.finite`, whose finite entries contain a canonical `RealAlgebraicNumber` and
+a positive multiplicity. Preserve `.all` exactly for the zero polynomial;
+nonzero constants return `.finite #[]`. Do not collapse these cases through
+`RootSet.toArray`, which maps `.all` to an empty array.
+
+Call `AlgebraicPoly.roots` on the underlying polynomial. Its finite entries
+contain **lazy** `AlgebraicRoot`s, not `AlgebraicNumber`s. Exactify each entry,
+then filter and package it through `ofAlgebraic?`, preserving multiplicity.
+Finally sort the retained entries by the real comparison. The result has
+distinct roots in strictly increasing order; multiplicities are attached,
+not repeated array entries. Prove membership iff polynomial evaluation is
+zero, multiplicity agreement, positivity, no duplicates, and sortedness.
+The sum of multiplicities is the number of real roots counted with
+multiplicity; it need not equal the degree when nonreal roots exist.
+
+For integer inputs, provide `ZPoly.realAlgebraicRoots : ZPoly →
+Array RealAlgebraicNumber` by filtering `ZPoly.algebraicRoots` and sorting by
+the same real comparison. This convenience API returns distinct roots and
+inherits the empty-array convention for every constant, including zero;
+state its membership theorem only for `p ≠ 0`. Use `RealAlgebraicPoly.roots`
+when the universal root set or multiplicities matter.
+
+## Rational recognition, rounding, and approximation
+
+`toRat? : RealAlgebraicNumber → Option Rat` tests whether the canonical
+minimal polynomial has degree one. If so, return the reduced rational
+`-p.coeff 0 / p.coeff 1`; the leading coefficient is nonzero. Prove
+`toRat?_eq_some : a.toRat? = some q ↔ a = ofRat q`, including `q = 0`.
+A polynomial of higher degree gives `none`, even if a low-precision decimal
+looks rational. Completeness needs the minimal-polynomial correspondence,
+not a search over possible denominators.
+
+`floor` and `ceil` return `Int`, with their usual exact contracts:
+
+```text
+ofInt (floor a) ≤ a < ofInt (floor a + 1)
+ofInt (ceil a - 1) < a ≤ ofInt (ceil a)
+ceil a = -floor (-a)
+```
+
+Use `toRat?` first for rational values, rounding with integer arithmetic.
+For the general path, `(a.toAlgebraic.approx 2)` gives a closed real enclosure
+`[c-r, c+r]` of width at most `1/2`. Compute the integer floors of its dyadic
+endpoints. They differ by at most one. If they differ, compare `a` exactly
+with the intervening integer to choose its floor, including equality with
+that integer. Thus an enclosure touching or crossing an integer never
+causes a refinement loop or an arbitrary rounding decision. Prove the
+enclosure and width bounds, the candidate bound, and the final floor
+inequalities; expose the companion's `FloorRing` using these algorithms.
+
+`approx (a : RealAlgebraicNumber) (prec : Int := 64) : Dyadic` returns the
+real centre of `a.toAlgebraic.approx prec`. The companion proves
+
+```text
+|a.toReal - Dyadic.toReal (a.approx prec)| ≤ (2 : ℝ) ^ (-prec).
+```
+
+Allow negative precisions with exactly the same bound. Also expose the
+underlying complex ball when a caller needs its radius. Approximation does
+not affect canonical equality, order, or the stored representative. The
+error theorem follows from `AlgebraicNumber.approx_mem`, `approx_radius`,
+and the real-coordinate projection of the disc bound.
+
+## Companion and proof inventory
+
+Define `toReal a := a.toAlgebraic.toComplex.re`. By `isReal_iff`, its complex
+inclusion equals `a.toAlgebraic.toComplex`; hence `toReal` is injective.
+Package it as a field embedding and an order embedding. Prove arithmetic and
+cast correspondence, `compare_eq`, `lt_iff`, `le_iff`, and correspondence for
+`min`, `max`, `sign`, `abs`, `sqrt`, `floor`, `ceil`, and approximation.
+The order proofs transport `realCompare_eq` using both subtype witnesses.
+
+Prove `isAlgebraic (a) : IsAlgebraic ℚ a.toReal` using its nonzero stored
+integer polynomial. Also prove `range_toReal`: a real number lies in the
+range exactly when it is algebraic over `ℚ`. Clear denominators of a nonzero
+rational annihilator, use `ZPoly.mem_algebraicRoots_iff`, and package the real
+root with `isReal_iff` for surjectivity onto that range.
+
+The [pinned Mathlib source](https://github.com/leanprover-community/mathlib4/blob/85e3a25e006c35636f0e53b0e9296caca2685bc0/Mathlib/FieldTheory/IsRealClosed/Basic.lean)
+contains `IsRealClosed` and `IsRealClosed.of_linearOrderedField`. Require an
+`IsRealClosed RealAlgebraicNumber` instance now. The constructor takes
+nonnegative-square closure and odd-degree-root existence in a `Field` with
+`LinearOrder` and `IsStrictOrderedRing`; it also discharges the semireal
+condition. Its source still lists a real-number instance as a TODO, so do
+not assume `[IsRealClosed ℝ]` is available.
+
+Prove square closure using real square-root existence and the complete
+algebraic-coefficient root driver to recover a canonical real witness.
+For any Mathlib polynomial over this field of odd natural degree, convert
+its finite coefficient support to `RealAlgebraicPoly`, preserving evaluation
+and degree. Its image in `ℝ[X]` has a real root by the intermediate value
+theorem. `AlgebraicPoly.contains_roots_iff` supplies a lazy algebraic witness
+for that complex value; exactification and `isReal_iff` retain it in the
+real-root list. This proves odd-degree-root existence without assuming
+real-closedness to justify the algorithm. Export both closure theorems as
+well as the instance.
+
+The following are existing dependencies, with their actual source locations:
+
+| Needed fact | Existing declaration and source |
+| --- | --- |
+| Reality test | `AlgebraicNumber.isReal_iff`, [IntegerRoots](../../HexNumberFieldMathlib/IntegerRoots.lean) |
+| Exact real comparison | `AlgebraicNumber.realCompare_eq`, [Nearest](../../HexNumberFieldMathlib/Nearest.lean), requiring both reality hypotheses |
+| Conjugation | `AlgebraicNumber.conj_toComplex`, [Nearest](../../HexNumberFieldMathlib/Nearest.lean) |
+| Canonical equality | `AlgebraicNumber.toComplex_injective`, `beq_iff`, `LawfulBEq`, `DecidableEq`, [Basic](../../HexNumberFieldMathlib/Basic.lean) |
+| Canonical arithmetic | `add_toComplex`, `sub_toComplex`, `neg_toComplex`, `mul_toComplex`, `inv_toComplex`, `div_toComplex`, [Lazy](../../HexNumberFieldMathlib/Lazy.lean) |
+| Casts, powers, field laws | `ofRat_toComplex`, `natPow_toComplex`, `intPow_toComplex`, `smul_toComplex`, `Field`, [Field](../../HexNumberFieldMathlib/Field.lean) |
+| Lazy-root exactification | `AlgebraicRoot.exact?_isSome`, `exact_toComplex`, [Exact](../../HexNumberFieldMathlib/Exact.lean) |
+| Integer-root completeness | `ZPoly.mem_algebraicRoots_iff` (nonzero input), `algebraicRoots_nodup`, [IntegerRoots](../../HexNumberFieldMathlib/IntegerRoots.lean) |
+| Algebraic-coefficient roots | `AlgebraicPoly.roots?_isSome`, `roots_all_iff`, `contains_roots_iff`, `multiplicity_roots`, `roots_noDuplicates`, [AlgebraicRoots](../../HexNumberFieldMathlib/AlgebraicRoots.lean) |
+| Approximation | `AlgebraicNumber.approx_mem`, `approx_radius`, [IntegerRoots](../../HexNumberFieldMathlib/IntegerRoots.lean) |
+| Minimal polynomial | `AlgebraicNumber.p_eq_minpoly`, [Basic](../../HexNumberFieldMathlib/Basic.lean) |
+
+Missing facts must be supplied, not presumed:
+
+- No value-sortedness theorem for `ZPoly.algebraicRoots` is present in these
+  sources. The implementation sorts by `AlgebraicNumber.rootLe`, which uses
+  stored centres after exactification. A theorem `ZPoly.realRoots_sorted`
+  would need to establish strict increase of the real values in its filtered
+  output. Canonicalization selects representatives for individual minimal
+  polynomials, so their stored precisions are not a common separation bound
+  for different factors. This property needs a separate correctness audit;
+  the new wrapper's explicit `realCompare` sort avoids assuming it.
+- `AlgebraicPoly.roots_ordered` exists, but describes `RootSet.Ordered`, a
+  deterministic representation order, not the increasing real-value order.
+  Prove the new `RealAlgebraicPoly.roots_sorted` after exactification and sorting.
+- The subtype closure lemmas, Mathlib-free equality/field/order laws, real
+  coefficient normalization and evaluation bridges, `toRat?_eq_some`, the
+  rounding lemmas, `range_toReal`, and the real-closedness construction are
+  new work. Existing semantic proofs can guide the core proofs but cannot
+  be imported into them. A Mathlib-free class signature does not remove
+  this dependency constraint.
+
+## Conformance and acceptance
+
+Use python-flint's exact `qqbar` arithmetic and comparisons as the oracle.
+The [generic-ring interface](https://python-flint.readthedocs.io/en/latest/_gr.html)
+exposes `gr_real_qqbar_ctx` and `gr_complex_qqbar_ctx`; do not assume a
+top-level `flint.qqbar` class. Pin the tested binding and FLINT versions and
+probe construction, comparison, and root support before running fixtures.
+An unavailable exact operation is an explicit oracle failure/skip under the
+[testing policy](../testing.md), never a successful decimal comparison.
+The [FLINT comparison contract](https://flintlib.org/doc/qqbar.html#comparisons)
+provides exact equality and real-part comparison; check reality before using
+the latter. cypari2 supplies no real-algebraic ordering oracle. Sage `AA`
+examples are informational only, following the rule that Sage is not an oracle.
+
+python-flint `0.9.0` with FLINT `3.6.0` supports the required scalar comparisons,
+square roots, and floor/ceil through `_gr`, but its polynomial context exposes
+no `roots` method. General root fixtures therefore need a binding for FLINT's
+`qqbar_roots_fmpz_poly` and, for algebraic coefficients, `gr_poly_roots_other`
+before conformance is complete. Supply this through python-flint or a test-only
+binding adapter; do not substitute numerical `acb` root approximations as
+the equality/order oracle. The scalar fixtures can run independently, but
+passing them alone does not cover the polynomial-root requirement.
+
+Serialize rationals as integer numerator/positive denominator and roots by
+integer polynomial plus certified isolating data. The oracle independently
+identifies the selected root; do not trust either a printed decimal or the
+producer's array index as a cross-system root identity. Record exact ordering,
+construction rejection, roots with multiplicities, and operation results.
+Check a returned dyadic error bound by exact algebraic inequalities.
+
+Required deterministic fixtures:
+
+- `-√2 < √2`, and both roots against the exact rationals `7071/5000`
+  (`1.4142`) and `14143/10000` (`1.4143`), including reversed comparisons.
+- The two close roots around `1/256` of the Mignotte polynomial
+  `X^8 - 2*(256*X - 1)^2`, with exact ordering and isolations identifying
+  each root. Include cross-factor close roots to test comparisons between
+  distinct minimal polynomials.
+- Equal values from independent constructions: `√8/2 = √2`, `√2*√2 = 2`,
+  and `(√2 + 1) - √2 = 1`. Check equality, `.eq`, both non-strict directions,
+  neither strict direction, and left-argument selection for both extrema.
+- `sqrt (a*a) = abs a` for zero, a negative rational, and both signs of `√2`;
+  `sqrt? (-1) = none`.
+- All eight roots of `(X²-2)(X²-3)(X²-5)(X²-7)`, initially permuted, sorted
+  as `[-√7, -√5, -√3, -√2, √2, √3, √5, √7]`. Also solve a polynomial with
+  an irrational real coefficient, such as `X²-√2`, and a repeated-root case.
+- Each member of the conjugate pair from `X²+1` is rejected by real
+  construction. A polynomial with coefficient `i` is rejected. Filtering
+  `X²+1` gives a finite empty real-root set; the zero polynomial gives `.all`.
+- `toRat?` on zero, negative rationals, and irrational values; floor/ceil at
+  integers, negative fractions, and algebraic values on both sides of an
+  integer; approximation at positive, zero, and negative precision; `Repr`
+  round trips through the real constructor.
+
+The order sanity cases have these required outcomes (`s` denotes `√2`):
+
+| Operation | Zero | Rational `q = -3/2` against zero | Equal routes `s` and `√8/2` | Nonreal `i` |
+| --- | --- | --- | --- | --- |
+| `compare` / `Ord` | `compare 0 0 = .eq` | `.lt`; reverse `.gt` | `.eq` | construction returns `none` |
+| `<` and its decision | `¬ 0 < 0` | `q < 0`, `¬ 0 < q` | false both ways | no real operand |
+| `≤` and its decision | `0 ≤ 0` | `q ≤ 0`, `¬ 0 ≤ q` | true both ways | no real operand |
+| `min` | `min 0 0 = 0` | `min q 0 = q` | left argument, equal value | no real operand |
+| `max` | `max 0 0 = 0` | `max q 0 = 0` | left argument, equal value | no real operand |
+| `sign` | `0` | `-1` | `1` for either route | no real operand |
+| `abs` | `0` | `3/2` | `s` for either route | no real operand |
+
+Conformance drivers and fixture emitters belong under `conformance/HexRealAlgebraic/`,
+fixtures under `conformance-fixtures/HexRealAlgebraic/`, and the oracle under
+`scripts/oracle/real_algebraic_flint.py` when implementation starts. Extend
+the existing oracle runner and its single CI job. Acceptance also requires
+the named totality and correspondence proofs, `IsRealClosed`, the independent
+Mathlib-free law instances, import-DAG checks, and compilable examples before
+and after importing the companion. No benchmark result or implementation is
+claimed by this SPEC.

--- a/SPEC/Libraries/hex-real-algebraic.md
+++ b/SPEC/Libraries/hex-real-algebraic.md
@@ -61,8 +61,8 @@ of `toAlgebraic`, and `BEq` delegates to its existing Boolean equality. Proof
 fields are erased. Do not introduce approximate equality or an additional
 quotient. The existing Boolean algorithm compares minimal polynomials and
 tests the stored discs; its agreement with structural Lean equality currently
-has its proof in the companion. Supplying Mathlib-free `LawfulBEq` and
-`DecidableEq` is an explicit proof obligation below.
+has its proof in the companion. The Mathlib-free `LawfulBEq` and `DecidableEq`
+adapters below take an explicit law package, which the companion proves.
 
 Provide `0`, `1`, natural and integer casts, `ofRat`, rational casts, negation,
 addition, subtraction, multiplication, inversion, division, natural and integer
@@ -88,9 +88,8 @@ Prove `ofAlgebraic?_isSome` from `a.isReal = true`. The companion supplies
 reduce to `ofRat_isReal`. Their hypotheses are reality of the operands, with
 no nonzero hypothesis for inversion. Together with the underlying arithmetic
 correspondence and `isReal_iff`, these prove every packer call succeeds and
-that `toAlgebraic` commutes with every operation. The analogous Mathlib-free
-closure laws are also needed for the core law instances; a companion theorem
-alone cannot inhabit an instance in a computational module.
+that `toAlgebraic` commutes with every operation. These proofs also discharge
+the law package used by the conditional core instances below.
 
 Threading closure proofs through each operation is an alternative. It would
 remove the runtime check but require all closure proofs in the computational
@@ -100,11 +99,19 @@ existing `exact` / `exact?_isSome` design. It is the chosen implementation.
 
 Reuse `conj` on the underlying value and prove `conj_eq : a.conj = a`; its real
 branch already returns its argument. Reuse `AlgebraicNumber.approx` for complex
-balls. Delegate display to the canonical value. `Repr` emits a checked real
-constructor around the underlying round-trip representation, with no printed
-proof terms; elaborating it must recover the same subtype value. It must not
-use a decimal approximation or a partial `Option.get!` requiring a new
-unreachability assumption.
+balls. Delegate display to the canonical value. `Repr` emits
+`real_algebraic% (<underlying Repr term>)`, using a public checked term
+elaborator for closed `AlgebraicNumber` expressions. The elaborator rejects
+nonreal values and generates `ofAlgebraic a h`, with a kernel-checked proof
+`h : a.isReal = true` for the parsed expression `a`. It must explicitly unfold
+the underlying `rootNear` and `algebraicRoots` definitions when checking that
+proof: they are irreducible, so bare `by decide` is not a sufficient design.
+Evaluation may propose a result, but may not supply trusted proof evidence;
+no `native_decide` or unchecked cast is permitted. Bound elaboration work and
+report resource exhaustion as a diagnostic. Require round trips on the
+committed fixtures within that budget and value preservation for every
+successful elaboration. This adds no public total packer accepting arbitrary
+nonreal values and no `Option.get!` fallback.
 
 ## Order and core instances
 
@@ -134,8 +141,9 @@ carrier. Nonreal input is rejected before any order operation is called.
 In the pinned Lean `v4.34.0-rc2`, the core law classes are in namespace `Std`.
 Provide `Std.IsLinearOrder` (and its preorder and partial-order parents),
 `Std.LawfulOrderLT`, `Std.LawfulOrderBEq`, `Std.LawfulOrderOrd`,
-`Std.LawfulEqOrd`, `Std.TransOrd`, `Std.LawfulOrderMin`, and
-`Std.LawfulOrderMax`, with the left-leaning min/max laws. They relate all the
+`Std.LawfulEqOrd`, `Std.TransOrd`, `Std.LawfulOrderMin`,
+`Std.LawfulOrderMax`, `Std.LawfulOrderLeftLeaningMin`, and
+`Std.LawfulOrderLeftLeaningMax`. They relate all the
 operations above to one order; a bare `Ord` instance is not enough.
 
 Provide `Lean.Grind.Field RealAlgebraicNumber` and
@@ -145,26 +153,50 @@ of strict inequalities by positive multiplication on each side. The core
 field and linear-order packages together let `grind` use ordered-field laws.
 They must remain executable when passed as dictionaries to generic code.
 
-These are **new Mathlib-free proof obligations**, not automatic consequences
-of having Mathlib-free class definitions. The existing
+Use a proof-only `RealAlgebraicNumber.Laws : Prop` class to parameterize the
+Mathlib-free instance definitions. Its fields state canonical Boolean equality,
+the field equations for the executable operations, reflexivity, transitivity,
+antisymmetry and totality of `≤`, compatibility of `<` and `compare` with `≤`,
+and the ordered-addition and positive-multiplication laws. Fields must mention
+the executable data definitions and contain only proofs; they must not choose
+replacement operations or assume a `Field` or order instance on this carrier.
+The computational module constructs the core dictionaries under `[Laws]`.
+
+The companion proves an unconditional `Laws` instance by the injective real
+interpretation and the closure and comparison theorems. This is the same
+dependency pattern as Mathlib-free algorithms parameterized by
+`[Lean.Grind.Field K]`: consumers and dictionary constructors remain
+Mathlib-free, while the concrete law witness can come from a companion.
+All executable operations work without `[Laws]`. Core `grind` examples in a
+Mathlib-free module take `[Laws]`; after importing the companion the instance
+is synthesized without a user hypothesis. There is no unproved concrete law
+assumption at a companion use site.
+
+This distinction matters because the existing
 [field proof](../../HexNumberFieldMathlib/Field.lean) and
 [equality proof](../../HexNumberFieldMathlib/Basic.lean) import Mathlib;
 the `Field.toGrindField` bridge available there does not provide a
-Mathlib-free field instance. A computational `Laws` module must prove the
-closure, canonical equality, field, comparison transitivity, and arithmetic
-monotonicity laws from the executable algorithms and their certificates.
-Place reusable underlying laws in `hex-number-field` when appropriate. No
-axiom, assumed law typeclass, imported companion proof, or `native_decide`
-may stand in for these proofs. This work is required before claiming the
-Mathlib-free ordered-field interface complete.
+Mathlib-free proof of field laws. An unconditional law witness with no
+Mathlib dependency would require new proof infrastructure for exactification,
+canonical equality, and root separation. It is separate follow-up work, not
+an implicit prerequisite of this wrapper. No axiom or `native_decide` may
+replace the required companion proof of `Laws`.
 
 Keep the executable definitions independent of the law module. In the
 companion, build `LinearOrder`, `Field`, and `IsStrictOrderedRing` using the
-same data fields and the real interpretation. The pinned Mathlib expresses an
-ordered field with these separate classes. Its generic core bridges must
-agree with the explicit core instances. Regression examples must compile
-both with only the computational umbrella and after importing the companion;
-check arithmetic, numerals, comparisons, extrema, and small `grind` proofs.
+same data fields and the real interpretation, independently of `[Laws]` so
+proving that package is not circular. Set `LinearOrder`'s `le`, `lt`,
+`compare`, `min`, `max`, `decidableLE`, `decidableLT`, and `decidableEq` fields
+explicitly to the executable definitions. The pinned Mathlib expresses an
+ordered field with these separate classes. Give the explicit core adapters
+priority over Mathlib's generic bridges, and require definitional-equality
+regressions for the inferred `Lean.Grind.Field`, `Lean.Grind.OrderedRing`,
+and `Ord` dictionaries against the named adapters (`... = ... := rfl`).
+Also check the data projections of `LinearOrder`, arithmetic, numerals,
+comparisons, extrema, and small `grind` proofs, both in a computational module
+under `[Laws]` and without that hypothesis in a companion module. The data
+dictionaries must compile; proof erasure must not conceal noncomputable
+replacement data.
 
 ## Square roots and polynomial roots
 
@@ -182,7 +214,7 @@ fallback as unreachable by `sqrt?_isSome` under `0 ≤ a`. Also name and prove
 the internal root-selection success lemma `sqrtRoot?_isSome` under that
 hypothesis, so a failed root search cannot masquerade as a negative argument.
 Require `sqrt_nonneg`, `sqrt_sq` (`sqrt a h * sqrt a h = a`), uniqueness, and
-`sqrt_square` (`sqrt (a*a) h = abs a`, independent of the proof `h`).
+`sqrt_square` (`sqrt (a*a) h = abs a` for any `h : 0 ≤ a*a`).
 
 Represent `RealAlgebraicPoly` as an `AlgebraicPoly` with an erased proof that
 each stored coefficient passes `isReal`. Its array constructor accepts only
@@ -202,8 +234,9 @@ contain **lazy** `AlgebraicRoot`s, not `AlgebraicNumber`s. Exactify each entry,
 then filter and package it through `ofAlgebraic?`, preserving multiplicity.
 Finally sort the retained entries by the real comparison. The result has
 distinct roots in strictly increasing order; multiplicities are attached,
-not repeated array entries. Prove membership iff polynomial evaluation is
-zero, multiplicity agreement, positivity, no duplicates, and sortedness.
+not repeated array entries. For every `a : RealAlgebraicNumber`, prove
+membership iff evaluation at `a.toReal` of the interpreted real polynomial is
+zero; also prove multiplicity agreement, positivity, no duplicates, and sortedness.
 The sum of multiplicities is the number of real roots counted with
 multiplicity; it need not equal the degree when nonreal roots exist.
 
@@ -211,7 +244,8 @@ For integer inputs, provide `ZPoly.realAlgebraicRoots : ZPoly →
 Array RealAlgebraicNumber` by filtering `ZPoly.algebraicRoots` and sorting by
 the same real comparison. This convenience API returns distinct roots and
 inherits the empty-array convention for every constant, including zero;
-state its membership theorem only for `p ≠ 0`. Use `RealAlgebraicPoly.roots`
+state its membership theorem for real algebraic values and `p ≠ 0` only.
+Use `RealAlgebraicPoly.roots`
 when the universal root set or multiplicities matter.
 
 ## Rational recognition, rounding, and approximation
@@ -313,17 +347,37 @@ Missing facts must be supplied, not presumed:
   would need to establish strict increase of the real values in its filtered
   output. Canonicalization selects representatives for individual minimal
   polynomials, so their stored precisions are not a common separation bound
-  for different factors. This property needs a separate correctness audit;
+  for different factors. The existing docstring's assertion of value order
+  therefore overstates the established theorem contract: it needs either a
+  proof or a correction following a separate correctness audit;
   the new wrapper's explicit `realCompare` sort avoids assuming it.
 - `AlgebraicPoly.roots_ordered` exists, but describes `RootSet.Ordered`, a
   deterministic representation order, not the increasing real-value order.
   Prove the new `RealAlgebraicPoly.roots_sorted` after exactification and sorting.
-- The subtype closure lemmas, Mathlib-free equality/field/order laws, real
+- The subtype closure lemmas, the proof of `Laws`, real
   coefficient normalization and evaluation bridges, `toRat?_eq_some`, the
   rounding lemmas, `range_toReal`, and the real-closedness construction are
-  new work. Existing semantic proofs can guide the core proofs but cannot
-  be imported into them. A Mathlib-free class signature does not remove
-  this dependency constraint.
+  new companion work. The Mathlib-free conditional instance adapters and
+  checked real-literal elaborator are new computational work. The distinction
+  between a conditional adapter and a concrete law witness is part of the
+  dependency contract.
+
+## Complexity
+
+Canonical equality uses the underlying polynomial/disc test. Each unequal
+comparison forms `a.p * b.p`, computes its separation precision, and refines
+both operands to that precision. If `C(a,b)` denotes this cost, no constant-time
+comparison bound is claimed. Close roots and large degrees or coefficient
+heights can force high precision. Sorting `r` real roots uses `O(r log r)`
+comparisons, in addition to the existing root driver and exactification costs.
+
+Arithmetic retains the eliminant, factorization, and exactification costs
+of `AlgebraicNumber`, plus one stored-precision reality test per wrapper call.
+`toRat?` inspects degree and coefficients; rounding adds one bounded-precision
+approximation and at most one exact comparison. Size the committed fixtures
+to fit the existing conformance job's wallclock cap. Larger Mignotte parameters,
+degree products, and literal-elaboration costs belong in separately reported
+local measurements under the [benchmarking policy](../benchmarking.md).
 
 ## Conformance and acceptance
 
@@ -332,7 +386,7 @@ The [generic-ring interface](https://python-flint.readthedocs.io/en/latest/_gr.h
 exposes `gr_real_qqbar_ctx` and `gr_complex_qqbar_ctx`; do not assume a
 top-level `flint.qqbar` class. Pin the tested binding and FLINT versions and
 probe construction, comparison, and root support before running fixtures.
-An unavailable exact operation is an explicit oracle failure/skip under the
+An unavailable exact operation follows the profile's mode under the
 [testing policy](../testing.md), never a successful decimal comparison.
 The [FLINT comparison contract](https://flintlib.org/doc/qqbar.html#comparisons)
 provides exact equality and real-part comparison; check reality before using
@@ -341,12 +395,23 @@ examples are informational only, following the rule that Sage is not an oracle.
 
 python-flint `0.9.0` with FLINT `3.6.0` supports the required scalar comparisons,
 square roots, and floor/ceil through `_gr`, but its polynomial context exposes
-no `roots` method. General root fixtures therefore need a binding for FLINT's
-`qqbar_roots_fmpz_poly` and, for algebraic coefficients, `gr_poly_roots_other`
-before conformance is complete. Supply this through python-flint or a test-only
-binding adapter; do not substitute numerical `acb` root approximations as
-the equality/order oracle. The scalar fixtures can run independently, but
-passing them alone does not cover the polynomial-root requirement.
+no `roots` method. For integer polynomials, reuse the certified-ball method in
+[realroots_flint.py](../../scripts/oracle/realroots_flint.py): independent
+`fmpz_poly` factorization identifies rational roots, and certified complex-root
+balls with exact imaginary zero identify the remaining real roots. Escalate
+precision until exact rational endpoint tests establish a bijection with the
+selected isolations and strict order of distinct roots. This covers integer
+root fixtures without a new `qqbar_roots_fmpz_poly` binding. Overlapping balls
+never prove equality, and rounded centres never decide order.
+
+Keep `qqbar` as the scalar arithmetic/equality/comparison oracle. A binding to
+FLINT's `qqbar_roots_fmpz_poly` can additionally construct general scalar root
+inputs directly. General algebraic-coefficient root solving needs
+`gr_poly_roots_other` through python-flint or a test-only adapter before that
+part of conformance is complete; the special `X²-√2` fixture can already be
+checked with iterated `qqbar.sqrt`. Certified enclosures are admissible for
+integer-root matching; uncertified numerical approximations are not an
+equality or ordering oracle.
 
 Serialize rationals as integer numerator/positive denominator and roots by
 integer polynomial plus certified isolating data. The oracle independently
@@ -355,7 +420,20 @@ producer's array index as a cross-system root identity. Record exact ordering,
 construction rejection, roots with multiplicities, and operation results.
 Check a returned dyadic error bound by exact algebraic inequalities.
 
-Required deterministic fixtures:
+Profiles and oracle modes:
+
+- *core*: Oracle `none`, Mode `always`. Run deterministic Lean checks covering
+  every operation and the fixtures below, including the order sanity table.
+- *ci*: Oracle python-flint `qqbar` for scalar operations and certified FLINT
+  root balls for integer polynomials, Mode `required` for both. Install pinned
+  dependencies and require the capabilities exercised by each fixture;
+  missing bindings or inconclusive root matching fail the job. Include the
+  algebraic-coefficient root adapter when its general fixtures are admitted.
+- *local*: the same oracles, Mode `if_available`, with larger degrees, close
+  roots, and randomized construction paths. Report unavailable components as
+  explicit skips; these runs do not replace required CI coverage.
+
+Required deterministic core fixtures, also exported to the CI oracle:
 
 - `-√2 < √2`, and both roots against the exact rationals `7071/5000`
   (`1.4142`) and `14143/10000` (`1.4143`), including reversed comparisons.
@@ -395,7 +473,8 @@ Conformance drivers and fixture emitters belong under `conformance/HexRealAlgebr
 fixtures under `conformance-fixtures/HexRealAlgebraic/`, and the oracle under
 `scripts/oracle/real_algebraic_flint.py` when implementation starts. Extend
 the existing oracle runner and its single CI job. Acceptance also requires
-the named totality and correspondence proofs, `IsRealClosed`, the independent
-Mathlib-free law instances, import-DAG checks, and compilable examples before
-and after importing the companion. No benchmark result or implementation is
+the named totality and correspondence proofs, `IsRealClosed`, the Mathlib-free
+conditional law adapters and their proved companion witness, import-DAG checks,
+and compilable examples before and after importing the companion as specified
+above. No benchmark result or implementation is
 claimed by this SPEC.

--- a/SPEC/Libraries/hex-real-algebraic.md
+++ b/SPEC/Libraries/hex-real-algebraic.md
@@ -99,19 +99,29 @@ existing `exact` / `exact?_isSome` design. It is the chosen implementation.
 
 Reuse `conj` on the underlying value and prove `conj_eq : a.conj = a`; its real
 branch already returns its argument. Reuse `AlgebraicNumber.approx` for complex
-balls. Delegate display to the canonical value. `Repr` emits
-`real_algebraic% (<underlying Repr term>)`, using a public checked term
-elaborator for closed `AlgebraicNumber` expressions. The elaborator rejects
-nonreal values and generates `ofAlgebraic a h`, with a kernel-checked proof
-`h : a.isReal = true` for the parsed expression `a`. It must explicitly unfold
-the underlying `rootNear` and `algebraicRoots` definitions when checking that
-proof: they are irreducible, so bare `by decide` is not a sufficient design.
-Evaluation may propose a result, but may not supply trusted proof evidence;
-no `native_decide` or unchecked cast is permitted. Bound elaboration work and
-report resource exhaustion as a diagnostic. Require round trips on the
-committed fixtures within that budget and value preservation for every
-successful elaboration. This adds no public total packer accepting arbitrary
-nonreal values and no `Option.get!` fallback.
+balls. Delegate display to the canonical value. `Repr` emits the following
+ordinary Lean expression, substituting the underlying `Repr` term for `t`:
+
+```lean
+(RealAlgebraicNumber.ofAlgebraic? t).getD
+  (Hex.panicWith RealAlgebraicNumber.zero "RealAlgebraicNumber.repr: nonreal result")
+```
+
+The checked constructor produces the erased reality proof inside its successful
+branch. The expression can therefore be typechecked without evaluating `t` or
+proving a `decide` side condition about `ZPoly.rootNear`. Root search runs only
+when the value is evaluated, as it does for the underlying `Repr`. Do not add
+a literal elaborator that proves reality by kernel evaluation of root search.
+
+This fallback is **unreachable-by-pipeline-invariant** specifically for terms
+emitted by `Repr` on a `RealAlgebraicNumber`. Require `repr_isSome`: the
+underlying round-trip term passes `ofAlgebraic?`, using the existing
+`rootNear_of_close` round-trip argument and the original value's reality proof.
+Prove that the generated expression recovers the same subtype value. The
+fallback is confined to generated representations; there is no public total
+constructor for arbitrary algebraic input. Such input always uses
+`ofAlgebraic?` and receives `none` when nonreal. This preserves the existing
+representation and avoids a new serialization format or trusted proof path.
 
 ## Order and core instances
 
@@ -160,7 +170,11 @@ antisymmetry and totality of `≤`, compatibility of `<` and `compare` with `≤
 and the ordered-addition and positive-multiplication laws. Fields must mention
 the executable data definitions and contain only proofs; they must not choose
 replacement operations or assume a `Field` or order instance on this carrier.
-The computational module constructs the core dictionaries under `[Laws]`.
+All primitive data instances (`BEq`, arithmetic, casts, scalar actions, powers,
+`LE`, `LT`, `Ord`, `Min`, and `Max`) are unconditional and defined before
+`Laws`; none may be obtained only from a conditional `Lean.Grind` parent.
+The computational module constructs the law-bearing core dictionaries under
+`[Laws]`.
 
 The companion proves an unconditional `Laws` instance by the injective real
 interpretation and the closure and comparison theorems. This is the same
@@ -184,19 +198,33 @@ replace the required companion proof of `Laws`.
 
 Keep the executable definitions independent of the law module. In the
 companion, build `LinearOrder`, `Field`, and `IsStrictOrderedRing` using the
-same data fields and the real interpretation, independently of `[Laws]` so
-proving that package is not circular. Set `LinearOrder`'s `le`, `lt`,
+real interpretation, independently of `[Laws]` so proving that package is
+not circular. Set `LinearOrder`'s `le`, `lt`,
 `compare`, `min`, `max`, `decidableLE`, `decidableLT`, and `decidableEq` fields
 explicitly to the executable definitions. The pinned Mathlib expresses an
-ordered field with these separate classes. Give the explicit core adapters
-priority over Mathlib's generic bridges, and require definitional-equality
-regressions for the inferred `Lean.Grind.Field`, `Lean.Grind.OrderedRing`,
-and `Ord` dictionaries against the named adapters (`... = ... := rfl`).
-Also check the data projections of `LinearOrder`, arithmetic, numerals,
-comparisons, extrema, and small `grind` proofs, both in a computational module
-under `[Laws]` and without that hypothesis in a companion module. The data
-dictionaries must compile; proof erasure must not conceal noncomputable
-replacement data.
+ordered field with these separate classes. Set `Field`'s `add`, `zero`, `mul`,
+`one`, `neg`, `sub`, `inv`, `div`, `nsmul`, `zsmul`, `npow`, `zpow`, `natCast`,
+`intCast`, `nnratCast`, `ratCast`, `nnqsmul`, and `qsmul` explicitly to the
+executable operations, following [the existing field
+instance](../../HexNumberFieldMathlib/Field.lean). Nonnegative-rational cases
+delegate to `ofRat` and rational scalar multiplication. In particular, powers
+must not default to unary recursion and rational casts must remain `ofRat`.
+
+Give the explicit core adapters priority over Mathlib's generic bridges for
+ordinary use. In a regression section, temporarily disable the primitive and
+adapter instances, following the `OperationRegression` section in that same
+file, to force operations through Mathlib's structures. Compare the named
+`Field.toGrindField` and `LinearOrder`-derived `Ord` dictionaries and all their
+data projections with the executable adapters by `rfl`. Merely comparing
+`inferInstance` to the highest-priority instance is not a coherence test.
+First pin the derived `Lean.Grind.Semiring` and `Std.IsPreorder` dictionaries;
+then compare `OrderedRing` packages at the same explicit type
+`@Lean.Grind.OrderedRing R instSemiring instLE instLT instIsPreorder`.
+
+Also require operation equations and small `grind` examples, both in a
+computational module under `[Laws]` and without that hypothesis in a companion
+module. The data dictionaries must compile; proof erasure must not conceal
+noncomputable replacement data.
 
 ## Square roots and polynomial roots
 
@@ -358,7 +386,7 @@ Missing facts must be supplied, not presumed:
   coefficient normalization and evaluation bridges, `toRat?_eq_some`, the
   rounding lemmas, `range_toReal`, and the real-closedness construction are
   new companion work. The Mathlib-free conditional instance adapters and
-  checked real-literal elaborator are new computational work. The distinction
+  real `Repr` wrapper are new computational work. The distinction
   between a conditional adapter and a concrete law witness is part of the
   dependency contract.
 
@@ -376,7 +404,7 @@ of `AlgebraicNumber`, plus one stored-precision reality test per wrapper call.
 `toRat?` inspects degree and coefficients; rounding adds one bounded-precision
 approximation and at most one exact comparison. Size the committed fixtures
 to fit the existing conformance job's wallclock cap. Larger Mignotte parameters,
-degree products, and literal-elaboration costs belong in separately reported
+degree products, and representation round-trip costs belong in separately reported
 local measurements under the [benchmarking policy](../benchmarking.md).
 
 ## Conformance and acceptance
@@ -397,9 +425,13 @@ python-flint `0.9.0` with FLINT `3.6.0` supports the required scalar comparisons
 square roots, and floor/ceil through `_gr`, but its polynomial context exposes
 no `roots` method. For integer polynomials, reuse the certified-ball method in
 [realroots_flint.py](../../scripts/oracle/realroots_flint.py): independent
-`fmpz_poly` factorization identifies rational roots, and certified complex-root
-balls with exact imaginary zero identify the remaining real roots. Escalate
-precision until exact rational endpoint tests establish a bijection with the
+`fmpz_poly.factor()` supplies the irreducible factors and their multiplicities.
+Run the ball tier on their squarefree product, not on a repeated-root input;
+attach each root's multiplicity from its factor's exponent. This extends the
+squarefree-only oracle method to repeated roots without treating them as
+rejected inputs. Linear factors identify rational roots, and certified
+complex-root balls with exact imaginary zero identify the remaining real roots.
+Escalate precision until exact rational endpoint tests establish a bijection with the
 selected isolations and strict order of distinct roots. This covers integer
 root fixtures without a new `qqbar_roots_fmpz_poly` binding. Overlapping balls
 never prove equality, and rounded centres never decide order.
@@ -409,8 +441,8 @@ FLINT's `qqbar_roots_fmpz_poly` can additionally construct general scalar root
 inputs directly. General algebraic-coefficient root solving needs
 `gr_poly_roots_other` through python-flint or a test-only adapter before that
 part of conformance is complete; the special `X²-√2` fixture can already be
-checked with iterated `qqbar.sqrt`. Certified enclosures are admissible for
-integer-root matching; uncertified numerical approximations are not an
+checked with iterated `sqrt` in `gr_real_qqbar_ctx`. Certified enclosures are
+admissible for integer-root matching; uncertified numerical approximations are not an
 equality or ordering oracle.
 
 Serialize rationals as integer numerator/positive denominator and roots by
@@ -425,13 +457,23 @@ Profiles and oracle modes:
 - *core*: Oracle `none`, Mode `always`. Run deterministic Lean checks covering
   every operation and the fixtures below, including the order sanity table.
 - *ci*: Oracle python-flint `qqbar` for scalar operations and certified FLINT
-  root balls for integer polynomials, Mode `required` for both. Install pinned
-  dependencies and require the capabilities exercised by each fixture;
-  missing bindings or inconclusive root matching fail the job. Include the
-  algebraic-coefficient root adapter when its general fixtures are admitted.
-- *local*: the same oracles, Mode `if_available`, with larger degrees, close
-  roots, and randomized construction paths. Report unavailable components as
-  explicit skips; these runs do not replace required CI coverage.
+  root balls for integer polynomials, Mode `if_available` for both. Missing
+  optional components produce explicit skips; an available oracle reporting
+  a mismatch or inconclusive root matching fails. The repository's
+  `HEX_REQUIRE_ORACLES=1` CI preflight upgrades these components to required.
+- *local*: the same oracles, Mode `required` for designated manual runs with
+  larger degrees, close roots, and randomized construction paths. Missing
+  dependencies fail these runs; they do not replace CI coverage.
+
+When implementing conformance, extend the existing preflight in
+`scripts/ci/run_oracles.sh` to probe `gr_real_qqbar_ctx`, comparison and
+`sqrt`/`floor`/`ceil`, `gr_complex_qqbar_ctx` rejection, and
+`fmpz_poly.complex_roots`. Add the general algebraic-coefficient root adapter
+to that probe when its fixtures are admitted. Pin `python-flint==0.9.0` in the
+existing installation step and check the supported FLINT version (`3.6.0` for
+that tested wheel). A required component's missing capability fails preflight;
+an optional missing capability skips only its component. This document does
+not change the workflow or implement the probes.
 
 Required deterministic core fixtures, also exported to the CI oracle:
 

--- a/SPEC/future-work.md
+++ b/SPEC/future-work.md
@@ -1055,6 +1055,23 @@ resolvent values, and certified non-containment at rejected branches.
 
 ## Lattices and real algebra
 
+### Ordered real algebraic numbers
+
+[hex-real-algebraic](Libraries/hex-real-algebraic.md) specifies the real subtype
+of canonical `AlgebraicNumber`, with exact comparison, field arithmetic,
+square roots, ordered polynomial real roots, floor and ceil, rational
+recognition, and dyadic approximation. Its companion supplies the ordered-field
+structure, the order embedding into `ℝ`, and `IsRealClosed`. The design reuses
+`hex-number-field` and fixes `realCompare` as the comparison semantics. It also
+identifies the independent Mathlib-free law proofs and real-root sortedness
+bridges still needed; existing companion proofs do not become computational
+dependencies.
+
+Faster comparison by refinement on overlap, comparison of lazy roots, and
+Tarski queries remain separate extensions behind the same order contract.
+This library provides exact real values for later sign determination and
+algebraic sample points without depending on a quantifier-elimination tactic.
+
 ### Lattice applications beyond factor recombination
 
 Build certified APIs on top of `hex-lll` for:
@@ -1123,7 +1140,8 @@ variable, exact algebraic sample points, and sign determination for
 polynomials with algebraic coefficients.
 
 Dependencies include `hex-mv-poly`, `hex-mv-factor`, `hex-resultant`,
-`hex-real-roots`, `hex-number-field`, and `hex-number-field-tower`. Scope the
+`hex-real-roots`, `hex-real-algebraic`, `hex-number-field`, and
+`hex-number-field-tower`. Scope the
 first version to two or three variables. Before fixing a public API, prototype
 the projection phase and a certificate that carries a complete cell
 decomposition with the sign-invariance evidence needed for a negative as well

--- a/SPEC/future-work.md
+++ b/SPEC/future-work.md
@@ -1069,6 +1069,13 @@ Companion proofs do not become computational dependencies.
 
 Faster comparison by refinement on overlap, comparison of lazy roots, and
 Tarski queries remain separate extensions behind the same order contract.
+An unconditional Mathlib-free law witness additionally needs proof
+infrastructure for exactification, canonical equality, and root separation.
+The existing `hex-number-field` SPEC's claim that `ZPoly.algebraicRoots` is
+sorted by real value also needs an audit: exactification reselects stored
+representatives at each minimal polynomial's precision before sorting their
+centres, and no value-sortedness theorem establishes that cross-factor order.
+The new real-root API explicitly sorts with `realCompare`.
 This library provides exact real values for later sign determination and
 algebraic sample points without depending on a quantifier-elimination tactic.
 

--- a/SPEC/future-work.md
+++ b/SPEC/future-work.md
@@ -1063,9 +1063,9 @@ square roots, ordered polynomial real roots, floor and ceil, rational
 recognition, and dyadic approximation. Its companion supplies the ordered-field
 structure, the order embedding into `ℝ`, and `IsRealClosed`. The design reuses
 `hex-number-field` and fixes `realCompare` as the comparison semantics. It also
-identifies the independent Mathlib-free law proofs and real-root sortedness
-bridges still needed; existing companion proofs do not become computational
-dependencies.
+uses Mathlib-free core instances parameterized by a law package proved in the
+companion, and identifies the real-root sortedness bridges still needed.
+Companion proofs do not become computational dependencies.
 
 Faster comparison by refinement on overlap, comparison of lazy roots, and
 Tarski queries remain separate extensions behind the same order contract.


### PR DESCRIPTION
Specify `hex-real-algebraic` as the real subtype of canonical algebraic numbers, with exact ordered-field operations, real roots, rounding, rational recognition, and dyadic approximation. Specify its Mathlib companion, including the pinned `IsRealClosed` instance, and update the library index and real-algebra roadmap.

The design fixes `realCompare` as the reference and names the proof and oracle gaps found in the source audit: integer-root value sortedness and the general algebraic-coefficient root binding. Mathlib-free core instances are parameterized by a proof-only law package, which the companion proves; an unconditional Mathlib-free law witness requires separate infrastructure. Polynomial root results are exactified, filtered, and explicitly sorted; zero-polynomial and nonreal-input behavior are specified. No library implementation or release changes are included.

Validation:
- `git diff --check` and `python3 scripts/check_dag.py` pass.
- All 126 relative links/anchors in the three changed documents resolve.
- The proposed dependency graph is acyclic and the computational closure is Mathlib-free. Forced Mathlib-instance coherence checks, the Repr constructor-success invariant, and oracle profile/mode contracts are explicit.
- Scalar comparison, equality routes, square roots, floor/ceil, eight-root sorting, and nonreal rejection were checked against python-flint 0.9.0 / FLINT 3.6.0 `qqbar`.
- Existing theorem names and pinned Lean/Mathlib class definitions were checked against source. No Lean code changed, so no local library rebuild was needed.

Closes #10141.
