### PR TITLE
doc: reconcile linear-algebra bridge SPECs

### DIFF
--- a/HexDeterminantMathlib/DesnanotJacobi.lean
+++ b/HexDeterminantMathlib/DesnanotJacobi.lean
@@ -16,9 +16,14 @@ authored by Slava Naprienko, commit `bbe9ab491bc1`). The proof was
 copied verbatim from that commit and has since been migrated to the
 `module`/`public import` system and had two `simp` sets repaired across
 toolchain bumps, so it is no longer character-for-character upstream.
-Delete this file and import the upstream module once mathlib4 PR #37716
-merges; the upstream branch has moved on from `bbe9ab491bc1`, so re-check
-the statement rather than assuming a drop-in swap.
+When mathlib4 PR #37716 merges, compare the upstream theorem's namespace,
+hypotheses, index maps, and factor order before deleting this file; the PR
+head currently places it in the `Matrix` namespace. Re-check the direct
+consumers `desnanot_jacobi_deleteRowCol_endpoints`,
+`desnanot_jacobi_matrixEquiv_reindex`, and
+`desnanot_jacobi_borderedMinor_reindex`, then rebuild the downstream
+`desnanot_jacobi_borderedMinor` bridge and its Bareiss and integer
+Gram–Schmidt consumers before replacing this module's `public import`.
 -/
 module
 

--- a/HexDeterminantMathlib/SPEC/hex-determinant-mathlib.md
+++ b/HexDeterminantMathlib/SPEC/hex-determinant-mathlib.md
@@ -15,12 +15,43 @@ the tree consumes yet).
 
 **Determinant correspondence:**
 ```lean
-theorem det_eq (M : Hex.Matrix R n n) :
-    Hex.det M = Matrix.det (matrixEquiv M)
+theorem det_eq [CommRing R] (M : Hex.Matrix R n n) :
+    Hex.Matrix.det M = _root_.Matrix.det (matrixEquiv M)
 ```
 
 Through `det_eq`, Mathlib determinant theorems (Cramer's rule, Cauchy-Binet,
 adjugate identities) transfer to our executable determinant.
+
+## Outstanding obligations
+
+| obligation | status | requirement |
+|---|---|---|
+| closed `Matrix.det` kernel proof | required; not yet implemented | add the worked theorem below to the manual recipe and a compile-checked `examples/` entry |
+
+The worked example must start with a closed Mathlib matrix literal and prove
+its Mathlib determinant by rewriting through `det_eq` before kernel evaluation:
+
+```lean
+open Hex Hex.Matrix HexMatrixMathlib
+
+namespace HexDeterminantKernelProof
+
+def A : _root_.Matrix (Fin 3) (Fin 3) ℤ :=
+  !![2, 0, 1; 1, 3, 2; 0, 1, 1]
+
+theorem det_eq_three : A.det = 3 := by
+  rw [← matrixEquiv.apply_symm_apply A, ← det_eq]
+  decide +kernel
+
+end HexDeterminantKernelProof
+```
+
+The corresponding section in `HexManual/Chapters/HexDeterminant.lean` must be
+a recipe for discharging a closed `Matrix.det` goal, following the shape of
+the rank recipe in `HexManual/Chapters/HexRowReduce.lean`. The same theorem
+must also appear in a dedicated file under `examples/`, wired into the Lake
+build so that it cannot silently go stale. `native_decide` is not an acceptable
+substitute for `decide +kernel`.
 
 ## Module layout and export chain
 
@@ -48,16 +79,25 @@ umbrella's export surface. The module would still exist and stay directly
 importable as `HexDeterminantMathlib.DesnanotJacobi`, which is exactly what
 makes the regression easy to miss.
 
-`DesnanotJacobi.lean` was copied verbatim from commit `bbe9ab491bc1` of
+`DesnanotJacobi.lean` was copied from commit `bbe9ab491bc1` of
 https://github.com/leanprover-community/mathlib4/pull/37716
 ("feat(LinearAlgebra/Matrix/Determinant): Desnanot-Jacobi identity", by Slava
 Naprienko) and carries its own copyright header. It is no longer verbatim: it
 has since been migrated to the `module` / `public import` system and had two
