### PR TITLE
spec(matrix): cover symbolic determinant carriers

### DIFF
--- a/HexBareiss/SPEC/hex-bareiss.md
+++ b/HexBareiss/SPEC/hex-bareiss.md
@@ -393,16 +393,18 @@ Implementation split (the proofs live in the Mathlib bridge layer):
 
 ## Supported coefficient carriers
 
-The `Int` aliases are only one instantiation of `bareissWith`. Support is pinned
-for every exact-quotient carrier already provided by the graph:
+The `Int` aliases are only one instantiation of `bareissWith`. This revision
+pins the following carrier surface; it does not claim that every future field
+or quotient-ring type in the monorepo is automatically a supported Bareiss
+carrier:
 
 | carrier | quotient and exact-law provider | assumptions beyond the carrier's ring operations | required fixture family | exact oracle |
 |---|---|---|---|---|
 | `Rat` | `Hex.exactDiv`; `Hex.instExactDivLawsField` | none beyond the core `Lean.Grind.Field Rat`, `Div Rat`, and `DecidableEq Rat` instances | rational matrices covering ordinary elimination, row swap, singularity, `n = 0`, and `n = 1` | python-flint `fmpq_mat.det()` |
-| `ZMod64 p` | `Hex.exactDiv`; the field instance from `HexPolyFp.PrimeField`, then `Hex.instExactDivLawsField` | `[ZMod64.Bounds p] [ZMod64.PrimeModulus p]` | the rational shapes modulo one fixed word-sized prime, plus coefficient reduction and a pivot that is nonzero only after reduction | python-flint `nmod_mat.det()` |
-| `DensePoly F` | `Hex.exactDiv`; `Hex.instExactDivLawsDensePoly` in `HexResultant.ExactDiv` | `[Lean.Grind.Field F] [DecidableEq F]`; concretely exercise `F = Rat` and `F = ZMod64 p` | univariate polynomial matrices with a nonconstant previous pivot and nontrivial exact polynomial quotients | SymPy over `QQ[x]` and `GF(p)[x]` |
-| `ZPoly` (`DensePoly Int`) | `Hex.exactDiv`; the same recursive dense-polynomial instance over `Hex.instExactDivLawsInt` | no extra coefficient hypothesis | integer-polynomial matrices with nonconstant pivots, row swap, and a singular case | SymPy over `ZZ[x]` |
-| `MvPoly n R cmp` | `Hex.exactDiv`; `Hex.MvPoly.instDiv` and `Hex.MvPoly.instExactDivLaws` in `HexMvGcd.Divide` | `[Std.TransCmp cmp] [Std.LawfulEqCmp cmp] [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R] [Dvd R] [GcdOps R] [IsMonomialOrder cmp] [LawfulGcdOps R]`; concretely exercise `R = Int` and `R = Rat` | sparse two- and three-variable matrices with mixed monomials, nonconstant previous pivots, row swap, and singularity | SymPy over `ZZ[x0, ...]` and `QQ[x0, ...]` |
+| `ZMod64 p` | `Hex.exactDiv`; the field instance from `HexPolyFp.PrimeField`, then `Hex.instExactDivLawsField` | `[ZMod64.Bounds p] [ZMod64.PrimeModulus p]` | the rational shapes modulo one fixed prime below `2^31`, plus coefficient reduction and a pivot that is nonzero only after reduction | python-flint `nmod_mat.det()` |
+| `DensePoly F` | `Hex.exactDiv`; polynomial `Div` plus `Hex.instExactDivLawsDensePoly` in `HexResultant.ExactDiv` | `[Lean.Grind.Field F] [DecidableEq F]`; concretely exercise `F = Rat` and `F = ZMod64 p` | univariate polynomial matrices with a nonconstant previous pivot and nontrivial exact polynomial quotients | SymPy `Matrix.det(method="berkowitz")` over `QQ[x]` and `GF(p, symmetric=False)[x]` |
+| `ZPoly` (`DensePoly Int`) | `Hex.exactDiv`; the same polynomial `Div` and recursive exact-law instance over `Hex.instExactDivLawsInt` | no extra coefficient hypothesis | integer-polynomial matrices with nonconstant pivots, row swap, and a singular case | SymPy `Matrix.det(method="berkowitz")` over `ZZ[x]` |
+| `MvPoly n R cmp` | `Hex.exactDiv`; `Hex.MvPoly.instDiv` and `Hex.MvPoly.instExactDivLaws` in `HexMvGcd.Divide` | `[Std.TransCmp cmp] [Std.LawfulEqCmp cmp] [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R] [Dvd R] [GcdOps R] [IsMonomialOrder cmp] [LawfulGcdOps R]`; concretely exercise `R = Int` and `R = Rat` | sparse two- and three-variable matrices with mixed monomials, nonconstant previous pivots, row swap, and singularity | SymPy `Matrix.det(method="berkowitz")` over `ZZ[x0, ...]` and `QQ[x0, ...]` |
 
 Every row uses the same law term:
 
@@ -410,11 +412,15 @@ Every row uses the same law term:
 fun a b hb => Hex.exactDiv_mul_right a hb
 ```
 
-The table records the actual instance declarations, not inferred stronger
-hypotheses. In particular, the recursive `ExactDivLaws (DensePoly R)` instance
+The generic provider declarations behind the concrete rows are not inferred
+field-only approximations. In particular, polynomial `Div` is induced by
+coefficient `Div`, while the recursive `ExactDivLaws (DensePoly R)` instance
 requires `[Lean.Grind.CommRing R] [DecidableEq R] [Div R]
-[ExactDivLaws R]`; the `MvPoly` instance inherits the full section context
-listed above and requires `LawfulGcdOps R`, not merely `GcdOps R`.
+[ExactDivLaws R]`; this is why its separate `ZPoly` specialization works. The
+`MvPoly` instance inherits the full section context listed above and requires
+`LawfulGcdOps R`, not merely `GcdOps R`. Conformance fixes
+`Hex.Mono.grevlex`, whose existing `IsMonomialOrder` instance supplies the
+required well-founded order laws.
 
 ### Placement in the dependency graph
 
@@ -423,16 +429,24 @@ division in `HexResultant`, above `HexPoly`, and multivariate division in
 `HexMvGcd`, above `HexMvPoly` and `HexResultant`. Nothing in `HexBareiss/*`
 imports either provider, and no carrier-specific public alias is added there.
 
-Direct integration calls live in `conformance/HexBareiss/Carriers.lean` and
-`bench/HexBareiss/Carriers.lean`. These are build-only roots, so they may import
-`HexBareiss` together with `HexPolyFp.PrimeField`, `HexResultant.ExactDiv`, and
-`HexMvGcd.Divide`; they are neither part of the published `HexBareiss` umbrella
-nor owners in `libraries.yml`. This is the only placement that exercises the
-existing providers without creating an upward production dependency.
-`scripts/check_dag.py` checks all production imports and accepts these
-build-only integration roots. If a carrier specialization later becomes
-reusable API, it must move to a production library already above both
-dependencies, never into `hex-bareiss`.
+Direct typechecking and value guards live in the existing build-only
+`conformance/HexBareiss/Conformance.lean`; the carrier emitter is a separate
+`conformance/HexBareiss/EmitCarrierFixtures.lean` executable root, and the
+bench registrations live in the existing `bench/HexBareiss/Bench.lean`. These
+modules may import `HexBareiss` together with `HexPolyFp.PrimeField`,
+`HexResultant.ExactDiv`, and `HexMvGcd.Divide`; they are neither part of the
+published `HexBareiss` umbrella nor owners in `libraries.yml`. The conformance
+module remains listed in the `HexConformance` glob and the emitter and bench are
+explicit Lake executable roots.
+
+This placement exercises the providers without creating an upward production
+dependency. `scripts/check_dag.py` enforces the production graph from
+`libraries.yml`; the integration paths have no production owner (while its
+sealed-import check still scans them). If a carrier specialization later
+becomes reusable API, it must move to a production library already above both
+dependencies, never into `hex-bareiss`. `ZPoly` fixtures use the underlying
+`DensePoly Int` type directly, so this test-only integration does not import
+`HexPolyZ` merely for an abbreviation.
 
 ## Changes required of a later implementation
 
