### PR TITLE
doc: mark Array shim removal release

### DIFF
--- a/HexBasic/OfFn.lean
+++ b/HexBasic/OfFn.lean
@@ -86,8 +86,9 @@ only so that the kernel can reduce it. -/
 /-- An {name}`Array.map` equivalent that reduces in the kernel under the
 module system: core {name}`Array.map`'s implementation loop is not exposed,
 so `(a.map f)` stalls downstream exactly like {name}`Array.ofFn`.
-Retire once <https://github.com/leanprover/lean4/pull/14996> reaches the
-pinned toolchain. -/
+Remove this shim and migrate its callers to core {name}`Array.map` when the
+pinned toolchain reaches Lean v4.35.0-rc1, which includes
+<https://github.com/leanprover/lean4/pull/14996>. -/
 @[expose] def Array.map' {α : Type u} {β : Type v} (f : α → β)
     (a : Array α) : Array β :=
   (a.toList.map f).toArray
@@ -116,8 +117,10 @@ so that the kernel can reduce it. -/
 /-- An {name}`Array.zipWith` equivalent that reduces in the kernel under the
 module system: core {name}`Array.zipWith` runs its `zipWithMAux` loop by
 well-founded recursion, so `(Array.zipWith f a b)` stalls downstream
-exactly like {name}`Array.map`. Retire once core exposes a structurally
-recursive implementation. -/
+exactly like {name}`Array.map`. Remove this shim and migrate its callers to
+core {name}`Array.zipWith` when the pinned toolchain reaches Lean
+v4.35.0-rc1, which includes
+<https://github.com/leanprover/lean4/pull/15078>. -/
 @[expose] def Array.zipWith' {α : Type u} {β : Type v} {γ : Type w}
     (f : α → β → γ) (a : Array α) (b : Array β) : Array γ :=
   (List.zipWith f a.toList b.toList).toArray

--- a/scripts/bench/proof_only_runtime_exemptions/hexbasic-offn-lean-525b585a-63727f2a.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexbasic-offn-lean-525b585a-63727f2a.json
@@ -1,0 +1,6 @@
+{
+  "path": "HexBasic/OfFn.lean",
+  "baseline_blob": "525b585adac4213b07b34b2b5b6f08ef12e09f6c",
+  "current_blob": "63727f2a00e049cae7890ca4406ca1e39d57c176",
+  "reason": "Updates only the docstrings on the Array.map' and Array.zipWith' compatibility shims to record their Lean v4.35.0-rc1 removal point. No declaration or executable code changes."
+}


### PR DESCRIPTION
This PR records Lean v4.35.0-rc1 as the removal point for the downstream `Array.map'` and `Array.zipWith'` kernel-reduction shims.

The notes link the merged upstream exposure fixes and direct the toolchain upgrade to migrate callers back to the core operations.

:robot: prepared using Codex+Claude