-`simp` sets repaired across toolchain bumps. It is to be deleted in favour of
-the upstream module once that PR merges, and the upstream branch has itself
-moved on from the pinned commit, so expect to re-check the statement rather
-than assume a drop-in swap. Everything in the file except the final theorem is
-`private`.
+`simp` sets repaired across toolchain bumps. Everything in the file except the
+final theorem is `private`.
+
+When the upstream PR merges, compare the merged theorem's namespace,
+hypotheses, index maps, and factor order with this vendored
+`desnanot_jacobi` before deleting the file; the current upstream branch places
+the theorem in the `Matrix` namespace rather than the root namespace. Then
+update and re-check the three Hex theorems that directly invoke it:
+`desnanot_jacobi_deleteRowCol_endpoints`,
+`desnanot_jacobi_matrixEquiv_reindex`, and
+`desnanot_jacobi_borderedMinor_reindex`. Rebuild their downstream
+`desnanot_jacobi_borderedMinor` bridge and its Bareiss and integer
+Gram--Schmidt consumers before removing the vendored module or changing the
+`public import` export chain.
 
 ## Desnanot-Jacobi: the four public forms
 

--- a/HexDeterminantMathlib/SPEC/hex-determinant-mathlib.md
+++ b/HexDeterminantMathlib/SPEC/hex-determinant-mathlib.md
@@ -22,7 +22,7 @@ theorem det_eq [CommRing R] (M : Hex.Matrix R n n) :
 Through `det_eq`, Mathlib determinant theorems (Cramer's rule, Cauchy-Binet,
 adjugate identities) transfer to our executable determinant.
 
-## Outstanding obligations
+## Required outstanding obligations
 
 | obligation | status | requirement |
 |---|---|---|
@@ -96,7 +96,7 @@ update and re-check the three Hex theorems that directly invoke it:
 `desnanot_jacobi_matrixEquiv_reindex`, and
 `desnanot_jacobi_borderedMinor_reindex`. Rebuild their downstream
 `desnanot_jacobi_borderedMinor` bridge and its Bareiss and integer
-Gram--Schmidt consumers before removing the vendored module or changing the
+Gram–Schmidt consumers before removing the vendored module or changing the
 `public import` export chain.
 
 ## Desnanot-Jacobi: the four public forms

--- a/HexRowReduceMathlib/SPEC/hex-row-reduce-mathlib.md
+++ b/HexRowReduceMathlib/SPEC/hex-row-reduce-mathlib.md
@@ -27,11 +27,28 @@ computed nullspace basis, whose completeness and independence require
 row-reduction, span, and nullspace APIs in `HexRowReduce` use
 `Lean.Grind.Field` (and `DecidableEq` where computation requires it).
 
-**Nullspace:** Our computed nullspace basis spans the same submodule as
-`LinearMap.ker (Matrix.mulVecLin (matrixEquiv M))`.
+**Nullspace:** Our computed nullspace basis spans exactly the kernel of the
+Mathlib matrix:
+```lean
+theorem nullspace_span_eq_ker [Field R]
+    {M : Hex.Matrix R n m} {D : Hex.Matrix.RowEchelonData R n m}
+    (E : Hex.Matrix.IsRowReduced M D) :
+    Submodule.span R
+        (Set.range fun k : Fin (m - D.rank) => vectorEquiv (E.nullspace.get k)) =
+      LinearMap.ker (_root_.Matrix.mulVecLin (matrixEquiv M))
+```
 
-**Span:** Our `IsEchelonForm.spanContains` agrees with membership in
-`Submodule.span R (Set.range M.row)`.
+**Span:** The executable `IsEchelonForm.spanContains` test, called through a
+reduced row-echelon witness, agrees with membership in the span of the Mathlib
+matrix's rows:
+```lean
+theorem spanContains_iff_mem_span [Field R] [DecidableEq R]
+    {M : Hex.Matrix R n m} {D : Hex.Matrix.RowEchelonData R n m}
+    (E : Hex.Matrix.IsRowReduced M D) (v : Vector R m) :
+    E.toIsEchelonForm.spanContains v = true ↔
+      vectorEquiv v ∈
+        Submodule.span R (Set.range (_root_.Matrix.row (matrixEquiv M)))
+```
 
 This makes our row-reduction computations computable witnesses for Mathlib's
 noncomputable rank/kernel/span definitions.

--- a/HexRowReduceMathlib/SPEC/hex-row-reduce-mathlib.md
+++ b/HexRowReduceMathlib/SPEC/hex-row-reduce-mathlib.md
@@ -14,10 +14,18 @@ the base `matrixEquiv` from `hex-matrix-mathlib`.
 **Rank:** Our `RowEchelonData.rank` (computed via RREF) agrees with Mathlib's
 `Matrix.rank` (noncomputable, `finrank R (LinearMap.range M.mulVecLin)`):
 ```lean
-theorem rank_eq (M : Hex.Matrix R n m)
-    (D : RowEchelonData R n m) (E : IsEchelonForm M D) :
-    D.rank = Matrix.rank (matrixEquiv M)
+theorem rank_eq [Field R]
+    {M : Hex.Matrix R n m} {D : Hex.Matrix.RowEchelonData R n m}
+    (E : Hex.Matrix.IsRowReduced M D) :
+    D.rank = _root_.Matrix.rank (matrixEquiv M)
 ```
