### PR TITLE
doc: specify determinantal ideals and the rank-versus-minors theorem

### DIFF
--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -17,6 +17,7 @@
 - **hex-row-reduce**: row reduction (RREF), rank, span, nullspace
 - **hex-determinant**: the Leibniz determinant and its cofactor/Cauchy-Binet/Plücker theory
 - **hex-bareiss**: the fraction-free Bareiss determinant algorithm
+- **[hex-determinantal-ideal](hex-determinantal-ideal.md)** (planned): executable minors and determinantal-ideal generators of a matrix over a commutative ring, and the theorem that the rank over a field is below `r` exactly when every `r × r` minor vanishes
 - **hex-char-poly**: the characteristic polynomial by the division-free Samuelson-Berkowitz algorithm, over any commutative ring
 - **hex-min-poly**: the matrix minimal polynomial over a field, from Krylov sequences, with a certificate proving annihilation and minimality
 - **hex-hermite**: Hermite normal form over `Int`, unimodular transforms, integer lattice membership, integer kernel bases
@@ -82,6 +83,7 @@ Mathlib, and supplies correspondence proofs or Mathlib-facing APIs):
 - **hex-row-reduce-mathlib**: rank = `Matrix.rank`, nullspace = `LinearMap.ker`, span agreement
 - **hex-determinant-mathlib**: `det` agreement with `Matrix.det`, plus the Plücker / Desnanot-Jacobi assembly
 - **hex-bareiss-mathlib**: Bareiss determinant = `Matrix.det`, via the bordered-minor invariant
+- **[hex-determinantal-ideal-mathlib](hex-determinantal-ideal-mathlib.md)** (planned): minors as `Matrix.det` of a `submatrix`, the rank-versus-minors theorem for `Matrix.rank` under any ring homomorphism into a field, rank-drop loci as zero sets, and invariance of `I_r(A)` under invertible row and column operations
 - **hex-char-poly-mathlib**: agreement with `Matrix.charpoly`, Cayley-Hamilton, the trace and determinant coefficients, transpose and similarity invariance
 - **hex-min-poly-mathlib**: agreement with `minpoly`, the annihilator-generator statement for the vector order polynomial, divisibility into the characteristic polynomial, and the degree bound
 - **hex-hermite-mathlib**: row lattice = `Submodule.span ℤ`, integer rank = `Matrix.rank`, and an executable basis of the kernel submodule
@@ -131,6 +133,7 @@ Each library with its immediate dependencies:
 - **hex-row-reduce**: hex-matrix
 - **hex-determinant**: hex-matrix
 - **hex-bareiss**: hex-determinant, hex-matrix
+- **hex-determinantal-ideal** (planned): hex-basic, hex-matrix, hex-determinant, hex-row-reduce, hex-mv-poly
 - **hex-char-poly**: hex-matrix, hex-poly
 - **hex-min-poly**: hex-matrix, hex-row-reduce, hex-poly
 - **hex-hermite**: hex-row-reduce, hex-arith, hex-determinant
@@ -202,6 +205,7 @@ Mathlib companion libraries (each also depends on Mathlib):
 - **hex-row-reduce-mathlib**: hex-row-reduce, hex-matrix-mathlib
 - **hex-determinant-mathlib**: hex-determinant, hex-bareiss, hex-matrix-mathlib
 - **hex-bareiss-mathlib**: hex-determinant-mathlib
+- **hex-determinantal-ideal-mathlib** (planned): hex-determinantal-ideal, hex-determinant-mathlib, hex-row-reduce-mathlib, hex-mv-poly-mathlib
 - **hex-char-poly-mathlib**: hex-char-poly, hex-matrix-mathlib, hex-poly-mathlib, hex-determinant-mathlib
 - **hex-min-poly-mathlib**: hex-min-poly, hex-matrix-mathlib, hex-poly-mathlib, hex-char-poly-mathlib
 - **hex-hermite-mathlib**: hex-hermite, hex-row-reduce-mathlib, hex-determinant-mathlib
@@ -279,6 +283,28 @@ The integer normal forms within it:
 hex-row-reduce ───┐
 hex-arith ─────────┼── hex-hermite ── hex-smith
 hex-determinant ───┘
