### PR TITLE
doc: mark remaining Array shim removals

### DIFF
--- a/HexBasic/ArrayDecEq.lean
+++ b/HexBasic/ArrayDecEq.lean
@@ -34,6 +34,11 @@ conversion that allocates both lists in full
 before comparison begins and gives up early exit, so each carries a `@[csimp]`
 redirect back to the core instance. The `List` route is then paid only in the
 kernel, which is where it is needed.
+
+Remove these scoped instances and their compiler redirects when the pinned
+toolchain reaches Lean v4.35.0-rc1, which includes the upstream fixes for
+{name}`Array` equality (<https://github.com/leanprover/lean4/pull/14270>) and
+{name}`Vector` equality (<https://github.com/leanprover/lean4/pull/14988>).
 -/
 
 namespace Hex

--- a/HexBasic/OfFn.lean
+++ b/HexBasic/OfFn.lean
@@ -24,6 +24,11 @@ array of known capacity rather than build a linked list and convert, so each
 carries a `@[csimp]` lemma redirecting the compiler back to the core version.
 The {name}`List` route is then paid only in the kernel, which is where it is
 needed.
+
+Remove the `Array.ofFn'` and `Vector.ofFn'` shims and migrate their
+callers to the core operations when the pinned toolchain reaches Lean
+v4.35.0-rc1, which includes
+<https://github.com/leanprover/lean4/pull/14989>.
 -/
 
 namespace Hex

--- a/scripts/bench/proof_only_runtime_exemptions/hexbasic-arraydeceq-lean-b67027bc-25e2ef42.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexbasic-arraydeceq-lean-b67027bc-25e2ef42.json
@@ -1,0 +1,6 @@
+{
+  "path": "HexBasic/ArrayDecEq.lean",
+  "baseline_blob": "b67027bccef0d1c706fa1c2b35473dcb4fa52338",
+  "current_blob": "25e2ef4207843776854211debddd6af069de698b",
+  "reason": "Adds only a module docstring reminder to remove the downstream Array and Vector DecidableEq shims at Lean v4.35.0-rc1. No declaration or executable code changes."
+}

--- a/scripts/bench/proof_only_runtime_exemptions/hexbasic-offn-lean-7fa5f278-2c512ed4.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexbasic-offn-lean-7fa5f278-2c512ed4.json
@@ -1,0 +1,6 @@
+{
+  "path": "HexBasic/OfFn.lean",
+  "baseline_blob": "7fa5f2789534fe0333160fa3005a7d003840cc4d",
+  "current_blob": "2c512ed44a2de6ed7d96551d4ca8233115f02f3f",
+  "reason": "Updates only docstrings to record Lean v4.35.0-rc1 as the removal point for the downstream Array.ofFn', Vector.ofFn', Array.map', and Array.zipWith' shims. No declaration or executable code changes."
+}


### PR DESCRIPTION
This PR records Lean v4.35.0-rc1 as the removal point for the downstream Array and Vector equality instances and the `ofFn'` compatibility definitions.

The notes link the three additional merged upstream exposure fixes that make these shims obsolete after the toolchain upgrade.

:robot: prepared using Codex+Claude