+
+This is deliberately a theorem about a reduced row-echelon witness, not an
+arbitrary `IsEchelonForm`: the proof obtains the kernel dimension from the
+computed nullspace basis, whose completeness and independence require
+`IsRowReduced`. The bridge theorem uses Mathlib's `Field`; the executable
+row-reduction, span, and nullspace APIs in `HexRowReduce` use
+`Lean.Grind.Field` (and `DecidableEq` where computation requires it).
 
 **Nullspace:** Our computed nullspace basis spans the same submodule as
 `LinearMap.ker (Matrix.mulVecLin (matrixEquiv M))`.

--- a/HexSmithMathlib/SPEC/hex-smith-mathlib.md
+++ b/HexSmithMathlib/SPEC/hex-smith-mathlib.md
@@ -45,7 +45,11 @@ be exactly `rowSpan A`, and explicit coordinate representatives prove
 surjectivity. This avoids Mathlib's helper for full-rank submodules, which
 cannot represent the free complement.
 
-## Outstanding obligations
+The authoritative algorithm, correctness, uniqueness, conformance, and
+benchmark requirements shared with this layer are in
+[`SPEC/Libraries/hex-smith.md`](../../SPEC/Libraries/hex-smith.md).
+
+## Required outstanding obligations
 
 | obligation | status | requirement |
 |---|---|---|
@@ -66,10 +70,6 @@ of the Mathlib-free Smith/Hermite rank equality and the Hermite-to-Mathlib rank
 bridge, not a new computation in `HexSmith`. The implementing module must also
 import `HexHermiteMathlib.Rank`: the current `HexSmithMathlib` chain reaches
 `HexHermiteMathlib.Span`, which does not export `hnfRank_eq_rank`.
-
-The authoritative algorithm, correctness, uniqueness, conformance, and
-benchmark requirements shared with this layer are in
-[`SPEC/Libraries/hex-smith.md`](../../SPEC/Libraries/hex-smith.md).
 
 ## Runtime boundary
 

--- a/HexSmithMathlib/SPEC/hex-smith-mathlib.md
+++ b/HexSmithMathlib/SPEC/hex-smith-mathlib.md
@@ -45,6 +45,28 @@ be exactly `rowSpan A`, and explicit coordinate representatives prove
 surjectivity. This avoids Mathlib's helper for full-rank submodules, which
 cannot represent the free complement.
 
+## Outstanding obligations
+
+| obligation | status | requirement |
+|---|---|---|
+| `snfRank_eq_rank` | required; not yet implemented | one line from `Hex.Matrix.snfRank_eq_hnfRank` followed by `HexHermiteMathlib.hnfRank_eq_rank` |
+
+The required theorem and its intended proof are exactly the existing integer
+correspondence chain:
+
+```lean
+theorem snfRank_eq_rank (A : Hex.Matrix Int n m) :
+    Hex.Matrix.snfRank A = (matrixEquiv A).rank := by
+  rw [Hex.Matrix.snfRank_eq_hnfRank,
+    HexHermiteMathlib.hnfRank_eq_rank]
+```
+
+This theorem must live in `HexSmithMathlib`; it is a consumer-facing corollary
+of the Mathlib-free Smith/Hermite rank equality and the Hermite-to-Mathlib rank
+bridge, not a new computation in `HexSmith`. The implementing module must also
+import `HexHermiteMathlib.Rank`: the current `HexSmithMathlib` chain reaches
+`HexHermiteMathlib.Span`, which does not export `hnfRank_eq_rank`.
+
 The authoritative algorithm, correctness, uniqueness, conformance, and
 benchmark requirements shared with this layer are in
 [`SPEC/Libraries/hex-smith.md`](../../SPEC/Libraries/hex-smith.md).


### PR DESCRIPTION
## Summary

- align the row-reduction rank, nullspace, and span correspondence entries with their shipped `IsRowReduced`/Mathlib class signatures
- specify the pending Smith-to-Mathlib rank corollary, its one-line proof, and its required Hermite rank import
- specify a compile-checked `Matrix.det` kernel-proof example and concrete Desnanot–Jacobi upstream replacement checks in both the SPEC and vendored source header

## Verification

- compiled a temporary probe for the shipped rank signature, the Smith proof chain, and the determinant `det_eq`/`decide +kernel` recipe, then removed it
- `python3 scripts/check_dag.py`
- `python3 scripts/check_copyright_headers.py`
- `python3 scripts/check_file_line_counts.py`
- `git diff --check`
- `lake build` (passes; existing unrelated warnings remain)
- `lake build HexRowReduceMathlib HexSmithMathlib HexDeterminantMathlib` after review revisions

Closes #10150