+```
+
+`hex-determinantal-ideal` enumerates the minors of a matrix over any
+commutative ring and proves that the rank over a field is below `r` exactly
+when every `r × r` minor vanishes. Its proof uses the row-reduced echelon
+certificate from `hex-row-reduce` and Cauchy-Binet from `hex-determinant`,
+so both are computational dependencies, and `hex-mv-poly` supplies the
+polynomial matrices whose rank-drop loci are the intended application. It
+does not depend on `hex-bareiss`, on `hex-poly-smith`, or on the planned
+`hex-rank`: those compute a rank and only choose a default `r`. The
+reasoning is in
+[hex-determinantal-ideal §Scope and dependencies](hex-determinantal-ideal.md#scope-and-dependencies).
+
+```text
+hex-matrix ──────────────┐
+hex-determinant ─────────┤
+hex-row-reduce ──────────┼── hex-determinantal-ideal ──┐
+hex-mv-poly ─────────────┘                             │
+                                                       │
+hex-determinant-mathlib ─┐                             │
+hex-row-reduce-mathlib ──┼─────────────────────────────┴── hex-determinantal-ideal-mathlib
+hex-mv-poly-mathlib ─────┘
 ```
 
 `hex-char-poly` sits on the matrix family too, with `hex-poly` rather
@@ -653,6 +679,8 @@ for developments whose source-local move has not happened yet.
 - [hex-row-reduce-mathlib](https://github.com/leanprover/hex-row-reduce-mathlib/blob/main/SPEC/hex-row-reduce-mathlib.md) (released): rank/nullspace/span correspondence
 - [hex-determinant-mathlib](https://github.com/leanprover/hex-determinant-mathlib/blob/main/SPEC/hex-determinant-mathlib.md) (released): `det` agreement with `Matrix.det`
 - [hex-bareiss-mathlib](https://github.com/leanprover/hex-bareiss-mathlib/blob/main/SPEC/hex-bareiss-mathlib.md) (released): Bareiss determinant correctness
+- [hex-determinantal-ideal](hex-determinantal-ideal.md) (planned): executable minors, determinantal-ideal generators, and the rank-versus-minors theorem with a Mathlib-free proof
+- [hex-determinantal-ideal-mathlib](hex-determinantal-ideal-mathlib.md) (planned): `Matrix.rank` versus minors under any ring homomorphism into a field, rank-drop loci, and invariance of determinantal ideals
 - [hex-char-poly.md](hex-char-poly.md): the characteristic polynomial by the division-free Samuelson-Berkowitz algorithm, with Cayley-Hamilton and the `Matrix.charpoly` correspondence (the Mathlib companion is specified in the same file)
 - [hex-min-poly.md](hex-min-poly.md): the matrix minimal polynomial from Krylov sequences, the vector order polynomial, the lcm over the standard basis, and a certificate carrying an independence witness for minimality (the Mathlib companion is specified in the same file)
 - [hex-hermite.md](hex-hermite.md): Hermite normal form over `Int`, unimodular transforms, integer lattice membership and kernel bases (the Mathlib companion is specified in the same file)

--- a/SPEC/Libraries/hex-determinantal-ideal-mathlib.md
+++ b/SPEC/Libraries/hex-determinantal-ideal-mathlib.md
@@ -1,0 +1,171 @@
+# hex-determinantal-ideal-mathlib
+
+Correspondence between the executable minors of
+[hex-determinantal-ideal](hex-determinantal-ideal.md) and Mathlib's
+`Matrix.det` of a `submatrix`, and the rank-versus-minors theorem stated for
+`Matrix.rank` under an arbitrary ring homomorphism into a field.
+Dependencies are `HexDeterminantalIdeal`, `HexDeterminantMathlib`,
+`HexRowReduceMathlib` and `HexMvPolyMathlib`, plus Mathlib. The
+computational contracts, the conventions at `r = 0` and `r > min n m`, and
+the Mathlib-free proof route are in the computational SPEC and are not
+restated here.
+
+This library is `correspondence_only: true`, with comparator absence class
+**correspondence-only-layer**. It owns no runtime search, conformance
+driver or benchmark process. Build-only examples live in
+`HexDeterminantalIdealMathlib/Tests.lean`.
+
+Computational conformance owner: `HexDeterminantalIdeal`.
+
+Computational performance owner: `HexDeterminantalIdeal`.
+
+## Transport
+
+Over `[CommRing R]`, with `matrixEquiv` from `HexMatrixMathlib` and
+`det_eq` from `HexDeterminantMathlib`:
+
+```lean
+theorem matrixEquiv_map (A : Hex.Matrix R n m) (f : R → S) :
+    matrixEquiv (A.map f) = (matrixEquiv A).map f
+theorem matrixEquiv_selectedSubmatrix (A : Hex.Matrix R n m)
+    (rows : Vector (Fin n) k) (cols : Vector (Fin m) k) :
+    matrixEquiv (Hex.Matrix.selectedSubmatrix A rows cols) =
+      (matrixEquiv A).submatrix rows.get cols.get
+theorem det_selectedSubmatrix_eq (A : Hex.Matrix R n m) (rows cols) :
+    Hex.Matrix.det (Hex.Matrix.selectedSubmatrix A rows cols) =
+      ((matrixEquiv A).submatrix rows.get cols.get).det
+theorem map_minors [CommRing S] (φ : R →+* S) (A : Hex.Matrix R n m) (r : Nat) :
+    (Hex.Matrix.minors r A).map φ = Hex.Matrix.minors r (A.map φ)
+```
+
+`map_minors` is `RingHom.map_det` read through `det_selectedSubmatrix_eq`
+and `matrixEquiv_map`, applied to each member of the enumeration. It is the
+only place a homomorphism property of `φ` is used, so the headline theorem
+below holds for every `RingHom`, including evaluation of polynomials,
+reduction modulo a prime and the inclusion of a domain into its fraction
+field.
+
+## The headline theorem
+
+Over `[CommRing R]`, `[Field K]`, `φ : R →+* K`:
+
+```lean
+theorem rank_lt_iff_minors_map_eq_zero (A : Hex.Matrix R n m) (r : Nat) :
+    ((matrixEquiv A).map φ).rank < r ↔ ∀ M ∈ Hex.Matrix.minors r A, φ M = 0
+theorem le_rank_iff_exists_minor_map_ne_zero (A : Hex.Matrix R n m) (r : Nat) :
+    r ≤ ((matrixEquiv A).map φ).rank ↔ ∃ M ∈ Hex.Matrix.minors r A, φ M ≠ 0
+theorem rank_le_iff_minors_succ_map_eq_zero (A : Hex.Matrix R n m) (r : Nat) :
+    ((matrixEquiv A).map φ).rank ≤ r ↔ ∀ M ∈ Hex.Matrix.minors (r + 1) A, φ M = 0
+```
+
+Proof: `matrixEquiv_map` rewrites the left side as the rank of
+`matrixEquiv (A.map φ)`; `HexRowReduceMathlib.rank_eq` applied to
+`rowReduce_isRowReduced (A.map φ)` replaces `Matrix.rank` by
+`rowReduce_rank (A.map φ)`, using `Field.toGrindField` for the
+`Lean.Grind.Field K` instance `rowReduce` needs and `Classical.decEq` for
+`DecidableEq K`; the computational `rank_lt_iff_minors_eq_zero` then
+applies, and `map_minors` moves `φ` back onto the minors of `A`. The
+boundary cases need no separate treatment: for `r = 0` both sides are
+false (`φ 1 = 1 ≠ 0`), and for `r > min n m` both sides are true.
+
+The statement deliberately uses `(matrixEquiv A).map φ` rather than
+`matrixEquiv (A.map φ)`, so that a consumer holding a Mathlib matrix
+`B : Matrix (Fin n) (Fin m) K` and a factorisation `B = (matrixEquiv A).map φ`
+rewrites once. The specialisation `φ = RingHom.id K` gives the field case:
+
+```lean
+theorem rank_lt_iff_minors_eq_zero [Field K] (A : Hex.Matrix K n m) (r : Nat) :
+    (matrixEquiv A).rank < r ↔ ∀ M ∈ Hex.Matrix.minors r A, M = 0
+```
+
+The same statement for a Mathlib matrix `B : Matrix (Fin n) (Fin m) R` is
+obtained by `A := matrixEquiv.symm B` and `Equiv.apply_symm_apply`; the
+library states that form too, as `Matrix.rank_lt_iff_minors_eq_zero'`, so
+the tactic does not re-derive it.
+
+## Specialisation bounds and rank loci
+
+```lean
+theorem rank_map_le_rank_fractionRing [IsDomain R] (φ : R →+* K) (A : Hex.Matrix R n m) :
+    ((matrixEquiv A).map φ).rank ≤
+      ((matrixEquiv A).map (algebraMap R (FractionRing R))).rank
+```
+
+Proof: by `le_rank_iff_exists_minor_map_ne_zero` twice. A nonzero
+`φ M` forces `M ≠ 0`, and `algebraMap R (FractionRing R)` is injective on a
+domain, so `algebraMap M ≠ 0`. This is the statement "no specialisation has
+rank above the generic rank". The generic rank itself is computed
+elsewhere (`hex-rank`, or `HexPolySmith.snfRank` with
+`rank_eq_ratFunc_rank` over `F[x]`) and enters only as the right side.
+
+For polynomial matrices, over `[Field F]`, `A : Hex.Matrix (MvPoly k F cmp) n m`
+and a point `p : Vector F k`:
+
+```lean
+theorem rankAt_lt_iff_inLocus (A) (p) (r : Nat) :
+    Hex.Matrix.rankAt A p < r ↔ Hex.Matrix.InLocus r A p
+theorem mem_zeroLocus_iff_rank_lt (A) (p : Fin k → F) (r : Nat) :
+    p ∈ MvPolynomial.zeroLocus F
+        (Ideal.span (HexMvPolyMathlib.equiv '' {M | M ∈ Hex.Matrix.minors r A})) ↔
+      ((matrixEquiv A).map (HexMvPolyMathlib.aevalMathlib p)).rank < r
+```
+
+Both are the headline theorem with `φ` the evaluation homomorphism at `p`.
+`HexMvPolyMathlib.aeval_eq_eval` identifies the executable `MvPoly.eval p`
+with `MvPolynomial.aeval p` composed with `HexMvPolyMathlib.equiv`, which
+is how `rankAt` and `InLocus`, defined through `MvPoly.eval`, meet the
+ring-homomorphism hypothesis. `mem_zeroLocus_iff_rank_lt` uses
+`MvPolynomial.zeroLocus` from `Mathlib/RingTheory/Nullstellensatz.lean`,
+whose membership condition `∀ q ∈ I, aeval p q = 0` reduces to the
+generators by `Ideal.span_induction`.
+
+## Ideals and invariance
+
+Over `[CommRing R]`, writing `I_r(A)` for
+`Ideal.span {x | x ∈ Hex.Matrix.minors r A}`:
+
+```lean
+theorem span_detIdealGens_eq [DecidableEq R] (A) (r) :
+    Ideal.span {x | x ∈ Hex.Matrix.detIdealGens r A} = I_r(A)
+theorem span_minors_zero (A) : I_0(A) = ⊤
+theorem span_minors_eq_bot_of_lt (A) (h : n < r ∨ m < r) : I_r(A) = ⊥
+theorem span_minors_succ_le (A) (r) : I_(r+1)(A) ≤ I_r(A)
+theorem span_minors_transpose (A) (r) : I_r(Aᵀ) = I_r(A)
+theorem span_minors_mul_left_le (P : Hex.Matrix R q n) (A) (r) : I_r(P * A) ≤ I_r(A)
+theorem span_minors_mul_right_le (A) (Q : Hex.Matrix R m q) (r) : I_r(A * Q) ≤ I_r(A)
+theorem span_minors_mul_left_eq (P Pinv : Hex.Matrix R n n) (h : Pinv * P = identity n) (A) (r) :
+    I_r(P * A) = I_r(A)
+theorem span_minors_mul_right_eq (Q Qinv : Hex.Matrix R m m) (h : Q * Qinv = identity m) (A) (r) :
+    I_r(A * Q) = I_r(A)
+```
+
+`span_minors_mul_left_le` is `minor_mul_left_expand` read as ideal
+membership: each minor of `P * A` is a finite sum of products with minors
+of `A`. `span_minors_succ_le` is the Laplace expansion
+`det_eq_foldl_laplace_col` together with `deleteRowCol_selectedSubmatrix`.
+The equalities follow from the two inequalities applied to `P * A` and
+`Pinv * (P * A) = A`. A one-sided inverse suffices because
+`Hex.Matrix.mul_eq_one_comm` makes it two-sided.
+
+These theorems say that `I_r` is an invariant of the matrix under
+invertible row and column operations. They do **not** say that `I_r` is an
+invariant of the module a matrix presents: two presentation matrices of
+the same module can have different shapes and are not related by
+invertible square factors alone. That presentation independence is the
+Fitting-ideal theorem, which this library does not prove and the pinned
+Mathlib does not contain.
+
+## Tests
+
+`HexDeterminantalIdealMathlib/Tests.lean`, build-only, no runtime checks:
+
+- `rank_lt_iff_minors_map_eq_zero` on a closed `Hex.Matrix ℤ 2 3` through
+  `Int.castRingHom ℚ`, both at `r = 2` (nonzero minor, rank `2`) and at
+  `r = 3` (empty list, rank below `3`), with the minors evaluated by
+  `decide +kernel` on the Hex side and the rank rewritten through the
+  theorem;
+- `rankAt_lt_iff_inLocus` on the `2 × 2` Vandermonde matrix in two
+  indeterminates over `ℚ`, at `(1, 1)` (in the locus at `r = 2`) and at
+  `(1, 2)` (not in the locus);
+- `span_minors_mul_left_eq` on a `2 × 2` unimodular `P` and a closed `A`,
+  to check that the hypotheses are stated in the form a consumer has.

--- a/SPEC/Libraries/hex-determinantal-ideal-mathlib.md
+++ b/SPEC/Libraries/hex-determinantal-ideal-mathlib.md
@@ -95,26 +95,31 @@ Proof: by `le_rank_iff_exists_minor_map_ne_zero` twice. A nonzero
 `φ M` forces `M ≠ 0`, and `algebraMap R (FractionRing R)` is injective on a
 domain, so `algebraMap M ≠ 0`. This is the statement "no specialisation has
 rank above the generic rank". The generic rank itself is computed