@@ -447,18 +461,26 @@ The existing `Int` fixture records stay byte-identical: a re-emission change is
 a regression. `conformance/HexBareiss/Conformance.lean` also checks
 `bareissWith Hex.exactDiv M = bareiss M` on every existing matrix.
 
-The carrier families above append records to
-`conformance-fixtures/HexBareiss/bareiss.jsonl`. Scalar rational and modular
-records are checked by the existing python-flint installation. Polynomial
-records use canonical ascending coefficient arrays for `DensePoly`, ordered
-exponent-vector terms for `MvPoly`, and an exact SymPy domain. The oracle
-computes the determinant of the same matrix; it does not reproduce the Bareiss
-recurrence. Complete canonical results are compared coefficientwise, with no
-sampling or heuristic simplification.
+The added families are emitted separately by
+`hexbareiss_emit_carrier_fixtures` to
+`conformance-fixtures/HexBareiss/carriers.jsonl`. A new
+`scripts/oracle/matrix_carriers.py` tuple in `scripts/ci/run_oracles.sh` checks
+that complete stream; the existing integer emitter, fixture and
+`matrix_flint.py` tuple remain byte-identical. The carrier driver uses
+python-flint for scalar rational and modular records. For polynomial records it
+constructs an exact SymPy matrix and explicitly calls
+`Matrix.det(method="berkowitz")`, an independent division-free recurrence
+rather than SymPy's default Bareiss method. It never asks an expression
+simplifier to decide equality.
+
+Records use canonical ascending coefficient arrays for `DensePoly`, ordered
+exponent-vector terms for `MvPoly`, and residues normalized to `[0, p)` (using
+`GF(p, symmetric=False)`). Complete canonical results are compared
+coefficientwise, with no sampling or heuristic simplification.
 
 SymPy and python-flint are already installed and preflighted by the existing
-single oracle job. The `HexBareiss` tuple in `scripts/ci/run_oracles.sh` is
-extended in place; there is no new package, workflow, job, or matrix.
+single oracle job. The carrier tuple extends that job; there is no new package,
+workflow, job, or matrix.
 
 ### Manual changes
 
@@ -502,9 +524,9 @@ measures exact division rather than only ring arithmetic.
 |---|---|---|
 | `runBareissRat` | python-flint `fmpq_mat.det()` | informational |
 | `runBareissMod` | python-flint `nmod_mat.det()` at the identical prime | informational |
-| `runBareissDenseRat`, `runBareissDenseMod` | SymPy determinant over the identical exact polynomial domain | informational |
-| `runBareissZPoly` | SymPy determinant over `ZZ[x]` | informational |
-| `runBareissMvInt`, `runBareissMvRat` | SymPy determinant over the identical multivariate polynomial domain | informational |
+| `runBareissDenseRat`, `runBareissDenseMod` | SymPy Berkowitz determinant over the identical exact polynomial domain | informational |
+| `runBareissZPoly` | SymPy Berkowitz determinant over `ZZ[x]` | informational |
+| `runBareissMvInt`, `runBareissMvRat` | SymPy Berkowitz determinant over the identical multivariate polynomial domain | informational |
 
 All external comparisons are informational, never Phase-4 gates. FLINT's
 determinant selection is structurally different from the prescribed Bareiss
@@ -512,12 +534,27 @@ recurrence, while the SymPy calls additionally include Python process overhead
 and independent algorithm selection. Result hashes cover the full canonical
 answer.
 