-elsewhere (`hex-rank`, or `HexPolySmith.snfRank` with
+elsewhere (`hex-rank`, or `Hex.PolyMatrix.snfRank` in `hex-poly-smith` with
 `rank_eq_ratFunc_rank` over `F[x]`) and enters only as the right side.
 
-For polynomial matrices, over `[Field F]`, `A : Hex.Matrix (MvPoly k F cmp) n m`
-and a point `p : Vector F k`:
+For polynomial matrices, over `[Field F] [DecidableEq F]` with
+`[Std.TransCmp cmp] [Std.LawfulEqCmp cmp]` (the instances `HexMvPoly` and
+`HexMvPolyMathlib.equiv` assume), `A : Hex.Matrix (MvPoly k F cmp) n m` and
+a point `p : Fin k → F`:
 
 ```lean
 theorem rankAt_lt_iff_inLocus (A) (p) (r : Nat) :
     Hex.Matrix.rankAt A p < r ↔ Hex.Matrix.InLocus r A p
-theorem mem_zeroLocus_iff_rank_lt (A) (p : Fin k → F) (r : Nat) :
+theorem mem_zeroLocus_iff_rank_lt (A) (p) (r : Nat) :
     p ∈ MvPolynomial.zeroLocus F
         (Ideal.span (HexMvPolyMathlib.equiv '' {M | M ∈ Hex.Matrix.minors r A})) ↔
-      ((matrixEquiv A).map (HexMvPolyMathlib.aevalMathlib p)).rank < r
+      ((matrixEquiv A).map (HexMvPolyMathlib.aeval p)).rank < r
 ```
 
-Both are the headline theorem with `φ` the evaluation homomorphism at `p`.
-`HexMvPolyMathlib.aeval_eq_eval` identifies the executable `MvPoly.eval p`
-with `MvPolynomial.aeval p` composed with `HexMvPolyMathlib.equiv`, which
-is how `rankAt` and `InLocus`, defined through `MvPoly.eval`, meet the
-ring-homomorphism hypothesis. `mem_zeroLocus_iff_rank_lt` uses
+Both are the headline theorem with `φ := (HexMvPolyMathlib.aeval p).toRingHom`,
+the executable evaluation as an `AlgHom` (`HexMvPolyMathlib/Aeval.lean`).
+`HexMvPolyMathlib.aeval_eq_eval` says its underlying function is
+`MvPoly.eval p`, which is how `rankAt` and `InLocus`, defined through
+`MvPoly.eval`, meet the ring-homomorphism hypothesis, and
+`HexMvPolyMathlib.aeval_apply` rewrites it as `MvPolynomial.aeval p` after
+`HexMvPolyMathlib.equiv`, which is how the zero-locus membership condition
+meets it. `mem_zeroLocus_iff_rank_lt` uses
 `MvPolynomial.zeroLocus` from `Mathlib/RingTheory/Nullstellensatz.lean`,
 whose membership condition `∀ q ∈ I, aeval p q = 0` reduces to the
 generators by `Ideal.span_induction`.

--- a/SPEC/Libraries/hex-determinantal-ideal.md
+++ b/SPEC/Libraries/hex-determinantal-ideal.md
@@ -1,0 +1,565 @@
+# hex-determinantal-ideal
+
+Executable minors and determinantal ideals of a matrix over a commutative
+ring, and the theorem that a matrix over a field has rank below `r` exactly
+when every `r × r` minor vanishes. Applied to a matrix of polynomials and a
+point, the theorem says where the rank of the specialised matrix drops: the
+set of points at which every `r × r` minor vanishes. That set is the zero set
+of the `r`-th determinantal ideal `I_r(A)`. This library computes the
+generators of that ideal and proves the theorem. The `rank_locus` tactic, a
+later SPEC, packages the theorem for Mathlib goals and adds nothing to its
+mathematics.
+
+## Why this library exists
+
+Minors already appear in four places in the repository, all as proof devices
+rather than as a computation a user can run:
+
+- `Hex.Matrix.selectedSubmatrix`, `deleteRowCol` and `cofactor` in
+  `HexDeterminant/Minor.lean`, used by the Laplace expansion and the
+  adjugate;
+- `Hex.Matrix.borderedMinor` in `HexBareiss/BorderedMinor.lean`, used by the
+  Bareiss invariant;
+- `Hex.Matrix.detDivisor` in `HexSmith/Divisor.lean` and
+  `Hex.PolyMatrix.minors`/`detDivisor` in `HexPolySmith/Divisor.lean`, both
+  `noncomputable`, each enumerating all `k × k` minors through
+  `selectedColumnTuples` and used only to prove that the Smith form is
+  unique.
+
+Cauchy-Binet for an arbitrary selected minor of a product
+(`det_minor_mul` in `HexDeterminant/Gram.lean`) and the Laplace expansion
+(`det_eq_foldl_laplace_col` in `HexDeterminant/Laplace.lean`) are proved, but
+no statement relates the vanishing of minors to the rank, and the only fact
+about a symbolic matrix's rank is
+`HexPolySmithMathlib.rank_eq_ratFunc_rank`, which identifies the executable
+Smith rank over `F[x]` with the rank over `RatFunc F` and says nothing about
+specialisation.
+
+This library turns the enumeration into an executable function with fixed
+conventions at every size, proves the rank-versus-minors theorem once, over
+any field and with a Mathlib-free proof, and leaves the consumers (the
+`rank_locus` tactic and, through its companion, any Mathlib development) to
+instantiate it.
+
+## Scope and dependencies
+
+`HexDeterminantalIdeal` is Mathlib-free. Its modules import, in this order:
+
+- `Minors.lean`: `HexDeterminant` (and through it `HexMatrix`, `HexBasic`).
+- `Rank.lean`: additionally `HexRowReduce`, for `rowReduce_rank` and the
+  row-reduced echelon certificate the nonzero-minor direction is built from.
+- `MvPoly.lean`: additionally `HexMvPoly`, for the specialisation of a
+  polynomial matrix at a point.
+
+The library's dependency list is therefore `HexBasic`, `HexMatrix`,
+`HexDeterminant`, `HexRowReduce`, `HexMvPoly`. It does not depend on
+`hex-bareiss`, `hex-rank`, `hex-poly-smith`, `hex-mv-gcd` or anything that
+computes a generic rank. Those libraries only choose a default `r`; the
+theorem here is stated for every `r`. `hex-rank` and this library are
+independent siblings: neither imports the other, and `hex-rank`'s
+certificate (a nonzero `r × r` minor plus a column expression) is an
+instance of the nonzero-minor direction proved here, not a dependency of it.
+
+The companion `HexDeterminantalIdealMathlib` depends on this library,
+`HexDeterminantMathlib`, `HexRowReduceMathlib` and `HexMvPolyMathlib`, plus
+Mathlib. It is specified in
+[hex-determinantal-ideal-mathlib](hex-determinantal-ideal-mathlib.md).
+
+Gröbner bases, ideal membership, radicals, primary decomposition and
+Fitting ideals are outside this library. The ideal `I_r(A)` is presented by
+its generating minors and nothing else. See
+[What this library does not claim](#what-this-library-does-not-claim).
+
+The namespace is `Hex.Matrix`, beside `det` and `selectedSubmatrix`. The
+names `Hex.Matrix.minorSelections`, `minorValue` and `detDivisor` are
+already taken by `HexSmith/Divisor.lean`, and this library does not reuse
+them.
+
+## Conventions: a minor of every size
+
+For `A : Matrix R n m` and `r : Nat`, an `r × r` minor of `A` is the
+determinant of `selectedSubmatrix A rows cols` for strictly increasing
+`rows : Vector (Fin n) r` and `cols : Vector (Fin m) r`. The strictly
+increasing tuples are exactly the members of `selectedColumnTuples r n` and
+`selectedColumnTuples r m` (`mem_selectedColumnTuples_iff` in
+`HexDeterminant/Gram.lean`), so every row set and column set is listed once,
+in lexicographic order of the tuples.
+
+The two boundary cases are fixed by the definitions rather than by special
+cases in the code:
+
+- **`r = 0`.** `selectedColumnTuples 0 n = [#v[]]` for every `n`, and the
+  determinant of the `0 × 0` matrix is `1` (the Leibniz sum over the single
+  empty permutation). So `minors 0 A = [1]`: there is one zero-sized minor
+  and it is `1`. The ideal `I_0(A)` is the unit ideal.
+- **`r > min n m`.** A strictly increasing `r`-tuple in `Fin n` requires
+  `r ≤ n` (its last entry is at least `r - 1`), so
+  `selectedColumnTuples r n = []` when `n < r`, and `minors r A = []`. The
+  ideal `I_r(A)` is the zero ideal.
+
+These conventions make the chain
+
+```text
+R = I_0(A) ⊇ I_1(A) ⊇ ... ⊇ I_{min n m}(A) ⊇ I_{min n m + 1}(A) = 0
+```
+
+hold with no side conditions, and they make the main theorem true at
+`r = 0` and at `r > min n m` without separate clauses.
+
+## API
+
+All definitions are executable and `@[expose]`d so that `decide +kernel`
+can evaluate them on closed inputs.
+
+| Operation | Type and contract |
+| --- | --- |
+| `minors r A` | `[Lean.Grind.Ring R] (A : Matrix R n m) (r : Nat) : List R`. Every `r × r` minor of `A`, rows outer and columns inner, both in the order of `selectedColumnTuples`. Length `n.choose r * m.choose r`. |
+| `detIdealGens r A` | `[Lean.Grind.Ring R] [DecidableEq R] : List R`. `minors r A` with the zero entries removed and exact duplicates removed, keeping first occurrences. A generating list for `I_r(A)`. |
+| `Matrix.map A f` | `(A : Matrix R n m) (f : R → S) : Matrix S n m`, entrywise. Added to `HexMatrix/Basic.lean` if still absent when this library is implemented (at the time of writing `HexMatrix` has `mapRows` and `mapRowsIdx` but no entrywise map), with `getElem_map`. |
+| `specialize A p` | `[Lean.Grind.CommRing R] [DecidableEq R] (A : Matrix (MvPoly k R cmp) n m) (p : Vector R k) : Matrix R n m`, defined as `A.map (MvPoly.eval p)`. |
+| `rankAt A p` | `[Lean.Grind.Field F] [DecidableEq F] : Nat`, defined as `rowReduce_rank (specialize A p)`. The rank of the polynomial matrix at the point `p`. |
+| `InLocus r A p` | `Prop`, `∀ M ∈ minors r A, MvPoly.eval p M = 0`, with a `Decidable` instance. The point `p` lies in the zero set of `I_r(A)`. |
+
+`detIdealGens` is a convenience for display and for fixtures. Every theorem
+is stated about `minors`, and the companion proves that the two lists
+generate the same ideal. No normalisation beyond dropping zeros and exact
+duplicates is performed: `M` and `-M` both stay, and no leading-coefficient
+or sign convention is imposed, because any such convention would be
+ring-specific and the library is generic.
+
+## Enumeration theorems
+
+Proved in `Minors.lean`, all Mathlib-free:
+
+```lean
+theorem mem_minors_iff (A : Matrix R n m) (r : Nat) (x : R) :
+    x ∈ minors r A ↔ ∃ rows ∈ selectedColumnTuples r n, ∃ cols ∈ selectedColumnTuples r m,
+      x = det (selectedSubmatrix A rows cols)
+theorem length_minors (A : Matrix R n m) (r : Nat) :
+    (minors r A).length = n.choose r * m.choose r
+theorem minors_zero (A : Matrix R n m) : minors 0 A = [1]
+theorem minors_eq_nil_iff (A : Matrix R n m) (r : Nat) :
+    minors r A = [] ↔ n < r ∨ m < r
+theorem selectedColumnTuples_eq_nil_of_lt (h : n < r) : selectedColumnTuples r n = []
+theorem minors_transpose [Lean.Grind.CommRing R] (A : Matrix R n m) (r : Nat) :
+    (minors r A.transpose).Perm (minors r A)
+theorem mem_detIdealGens_iff [DecidableEq R] (x : R) :
+    x ∈ detIdealGens r A ↔ x ∈ minors r A ∧ x ≠ 0
+theorem deleteRowCol_selectedSubmatrix (A : Matrix R n m)
+    (rows : Vector (Fin n) (k + 1)) (cols : Vector (Fin m) (k + 1)) (i j : Fin (k + 1)) :
+    deleteRowCol (selectedSubmatrix A rows cols) i j =
+      selectedSubmatrix A (rows.eraseIdx i) (cols.eraseIdx j)
+theorem isStrictlyIncreasingColumnTuple_eraseIdx (h : IsStrictlyIncreasingColumnTuple cols)
+    (i : Fin (k + 1)) : IsStrictlyIncreasingColumnTuple (cols.eraseIdx i)
+```
+
+`minors_transpose` is a permutation, not an equality, because the transpose
+swaps the roles of the outer and inner loops. It comes from
+`selectedSubmatrix_transpose` and `det_transpose`.
+
+## The rank-versus-minors theorem
+
+Proved in `Rank.lean`, over a `Lean.Grind.Field K` with `DecidableEq K`,
+about the rank computed by `HexRowReduce.rowReduce`:
+
+```lean
+theorem rank_lt_iff_minors_eq_zero (A : Matrix K n m) (r : Nat) :
+    rowReduce_rank A < r ↔ ∀ M ∈ minors r A, M = 0
+theorem le_rank_iff_exists_minor_ne_zero (A : Matrix K n m) (r : Nat) :
+    r ≤ rowReduce_rank A ↔ ∃ M ∈ minors r A, M ≠ 0
+theorem rank_le_iff_minors_succ_eq_zero (A : Matrix K n m) (r : Nat) :
+    rowReduce_rank A ≤ r ↔ ∀ M ∈ minors (r + 1) A, M = 0
+theorem rank_eq_iff_minors (A : Matrix K n m) (r : Nat) :
+    rowReduce_rank A = r ↔ (∃ M ∈ minors r A, M ≠ 0) ∧ ∀ M ∈ minors (r + 1) A, M = 0
+```
+
+The three corollaries are restatements of the first theorem. The companion
+replaces `rowReduce_rank A` by `Matrix.rank` through
+`HexRowReduceMathlib.rank_eq`.
+
+### Both boundary cases, checked against the statement
+
+- `r = 0`: the left side `rowReduce_rank A < 0` is false. The right side
+  says every member of `minors 0 A = [1]` is zero, which is `1 = 0`, false
+  by `Lean.Grind.Field.zero_ne_one`. Both sides false.
+- `r > min n m`: the left side holds by `IsEchelonForm.rank_le_n` and
+  `rank_le_m`. The right side is vacuous because `minors r A = []`. Both
+  sides true.
+
+The general proof below covers both cases without a case split. They are
+listed so that an implementation that special-cases either one is seen to be
+unnecessary, and so that the conformance suite tests them.
+
+### Proof route
+
+The proof is Mathlib-free and uses three existing results: the row-reduced
+echelon certificate (`rowReduce_isRowReduced`, giving `IsRowReduced A D`),
+rectangular Cauchy-Binet (`det_mul_rectangular` and `det_minor_mul` in
+`HexDeterminant/Gram.lean`) and the Laplace expansion
+(`det_eq_foldl_laplace_col`). Mathlib's
+`Mathlib/LinearAlgebra/Matrix/Echelon/Pivot.lean` proves the corresponding
+step for a matrix already in echelon form (`IsPivotedBy.rank_eq` builds an
+upper-triangular nonsingular `submatrix` of size equal to the rank), but
+Mathlib has no theorem producing an echelon form of an arbitrary matrix, so
+the executable certificate from `HexRowReduce` is the route that closes the
+argument. Write `ρ := rowReduce_rank A`, `D := rowReduce A`, `T :=
+D.transform`, `E := D.echelon`, `J := D.pivotCols`.
+
+**Vanishing direction (`ρ < r` implies every `r × r` minor is zero).**
+`rowReduce_rank_factorization` gives `C : Matrix K n ρ` and
+`B : Matrix K ρ m` with `A = C * B`. For any `rows, cols` of length `r`,
+`det_minor_mul` expands `det (selectedSubmatrix (C * B) rows cols)` as a sum
+over `middle ∈ selectedColumnTuples r ρ`. Since `ρ < r`, that list is empty
+(`selectedColumnTuples_eq_nil_of_lt`) and the sum is `0`.
+
+**Nonzero-minor direction (`r ≤ ρ` implies some `r × r` minor is
+nonzero).** First a nonzero `ρ × ρ` minor, then a descent to size `r`.
+
+1. *The pivot columns of `A` are the first `ρ` columns of `T⁻¹`.*
+   `pivotCols_sorted` says `J` is strictly increasing, so
+   `J ∈ selectedColumnTuples ρ m`. In the reduced echelon form,
+   `selectCols E J = pad (identity ρ) n ρ`: rows below `ρ` are zero
+   (`zero_row`), and within the first `ρ` rows the pivot entries are `1`
+   (`pivot_one`) and the other entries of a pivot column are `0`
+   (`above_pivot_zero`, `below_pivot_zero`). From `transform_mul`
+   (`T * A = E`) and `transform_inv` (`Tinv * T = identity n`),
+   `A = Tinv * E`, so `selectCols A J = Tinv * pad (identity ρ) n ρ`, which
+   is the `n × ρ` matrix `C` formed by the first `ρ` columns of `Tinv`
+   (a new lemma `selectCols_mul`, the column analogue of
+   `selectedSubmatrix_mul`).
+2. *The first `ρ` rows of `T` are a left inverse of `C`.*
+   `mul_eq_one_comm` turns `Tinv * T = identity n` into
+   `T * Tinv = identity n`, and `takeRows_mul` with `pad_identity_mul` give
+   `takeRows T ρ * C = identity ρ`, so `det (takeRows T ρ * C) = 1`.
+3. *Cauchy-Binet produces a nonzero `ρ × ρ` minor of `A`.*
+   `det_mul_rectangular` applied to `takeRows T ρ : Matrix K ρ n` and
+   `C : Matrix K n ρ` writes `1` as a `foldl` sum over
+   `I ∈ selectedColumnTuples ρ n` of
+   `det (columnTupleMatrix C.transpose I) * det (columnTupleMatrix (takeRows T ρ) I)`.
+   Since `1 ≠ 0`, some summand is nonzero (a small lemma: a `foldl` of
+   additions from `0` whose summands are all zero is zero), hence
+   `det (columnTupleMatrix C.transpose I) ≠ 0` for some strictly increasing
+   `I`. Entrywise, `columnTupleMatrix C.transpose I` is the transpose of
+   `selectedSubmatrix A I J`, so by `det_transpose`
+   `det (selectedSubmatrix A I J) ≠ 0`, and this value is a member of
+   `minors ρ A` by `mem_minors_iff`.
+4. *Descent by one.* If `det (selectedSubmatrix A rows cols) ≠ 0` with
+   `rows, cols` strictly increasing of length `k + 1`, then Laplace
+   expansion along column `0` (`det_eq_foldl_laplace_col`) writes the
+   determinant as a sum over `i` of `B[i][0] * cofactor B i 0`; some
+   summand is nonzero, so `det (deleteRowCol B i 0) ≠ 0` (the cofactor is
+   `±1` times that determinant). By `deleteRowCol_selectedSubmatrix` and
+   `isStrictlyIncreasingColumnTuple_eraseIdx`, that is a nonzero `k × k`
+   minor of `A` indexed by strictly increasing tuples.
+5. *Iterate.* Induction on `ρ - r` starting from step 3 and applying
+   step 4 gives a nonzero member of `minors r A` for every `r ≤ ρ`.
+
+The contrapositive of the nonzero-minor direction is the right-to-left
+implication of `rank_lt_iff_minors_eq_zero`.
+
+An alternative for step 4 is the generalised Laplace expansion along `r`
+rows, which would give the descent in one step. It is not in
+`HexDeterminant` and is not needed, since the single-column expansion
+iterated is enough.
+
+## Invariance under multiplication
+
+Proved in `Minors.lean` over a `Lean.Grind.CommRing R`:
+
+```lean
+theorem minor_mul_left_expand (P : Matrix R q n) (A : Matrix R n m)
+    (rows : Vector (Fin q) r) (cols : Vector (Fin m) r) :
+    det (selectedSubmatrix (P * A) rows cols) =
+      (selectedColumnTuples r n).foldl (fun acc middle => acc +
+        det (selectedSubmatrix A middle cols) * det (selectedSubmatrix P rows middle)) 0
+theorem minor_mul_right_expand (A : Matrix R n m) (Q : Matrix R m q)
+    (rows : Vector (Fin n) r) (cols : Vector (Fin q) r) :
+    det (selectedSubmatrix (A * Q) rows cols) =
+      (selectedColumnTuples r m).foldl (fun acc middle => acc +
+        det (selectedSubmatrix Q middle cols) * det (selectedSubmatrix A rows middle)) 0
+```
+
+Both are `det_minor_mul` with the factors named. They say that every
+`r × r` minor of `P * A` or `A * Q` is an `R`-linear combination of
+`r × r` minors of `A`, which is the Mathlib-free content of
+`I_r(P * A) ⊆ I_r(A)` and `I_r(A * Q) ⊆ I_r(A)`. Equality for invertible
+`P` and `Q`, the descending chain `I_{r+1}(A) ⊆ I_r(A)` (each
+`(r+1) × (r+1)` minor is a combination of `r × r` minors by Laplace
+expansion), and the statement that `minors` and `detIdealGens` generate the
+same ideal, all need `Ideal.span` and are theorems of the companion.
+
+## Specialisation and rank loci
+
+`MvPoly.lean` provides `specialize`, `rankAt` and `InLocus` as executable
+operations. Their theorem is the main theorem read at a point:
+
+```text
+rankAt A p < r  ↔  InLocus r A p
+```
+
+This requires that `MvPoly.eval p` commutes with `det`, which is a ring
+homomorphism property. `HexMvPoly` does not state `eval_add`/`eval_mul` in
+the Mathlib-free layer, so the theorem `rankAt_lt_iff_inLocus` is proved in
+the companion through `HexMvPolyMathlib.aeval_eq_eval` and
+`RingHom.map_det`. The Mathlib-free layer ships the definitions, the
+`Decidable` instance, and the unfolding lemmas `specialize_getElem`,
+`rankAt_eq` and `inLocus_iff`, so that a kernel evaluation of
+`InLocus r A p` on closed inputs is available without Mathlib.
+
+The consequences a consumer wants are all instances of the one theorem
+with a particular `r`:
+
+- the locus where the rank of `A` drops below `r` is the zero set of
+  `I_r(A)`;
+- "rank at most `r`" at a point is `InLocus (r + 1) A p`;
+- "rank drops below the generic rank" is `InLocus g A p` where `g` is the
+  rank of `A` over the fraction field of the coefficient ring. Computing
+  `g` is the job of `hex-rank` (over a general domain) or
+  `HexPolySmith.snfRank` (over `F[x]`); this library takes `g` as an input.
+  The companion proves that no specialisation has rank above `g`.
+
+Nothing here asserts that the complement of the locus is nonempty. Over a
+finite field every point may lie in the locus while the generic rank is
+larger (the `hex-rank` SPEC, https://github.com/kim-em/hex-dev/issues/10153,
+gives the example `[X^q - X]` over `𝔽_q[X]`), and the theorem is consistent with that: it is an equivalence
+at each point, not an existence statement.
+
+## What this library does not claim
+
+**Not Fitting ideals.** For a finitely presented module `M` with
+presentation matrix `A` (`n` generators, `m` relations), the Fitting ideals
+`Fitt_j(M) = I_{n-j}(A)` are independent of the presentation. That
+independence is a theorem about modules, not about matrices, and its proof
+goes through comparing two presentations of the same module, not through
+`I_r(P * A) = I_r(A)` for invertible `P`. This library proves only the
+latter. The object here is called a *determinantal ideal* throughout, and
+Fitting ideals are deferred to a later module-theoretic library. The
+pinned Mathlib has no Fitting ideals either (see the next section), so
+there is nothing to transport to.
+
+**Not a Gröbner computation.** `I_r(A)` is presented by a generating list.
+Membership, equality of ideals, radicals, minimal generators and dimension
+of the zero set are out of scope; the planned `hex-groebner`
+([SPEC/future-work.md §Gröbner bases](../future-work.md#gröbner-bases))
+is the consumer that would decide them. In particular `detIdealGens` is
+*a* generating list, not a reduced one.
+
+**Not a rank algorithm.** Over a field the rank is `rowReduce_rank`. Over a
+domain or a polynomial ring, rank with a certificate is `hex-rank`
+(https://github.com/kim-em/hex-dev/issues/10153). This library's `rankAt` is row reduction over the
+field after specialisation and exists to state the locus theorem
+executably, not as a general rank entry point.
+
+**No pruning.** `minors` enumerates every selection. Row-selection sharing
+(computing the minors of a fixed row set for all column sets from one
+elimination), the Bareiss-style recurrence between bordered minors, and
+early exit when a unit minor is found are all possible later
+optimisations. None is promised, and none changes the API or the theorems
+because `minors` is the specification.
+
+## Mathlib inventory
+
+Checked against the pinned Mathlib, `v4.34.0-rc2` (Mathlib commit
+`85e3a25e006c35636f0e53b0e9296caca2685bc0`, 2026-08-21):
+
+- **Fitting ideals: absent.** No declaration named `FittingIdeal` or
+  `fittingIdeal`, and no definition of the ideals generated by the minors
+  of a presentation matrix. The occurrences of "Fitting" in
+  `Mathlib/Algebra/Lie/` and `Mathlib/RingTheory/Artinian/Module.lean`
+  are the Fitting lemma and Fitting decomposition, unrelated.
+- **Rank versus minors: absent.** No lemma of the form "`r ≤ A.rank` iff
+  some `r × r` minor is nonzero", nor its negation. The closest
+  statements are:
+  - `Matrix.IsPivotedBy.rank_eq`
+    (`Mathlib/LinearAlgebra/Matrix/Echelon/Pivot.lean`): for a matrix
+    already in echelon form with pivot map `l`, `A.rank = #{i | l i ≠ ⊤}`;
+    its proof builds the `submatrix` on the pivot rows and columns, shows
+    it is upper triangular with nonzero diagonal, and uses
+    `rank_of_det_ne_zero` and `rank_submatrix_le`. That is the
+    nonzero-minor direction for an echelon matrix, with no theorem
+    producing an echelon form of an arbitrary matrix.
+  - `Matrix.Echelon.Decomposition.rank_eq`
+    (`Mathlib/LinearAlgebra/Matrix/Echelon/Decomposition.lean`): rank from
+    a certificate `L * A.submatrix σ id` pivoted, over `[CommRing R]
+    [IsDomain R]`; this is the checker `norm_rank` uses, and the
+    certificate is produced by meta code, not by a theorem.
+  - `Matrix.rank_submatrix_le`, `Matrix.rank_of_det_ne_zero`
+    (`Mathlib/LinearAlgebra/Matrix/Rank.lean`) and
+    `Matrix.det_eq_zero_of_not_linearIndependent_cols`
+    (`Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean`): the
+    ingredients of both directions, without the assembly.
+- **Present and used by the companion.** `Matrix.map`, `RingHom.map_det`
+  (`Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean`),
+  `Matrix.rank` (`Mathlib/LinearAlgebra/Matrix/Rank.lean`),
+  `MvPolynomial.zeroLocus` (`Mathlib/RingTheory/Nullstellensatz.lean`),
+  `Field.toGrindField` (`Mathlib/Algebra/Field/Basic.lean`, which lets
+  `rowReduce` run over a Mathlib `Field`).
+
+An implementer must re-run these searches when the Mathlib pin moves. If
+Mathlib gains either absent item, the companion should state agreement with
+it rather than a second copy.
+
+## Complexity
+
+`minors r A` computes `n.choose r * m.choose r` determinants, each by
+`Hex.Matrix.det`, the Leibniz sum with `r!` terms of `r` factors. The ring
+operation count is therefore
+
+```text
+Θ( n.choose r · m.choose r · r! · r )
+```
+
+and over `MvPoly` each ring operation is a polynomial product whose cost
+depends on the supports. This is the specification cost and the shipped
+cost, and no pruning is promised (see above). The function is intended for the
+small symbolic matrices a tactic meets, typically `n, m ≤ 6`, where the
+count is in the thousands. The conformance and benchmark sizes below are
+chosen so that the cap in `SPEC/benchmarking.md` is met with this count.
+
+A later per-minor determinant that is faster than Leibniz (Bareiss with an
+exact quotient from `hex-mv-gcd`, or Berkowitz from `hex-char-poly`) must be
+proved equal to `det` and plugged in behind the same `minors`; it would
+change the library's dependency list and is not part of this SPEC.
+
+## Conformance
+
+Per [SPEC/testing.md](../testing.md). The Lean drivers are
+`conformance/HexDeterminantalIdeal/Conformance.lean` and
+`conformance/HexDeterminantalIdeal/EmitFixtures.lean`, the latter exposed as
+`lean_exe hexdeterminantalideal_emit_fixtures`. The committed snapshot is
+`conformance-fixtures/HexDeterminantalIdeal/detideal.jsonl` and the oracle
+driver is `scripts/oracle/detideal_sympy.py`. Adding it extends the existing
+single conformance job: append `HexDeterminantalIdeal.Conformance` to the
+`HexConformance` globs in `lakefile.lean`, and append one tuple to `ORACLES`
+in `scripts/ci/run_oracles.sh`:
+
+```
+"HexDeterminantalIdeal|hexdeterminantalideal_emit_fixtures|scripts/oracle/detideal_sympy.py|conformance-fixtures/HexDeterminantalIdeal/detideal.jsonl"
+```
+
+SymPy is already installed and preflighted for `hex-mv-poly`, so no install
+or preflight line changes.
+
+**Record format.** A record carries the arity and comparator name of the
+entry ring, the matrix as a list of rows of polynomials, each polynomial in
+the `(exponent vector, coefficient)` encoding of the `mvpoly` fixture kind,
+the size `r`, and one of the operations below with its Lean `value`.
+Matrices over `Int` are arity-`0` polynomial matrices, so one stream covers
+both.
+
+| `op` | Lean value | Oracle recomputation and comparison |
+| --- | --- | --- |
+| `minors` | the list `minors r A` in enumeration order | `itertools.combinations` of rows and of columns in lexicographic order, `Matrix.extract(...).det()`, compared polynomial by polynomial after `expand`, in the same order |
+| `detIdealGens` | `detIdealGens r A` | the nonzero distinct minors, compared as sets of expanded polynomials |
+| `rankAt` | `rankAt A p` for a point `p` over `ℚ` | `Matrix.subs(...).rank()` |
+| `inLocus` | `decide (InLocus r A p)` | every minor evaluates to zero at `p` |
+
+**Cases that must be present**, since these are what a plausible
+implementation gets wrong:
+
+- `r = 0` on every matrix shape, including `0 × 0`, `0 × m` and `n × 0`,
+  checking `minors 0 A = [1]`;
+- `r > min n m`, checking `minors r A = []`, for square and for both
+  rectangular orientations;
+- the zero matrix at `r = 1`, checking that `minors` is a list of zeros of
+  the right length and `detIdealGens` is empty;
+- the generic `2 × 3` matrix of six indeterminates at `r = 2`, whose three
+  minors are the classical generators, and its transpose, checking
+  `minors_transpose` as a permutation;
+- a matrix with repeated minors (two equal columns of indeterminates),
+  checking that `detIdealGens` keeps one copy and that `minors` keeps both;
+- the Vandermonde matrices `V_2` and `V_3` in indeterminates
+  `x_1, ..., x_k`: at `r = k` the single minor is `∏_{i<j} (x_j - x_i)`,
+  and `rankAt`/`inLocus` are checked at points with two equal coordinates
+  (rank drop) and with distinct coordinates (full rank), and at `r = k - 1`
+  at points where all coordinates coincide;
+- the bordered identity `[[identity k, u], [vᵀ, t]]` of size `k + 1` with
+  indeterminate `u`, `v`, `t`, for `k = 1, 2`: `minors k` contains `1`, so
+  no point is in the locus at `r = k` and `rankAt ≥ k` everywhere, while
+  `detIdealGens (k + 1)` is the single polynomial `t - v · u` up to sign,
+  with points on and off the hypersurface `t = v · u`;
+- a `3 × 3` matrix over `Int` of rank `2`, checking `rank_eq_iff_minors` by
+  `decide +kernel` in `Conformance.lean`: some `2 × 2` minor is nonzero and
+  the determinant is zero;
+- invariance on one fixture: for an explicit unimodular integer `P`,
+  `rankAt (P * A) p = rankAt A p` and `InLocus r (P * A) p ↔ InLocus r A p`
+  at two points.
+
+The companion adds build-only transport checks in
+`HexDeterminantalIdealMathlib/Tests.lean`: the headline theorem applied to a
+closed `Matrix (Fin 2) (Fin 3) ℤ` through `Int.castRingHom ℚ`, and the
+locus corollary applied to `V_2` at one point on and one point off the
+diagonal. These are not an independent oracle. The SymPy stream is.
+
+## Benchmarking
+
+Per [SPEC/benchmarking.md](../benchmarking.md), a driver at
+`bench/HexDeterminantalIdeal/Bench.lean` with no Mathlib import.
+
+**Input families.**
+
+- `dense-int-minors`: `n = m ∈ {4, 5, 6}`, every `r` from `1` to `n`,
+  small random integer entries. The purpose is the shape of the curve in
+  `r`, which must follow `n.choose r ^ 2 · r!`.
+- `symbolic-2var`: `4 × 4` matrices whose entries are random linear forms
+  in two indeterminates over `Int`, `r ∈ {2, 3, 4}`, isolating the cost of
+  polynomial arithmetic inside the same enumeration.
+
+**Comparator.** SymPy, the same `combinations` and `det` loop the oracle
+runs, `informational`: SymPy chooses its own per-minor determinant
+algorithm (Bareiss or Berkowitz) and a ratio against a Leibniz sum compares
+algorithms, not implementations.
+
+**Decision rule written in advance.** Within a family, the wallclock ratio
+between consecutive `r` must be within a constant factor of the ratio of
+the operation counts above. A ratio that grows faster than the count
+indicates that the enumeration allocates per minor more than the `r × r`
+submatrix it needs, which is a bug rather than a benchmark result.
+
+## File organisation
+
+```text
+HexDeterminantalIdeal.lean              umbrella
+HexDeterminantalIdeal/
+  Minors.lean        minors, detIdealGens, enumeration theorems, invariance expansions
+  Rank.lean          rank_lt_iff_minors_eq_zero and its three corollaries
+  MvPoly.lean        Matrix.map (if not yet in HexMatrix), specialize, rankAt, InLocus
+  SPEC/hex-determinantal-ideal.md
+  README.md
+conformance/HexDeterminantalIdeal/{Conformance,EmitFixtures}.lean
+conformance-fixtures/HexDeterminantalIdeal/detideal.jsonl
+scripts/oracle/detideal_sympy.py
+bench/HexDeterminantalIdeal/Bench.lean
+```
+
+## Consumers
+
+- The `rank_locus` tactic (later SPEC) takes a Mathlib matrix with
+  symbolic entries, reifies it through `hex-reflect`
+  ([spec issue](https://github.com/kim-em/hex-dev/issues/10152)) into a
+  `Matrix (MvPoly k R cmp) n m`, runs `detIdealGens r A` to display the
+  generators, and closes goals of the form "the rank at `p` is below `r`
+  iff `p` is in the zero set" with the companion's
+  `mem_zeroLocus_iff_rank_lt`. It needs this library for the theorem and
+  `hex-reflect` for its input, and nothing from `hex-rank` unless the
+  user asks for the generic rank as the default `r`.
+- `hex-matrix-tactic` ([spec issue](https://github.com/kim-em/hex-dev/issues/10151))
+  may use `le_rank_iff_exists_minor_ne_zero` as the lower-bound half of a
+  rank certificate. It is not required to.
+- `hex-smith` and `hex-poly-smith` keep their `noncomputable`
+  determinantal-divisor copies. Replacing them by an import of this
+  library would add `hex-row-reduce` and `hex-mv-poly` to their dependency
+  closures for the sake of a specification function, which is not worth it
+  until this library is released and the module split above lets
+  `Minors.lean` be imported alone.
+
+## Open questions
+
+- Whether `Matrix.map` belongs in `HexMatrix` (released) or here. The
+  SPEC says `HexMatrix`, because `selectRows`/`selectCols` are there and an
+  entrywise map is a basic operation. The released repo is regenerated from
+  this monorepo, so the addition is an ordinary change.
+- Whether to ship a `Bool`-valued `rankDropsBelow r A p` beside the
+  `Decidable` instance on `InLocus`. The instance is enough for `decide
+  +kernel` and for the fixtures; a named Boolean is only worth adding if
+  the tactic wants it.

--- a/SPEC/Libraries/hex-determinantal-ideal.md
+++ b/SPEC/Libraries/hex-determinantal-ideal.md
@@ -82,8 +82,13 @@ determinant of `selectedSubmatrix A rows cols` for strictly increasing
 `rows : Vector (Fin n) r` and `cols : Vector (Fin m) r`. The strictly
 increasing tuples are exactly the members of `selectedColumnTuples r n` and
 `selectedColumnTuples r m` (`mem_selectedColumnTuples_iff` in
-`HexDeterminant/Gram.lean`), so every row set and column set is listed once,
-in lexicographic order of the tuples.
+`HexDeterminant/Gram.lean`), so every row set and column set is listed once.
+The order is the one `selectedColumnTuplesUpTo` produces: tuples are grouped
+by their last entry in increasing order, and within a group the prefixes
+recur in the same order, so `selectedColumnTuples 2 4` is
+`01, 02, 12, 03, 13, 23`. This is colexicographic order, not the
+lexicographic order `itertools.combinations` produces, and the oracle
+below sorts its combinations by reversed tuple to match.
 
 The two boundary cases are fixed by the definitions rather than by special
 cases in the code:
@@ -109,14 +114,16 @@ hold with no side conditions, and they make the main theorem true at
 ## API
 
 All definitions are executable and `@[expose]`d so that `decide +kernel`
-can evaluate them on closed inputs.
+can evaluate them on closed inputs. The `MvPoly` rows assume the instances
+every `HexMvPoly` operation assumes: `[Std.TransCmp cmp]`,
+`[Std.LawfulEqCmp cmp]` and `[DecidableEq R]` on the coefficient ring.
 
 | Operation | Type and contract |
 | --- | --- |
 | `minors r A` | `[Lean.Grind.Ring R] (A : Matrix R n m) (r : Nat) : List R`. Every `r × r` minor of `A`, rows outer and columns inner, both in the order of `selectedColumnTuples`. Length `n.choose r * m.choose r`. |
 | `detIdealGens r A` | `[Lean.Grind.Ring R] [DecidableEq R] : List R`. `minors r A` with the zero entries removed and exact duplicates removed, keeping first occurrences. A generating list for `I_r(A)`. |
 | `Matrix.map A f` | `(A : Matrix R n m) (f : R → S) : Matrix S n m`, entrywise. Added to `HexMatrix/Basic.lean` if still absent when this library is implemented (at the time of writing `HexMatrix` has `mapRows` and `mapRowsIdx` but no entrywise map), with `getElem_map`. |
-| `specialize A p` | `[Lean.Grind.CommRing R] [DecidableEq R] (A : Matrix (MvPoly k R cmp) n m) (p : Vector R k) : Matrix R n m`, defined as `A.map (MvPoly.eval p)`. |
+| `specialize A p` | `[Lean.Grind.CommRing R] (A : Matrix (MvPoly k R cmp) n m) (p : Fin k → R) : Matrix R n m`, defined as `A.map (MvPoly.eval p)`. The point is a function, as `MvPoly.eval` takes it. |
 | `rankAt A p` | `[Lean.Grind.Field F] [DecidableEq F] : Nat`, defined as `rowReduce_rank (specialize A p)`. The rank of the polynomial matrix at the point `p`. |
 | `InLocus r A p` | `Prop`, `∀ M ∈ minors r A, MvPoly.eval p M = 0`, with a `Decidable` instance. The point `p` lies in the zero set of `I_r(A)`. |
 
@@ -160,7 +167,7 @@ swaps the roles of the outer and inner loops. It comes from
 ## The rank-versus-minors theorem
 
 Proved in `Rank.lean`, over a `Lean.Grind.Field K` with `DecidableEq K`,
-about the rank computed by `HexRowReduce.rowReduce`:
+about the rank computed by `Hex.Matrix.rowReduce` (library `HexRowReduce`):
 
 ```lean
 theorem rank_lt_iff_minors_eq_zero (A : Matrix K n m) (r : Nat) :
@@ -193,7 +200,8 @@ unnecessary, and so that the conformance suite tests them.
 ### Proof route
 
 The proof is Mathlib-free and uses three existing results: the row-reduced
-echelon certificate (`rowReduce_isRowReduced`, giving `IsRowReduced A D`),
+echelon certificate (`rowReduce_isRowReduced`, giving
+`IsRowReduced A (Hex.Matrix.rowReduce A)`),
 rectangular Cauchy-Binet (`det_mul_rectangular` and `det_minor_mul` in
 `HexDeterminant/Gram.lean`) and the Laplace expansion
 (`det_eq_foldl_laplace_col`). Mathlib's
@@ -215,34 +223,36 @@ over `middle ∈ selectedColumnTuples r ρ`. Since `ρ < r`, that list is empty
 **Nonzero-minor direction (`r ≤ ρ` implies some `r × r` minor is
 nonzero).** First a nonzero `ρ × ρ` minor, then a descent to size `r`.
 
-1. *The pivot columns of `A` are the first `ρ` columns of `T⁻¹`.*
+1. *The pivot columns of `A` are sent to a padded identity by `T`.*
    `pivotCols_sorted` says `J` is strictly increasing, so
-   `J ∈ selectedColumnTuples ρ m`. In the reduced echelon form,
-   `selectCols E J = pad (identity ρ) n ρ`: rows below `ρ` are zero
-   (`zero_row`), and within the first `ρ` rows the pivot entries are `1`
-   (`pivot_one`) and the other entries of a pivot column are `0`
-   (`above_pivot_zero`, `below_pivot_zero`). From `transform_mul`
-   (`T * A = E`) and `transform_inv` (`Tinv * T = identity n`),
-   `A = Tinv * E`, so `selectCols A J = Tinv * pad (identity ρ) n ρ`, which
-   is the `n × ρ` matrix `C` formed by the first `ρ` columns of `Tinv`
-   (a new lemma `selectCols_mul`, the column analogue of
-   `selectedSubmatrix_mul`).
-2. *The first `ρ` rows of `T` are a left inverse of `C`.*
-   `mul_eq_one_comm` turns `Tinv * T = identity n` into
-   `T * Tinv = identity n`, and `takeRows_mul` with `pad_identity_mul` give
-   `takeRows T ρ * C = identity ρ`, so `det (takeRows T ρ * C) = 1`.
+   `J ∈ selectedColumnTuples ρ m`. Let `C := selectCols A J : Matrix K n ρ`.
+   Column selection commutes with left multiplication
+   (a new lemma `selectCols_mul : selectCols (P * X) cols = P * selectCols X cols`,
+   the column analogue of `selectedSubmatrix_mul`), so `transform_mul`
+   (`T * A = E`) gives `T * C = selectCols E J`. In the reduced echelon
+   form, `selectCols E J = pad (identity ρ) n ρ`: rows at or below `ρ` are
+   zero (`zero_row`), and within the first `ρ` rows the pivot entries are
+   `1` (`pivot_one`) and the other entries of a pivot column are `0`
+   (`above_pivot_zero`, `below_pivot_zero`). No inverse of `T` is used.
+2. *The first `ρ` rows of `T` are a left inverse of `C`.* With
+   `hρ : ρ ≤ n` from `rank_le_n`, `takeRows_mul` gives
+   `takeRows T ρ hρ * C = takeRows (T * C) ρ hρ = takeRows (pad (identity ρ) n ρ) ρ hρ`,
+   and the last matrix is `identity ρ` (a new lemma
+   `takeRows_pad_identity`; the private `pad_identity_mul` in
+   `HexRowReduce/Api.lean` is about a padded identity on the left and does
+   not apply). Hence `det (takeRows T ρ hρ * C) = 1`.
 3. *Cauchy-Binet produces a nonzero `ρ × ρ` minor of `A`.*
-   `det_mul_rectangular` applied to `takeRows T ρ : Matrix K ρ n` and
+   `det_mul_rectangular` applied to `takeRows T ρ hρ : Matrix K ρ n` and
    `C : Matrix K n ρ` writes `1` as a `foldl` sum over
    `I ∈ selectedColumnTuples ρ n` of
-   `det (columnTupleMatrix C.transpose I) * det (columnTupleMatrix (takeRows T ρ) I)`.
+   `det (columnTupleMatrix C.transpose (columnTupleVectorFn I)) * det (columnTupleMatrix (takeRows T ρ hρ) (columnTupleVectorFn I))`.
    Since `1 ≠ 0`, some summand is nonzero (a small lemma: a `foldl` of
    additions from `0` whose summands are all zero is zero), hence
-   `det (columnTupleMatrix C.transpose I) ≠ 0` for some strictly increasing
-   `I`. Entrywise, `columnTupleMatrix C.transpose I` is the transpose of
-   `selectedSubmatrix A I J`, so by `det_transpose`
-   `det (selectedSubmatrix A I J) ≠ 0`, and this value is a member of
-   `minors ρ A` by `mem_minors_iff`.
+   `det (columnTupleMatrix C.transpose (columnTupleVectorFn I)) ≠ 0` for
+   some strictly increasing `I`. Entrywise, that matrix is the transpose of
+   `selectedSubmatrix A I J` (its `(i, j)` entry is `C[I[j]][i] = A[I[j]][J[i]]`),
+   so by `det_transpose` `det (selectedSubmatrix A I J) ≠ 0`, and this
+   value is a member of `minors ρ A` by `mem_minors_iff`.
 4. *Descent by one.* If `det (selectedSubmatrix A rows cols) ≠ 0` with
    `rows, cols` strictly increasing of length `k + 1`, then Laplace
    expansion along column `0` (`det_eq_foldl_laplace_col`) writes the
@@ -300,8 +310,9 @@ rankAt A p < r  ↔  InLocus r A p
 This requires that `MvPoly.eval p` commutes with `det`, which is a ring
 homomorphism property. `HexMvPoly` does not state `eval_add`/`eval_mul` in
 the Mathlib-free layer, so the theorem `rankAt_lt_iff_inLocus` is proved in
-the companion through `HexMvPolyMathlib.aeval_eq_eval` and
-`RingHom.map_det`. The Mathlib-free layer ships the definitions, the
+the companion: `HexMvPolyMathlib.aeval p` is an `AlgHom` whose underlying
+function is `MvPoly.eval p` (`HexMvPolyMathlib.aeval_eq_eval`), and
+`RingHom.map_det` applies to its `toRingHom`. The Mathlib-free layer ships the definitions, the
 `Decidable` instance, and the unfolding lemmas `specialize_getElem`,
 `rankAt_eq` and `inLocus_iff`, so that a kernel evaluation of
 `InLocus r A p` on closed inputs is available without Mathlib.
@@ -315,7 +326,8 @@ with a particular `r`:
 - "rank drops below the generic rank" is `InLocus g A p` where `g` is the
   rank of `A` over the fraction field of the coefficient ring. Computing
   `g` is the job of `hex-rank` (over a general domain) or
-  `HexPolySmith.snfRank` (over `F[x]`); this library takes `g` as an input.
+  `Hex.PolyMatrix.snfRank` in `hex-poly-smith` (over `F[x]`); this library
+  takes `g` as an input.
   The companion proves that no specialisation has rank above `g`.
 
 Nothing here asserts that the complement of the locus is nonempty. Over a
@@ -378,8 +390,9 @@ Checked against the pinned Mathlib, `v4.34.0-rc2` (Mathlib commit
     `rank_of_det_ne_zero` and `rank_submatrix_le`. That is the
     nonzero-minor direction for an echelon matrix, with no theorem
     producing an echelon form of an arbitrary matrix.
-  - `Matrix.Echelon.Decomposition.rank_eq`
-    (`Mathlib/LinearAlgebra/Matrix/Echelon/Decomposition.lean`): rank from
+  - `Echelon.Decomposition.rank_eq`
+    (`Mathlib/LinearAlgebra/Matrix/Echelon/Decomposition.lean`, in the
+    top-level namespace `Echelon`, not `Matrix.Echelon`): rank from
     a certificate `L * A.submatrix σ id` pivoted, over `[CommRing R]
     [IsDomain R]`; this is the checker `norm_rank` uses, and the
     certificate is produced by meta code, not by a theorem.
@@ -449,9 +462,9 @@ both.
 
 | `op` | Lean value | Oracle recomputation and comparison |
 | --- | --- | --- |
-| `minors` | the list `minors r A` in enumeration order | `itertools.combinations` of rows and of columns in lexicographic order, `Matrix.extract(...).det()`, compared polynomial by polynomial after `expand`, in the same order |
+| `minors` | the list `minors r A` in enumeration order | `itertools.combinations` of rows and of columns, each sorted by reversed tuple to reproduce the colexicographic order of `selectedColumnTuples`, `Matrix.extract(...).det()`, compared polynomial by polynomial after `expand`, in the same order |
 | `detIdealGens` | `detIdealGens r A` | the nonzero distinct minors, compared as sets of expanded polynomials |
-| `rankAt` | `rankAt A p` for a point `p` over `ℚ` | `Matrix.subs(...).rank()` |
+| `rankAt` | `rankAt A p` for a point `p` over `Rat` | `Matrix.subs(...).rank()` over `QQ` |
 | `inLocus` | `decide (InLocus r A p)` | every minor evaluates to zero at `p` |
 
 **Cases that must be present**, since these are what a plausible
@@ -463,6 +476,10 @@ implementation gets wrong:
   rectangular orientations;
 - the zero matrix at `r = 1`, checking that `minors` is a list of zeros of
   the right length and `detIdealGens` is empty;
+- a `2 × 4` matrix of eight distinct integers at `r = 2`, whose six minors
+  are pairwise distinct, so that the colexicographic order of the column
+  selections is checked against the oracle and a lexicographic enumeration
+  fails;
 - the generic `2 × 3` matrix of six indeterminates at `r = 2`, whose three
   minors are the classical generators, and its transpose, checking
   `minors_transpose` as a permutation;
@@ -478,9 +495,11 @@ implementation gets wrong:
   no point is in the locus at `r = k` and `rankAt ≥ k` everywhere, while
   `detIdealGens (k + 1)` is the single polynomial `t - v · u` up to sign,
   with points on and off the hypersurface `t = v · u`;
-- a `3 × 3` matrix over `Int` of rank `2`, checking `rank_eq_iff_minors` by
-  `decide +kernel` in `Conformance.lean`: some `2 × 2` minor is nonzero and
-  the determinant is zero;
+- a `3 × 3` matrix over `Rat` with integer entries and rank `2`, checking
+  `rank_eq_iff_minors` by `decide +kernel` in `Conformance.lean`: some
+  `2 × 2` minor is nonzero and the determinant is zero. `Int` is not a
+  `Lean.Grind.Field`, so the rank theorem is exercised over `Rat` here and
+  over `Int.castRingHom ℚ` in the companion's tests;
 - invariance on one fixture: for an explicit unimodular integer `P`,
   `rankAt (P * A) p = rankAt A p` and `InLocus r (P * A) p ↔ InLocus r A p`
   at two points.
@@ -510,11 +529,18 @@ runs, `informational`: SymPy chooses its own per-minor determinant
 algorithm (Bareiss or Berkowitz) and a ratio against a Leibniz sum compares
 algorithms, not implementations.
 
-**Decision rule written in advance.** Within a family, the wallclock ratio
-between consecutive `r` must be within a constant factor of the ratio of
-the operation counts above. A ratio that grows faster than the count
-indicates that the enumeration allocates per minor more than the `r × r`
-submatrix it needs, which is a bug rather than a benchmark result.
+**What the curve is for.** The operation count above is the model the
+measurements are compared with, not an acceptance threshold. The
+`dense-int-minors` family isolates the enumeration, since integer
+operations at these sizes cost about the same at every `r`; the
+`symbolic-2var` family adds polynomial arithmetic whose per-operation cost
+grows with the supports, so its curve is expected to rise faster than the
+count. A `dense-int-minors` curve that departs from the model by more than
+the noise between adjacent arms is a result to explain by profiling
+(per-minor allocation beyond the `r × r` submatrix, permutation-sign
+computation, host activity recorded as context), per
+[SPEC/benchmarking.md](../benchmarking.md); it is not by itself a bug
+verdict.
 
 ## File organisation
 
@@ -548,10 +574,11 @@ bench/HexDeterminantalIdeal/Bench.lean
   rank certificate. It is not required to.
 - `hex-smith` and `hex-poly-smith` keep their `noncomputable`
   determinantal-divisor copies. Replacing them by an import of this
-  library would add `hex-row-reduce` and `hex-mv-poly` to their dependency
-  closures for the sake of a specification function, which is not worth it
-  until this library is released and the module split above lets
-  `Minors.lean` be imported alone.
+  library would add the whole package, and with it `hex-row-reduce` and
+  `hex-mv-poly`, to their dependency closures for the sake of a
+  specification function. Importing only `Minors.lean` avoids the Lean
+  imports but not the package requirement, so the duplication stays until
+  the enumeration is worth its own package.
 
 ## Open questions
 

--- a/SPEC/future-work.md
+++ b/SPEC/future-work.md
@@ -39,6 +39,23 @@ check and decide how an untrusted solver supplies candidates. An in-Lean
 floating-point implementation and an FFI solver are equivalent from the
 trusted layer's point of view.
 
+### Determinantal ideals and rank loci
+
+[hex-determinantal-ideal](Libraries/hex-determinantal-ideal.md) specifies
+executable minors of every size over any commutative ring, the generating
+list of the determinantal ideal `I_r(A)`, and the theorem that a matrix over
+a field has rank below `r` exactly when every `r × r` minor vanishes, with a
+Mathlib-free proof through the row-reduced echelon certificate, Cauchy-Binet
+and the Laplace expansion. Its companion
+[hex-determinantal-ideal-mathlib](Libraries/hex-determinantal-ideal-mathlib.md)
+states the theorem for `Matrix.rank` under any ring homomorphism into a
+field, so the locus where a polynomial matrix's rank drops below `r` is the
+zero set of `I_r(A)`, and proves that `I_r(A)` is unchanged by invertible
+row and column operations. Fitting ideals, whose presentation independence
+is a theorem about modules rather than matrices, and Gröbner-basis questions
+about `I_r(A)` (membership, radical, dimension) remain future work. The
+pinned Mathlib has neither Fitting ideals nor a rank-versus-minors lemma.
+
 ### Sparse matrices
 
 Add a canonical sparse representation alongside the dense matrix type, with

--- a/libraries.yml
+++ b/libraries.yml
@@ -312,6 +312,27 @@ libraries:
       input_families:
         - name: structured-bareiss-determinant
           description: Deterministic tridiagonal integer matrices for row-pivoted Bareiss determinant scaling without arbitrary coefficient blow-up.
+  HexDeterminantalIdeal:
+    deps: [HexBasic, HexMatrix, HexDeterminant, HexRowReduce, HexMvPoly]
+    mathlib: false
+    done_through: 0
+    status: planned
+    phase4:
+      comparators:
+        - tool: SymPy combinations-and-det loop over the same minors
+          class: informational
+          rationale: SymPy chooses Bareiss or Berkowitz per minor while the Hex enumeration uses the Leibniz specification determinant, so the ratio compares algorithms; the evidence is the growth curve in r against the binomial-times-factorial operation count.
+      input_families:
+        - name: dense-int-minors
+          description: Square integer matrices of size 4 to 6 with every minor size r, showing the curve in r against n.choose r squared times r factorial.
+        - name: symbolic-2var
+          description: 4 x 4 matrices of random linear forms in two indeterminates over Int at r in 2, 3, 4, isolating polynomial arithmetic inside the same enumeration.
+  HexDeterminantalIdealMathlib:
+    deps: [HexDeterminantalIdeal, HexDeterminantMathlib, HexRowReduceMathlib, HexMvPolyMathlib]
+    mathlib: true
+    correspondence_only: true
+    done_through: 0
+    status: planned
   HexCharPoly:
     deps: [HexMatrix, HexPoly]
     mathlib: false

--- a/progress/20260910T113105Z_issue-10155.md
+++ b/progress/20260910T113105Z_issue-10155.md
@@ -1,4 +1,4 @@
-# 2026-09-10 — spec: determinantal ideals and the rank-versus-minors theorem (issue #10155)
+# 2026-09-10, spec: determinantal ideals and the rank-versus-minors theorem (issue #10155)
 
 Session type: feature (spec-only), run via `claude -p` outside `pod`
 (`coordination` not on PATH; claimed with `gh`).

--- a/progress/20260910T113105Z_issue-10155.md
+++ b/progress/20260910T113105Z_issue-10155.md
@@ -1,0 +1,58 @@
+# 2026-09-10 — spec: determinantal ideals and the rank-versus-minors theorem (issue #10155)
+
+Session type: feature (spec-only), run via `claude -p` outside `pod`
+(`coordination` not on PATH; claimed with `gh`).
+
+## Accomplished
+
+- Wrote `SPEC/Libraries/hex-determinantal-ideal.md`: executable `minors r A`
+  over any `Lean.Grind.Ring`, conventions `minors 0 A = [1]` and
+  `minors r A = []` for `r > min n m`, `detIdealGens`, enumeration theorems,
+  `rank_lt_iff_minors_eq_zero` over a `Lean.Grind.Field` with a Mathlib-free
+  proof route (vanishing direction: `rowReduce_rank_factorization` plus
+  `det_minor_mul` over an empty `selectedColumnTuples r ρ`; nonzero-minor
+  direction: `T * selectCols A J = pad (identity ρ) n ρ` from the RREF
+  certificate, `det_mul_rectangular`, then Laplace descent), invariance
+  expansions, `specialize`/`rankAt`/`InLocus` for `MvPoly` matrices,
+  conformance (SymPy), complexity and benchmark sections.
+- Wrote `SPEC/Libraries/hex-determinantal-ideal-mathlib.md`: transport
+  lemmas, `rank_lt_iff_minors_map_eq_zero` for any `φ : R →+* K`, the
+  fraction-field bound, `mem_zeroLocus_iff_rank_lt`, ideal-level invariance
+  and the explicit non-claim about Fitting ideals.
+- Registered both as `planned` in `libraries.yml`; indexed in
+  `SPEC/Libraries/README.md` with a dependency diagram; pointer in
+  `SPEC/future-work.md`. `check_dag.py`, `check_phase4.py`,
+  `check_phase7.py`, release manifest checks pass.
+- PR https://github.com/kim-em/hex-dev/pull/10158, auto-merge enabled.
+
+## Decisions
+
+- Dependencies `HexBasic, HexMatrix, HexDeterminant, HexRowReduce, HexMvPoly`;
+  nothing from `hex-bareiss` or the planned `hex-rank`.
+- Namespace `Hex.Matrix`; no reuse of `HexSmith`'s `minorSelections`,
+  `minorValue`, `detDivisor` names.
+- Ring-homomorphism facts (`map_minors`, evaluation at a point) live in the
+  companion, since `HexMvPoly` has no Mathlib-free `eval_add`/`eval_mul`.
+- Enumeration order is the colexicographic order `selectedColumnTuples`
+  already produces; the oracle sorts `itertools.combinations` by reversed
+  tuple.
+
+## Patterns found
+
+- `HexDeterminant/SPEC/hex-determinant.md` cites `selectedRows`,
+  `selectedColumnCoeffs` and `det_selectedSubmatrix_mul_eq_sum_columnTuples`,
+  none of which exist; the shipped names are `selectRows`, `selectCols`,
+  `det_minor_mul` in `Gram.lean`. Relevant to #10150.
+- `pad_identity_mul` in `HexRowReduce/Api.lean` is private and is about a
+  padded identity on the left; a right-padded `takeRows_pad_identity` is a
+  new obligation.
+- `Int` is not a `Lean.Grind.Field`; field-level rank checks in conformance
+  run over `Rat`.
+- Codex (second opinion) confirmed the proof sketch and caught the
+  enumeration order, the private lemma, the `Int` test and three qualified
+  names.
+
+## Remains
+
+Implementation (separate issues), and the `rank_locus` tactic SPEC that
+consumes this one.


### PR DESCRIPTION
This PR specifies `hex-determinantal-ideal` and `hex-determinantal-ideal-mathlib` in `SPEC/Libraries/`: executable `minors r A` over any commutative ring with the conventions `minors 0 A = [1]` and `minors r A = []` for `r > min n m`, the generator list `detIdealGens r A` of the determinantal ideal `I_r(A)`, and the theorem `rowReduce_rank A < r ↔ ∀ M ∈ minors r A, M = 0` over a field, with a Mathlib-free proof sketch through the row-reduced echelon certificate (`HexRowReduce`), rectangular Cauchy-Binet (`det_mul_rectangular`, `det_minor_mul`) and the Laplace expansion, checked at both boundary cases. The companion states the theorem for `Matrix.rank` under any ring homomorphism into a field, derives the rank-drop locus of a polynomial matrix as the zero set of `I_r(A)` and the bound by the generic rank, and proves invariance of `I_r(A)` under invertible row and column operations, stated explicitly as distinct from Fitting-ideal presentation independence. The SPEC records that the pinned Mathlib (`v4.34.0-rc2`) has neither Fitting ideals nor a rank-versus-minors lemma, naming the nearest statements (`IsPivotedBy.rank_eq`, `Decomposition.rank_eq`, `rank_submatrix_le`, `rank_of_det_ne_zero`), and fixes the dependency list (`hex-basic`, `hex-matrix`, `hex-determinant`, `hex-row-reduce`, `hex-mv-poly`; nothing from `hex-bareiss` or the planned `hex-rank`). Both libraries are registered as `planned` in `libraries.yml`, listed in `SPEC/Libraries/README.md` with a dependency diagram, and pointed to from `SPEC/future-work.md`. `scripts/check_dag.py`, `check_phase4.py`, `check_phase7.py` and the release manifest checks pass.

Closes #10155

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pmnz3MiznaaUbNzyUiqAj