+The SymPy and python-flint registrations use a persistent-subprocess carrier
+driver, following `Hex.BenchOracle.Flint`. Because process-call benchmarks have
+an `IO` body, every point in a dimension/degree or dimension/term-count sweep
+is a separate `setup_fixed_benchmark`; there is no two-dimensional parametric
+`Nat → IO α` registration. The implementation PR records trivial-request
+overhead and overhead-adjusted ratios in
+`reports/hex-bareiss-performance.md §Comparator ratios`. These informational
+external rungs are scheduled-only; the matching Hex registrations still build
+and verify in the ordinary bench target.
+
+Over a field, Bareiss is primarily a conformance surface: fraction-free
+elimination buys no denominator control there and should not be inferred to be
+the preferred field determinant algorithm from these benchmark results.
+
 ### Symbolic coefficient growth
 
 The bordered-minor invariant in [§Complexity](#complexity) is also the symbolic
-growth contract. After step `k`, every stored entry is a `(k+1) × (k+1)` minor
-of the input matrix. Thus fraction-free elimination introduces no rational
-denominators and does not store accumulated products unrelated to input minors.
+growth contract: at state index `k`, every active entry is the corresponding
+`borderedMinor source k`, a `(k+1) × (k+1)` input minor. Thus fraction-free
+elimination introduces no rational denominators and does not store accumulated
+products unrelated to input minors.
 
 This does **not** claim compact expressions. Canonical dense or sparse
 polynomial arithmetic may expand a minor into many monomials, and the transient
@@ -534,7 +571,7 @@ silently substitutes one of them for Bareiss.
 | FLINT `fmpz_mat_det` via python-flint | informational | the `Int` Bareiss determinant targets (`runBareissDet` and the paired FLINT rungs) |
 | FLINT `fmpq_mat.det` via python-flint | informational | `runBareissRat` |
 | FLINT `nmod_mat.det` via python-flint | informational | `runBareissMod` |
-| SymPy exact-domain determinant | informational | the dense- and multivariate-polynomial Bareiss targets |
+| SymPy Berkowitz exact-domain determinant | informational | the dense- and multivariate-polynomial Bareiss targets |
 
 FLINT's `fmpz_mat_det` is a structurally distinct reference for integer matrix
 determinant: FLINT uses multimodular reduction (determinant modulo many small

--- a/HexBareiss/SPEC/hex-bareiss.md
+++ b/HexBareiss/SPEC/hex-bareiss.md
@@ -391,6 +391,49 @@ Implementation split (the proofs live in the Mathlib bridge layer):
    step k, prove `det M = 0`; otherwise compose row swaps into a permutation,
    apply the no-pivot theorem, use `det_rowSwap` for sign.
 
+## Supported coefficient carriers
+
+The `Int` aliases are only one instantiation of `bareissWith`. Support is pinned
+for every exact-quotient carrier already provided by the graph:
+
+| carrier | quotient and exact-law provider | assumptions beyond the carrier's ring operations | required fixture family | exact oracle |
+|---|---|---|---|---|
+| `Rat` | `Hex.exactDiv`; `Hex.instExactDivLawsField` | none beyond the core `Lean.Grind.Field Rat`, `Div Rat`, and `DecidableEq Rat` instances | rational matrices covering ordinary elimination, row swap, singularity, `n = 0`, and `n = 1` | python-flint `fmpq_mat.det()` |
+| `ZMod64 p` | `Hex.exactDiv`; the field instance from `HexPolyFp.PrimeField`, then `Hex.instExactDivLawsField` | `[ZMod64.Bounds p] [ZMod64.PrimeModulus p]` | the rational shapes modulo one fixed word-sized prime, plus coefficient reduction and a pivot that is nonzero only after reduction | python-flint `nmod_mat.det()` |
+| `DensePoly F` | `Hex.exactDiv`; `Hex.instExactDivLawsDensePoly` in `HexResultant.ExactDiv` | `[Lean.Grind.Field F] [DecidableEq F]`; concretely exercise `F = Rat` and `F = ZMod64 p` | univariate polynomial matrices with a nonconstant previous pivot and nontrivial exact polynomial quotients | SymPy over `QQ[x]` and `GF(p)[x]` |
+| `ZPoly` (`DensePoly Int`) | `Hex.exactDiv`; the same recursive dense-polynomial instance over `Hex.instExactDivLawsInt` | no extra coefficient hypothesis | integer-polynomial matrices with nonconstant pivots, row swap, and a singular case | SymPy over `ZZ[x]` |
+| `MvPoly n R cmp` | `Hex.exactDiv`; `Hex.MvPoly.instDiv` and `Hex.MvPoly.instExactDivLaws` in `HexMvGcd.Divide` | `[Std.TransCmp cmp] [Std.LawfulEqCmp cmp] [Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R] [Dvd R] [GcdOps R] [IsMonomialOrder cmp] [LawfulGcdOps R]`; concretely exercise `R = Int` and `R = Rat` | sparse two- and three-variable matrices with mixed monomials, nonconstant previous pivots, row swap, and singularity | SymPy over `ZZ[x0, ...]` and `QQ[x0, ...]` |
+
+Every row uses the same law term:
+
+```lean
+fun a b hb => Hex.exactDiv_mul_right a hb
+```
+
+The table records the actual instance declarations, not inferred stronger
+hypotheses. In particular, the recursive `ExactDivLaws (DensePoly R)` instance
+requires `[Lean.Grind.CommRing R] [DecidableEq R] [Div R]
+[ExactDivLaws R]`; the `MvPoly` instance inherits the full section context
+listed above and requires `LawfulGcdOps R`, not merely `GcdOps R`.
+
+### Placement in the dependency graph
+
+The exact-division implementations remain where they are: dense-polynomial
+division in `HexResultant`, above `HexPoly`, and multivariate division in
+`HexMvGcd`, above `HexMvPoly` and `HexResultant`. Nothing in `HexBareiss/*`
+imports either provider, and no carrier-specific public alias is added there.
+
+Direct integration calls live in `conformance/HexBareiss/Carriers.lean` and
+`bench/HexBareiss/Carriers.lean`. These are build-only roots, so they may import
+`HexBareiss` together with `HexPolyFp.PrimeField`, `HexResultant.ExactDiv`, and
+`HexMvGcd.Divide`; they are neither part of the published `HexBareiss` umbrella
+nor owners in `libraries.yml`. This is the only placement that exercises the
+existing providers without creating an upward production dependency.
+`scripts/check_dag.py` checks all production imports and accepts these
+build-only integration roots. If a carrier specialization later becomes
+reusable API, it must move to a production library already above both
+dependencies, never into `hex-bareiss`.
+
 ## Changes required of a later implementation
 
 These are obligations on the implementation issue, not on this SPEC. Until it
@@ -400,26 +443,22 @@ the implementation, not ahead of it.
 
 ### Conformance changes
 
-The committed fixture file `conformance-fixtures/HexBareiss/bareiss.jsonl` and
-the `scripts/oracle/matrix_flint.py` `bareiss` oracle tuple in
-`scripts/ci/run_oracles.sh` stay **byte-identical**: `Int` values do not change,
-so a re-emit is a regression signal, not a step.
+The existing `Int` fixture records stay byte-identical: a re-emission change is
+a regression. `conformance/HexBareiss/Conformance.lean` also checks
+`bareissWith Hex.exactDiv M = bareiss M` on every existing matrix.
 
-`conformance/HexBareiss/Conformance.lean` gains two kinds of guard.
+The carrier families above append records to
+`conformance-fixtures/HexBareiss/bareiss.jsonl`. Scalar rational and modular
+records are checked by the existing python-flint installation. Polynomial
+records use canonical ascending coefficient arrays for `DensePoly`, ordered
+exponent-vector terms for `MvPoly`, and an exact SymPy domain. The oracle
+computes the determinant of the same matrix; it does not reproduce the Bareiss
+recurrence. Complete canonical results are compared coefficientwise, with no
+sampling or heuristic simplification.
 
-First, `bareissWith Hex.exactDiv M = bareiss M` on the existing fixture
-matrices: the executable witness for `exactDiv_int_eq`, and the regression guard
-for the claim that the `Int` specialization is value-preserving.
-
-Second, a genuinely different carrier. `Rat` qualifies and is available at this
-depth without new dependencies: `Lean.Grind.Field Rat` is a core instance, so
-`Hex.instExactDivLawsField` supplies `ExactDivLaws Rat`, and
-`Lean.Grind.Field Rat`, `ExactDivLaws Rat`, `DecidableEq Rat` and `Div Rat` all
-resolve with only `HexBareiss` and `HexBasic.ExactDiv` imported. Cover ordinary
-elimination, a row swap, a singular input, and `n = 0` and `n = 1`. The
-`DensePoly` carrier stays out of reach here, since its `ExactDivLaws` instance
-lives in `hex-resultant` above this library; conformance for it belongs to the
-library that first instantiates it.
+SymPy and python-flint are already installed and preflighted by the existing
+single oracle job. The `HexBareiss` tuple in `scripts/ci/run_oracles.sh` is
+extended in place; there is no new package, workflow, job, or matrix.
 
 ### Manual changes
 
@@ -443,8 +482,7 @@ half of the existing ladder (the entries are multi-limb there, which is where
 `lean_int_div_exact` can differ), and record the ratio against the matching
 `runBareissDet` rung in `reports/hex-bareiss-performance.md`. This is an
 internal comparison, not an external comparator, so
-`HexBareiss.phase4.comparators` in `libraries.yml` is unchanged and no new
-input family is declared.
+the existing `Int` entry in `HexBareiss.phase4.comparators` is unchanged.
 
 Both rungs stay Mathlib-free and extend the script of the existing single
 bench job; no new workflow, job, or `strategy.matrix` (see
@@ -453,11 +491,50 @@ two extra rungs push the `Bench verify` step past its wallclock cap, they belong
 on the scheduled timing workflow instead, per
 [SPEC/benchmarking.md](https://github.com/kim-em/hex-dev/blob/main/SPEC/benchmarking.md).
 
+Every added carrier also has a required lean-bench family. Scalar carriers
+sweep matrix dimension; dense-polynomial carriers sweep dimension and entry
+degree at fixed coefficient support; multivariate carriers sweep dimension and
+term count at fixed arity and total degree. Each family includes matrices whose
+second and later steps divide by a nonconstant previous pivot, so the benchmark
+measures exact division rather than only ring arithmetic.
+
+| target family | external comparator | class |
+|---|---|---|
+| `runBareissRat` | python-flint `fmpq_mat.det()` | informational |
+| `runBareissMod` | python-flint `nmod_mat.det()` at the identical prime | informational |
+| `runBareissDenseRat`, `runBareissDenseMod` | SymPy determinant over the identical exact polynomial domain | informational |
+| `runBareissZPoly` | SymPy determinant over `ZZ[x]` | informational |
+| `runBareissMvInt`, `runBareissMvRat` | SymPy determinant over the identical multivariate polynomial domain | informational |
+
+All external comparisons are informational, never Phase-4 gates. FLINT's
+determinant selection is structurally different from the prescribed Bareiss
+recurrence, while the SymPy calls additionally include Python process overhead
+and independent algorithm selection. Result hashes cover the full canonical
+answer.
+
+### Symbolic coefficient growth
+
+The bordered-minor invariant in [§Complexity](#complexity) is also the symbolic
+growth contract. After step `k`, every stored entry is a `(k+1) × (k+1)` minor
+of the input matrix. Thus fraction-free elimination introduces no rational
+denominators and does not store accumulated products unrelated to input minors.
+
+This does **not** claim compact expressions. Canonical dense or sparse
+polynomial arithmetic may expand a minor into many monomials, and the transient
+difference of products can be larger still before exact division. Controlling
+that expression swell is outside this work. Evaluation/interpolation,
+multimodular reconstruction, and other modular symbolic determinant techniques
+belong to a later SPEC; neither the conformance plan nor the benchmark plan here
+silently substitutes one of them for Bareiss.
+
 ## External comparators
 
 | Comparator | Class | Scope |
 |---|---|---|
-| FLINT `fmpz_mat_det` via python-flint | informational | the Bareiss determinant bench targets (`runBareissDet` and the paired FLINT rungs) |
+| FLINT `fmpz_mat_det` via python-flint | informational | the `Int` Bareiss determinant targets (`runBareissDet` and the paired FLINT rungs) |
+| FLINT `fmpq_mat.det` via python-flint | informational | `runBareissRat` |
+| FLINT `nmod_mat.det` via python-flint | informational | `runBareissMod` |
+| SymPy exact-domain determinant | informational | the dense- and multivariate-polynomial Bareiss targets |
 
 FLINT's `fmpz_mat_det` is a structurally distinct reference for integer matrix
 determinant: FLINT uses multimodular reduction (determinant modulo many small
@@ -467,10 +544,8 @@ is recorded for orientation but is not a Phase-4 gate. Wired via a
 persistent-subprocess Python driver per
 [the benchmarking spec's "External comparators" section](https://github.com/kim-em/hex-dev/blob/main/SPEC/benchmarking.md#external-comparators).
 
-It applies to the `Int` specialization only. A generic carrier has no external
-determinant comparator, and none is proposed.
-
 Structured metadata in the project
 [`libraries.yml`](https://github.com/kim-em/hex-dev/blob/main/libraries.yml)
-under `HexBareiss.phase4.comparators`. See
+under `HexBareiss.phase4.comparators` records the carrier-scoped additions when
+their implementation lands. See
 `reports/hex-bareiss-performance.md` for the comparator ratio ladder.

--- a/HexBareissMathlib/SPEC/hex-bareiss-mathlib.md
+++ b/HexBareissMathlib/SPEC/hex-bareiss-mathlib.md
@@ -187,8 +187,13 @@ with instances obtained as follows:
 
 These instance-law terms are compile-time guards in the carrier integration
 modules, not new correspondence APIs in this library. The already-generic
-`bareissWith_eq_mathlib_det` covers every row verbatim once that `hquot` term is
-passed; it must not be duplicated under carrier-specific theorem names.
+`bareissWith_eq_mathlib_det` is the sole theorem needed once both a Mathlib
+`CommRing` and the `hquot` term are in scope; it must not be duplicated under
+carrier-specific theorem names. `Rat` and `MvPoly` already have the necessary
+Mathlib structures. Executable `DensePoly`/`ZPoly` and `ZMod64` do not currently
+have global Mathlib `CommRing` instances, so their computational conformance is
+independent of that separate bridge work; this SPEC does not invent local
+instances or weaken the theorem to claim otherwise.
 
 These are the theorems on the forbidden list in the Mathlib-free `hex-bareiss`
 SPEC: they must live here, never restated or reproven in the executable layer.

--- a/HexBareissMathlib/SPEC/hex-bareiss-mathlib.md
+++ b/HexBareissMathlib/SPEC/hex-bareiss-mathlib.md
@@ -167,9 +167,28 @@ law is `Int.mul_ediv_cancel`. `Hex.Matrix.bareiss` is by definition
 Nothing downstream (`HexGramSchmidtMathlib/Update.lean`,
 `HexGramSchmidtMathlib/Int/RowAdd.lean`) needs to change.
 
-**Other carriers.** A Mathlib `Field K` with `DecidableEq K` instantiates
-through `Hex.instExactDivLawsField` and `Hex.exactDiv_mul_right`; so does any
-`[CommRing R] [Div R] [Hex.ExactDivLaws R]`. Both were checked to elaborate.
+**Other carriers.** No carrier-specific determinant correspondence theorem is
+needed. At every supported carrier, the only extra proof supplied at the use
+site is the exact-quotient law
+
+```lean
+fun a b hb => Hex.exactDiv_mul_right a hb
+```
+
+with instances obtained as follows:
+
+| carrier | source of `[Div R] [Hex.ExactDivLaws R]` | additional assumptions |
+|---|---|---|
+| `Rat` | core division plus `Hex.instExactDivLawsField` | none |
+| `ZMod64 p` | `HexPolyFp.PrimeField` plus `Hex.instExactDivLawsField` | `[ZMod64.Bounds p] [ZMod64.PrimeModulus p]` |
+| `DensePoly F` | polynomial division and `Hex.instExactDivLawsDensePoly` from `HexResultant.ExactDiv` | `[Lean.Grind.Field F] [DecidableEq F]` |
+| `ZPoly` | the same dense-polynomial instance over `Hex.instExactDivLawsInt` | none |
+| `MvPoly n R cmp` | `Hex.MvPoly.instDiv` and `Hex.MvPoly.instExactDivLaws` from `HexMvGcd.Divide` | the lawful coefficient-GCD and monomial-order context listed in the `hex-bareiss` carrier table |
+
+These instance-law terms are compile-time guards in the carrier integration
+modules, not new correspondence APIs in this library. The already-generic
+`bareissWith_eq_mathlib_det` covers every row verbatim once that `hquot` term is
+passed; it must not be duplicated under carrier-specific theorem names.
 
 These are the theorems on the forbidden list in the Mathlib-free `hex-bareiss`
 SPEC: they must live here, never restated or reproven in the executable layer.

--- a/HexCharPoly/SPEC/hex-char-poly.md
+++ b/HexCharPoly/SPEC/hex-char-poly.md
@@ -81,7 +81,37 @@ determinant correspondence and Cayley--Hamilton live in
 `hex-char-poly-mathlib`; the computational package deliberately has no
 determinant dependency.
 
-## Verification and performance
+## Supported coefficient carriers
+
+`charPoly` is division-free and directly instantiates at every
+`[Lean.Grind.CommRing R] [DecidableEq R]`. The generic definition remains the
+only public entry point; support is pinned by the following conformance and
+benchmark matrix rather than by carrier-specific aliases:
+
+| carrier `R` | instance provider imported by the integration module | required fixture family | exact oracle |
+|---|---|---|---|
+| `DensePoly Int` | `HexPoly.Instances` | univariate integer-polynomial matrices with nonconstant trace, determinant and intermediate coefficients | SymPy over `ZZ[x,t]` |
+| `DensePoly Rat` | `HexPoly.Instances` | the same shapes with nonintegral coefficients | SymPy over `QQ[x,t]` |
+| `DensePoly (ZMod64 p)` | `HexPoly.Instances` and `HexModArith`, with `[ZMod64.Bounds p]` | the same shapes at a fixed word-sized prime, including characteristic reduction | SymPy over `GF(p)[x,t]` |
+| `MvPoly n Int cmp` | `HexMvPoly.Ring` | sparse two- and three-variable integer-polynomial matrices with mixed monomials | SymPy over `ZZ[x0, ..., t]` |
+| `MvPoly n Rat cmp` | `HexMvPoly.Ring` | the same shapes with rational coefficients | SymPy over `QQ[x0, ..., t]` |
+| `RationalFn Rat` | `HexRationalFn.Field` | matrices whose entries and output coefficients require nonconstant reduced denominators | SymPy over `QQ(x)[t]` |
+
+Here `t` is a fresh characteristic-polynomial indeterminate, distinct from all
+entry variables. For `MvPoly`, conformance fixes the standard graded reverse
+lexicographic comparator and supplies its `Std.TransCmp` and
+`Std.LawfulEqCmp` instances.
+
+The direct calls live in `conformance/HexCharPoly/Carriers.lean` and
+`bench/HexCharPoly/Carriers.lean`. Those are build-only integration roots and
+may import `HexMvPoly`, `HexModArith`, and `HexRationalFn` alongside
+`HexCharPoly`; they do not change the published library's
+`deps: [HexMatrix, HexPoly]`. A reusable source declaration involving one of
+these carriers must instead live above both libraries. This placement is the
+one accepted by `scripts/check_dag.py`: no carrier package is imported upward
+from a production `HexCharPoly/*` module.
+
+## Conformance
 
 Integer conformance fixtures cover dimensions zero and one, zero and diagonal
 matrices, nilpotent and repeated-eigenvalue Jordan blocks, both triangular
@@ -92,6 +122,29 @@ reversing either list.  Lean guards check Cayley--Hamilton on every fixture and
 retain the explicit counterexample showing that a monic degree-`n` annihilator
 need not be the characteristic polynomial.
 
+The six carrier families above append canonically encoded records to
+`conformance-fixtures/HexCharPoly/charpoly.jsonl`: ascending arrays for nested
+`DensePoly`, ordered exponent-vector terms for `MvPoly`, and reduced
+numerator/monic-denominator pairs for `RationalFn`. Each family includes `n = 0`
+and `n = 1`, diagonal and triangular cases, a singular dense case, and a dense
+case with genuinely nonconstant output coefficients.
+
+The symbolic oracle does **not** call SymPy's characteristic-polynomial
+routine. It constructs `tI - A` over the exact polynomial or fraction-field
+domain and computes `det(tI - A)`, then compares every coefficient in canonical
+ascending order. This is an independent route from Hex's Berkowitz recursion;
+no point sampling or expression simplifier decides equality. SymPy is already
+installed and preflighted by the existing single oracle job, so the
+`HexCharPoly` tuple in `scripts/ci/run_oracles.sh` is extended without a new
+dependency or job.
+
+This is an independent division-free arm: its emit target and oracle records do
+not import or wait for the `bareissWith` carrier integration. Exact-division
+availability can therefore neither enable nor suppress characteristic-
+polynomial coverage.
+
+## Performance
+
 Benchmarks cover dense random dimension and bit-width ladders, small-entry
 tridiagonal matrices, and self-checking companion/Jordan families.  Random
 runs observe the peak bit size among Toeplitz columns and intermediate
@@ -99,3 +152,23 @@ coefficient vectors.  `lake exe hexcharpoly_bench growth` emits a JSONL row for
 every dimension and bit-width rung with elapsed nanoseconds and the observed
 peak side by side.  FLINT's selected characteristic-polynomial routine and
 PARI's flag-3 Berkowitz routine are informational external comparators.
+
+Each added carrier also has a required Mathlib-free lean-bench family. Dense
+univariate carriers sweep matrix dimension and entry degree; multivariate
+carriers sweep dimension and term count at fixed arity and total degree;
+rational functions sweep dimension and numerator/denominator degree. Every run
+observes the maximum canonical coefficient size or term count among the
+Toeplitz columns and coefficient vectors, using the carrier's structural size
+measure rather than an evaluation.
+
+| target family | external comparator | class |
+|---|---|---|
+| `runCharDenseInt`, `runCharDenseRat`, `runCharDenseMod` | SymPy exact `det(tI-A)` on the identical matrix | informational |
+| `runCharMvInt`, `runCharMvRat` | SymPy exact `det(tI-A)` on the identical matrix | informational |
+| `runCharRatFn` | SymPy fraction-field `det(tI-A)` on the identical matrix | informational |
+
+These external comparisons are scheduled-capable process-call targets and are
+informational, never Phase-4 gates: SymPy uses a different implementation
+language and may select different determinant algorithms. They extend the
+existing single bench script, and all result hashes cover the full canonical
+polynomial.

--- a/HexCharPoly/SPEC/hex-char-poly.md
+++ b/HexCharPoly/SPEC/hex-char-poly.md
@@ -92,24 +92,27 @@ benchmark matrix rather than by carrier-specific aliases:
 |---|---|---|---|
 | `DensePoly Int` | `HexPoly.Instances` | univariate integer-polynomial matrices with nonconstant trace, determinant and intermediate coefficients | SymPy over `ZZ[x,t]` |
 | `DensePoly Rat` | `HexPoly.Instances` | the same shapes with nonintegral coefficients | SymPy over `QQ[x,t]` |
-| `DensePoly (ZMod64 p)` | `HexPoly.Instances` and `HexModArith`, with `[ZMod64.Bounds p]` | the same shapes at a fixed word-sized prime, including characteristic reduction | SymPy over `GF(p)[x,t]` |
+| `DensePoly (ZMod64 p)` | `HexPoly.Instances` and `HexModArith`, with `[ZMod64.Bounds p]` | the same shapes at a fixed prime below `2^31`, including characteristic reduction | SymPy over `GF(p, symmetric=False)[x,t]` |
 | `MvPoly n Int cmp` | `HexMvPoly.Ring` | sparse two- and three-variable integer-polynomial matrices with mixed monomials | SymPy over `ZZ[x0, ..., t]` |
 | `MvPoly n Rat cmp` | `HexMvPoly.Ring` | the same shapes with rational coefficients | SymPy over `QQ[x0, ..., t]` |
 | `RationalFn Rat` | `HexRationalFn.Field` | matrices whose entries and output coefficients require nonconstant reduced denominators | SymPy over `QQ(x)[t]` |
 
 Here `t` is a fresh characteristic-polynomial indeterminate, distinct from all
-entry variables. For `MvPoly`, conformance fixes the standard graded reverse
-lexicographic comparator and supplies its `Std.TransCmp` and
-`Std.LawfulEqCmp` instances.
+entry variables. For `MvPoly`, the ring instance additionally requires
+`[BEq R]` and `[LawfulBEq R]`. Conformance fixes `Hex.Mono.grevlex`; its
+existing `Std.TransCmp` and `Std.LawfulEqCmp` instances determine the term
+order.
 
-The direct calls live in `conformance/HexCharPoly/Carriers.lean` and
-`bench/HexCharPoly/Carriers.lean`. Those are build-only integration roots and
-may import `HexMvPoly`, `HexModArith`, and `HexRationalFn` alongside
-`HexCharPoly`; they do not change the published library's
+Direct typechecking and guards live in the existing build-only
+`conformance/HexCharPoly/Conformance.lean`; a separate
+`EmitCarrierFixtures.lean` is an explicit emitter root; and carrier benchmarks
+are registered by the existing `bench/HexCharPoly/Bench.lean` executable root.
+Those modules may import `HexMvPoly`, `HexModArith`, and `HexRationalFn`
+alongside `HexCharPoly`; they do not change the published library's
 `deps: [HexMatrix, HexPoly]`. A reusable source declaration involving one of
-these carriers must instead live above both libraries. This placement is the
-one accepted by `scripts/check_dag.py`: no carrier package is imported upward
-from a production `HexCharPoly/*` module.
+these carriers must instead live above both libraries. `scripts/check_dag.py`
+enforces the production graph from `libraries.yml`; the integration paths have
+no production owner, though its sealed-import check still scans them.
 
 ## Conformance
 
@@ -122,21 +125,25 @@ reversing either list.  Lean guards check Cayley--Hamilton on every fixture and
 retain the explicit counterexample showing that a monic degree-`n` annihilator
 need not be the characteristic polynomial.
 
-The six carrier families above append canonically encoded records to
-`conformance-fixtures/HexCharPoly/charpoly.jsonl`: ascending arrays for nested
-`DensePoly`, ordered exponent-vector terms for `MvPoly`, and reduced
-numerator/monic-denominator pairs for `RationalFn`. Each family includes `n = 0`
-and `n = 1`, diagonal and triangular cases, a singular dense case, and a dense
-case with genuinely nonconstant output coefficients.
+`hexcharpoly_emit_carrier_fixtures` writes the six added families to the
+separate `conformance-fixtures/HexCharPoly/carriers.jsonl`: ascending arrays for
+nested `DensePoly`, ordered exponent-vector terms for `MvPoly`, and reduced
+numerator/monic-denominator pairs for `RationalFn`. Finite-field residues are
+normalized to `[0, p)`. Each family includes `n = 0` and `n = 1`, diagonal and
+triangular cases, a singular dense case, and a dense case with genuinely
+nonconstant output coefficients. The existing integer emitter and
+`matrix_flint.py` stream stay unchanged.
 
-The symbolic oracle does **not** call SymPy's characteristic-polynomial
-routine. It constructs `tI - A` over the exact polynomial or fraction-field
-domain and computes `det(tI - A)`, then compares every coefficient in canonical
-ascending order. This is an independent route from Hex's Berkowitz recursion;
-no point sampling or expression simplifier decides equality. SymPy is already
-installed and preflighted by the existing single oracle job, so the
-`HexCharPoly` tuple in `scripts/ci/run_oracles.sh` is extended without a new
-dependency or job.
+The new `scripts/oracle/matrix_carriers.py` tuple does **not** call SymPy's
+characteristic-polynomial routine. It constructs a `DomainMatrix` for `tI - A`
+over the exact polynomial or fraction-field domain and calls
+`DomainMatrix.det()` (Bareiss), then compares every coefficient in canonical
+ascending order. Finite fields use `GF(p, symmetric=False)`. This is an
+independent route from Hex's Berkowitz recursion; no point sampling or
+expression simplifier decides equality. SymPy is already installed and
+preflighted by the existing single oracle job, so the extra
+emitter/fixture/oracle tuple introduces no dependency, workflow, job, or
+matrix.
 
 This is an independent division-free arm: its emit target and oracle records do
 not import or wait for the `bareissWith` carrier integration. Exact-division
@@ -163,12 +170,17 @@ measure rather than an evaluation.
 
 | target family | external comparator | class |
 |---|---|---|
-| `runCharDenseInt`, `runCharDenseRat`, `runCharDenseMod` | SymPy exact `det(tI-A)` on the identical matrix | informational |
-| `runCharMvInt`, `runCharMvRat` | SymPy exact `det(tI-A)` on the identical matrix | informational |
-| `runCharRatFn` | SymPy fraction-field `det(tI-A)` on the identical matrix | informational |
+| `runCharDenseInt`, `runCharDenseRat`, `runCharDenseMod` | SymPy `DomainMatrix.det()` (Bareiss) on the identical exact-domain `tI-A` | informational |
+| `runCharMvInt`, `runCharMvRat` | SymPy `DomainMatrix.det()` (Bareiss) on the identical exact-domain `tI-A` | informational |
+| `runCharRatFn` | SymPy `DomainMatrix.det()` (Bareiss) on the identical fraction-field `tI-A` | informational |
 
-These external comparisons are scheduled-capable process-call targets and are
-informational, never Phase-4 gates: SymPy uses a different implementation
-language and may select different determinant algorithms. They extend the
-existing single bench script, and all result hashes cover the full canonical
+These external comparisons are informational, never Phase-4 gates. They use the
+carrier driver's persistent-subprocess mode and are scheduled-only. Because the
+body is `IO`, each point of a dimension/degree or dimension/term-count sweep is
+a separate `setup_fixed_benchmark`; the SymPy `DomainMatrix.det()` method is
+pinned to Bareiss. The implementation PR records trivial-request overhead and
+overhead-adjusted ratios in
+`reports/hex-char-poly-performance.md §Comparator ratios`, updates
+`libraries.yml phase4.comparators` and `input_families`, and extends the
+existing single bench script. All result hashes cover the full canonical
 polynomial.

--- a/HexCharPolyMathlib/SPEC/hex-char-poly-mathlib.md
+++ b/HexCharPolyMathlib/SPEC/hex-char-poly-mathlib.md
@@ -18,6 +18,12 @@ theorem equiv_charPoly (A : Hex.Matrix R n n) :
 end HexCharPolyMathlib
 ```
 
+This theorem is coefficient-generic and already covers the `DensePoly`,
+`MvPoly`, and `RationalFn` carrier matrix from the computational SPEC whenever
+the corresponding Mathlib ring bridge is imported. No carrier-specific
+`equiv_charPoly` theorem or executable conformance suite is added here; the
+carrier fixtures remain owned by `HexCharPoly`.
+
 Importing the umbrella extends `char_poly` to closed
 `Matrix (Fin n) (Fin n) Int` terms:
 

--- a/HexCharPolyMathlib/SPEC/hex-char-poly-mathlib.md
+++ b/HexCharPolyMathlib/SPEC/hex-char-poly-mathlib.md
@@ -18,9 +18,12 @@ theorem equiv_charPoly (A : Hex.Matrix R n n) :
 end HexCharPolyMathlib
 ```
 
-This theorem is coefficient-generic and already covers the `DensePoly`,
-`MvPoly`, and `RationalFn` carrier matrix from the computational SPEC whenever
-the corresponding Mathlib ring bridge is imported. No carrier-specific
+This theorem is coefficient-generic. `MvPoly` obtains the required Mathlib
+`CommRing` from `HexMvPolyMathlib`, and `RationalFn` obtains a Mathlib `Field`
+from `HexRationalFnMathlib`, so those carrier specializations need no new
+characteristic-polynomial lemma. There is currently no global Mathlib
+`CommRing` instance for executable `DensePoly`; the computational carrier
+coverage does not wait for that separate bridge. No carrier-specific
 `equiv_charPoly` theorem or executable conformance suite is added here; the
 carrier fixtures remain owned by `HexCharPoly`.
 

--- a/HexDeterminant/SPEC/hex-determinant.md
+++ b/HexDeterminant/SPEC/hex-determinant.md
@@ -200,45 +200,52 @@ in conformance and benchmark code:
 |---|---|---|---|
 | `DensePoly Int` | `HexPoly.Instances` | dense univariate integer-polynomial matrices, including nonconstant determinant, cancellation, singular, triangular and row-swap cases | SymPy over `ZZ[x]` |
 | `DensePoly Rat` | `HexPoly.Instances` | the same shapes with nonintegral rational coefficients | SymPy over `QQ[x]` |
-| `DensePoly (ZMod64 p)` | `HexPoly.Instances` and `HexModArith`, with `[ZMod64.Bounds p]` | the same shapes at a fixed word-sized prime, including reduction of negative and oversized coefficients | SymPy over `GF(p)[x]` |
+| `DensePoly (ZMod64 p)` | `HexPoly.Instances` and `HexModArith`, with `[ZMod64.Bounds p]` | the same shapes at a fixed prime below `2^31`, including reduction of negative and oversized coefficients | SymPy over `GF(p, symmetric=False)[x]` |
 | `MvPoly n Int cmp` | `HexMvPoly.Ring` | sparse two- and three-variable integer-polynomial matrices, with mixed monomials and cancellation | SymPy over `ZZ[x0, ...]` |
 | `MvPoly n Rat cmp` | `HexMvPoly.Ring` | the same shapes with rational coefficients | SymPy over `QQ[x0, ...]` |
 | `RationalFn Rat` | `HexRationalFn.Field` | matrices with nonconstant, nonunit denominators and cancellations in the determinant | SymPy over `QQ(x)` |
 
-For `MvPoly`, the executable ring instance requires `[Std.TransCmp cmp]` and
-`[Std.LawfulEqCmp cmp]` in addition to the coefficient commutative ring and
-decidable equality. Conformance fixes the standard graded reverse
-lexicographic comparator, so the fixture encoding and output order are
-deterministic.
+For `MvPoly`, the executable ring instance requires `[Std.TransCmp cmp]`,
+`[Std.LawfulEqCmp cmp]`, `[BEq R]`, and `[LawfulBEq R]` in addition to the
+coefficient commutative ring and decidable equality. Conformance fixes
+`Hex.Mono.grevlex`; its existing lawful-comparator instances make fixture
+encoding and output order deterministic.
 
-These are integration instantiations, not new production definitions. They
-live in `conformance/HexDeterminant/Carriers.lean` and
-`bench/HexDeterminant/Carriers.lean`, whose build-only roots may import the
-carrier providers together with `HexDeterminant`. They do not add an edge to
-the published `HexDeterminant` library. `scripts/check_dag.py` deliberately
-checks production modules against `libraries.yml` while treating `conformance/`
-and `bench/` as build-only roots. If code from either module becomes reusable
-library API, it must move to a library already above both dependencies; the
-generic determinant library must not acquire upward imports merely to name test
+These are integration instantiations, not new production definitions. Direct
+typechecking and guards live in the existing build-only
+`conformance/HexDeterminant/Conformance.lean`; a separate
+`EmitCarrierFixtures.lean` is an explicit emitter root; and carrier benchmarks
+are registered by the existing `bench/HexDeterminant/Bench.lean` executable
+root. Those modules may import the carrier providers together with
+`HexDeterminant`. They do not add an edge to the published `HexDeterminant`
+library. `scripts/check_dag.py` enforces production imports from
+`libraries.yml`; these integration paths have no production owner, though its
+sealed-import check still scans them. If their code becomes reusable library
+API, it must move to a library already above both dependencies; the generic
+determinant library must not acquire upward imports merely to name test
 carriers.
 
 ### Conformance encoding
 
-The carrier families are appended to
-`conformance-fixtures/HexDeterminant/determinant.jsonl`. A matrix record names
-its coefficient domain and encodes every coefficient canonically: ascending
+`hexdeterminant_emit_carrier_fixtures` writes the added families to the separate
+`conformance-fixtures/HexDeterminant/carriers.jsonl`. A matrix record names its
+coefficient domain and encodes every coefficient canonically: ascending
 coefficient arrays for `DensePoly`, ordered exponent-vector/coefficient pairs
 for `MvPoly`, and reduced numerator/monic-denominator pairs for `RationalFn`.
-Lean emits the complete canonical determinant, not evaluations or hashes.
+Finite-field residues are normalized to `[0, p)`. Lean emits the complete
+canonical determinant, not evaluations or hashes. The existing integer emitter
+and `matrix_flint.py` fixture stream stay unchanged.
 
-The corresponding oracle path uses SymPy's exact polynomial and fraction-field
-domains. It constructs the matrix over the declared domain and computes its
-determinant there; equality is coefficientwise after canonical serialization.
-No sampling, simplification heuristic, or floating-point evaluation decides a
-fixture. SymPy is already installed and preflighted by
-`.github/workflows/ci.yml` and `scripts/ci/run_oracles.sh`, so adding these
-record kinds extends the existing `HexDeterminant` oracle tuple and introduces
-no package or CI-job change.
+A new `scripts/oracle/matrix_carriers.py` tuple uses SymPy's exact polynomial
+and fraction-field domains. It constructs a `DomainMatrix` over the declared
+domain and calls `DomainMatrix.det()`, whose pinned SymPy implementation is
+Bareiss and is independent of Hex's Leibniz enumeration; equality is
+coefficientwise after canonical serialization. Finite fields use
+`GF(p, symmetric=False)`. No sampling,
+simplification heuristic, or floating-point evaluation decides a fixture.
+SymPy is already installed and preflighted by `.github/workflows/ci.yml` and
+`scripts/ci/run_oracles.sh`, so the extra emitter/fixture/oracle tuple extends
+the existing single job without a new package, workflow, job, or matrix.
 
 This division-free fixture arm emits, builds, and runs independently of every
 `bareissWith` fixture. A missing exact-division instance or failed Bareiss build
@@ -257,14 +264,22 @@ timing out.
 
 | target family | external comparator | class |
 |---|---|---|
-| `runDetDenseInt`, `runDetDenseRat`, `runDetDenseMod` | SymPy exact-domain determinant on the identical matrix | informational |
-| `runDetMvInt`, `runDetMvRat` | SymPy exact-domain determinant on the identical matrix | informational |
-| `runDetRatFn` | SymPy fraction-field determinant on the identical matrix | informational |
+| `runDetDenseInt`, `runDetDenseRat`, `runDetDenseMod` | SymPy `DomainMatrix.det()` (Bareiss) on the identical exact-domain matrix | informational |
+| `runDetMvInt`, `runDetMvRat` | SymPy `DomainMatrix.det()` (Bareiss) on the identical exact-domain matrix | informational |
+| `runDetRatFn` | SymPy `DomainMatrix.det()` (Bareiss) on the identical fraction-field matrix | informational |
 
 The registrations and external calls extend the existing single bench script.
 The comparisons are informational because Python process cost and SymPy's
 algorithm selection are structurally unlike the executable Leibniz sum; none
 is a Phase-4 gate. Result hashes cover the full canonical output.
+
+The SymPy registrations use the carrier driver's persistent-subprocess mode.
+Each point of a dimension/degree or dimension/term-count sweep is a separate
+`setup_fixed_benchmark`, as required for an `IO` process-call body. The
+implementation PR records trivial-request overhead and overhead-adjusted ratios
+in `reports/hex-determinant-performance.md §Comparator ratios`; these external
+rungs are informational and scheduled-only. That same PR updates the
+carrier-scoped `libraries.yml phase4.comparators` and `input_families` entries.
 
 ## External comparators
 

--- a/HexDeterminant/SPEC/hex-determinant.md
+++ b/HexDeterminant/SPEC/hex-determinant.md
@@ -188,14 +188,89 @@ that connects the executable Bareiss determinant to this Leibniz `det`
 in `hex-bareiss`; the proof itself lives in `hex-determinant-mathlib` and
 `hex-bareiss-mathlib`.
 
+## Supported coefficient carriers
+
+`det` is a division-free operation over `[Lean.Grind.Ring R]`; its proofs use
+`[Lean.Grind.CommRing R]` only where commutativity is mathematically required.
+The generic signature is the public API. There are no carrier-specific aliases,
+but support is incomplete until the following direct instantiations are present
+in conformance and benchmark code:
+
+| carrier `R` | instance provider imported by the integration module | required fixture family | exact oracle |
+|---|---|---|---|
+| `DensePoly Int` | `HexPoly.Instances` | dense univariate integer-polynomial matrices, including nonconstant determinant, cancellation, singular, triangular and row-swap cases | SymPy over `ZZ[x]` |
+| `DensePoly Rat` | `HexPoly.Instances` | the same shapes with nonintegral rational coefficients | SymPy over `QQ[x]` |
+| `DensePoly (ZMod64 p)` | `HexPoly.Instances` and `HexModArith`, with `[ZMod64.Bounds p]` | the same shapes at a fixed word-sized prime, including reduction of negative and oversized coefficients | SymPy over `GF(p)[x]` |
+| `MvPoly n Int cmp` | `HexMvPoly.Ring` | sparse two- and three-variable integer-polynomial matrices, with mixed monomials and cancellation | SymPy over `ZZ[x0, ...]` |
+| `MvPoly n Rat cmp` | `HexMvPoly.Ring` | the same shapes with rational coefficients | SymPy over `QQ[x0, ...]` |
+| `RationalFn Rat` | `HexRationalFn.Field` | matrices with nonconstant, nonunit denominators and cancellations in the determinant | SymPy over `QQ(x)` |
+
+For `MvPoly`, the executable ring instance requires `[Std.TransCmp cmp]` and
+`[Std.LawfulEqCmp cmp]` in addition to the coefficient commutative ring and
+decidable equality. Conformance fixes the standard graded reverse
+lexicographic comparator, so the fixture encoding and output order are
+deterministic.
+
+These are integration instantiations, not new production definitions. They
+live in `conformance/HexDeterminant/Carriers.lean` and
+`bench/HexDeterminant/Carriers.lean`, whose build-only roots may import the
+carrier providers together with `HexDeterminant`. They do not add an edge to
+the published `HexDeterminant` library. `scripts/check_dag.py` deliberately
+checks production modules against `libraries.yml` while treating `conformance/`
+and `bench/` as build-only roots. If code from either module becomes reusable
+library API, it must move to a library already above both dependencies; the
+generic determinant library must not acquire upward imports merely to name test
+carriers.
+
+### Conformance encoding
+
+The carrier families are appended to
+`conformance-fixtures/HexDeterminant/determinant.jsonl`. A matrix record names
+its coefficient domain and encodes every coefficient canonically: ascending
+coefficient arrays for `DensePoly`, ordered exponent-vector/coefficient pairs
+for `MvPoly`, and reduced numerator/monic-denominator pairs for `RationalFn`.
+Lean emits the complete canonical determinant, not evaluations or hashes.
+
+The corresponding oracle path uses SymPy's exact polynomial and fraction-field
+domains. It constructs the matrix over the declared domain and computes its
+determinant there; equality is coefficientwise after canonical serialization.
+No sampling, simplification heuristic, or floating-point evaluation decides a
+fixture. SymPy is already installed and preflighted by
+`.github/workflows/ci.yml` and `scripts/ci/run_oracles.sh`, so adding these
+record kinds extends the existing `HexDeterminant` oracle tuple and introduces
+no package or CI-job change.
+
+This division-free fixture arm emits, builds, and runs independently of every
+`bareissWith` fixture. A missing exact-division instance or failed Bareiss build
+therefore cannot suppress determinant coverage at a carrier where `det` already
+typechecks.
+
+### Carrier benchmarks
+
+Every carrier has a required Mathlib-free lean-bench registration. The integer,
+rational and finite-field polynomial families sweep matrix dimension and entry
+degree at fixed dense coefficient support; the multivariate families sweep
+dimension and term count at fixed arity and total degree; the rational-function
+family sweeps dimension and numerator/denominator degree. Dimensions remain in
+the small Leibniz range so the factorial enumeration is measured rather than
+timing out.
+
+| target family | external comparator | class |
+|---|---|---|
+| `runDetDenseInt`, `runDetDenseRat`, `runDetDenseMod` | SymPy exact-domain determinant on the identical matrix | informational |
+| `runDetMvInt`, `runDetMvRat` | SymPy exact-domain determinant on the identical matrix | informational |
+| `runDetRatFn` | SymPy fraction-field determinant on the identical matrix | informational |
+
+The registrations and external calls extend the existing single bench script.
+The comparisons are informational because Python process cost and SymPy's
+algorithm selection are structurally unlike the executable Leibniz sum; none
+is a Phase-4 gate. Result hashes cover the full canonical output.
+
 ## External comparators
 
-The Leibniz determinant has no external comparator: it is the reference
-combinatorial definition, cross-checked for agreement against the row-pivoted
-Bareiss determinant (`hex-bareiss`) and against python-flint's `fmpz_mat.det`
-through the conformance oracle (`scripts/oracle/matrix_flint.py`, driven by
-`hexdeterminant_emit_fixtures`). It declares external-comparator absence for the
-Phase-4 bench surface (`runLeibnizDet`) with the **structural-layer** reason. See
-`reports/hex-determinant-performance.md` and the project
-[`libraries.yml`](https://github.com/kim-em/hex-dev/blob/main/libraries.yml)
-under `HexDeterminant.phase4`.
+The existing `Int` Leibniz surface remains cross-checked against row-pivoted
+Bareiss and python-flint's `fmpz_mat.det`; its `runLeibnizDet` benchmark keeps
+the existing **structural-layer** comparator-absence declaration. The symbolic
+carrier targets above add SymPy as an informational comparator, scoped only to
+those targets. `libraries.yml` records that scoped comparator and the carrier
+input families when the implementation lands.

--- a/HexDeterminantMathlib/SPEC/hex-determinant-mathlib.md
+++ b/HexDeterminantMathlib/SPEC/hex-determinant-mathlib.md
@@ -22,12 +22,13 @@ theorem det_eq [CommRing R] (M : Hex.Matrix R n n) :
 Through `det_eq`, Mathlib determinant theorems (Cramer's rule, Cauchy-Binet,
 adjugate identities) transfer to our executable determinant.
 
-The correspondence is coefficient-generic. In particular it already covers
-the `DensePoly`, `MvPoly`, and `RationalFn` carriers in the computational
-SPEC whenever their Mathlib `CommRing` bridge is in scope. Carrier conformance
-does not add specialized `det_eq` lemmas here; it exercises the executable
-operation in the Mathlib-free integration roots and keeps this library a
-correspondence-only layer.
+The correspondence theorem is coefficient-generic. `MvPoly` obtains the
+required Mathlib `CommRing` from `HexMvPolyMathlib`, and `RationalFn` obtains a
+Mathlib `Field` from `HexRationalFnMathlib`, so those carrier specializations
+need no new determinant lemma. There is currently no global Mathlib `CommRing`
+instance for executable `DensePoly`; the computational carrier coverage does
+not wait for that separate bridge. Carrier conformance adds no specialized
+`det_eq` lemmas here and keeps this library a correspondence-only layer.
 
 ## Required outstanding obligations
 

--- a/HexDeterminantMathlib/SPEC/hex-determinant-mathlib.md
+++ b/HexDeterminantMathlib/SPEC/hex-determinant-mathlib.md
@@ -22,6 +22,13 @@ theorem det_eq [CommRing R] (M : Hex.Matrix R n n) :
 Through `det_eq`, Mathlib determinant theorems (Cramer's rule, Cauchy-Binet,
 adjugate identities) transfer to our executable determinant.
 
+The correspondence is coefficient-generic. In particular it already covers
+the `DensePoly`, `MvPoly`, and `RationalFn` carriers in the computational
+SPEC whenever their Mathlib `CommRing` bridge is in scope. Carrier conformance
+does not add specialized `det_eq` lemmas here; it exercises the executable
+operation in the Mathlib-free integration roots and keeps this library a
+correspondence-only layer.
+
 ## Required outstanding obligations
 
 | obligation | status | requirement |


### PR DESCRIPTION
Closes #10154

## Summary

- specify division-free determinant and characteristic-polynomial support across dense, multivariate, modular, and rational-function carriers
- specify Bareiss exact-quotient support, including the precise existing instance assumptions and DAG-safe integration locations
- define separate carrier fixture streams, exact conformance oracles, and benchmark families for every enumerated carrier
- use scalar python-flint matrices where bindings exist; use SymPy Berkowitz as the independent Bareiss oracle and exact-domain SymPy Bareiss for the Leibniz/characteristic-polynomial arms
- normalize modular residues canonically and compute symbolic characteristic polynomials as `det(tI - A)`
- record process-call benchmark obligations, symbolic minor growth, and the explicit deferral of expression-swell techniques
- document which generic Mathlib correspondences are immediately instantiable and which await a separate ring bridge

## Second opinion

Claude Opus reviewed the complete initial patch while CI ran. The follow-up commit addresses its substantive findings: algorithm independence, fixture/emitter routing, finite-field canonicalization, missing `MvPoly` assumptions, process-call benchmark requirements, Mathlib bridge availability, and the state-index wording of the minor invariant. Source checks rejected two overstatements in the review: `Hex.Mono.grevlex` does have `IsMonomialOrder`, and `HexRationalFnMathlib` does provide a Mathlib `Field` instance.

## Verification

- `lake build` (11,881 jobs, after rebase onto current `origin/main`)
- `python3 scripts/check_dag.py`
- `git diff --check`
- audited `HexResultant.ExactDiv`, `HexMvGcd.Divide`, `HexMvPoly.Mono`, `HexPolyFp.PrimeField`, and the carrier ring/field bridges
- smoke-tested SymPy 1.14 `Matrix.det(method="berkowitz")`, exact-domain `DomainMatrix.det()`, nested polynomial/fraction-field domains, and `GF(p, symmetric=False)`
