### PR TITLE
spec: define hex-rank domain rank certificate and producer

### DIFF
--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -18,6 +18,7 @@
 - **hex-row-reduce**: row reduction (RREF), rank, span, nullspace
 - **hex-determinant**: the Leibniz determinant and its cofactor/Cauchy-Binet/Plücker theory
 - **hex-bareiss**: the fraction-free Bareiss determinant algorithm
+- **[hex-rank](hex-rank.md)** (planned): matrix rank over any integral domain with a two-sided certificate (a nonsingular minor with its adjugate, and the identity expressing every column over the selected ones), the rectangular fraction-free producer, and the row and column rank profiles
 - **[hex-determinantal-ideal](hex-determinantal-ideal.md)** (planned): executable minors and determinantal-ideal generators of a matrix over a commutative ring, and the theorem that the rank over a field is below `r` exactly when every `r × r` minor vanishes
 - **hex-char-poly**: the characteristic polynomial by the division-free Samuelson-Berkowitz algorithm, over any commutative ring
 - **hex-min-poly**: the matrix minimal polynomial over a field, from Krylov sequences, with a certificate proving annihilation and minimality
@@ -85,6 +86,7 @@ Mathlib, and supplies correspondence proofs or Mathlib-facing APIs):
 - **hex-row-reduce-mathlib**: rank = `Matrix.rank`, nullspace = `LinearMap.ker`, span agreement
 - **hex-determinant-mathlib**: `det` agreement with `Matrix.det`, plus the Plücker / Desnanot-Jacobi assembly
 - **hex-bareiss-mathlib**: Bareiss determinant = `Matrix.det`, via the bordered-minor invariant
+- **[hex-rank-mathlib](hex-rank-mathlib.md)** (planned): certificate soundness for `Matrix.rank` over any domain, rank invariance under `IsFractionRing` scalar extension, producer correctness, and the conversions to and from Mathlib's `Echelon.Decomposition`
 - **[hex-determinantal-ideal-mathlib](hex-determinantal-ideal-mathlib.md)** (planned): minors as `Matrix.det` of a `submatrix`, the rank-versus-minors theorem for `Matrix.rank` under any ring homomorphism into a field, rank-drop loci as zero sets, and invariance of `I_r(A)` under invertible row and column operations
 - **hex-char-poly-mathlib**: agreement with `Matrix.charpoly`, Cayley-Hamilton, the trace and determinant coefficients, transpose and similarity invariance
 - **hex-min-poly-mathlib**: agreement with `minpoly`, the annihilator-generator statement for the vector order polynomial, divisibility into the characteristic polynomial, and the degree bound
@@ -136,6 +138,7 @@ Each library with its immediate dependencies:
 - **hex-row-reduce**: hex-matrix
 - **hex-determinant**: hex-matrix
 - **hex-bareiss**: hex-determinant, hex-matrix
+- **hex-rank** (planned): hex-bareiss, hex-determinant, hex-matrix, hex-arith, hex-basic
 - **hex-determinantal-ideal** (planned): hex-basic, hex-matrix, hex-determinant, hex-row-reduce, hex-mv-poly
 - **hex-char-poly**: hex-matrix, hex-poly
 - **hex-min-poly**: hex-matrix, hex-row-reduce, hex-poly
@@ -209,6 +212,7 @@ Mathlib companion libraries (each also depends on Mathlib):
 - **hex-row-reduce-mathlib**: hex-row-reduce, hex-matrix-mathlib
 - **hex-determinant-mathlib**: hex-determinant, hex-bareiss, hex-matrix-mathlib
 - **hex-bareiss-mathlib**: hex-determinant-mathlib
+- **hex-rank-mathlib** (planned): hex-rank, hex-bareiss-mathlib, hex-determinant-mathlib, hex-matrix-mathlib
 - **hex-determinantal-ideal-mathlib** (planned): hex-determinantal-ideal, hex-determinant-mathlib, hex-row-reduce-mathlib, hex-mv-poly-mathlib
 - **hex-char-poly-mathlib**: hex-char-poly, hex-matrix-mathlib, hex-poly-mathlib, hex-determinant-mathlib
 - **hex-min-poly-mathlib**: hex-min-poly, hex-matrix-mathlib, hex-poly-mathlib, hex-char-poly-mathlib
@@ -683,6 +687,8 @@ for developments whose source-local move has not happened yet.
 - [hex-row-reduce-mathlib](https://github.com/leanprover/hex-row-reduce-mathlib/blob/main/SPEC/hex-row-reduce-mathlib.md) (released): rank/nullspace/span correspondence
 - [hex-determinant-mathlib](https://github.com/leanprover/hex-determinant-mathlib/blob/main/SPEC/hex-determinant-mathlib.md) (released): `det` agreement with `Matrix.det`
 - [hex-bareiss-mathlib](https://github.com/leanprover/hex-bareiss-mathlib/blob/main/SPEC/hex-bareiss-mathlib.md) (released): Bareiss determinant correctness
+- [hex-rank](hex-rank.md) (planned): rank over any integral domain with an adjugate-and-column-expression certificate, the rectangular fraction-free producer, and the rank profiles
+- [hex-rank-mathlib](hex-rank-mathlib.md) (planned): `Matrix.rank` soundness over any domain, `IsFractionRing` scalar extension, producer correctness, and `Echelon.Decomposition` conversions
 - [hex-determinantal-ideal](hex-determinantal-ideal.md) (planned): executable minors, determinantal-ideal generators, and the rank-versus-minors theorem with a Mathlib-free proof
 - [hex-determinantal-ideal-mathlib](hex-determinantal-ideal-mathlib.md) (planned): `Matrix.rank` versus minors under any ring homomorphism into a field, rank-drop loci, and invariance of determinantal ideals
 - [hex-char-poly.md](hex-char-poly.md): the characteristic polynomial by the division-free Samuelson-Berkowitz algorithm, with Cayley-Hamilton and the `Matrix.charpoly` correspondence (the Mathlib companion is specified in the same file)

--- a/SPEC/Libraries/hex-modular-matrix.md
+++ b/SPEC/Libraries/hex-modular-matrix.md
@@ -375,7 +375,8 @@ theorem checkRank_sound (h : checkRank A c = true) : ratRank A = c.r
 [hex-rank](hex-rank.md) specifies the same two-sided certificate over
 every integral domain, and this library's certificate is its `Int`
 instance: `RankCert n m` is `Hex.Matrix.RankCert Int n m` (`rows`, `cols`,
-`denom = det B`, and `adj = adjugate B` in place of `coeffs`), `checkRank`
+and `denom`, `adj` with `B * adj = denom • identity r`, which the producer
+fills with `det B` and `adjugate B`, in place of `coeffs`), `checkRank`
 is `Hex.Matrix.checkRank`, and `checkRank_sound` is hex-rank's soundness
 at `R = Int`. The `modulus` field, the modular minor test and the
 strictly-increasing check on `rows` and `cols` are dropped: the adjugate

--- a/SPEC/Libraries/hex-modular-matrix.md
+++ b/SPEC/Libraries/hex-modular-matrix.md
@@ -371,6 +371,26 @@ def ratRank (A : Matrix Int n m) : Nat :=
 theorem checkRank_sound (h : checkRank A c = true) : ratRank A = c.r
 ```
 
+**Amendment: this certificate is the `Int` instance of hex-rank's.**
+[hex-rank](hex-rank.md) specifies the same two-sided certificate over
+every integral domain, and this library's certificate is its `Int`
+instance: `RankCert n m` is `Hex.Matrix.RankCert Int n m` (`rows`, `cols`,
+`denom = det B`, and `adj = adjugate B` in place of `coeffs`), `checkRank`
+is `Hex.Matrix.checkRank`, and `checkRank_sound` is hex-rank's soundness
+at `R = Int`. The `modulus` field, the modular minor test and the
+strictly-increasing check on `rows` and `cols` are dropped: the adjugate
+identity `B * adj = denom • identity r` certifies nonsingularity with no
+modulus, so the completeness obstruction for a bounded modulus below does
+not arise, and the all-column identity `denom • A = A[·, cols] * (adj * A[rows, ·])`
+indexes no complement. `rankCert?` keeps the modular route for finding
+`rows` and `cols` and obtains `adj B` and `det B` by Dixon solves of
+`B * X = det B • identity r` (`r` solves rather than `m - r`). The
+unchecked `rank` below is named `rankModular` in the implementation,
+since `Hex.Matrix.rank` is hex-rank's `Int` entry point and
+hex-matrix-tactic imports both. The rest of this section predates
+hex-rank and is read with that amendment; hex-rank's SPEC records the
+same list under its `Int` carrier.
+
 The soundness theorem targets `ratRank`, not the `rank` defined below.
 A certificate checker whose conclusion mentions the function it is meant
 to certify says nothing, and an earlier draft of this SPEC made exactly

--- a/SPEC/Libraries/hex-rank-mathlib.md
+++ b/SPEC/Libraries/hex-rank-mathlib.md
@@ -1,0 +1,412 @@
+# hex-rank-mathlib
+
+Correspondence between the executable rank certificate of
+[hex-rank](hex-rank.md) and Mathlib's `Matrix.rank`: a checked certificate
+determines the rank over the domain itself, the rank is unchanged by
+extension of scalars to any fraction field (`IsFractionRing`), the
+producer's certificate checks, the producer's index sets are the row and
+column rank profiles, and a Hex certificate and a Mathlib
+`Echelon.Decomposition` each determine the other. Dependencies are
+`HexRank`, `HexBareissMathlib`, `HexDeterminantMathlib` and
+`HexMatrixMathlib`, plus Mathlib. The certificate shape, the checker, the
+Mathlib-free soundness statements and the producer are in the
+computational SPEC and are not restated here.
+
+This library is `correspondence_only: true`, with comparator absence class
+**correspondence-only-layer**. It owns no runtime search, conformance
+driver or benchmark process. Build-only examples live in
+`HexRankMathlib/Tests.lean`.
+
+Computational conformance owner: `HexRank`.
+
+Computational performance owner: `HexRank`.
+
+Throughout, `e` is `HexMatrixMathlib.matrixEquiv`, `A : Hex.Matrix R n m`,
+`c : Hex.Matrix.RankCert R n m`, and `B`, `C`, `P`, `U`, `d`, `r` are as
+in [hex-rank §The certificate](hex-rank.md#the-certificate).
+
+## Transport
+
+Over `[CommRing R]`, entrywise lemmas in the style of
+`HexMatrixMathlib.matrixEquiv_mul`:
+
+```lean
+theorem matrixEquiv_selectRows (A : Hex.Matrix R n m) (rows : Vector (Fin n) k) :
+    e (Hex.Matrix.selectRows A rows) = (e A).submatrix rows.get id
+theorem matrixEquiv_selectCols (A : Hex.Matrix R n m) (cols : Vector (Fin m) k) :
+    e (Hex.Matrix.selectCols A cols) = (e A).submatrix id cols.get
+theorem matrixEquiv_selectedSubmatrix (A : Hex.Matrix R n m)
+    (rows : Vector (Fin n) k) (cols : Vector (Fin m) k) :
+    e (Hex.Matrix.selectedSubmatrix A rows cols) = (e A).submatrix rows.get cols.get
+theorem matrixEquiv_smul (c : R) (A : Hex.Matrix R n m) : e (c • A) = c • e A
+theorem matrixEquiv_identity : e (Hex.Matrix.identity (R := R) n) = 1
+```
+
+`matrixEquiv_selectedSubmatrix` is also specified by
+[hex-determinantal-ideal-mathlib](hex-determinantal-ideal-mathlib.md).
+These belong in `HexMatrixMathlib` (released, regenerated from this
+monorepo) beside `matrixEquiv_mul`, and whichever of the two planned
+companions lands first adds them there.
+
+With these, `checkRank A c = true` transports to three facts about
+`M := e A : Matrix (Fin n) (Fin m) R`:
+
+```text
+d ≠ 0
+(M.submatrix c.rows.get c.cols.get) * e c.adj = d • 1
+d • M = (M.submatrix id c.cols.get) * (e c.adj * M.submatrix c.rows.get id)
+```
+
+## Soundness for `Matrix.rank`
+
+Over `[CommRing R] [IsDomain R] [DecidableEq R]`:
+
+```lean
+theorem checkRank_sound (h : Hex.Matrix.checkRank A c = true) :
+    (e A).rank = c.rank
+```
+
+Proof, from the pinned Mathlib's `Mathlib/LinearAlgebra/Matrix/Rank.lean`:
+
+- **Lower bound.** From the second transported identity,
+  `Matrix.det_mul` and `Matrix.det_smul` with `Matrix.det_one` give
+  `det B · det (e c.adj) = d ^ r`, and `pow_ne_zero` in a domain gives
+  `det B ≠ 0`. `Matrix.rank_of_det_ne_zero` gives `B.rank = r`, and
+  `Matrix.rank_submatrix_le` gives `r = B.rank ≤ (e A).rank`.
+- **Upper bound.** `d ∈ nonZeroDivisors R` by
+  `mem_nonZeroDivisors_of_ne_zero`, so
+  `Matrix.rank_smul_of_mem_nonZeroDivisors` gives `(d • M).rank = M.rank`.
+  The third identity and `Matrix.rank_mul_le_left` give
+  `(d • M).rank ≤ (M.submatrix id c.cols.get).rank`, and
+  `Matrix.rank_le_card_width` bounds that by `Fintype.card (Fin r) = r`.
+  The strong rank condition these lemmas assume is
+  `commRing_strongRankCondition` (`Mathlib/LinearAlgebra/InvariantBasisNumber.lean`)
+  from `IsDomain.toNontrivial`.
+
+The boundary cases need no separate treatment. At `r = 0` the lower bound
+is `0 ≤ rank` and the upper bound is `Matrix.rank_le_card_width` at width
+`0`. At `n = 0` or `m = 0` both `Matrix.rank` and `c.rank` are `0`.
+
+The same argument goes through any injective ring homomorphism into a
+domain, and that form is the one consumers use:
+
+```lean
+theorem checkRank_sound_map [CommRing R] [CommRing S] [IsDomain S] [DecidableEq R]
+    (φ : R →+* S) (hφ : Function.Injective φ)
+    (h : Hex.Matrix.checkRank A c = true) :
+    ((e A).map φ).rank = c.rank
+```
+
+`φ.mapMatrix` preserves products and scalar multiplication, so the three
+identities hold for `(e A).map φ` with `φ d ≠ 0` by injectivity, and the
+two bounds above apply over `S`. `checkRank_sound` is the case
+`φ = RingHom.id R`. Note the shape `(e A).map φ` rather than
+`e (A.map φ)`: `HexMatrix` has no entrywise map today, and a consumer
+holding a Mathlib matrix rewrites once.
+
+## Scalar extension
+
+```lean
+theorem rank_map_eq [CommRing R] [IsDomain R] [Field K] [Algebra R K] [IsFractionRing R K]
+    (M : Matrix (Fin n) (Fin m) R) :
+    (M.map (algebraMap R K)).rank = M.rank
+```
+
+This is the one reusable scalar-extension theorem, parameterised by
+`IsFractionRing R K` (`Mathlib/RingTheory/Localization/FractionRing.lean`,
+an abbreviation for `IsLocalization (nonZeroDivisors R) K`), so that a
+consumer is not forced through `FractionRing R`: `Rat.isFractionRing :
+IsFractionRing ℤ ℚ` (same file) and the instance
+`IsFractionRing K[X] (RatFunc K)` (`Mathlib/FieldTheory/RatFunc/Basic.lean`)
+apply directly, and `FractionRing R` is one more instance. The pinned
+Mathlib has no `Matrix.rank_map` and no statement relating `Matrix.rank`
+over a domain to `Matrix.rank` over a fraction field; the closest are
+`IsFractionRing.finrank_right_eq` and `IsLocalization.finrank_eq`
+(`Mathlib/LinearAlgebra/Dimension/Localization.lean`), which are about a
+module already over the fraction field and do not mention matrices.
+
+Proof, through the certificate. Every domain has an exact quotient
+classically: `quot a b := if h : ∃ q, a = q * b then Classical.choose h else 0`
+satisfies `quot (a * b) b = a` for `b ≠ 0` by `mul_right_cancel₀`. With
+`Classical.decEq R` and `IsDomain.toNontrivial`, `rankCertWith_check`
+below gives a certificate `c` for `e.symm M` that checks. Then
+`checkRank_sound` gives `M.rank = c.rank`, and `checkRank_sound_map` at
+`φ = algebraMap R K`, injective by `IsFractionRing.injective`, gives
+`(M.map φ).rank = c.rank`. The certificate is used as a proof device and
+never computed.
+
+Two consequences worth stating as corollaries:
+
+```lean
+theorem rank_map_eq_rank_fractionRing [CommRing R] [IsDomain R] (M : Matrix (Fin n) (Fin m) R) :
+    (M.map (algebraMap R (FractionRing R))).rank = M.rank
+theorem rank_eq_ratFunc_rank' [Field F] (M : Matrix (Fin n) (Fin m) (Polynomial F)) :
+    (M.map (algebraMap (Polynomial F) (RatFunc F))).rank = M.rank
+```
+
+The second makes `HexPolySmithMathlib.rank_eq_ratFunc_rank` a statement
+about `Matrix.rank` over `Polynomial F` itself, and identifies `snfRank`
+with `rankWith Hex.exactDiv` over `DensePoly F` through `polyMatrixEquiv`
+and `rankWith_eq` below.
+
+A direct proof through `IsLocalizedModule` (the `K`-span of the columns of
+`M.map φ` as the localisation of the `R`-span of the columns of `M`) is
+possible and would not need the producer. It is not required, and the
+certificate route reuses theorems this library proves anyway.
+
+## Producer correctness
+
+Over `[CommRing R] [DecidableEq R] [Nontrivial R]` with
+`(quot : R → R → R) (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)`.
+`HexMatrixMathlib.isDomain_of_quot` (`HexBareissMathlib/Bareiss.lean`)
+supplies the `IsDomain R` instance inside every proof.
+
+```lean
+theorem rowReduceWith_spec (A : Hex.Matrix R n m) :
+    let D := Hex.Matrix.rowReduceWith quot A
+    let B := (e A).submatrix D.profile.rows.get D.profile.cols.get
+    D.denom = B.det ∧
+    (∀ k : Fin D.profile.rank,
+      (e D.matrix) (D.profile.rows.get k) = (B.adjugate * (e A).submatrix D.profile.rows.get id) k) ∧
+    (∀ i, i ∉ D.profile.rows.toList → (e D.matrix) i = 0)
+theorem rankCertWith_check (A : Hex.Matrix R n m) :
+    Hex.Matrix.checkRank A (Hex.Matrix.rankCertWith quot A) = true
+theorem rankWith_eq (A : Hex.Matrix R n m) :
+    Hex.Matrix.rankWith quot A = (e A).rank
+theorem rank_eq (A : Hex.Matrix Int n m) :
+    Hex.Matrix.rank A = (e A).rank
+```
+
+`rowReduceWith_spec` is proved by induction along the column loop with the
+invariant of
+[hex-rank §Exactness and producer correctness](hex-rank.md#exactness-and-producer-correctness):
+after `k` pivots with block `B_k` and `p = B_k.det`, the pivot rows of the
+state are `B_k.adjugate * P_k` and each non-pivot row `i` is
+`p • A[i, :] − A[i, cols] * (B_k.adjugate * P_k)`. The pivot step
+verifies the update against the invariant by left-multiplying by
+`B_{k+1}` and cancelling the nonzero scalar `B_{k+1}.det` in a domain,
+using `Matrix.mul_adjugate` (`Mathlib/LinearAlgebra/Matrix/Adjugate.lean`)
+and nothing else about determinants. That equality is what turns each
+`quot (…) prev` into the primed invariant value through `hquot`, so
+exactness of every division is a consequence of the invariant and not a
+separate hypothesis. The skip step changes nothing. `denom = B.det` is the
+invariant's `prev = p` at the end. No Desnanot-Jacobi or Sylvester
+identity is used, and `HexMatrixMathlib.desnanot_jacobi_borderedMinor` is
+not imported for this proof.
+
+`rankCertWith_check` applies `rowReduceWith_spec` to the pass over `A`
+(for `rows`, `cols`) and to the pass over `[B | 1]` (for `adj` and
+`denom`): the second pass has every column a pivot column and every row a
+pivot row in some order `π`, its reported pivot rows restricted to the
+right block are `(B.submatrix π id).adjugate * (1 : Matrix).submatrix π id`,
+which is `sign π • B.adjugate` by `Matrix.adjugate_mul_distrib` and the
+adjugate of a permutation matrix, and its `denom` is
+`(B.submatrix π id).det = sign π • B.det`. The three identities then hold
+with the common sign. Identity 3 for a non-pivot row is the "non-pivot
+rows are zero" clause of the first pass, read as
+`p • A[i, :] = A[i, cols] * (B.adjugate * P)`.
+
+`rankWith_eq` is `rankCertWith_check` composed with `checkRank_sound`, and
+`rank_eq` is its instance at `quot := HexArith.Int.exactDiv`,
+`hquot := Int.mul_ediv_cancel`.
+
+### The rank profile
+
+Over `[CommRing R] [IsDomain R]`, for `M : Matrix (Fin n) (Fin m) R`, define
+the two profiles as predicates on index lists:
+
+```lean
+def IsColRankProfile (M : Matrix (Fin n) (Fin m) R) (J : List (Fin m)) : Prop :=
+  ∀ j, j ∈ J ↔ (M.submatrix id (Fin.castLE (Nat.succ_le_of_lt j.isLt))).rank
+                = (M.submatrix id (Fin.castLE j.isLt.le)).rank + 1
+def IsRowRankProfile (M : Matrix (Fin n) (Fin m) R) (I : List (Fin n)) : Prop :=
+  ∀ i, i ∈ I ↔ (M.submatrix (Fin.castLE (Nat.succ_le_of_lt i.isLt)) id).rank
+                = (M.submatrix (Fin.castLE i.isLt.le) id).rank + 1
+
+theorem rowReduceWith_cols_eq_colProfile (A : Hex.Matrix R n m) :
+    IsColRankProfile (e A) (Hex.Matrix.rowReduceWith quot A).profile.cols.toList
+theorem rowReduceWith_rows_eq_rowProfile (A : Hex.Matrix R n m) :
+    IsRowRankProfile (e A) (Hex.Matrix.rowReduceWith quot A).profile.rows.toList
+```
+
+(`Fin.castLE` embeds the first `j` or `j + 1` indices.) Both are proved
+from `rowReduceWith_spec` and `checkRank_sound`: column `j` is a pivot
+column exactly when the reduced form has a nonzero entry in column `j` in
+some non-pivot row at the moment column `j` is scanned, and that is
+exactly when the rank of the first `j + 1` columns exceeds the rank of the
+first `j`. The row statement is the argument in
+[hex-rank §The rank profile](hex-rank.md#the-rank-profile), formalised as:
+the chosen pivot row at each step is the least-index non-pivot row with a
+nonzero eliminated entry, and every smaller-index non-pivot row with a
+nonzero eliminated entry would have been chosen first, so the chosen row
+is not in the span of the rows before it. Neither theorem is needed for
+`rank_eq`; they are what makes `rankProfileWith` an API rather than an
+implementation detail.
+
+## Relation to `Echelon.Decomposition`
+
+The pinned Mathlib's certificate
+(`Mathlib/LinearAlgebra/Matrix/Echelon/Decomposition.lean`, namespace
+`Echelon`, over `[Fintype m] [LinearOrder m] [Fintype n] [LinearOrder n]
+[CommRing R] [IsDomain R]`) is
+
+```lean
+structure Decomposition (A : Matrix m n R) where
+  L : Matrix m m R
+  σ : Equiv.Perm m
+  pivot : m → WithTop n
+  isPivotedBy : (L * (A.submatrix σ id)).IsPivotedBy pivot
+  L_lowerTriangular : L.IsLowerTriangular
+  L_diag_ne_zero (i : m) : L.diag i ≠ 0
+```
+
+with `Decomposition.rank_eq : A.rank = #{i | cert.pivot i ≠ ⊤}`. Its
+checker is the `Decidable (A.IsPivotedBy l)` instance of
+`Mathlib/LinearAlgebra/Matrix/Echelon/Pivot.lean`, run by `decide` in the
+kernel on the product `L * A.submatrix σ id` (`certifyCondition` in
+`Mathlib/Tactic/Echelon/Bareiss.lean`). It carries an `n × n`
+transform and no minor; the Hex certificate carries an `r × r` adjugate
+and no transform. Neither is a projection of the other, and the two
+conversions below each compute one `r × r` object.
+
+**From a Hex certificate.** Given `checkRank A c = true` and a lower
+triangular `T : Matrix (Fin r) (Fin r) R` with nonzero diagonal such that
+`T * B` is upper triangular with nonzero diagonal (a fraction-free
+Gaussian transform of `B`, which exists because every leading principal
+minor of `B` in elimination row order is a pivot of the run, hence
+nonzero), set
+
+```text
+σ     := the permutation moving c.rows to positions 0 … r - 1 in order
+L     := [[T, 0], [-(M.submatrix id c.cols.get restricted to non-pivot rows) * e c.adj, d • 1]]
+pivot := fun i => if i < r then ↑(c.cols.get i) else ⊤
+```
+
+`L` is block lower triangular with triangular diagonal blocks and diagonal
+entries the diagonal of `T` and `d`, all nonzero. The first `r` rows of
+`L * M.submatrix σ id` are `T * (M.submatrix c.rows.get id)`, in echelon
+form with pivots at `c.cols` because the columns between pivot columns
+are zero in every non-pivot row at the moment they were skipped. The
+remaining rows are `d • M[i, :] − M[i, cols] * (e c.adj * P)`, which is
+`0` by identity 3. So:
+
+```lean
+def RankCert.toDecomposition (h : Hex.Matrix.checkRank A c = true)
+    (T : Matrix (Fin c.rank) (Fin c.rank) R) (hT : T.IsLowerTriangular)
+    (hTd : ∀ i, T.diag i ≠ 0) (hTB : (T * (e A).submatrix c.rows.get c.cols.get).IsUpperTriangular)
+    (hTBd : ∀ i, (T * (e A).submatrix c.rows.get c.cols.get).diag i ≠ 0) :
+    Echelon.Decomposition (e A)
+theorem RankCert.toDecomposition_pivot_card … :
+    #{i | (RankCert.toDecomposition h T …).pivot i ≠ ⊤} = c.rank
+theorem exists_decomposition_of_checkRank (h : Hex.Matrix.checkRank A c = true) :
+    ∃ D : Echelon.Decomposition (e A), #{i | D.pivot i ≠ ⊤} = c.rank
+```
+
+The transform `T` is an input because this library does not compute it:
+it is the transform of a below-only fraction-free pass over `B`, which
+`bareissNoPivotWith` performs without reporting. The existence theorem
+supplies `T` by the fraction-free LU factorisation of a matrix whose
+leading principal minors are nonzero (Bareiss 1968; the explicit
+entries are minors of `B`, so `T` is over `R`). The executable adapter
+that produces `T`, and the `bareiss_ext` model that lets Hex's producer
+feed `norm_rank` directly, are hex-matrix-tactic's
+(https://github.com/kim-em/hex-dev/issues/10151), which names both.
+
+**From a Decomposition.** Given `D : Echelon.Decomposition (e A)` with
+`r := #{i | D.pivot i ≠ ⊤}`, the rows with a pivot are the first `r` rows
+of `L * M.submatrix σ id` (`IsPivotedBy.monotone`), so
+`rows := (D.σ 0, …, D.σ (r - 1))` and `cols :=` the pivot columns in
+order. The `r × r` block of `M.submatrix σ id` at those positions is
+`(L.submatrix (first r) (first r))⁻¹ * (echelon block)` over the fraction
+field, a product of a lower triangular and an upper triangular matrix
+with nonzero diagonals, so its determinant is nonzero. Then
+`d := B.det`, `adj := B.adjugate`, and the three identities hold by
+`Matrix.mul_adjugate` and the argument of
+[hex-rank §Completeness](hex-rank.md#completeness):
+
+```lean
+theorem exists_rankCert_of_decomposition (D : Echelon.Decomposition (e A)) :
+    ∃ c : Hex.Matrix.RankCert R n m,
+      Hex.Matrix.checkRank A c = true ∧ c.rank = #{i | D.pivot i ≠ ⊤}
+```
+
+The executable form runs `rankCertWith`'s second pass on `[B | 1]` for
+`adj` and `denom`, with `rows`, `cols` read off `D`; it is one `O(r³)`
+pass and no elimination of `A`.
+
+## Decidability
+
+```lean
+instance (A : Matrix (Fin n) (Fin m) ℤ) (r : Nat) : Decidable (A.rank = r)
+```
+
+by `rank_eq` at `e.symm A`, in the style of hex-berlekamp-mathlib's
+`Decidable (Irreducible f)`. This is the instance
+[hex-modular-matrix](hex-modular-matrix.md) planned for its `rank`, now
+supplied here with the direct algorithm; the multi-modular route may
+later replace the computation behind it without changing the statement.
+A generic instance for every carrier with an executable exact quotient is
+not declared, because the quotient is a function argument and not an
+instance; a carrier consumer writes the one-line
+`decidable_of_iff (rankWith quot A = r)` with `rankWith_eq`.
+
+## Mathlib inventory
+
+Checked against the pinned Mathlib, `v4.34.0-rc2` (Mathlib commit
+`85e3a25e006c35636f0e53b0e9296caca2685bc0`), by file path:
+
+- `Mathlib/LinearAlgebra/Matrix/Echelon/Decomposition.lean`:
+  `Echelon.Decomposition` and `Echelon.Decomposition.rank_eq`, the only
+  declarations in the file, over `[CommRing R] [IsDomain R]`.
+- `Mathlib/LinearAlgebra/Matrix/Echelon/Pivot.lean`: `Matrix.IsPivotedBy`,
+  `Matrix.IsPivotedBy.rank_eq`, `Matrix.IsPivotedBy.monotone`, and the
+  `Decidable (A.IsPivotedBy l)` instance.
+- `Mathlib/Tactic/NormRank.lean` and `Mathlib/Tactic/Echelon/{Core,Bareiss,Rat,Zsqrtd,Parsing}.lean`:
+  `norm_rank`, `eval_rank`, `certifyCondition`, `bareissDecomp`,
+  `BareissExt`, `bareiss_ext`. The elimination invariant there is not a
+  theorem; only the final certificate is kernel-checked.
+- `Mathlib/LinearAlgebra/Matrix/Rank.lean`: `Matrix.rank`,
+  `rank_of_det_ne_zero`, `rank_submatrix_le`, `rank_mul_le_left`,
+  `rank_le_card_width`, `rank_smul_of_mem_nonZeroDivisors`,
+  `rank_mul_eq_left_of_det_ne_zero`, `rank_mul_eq_right_of_det_ne_zero`.
+- `Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean`: `det_mul`,
+  `det_smul`, `det_one`, `RingHom.map_det`.
+- `Mathlib/LinearAlgebra/Matrix/Adjugate.lean`: `adjugate`,
+  `mul_adjugate`, `adjugate_mul`, `adjugate_mul_distrib`.
+- `Mathlib/RingTheory/Localization/FractionRing.lean`: `IsFractionRing`
+  (an `abbrev` for `IsLocalization (nonZeroDivisors R) K`),
+  `IsFractionRing.injective`, `IsFractionRing.to_map_eq_zero_iff`,
+  `Rat.isFractionRing`, `FractionRing`.
+- `Mathlib/FieldTheory/RatFunc/Basic.lean`: the instance
+  `IsFractionRing K[X] (RatFunc K)`.
+- `Mathlib/LinearAlgebra/Dimension/Localization.lean`:
+  `IsLocalization.finrank_eq`, `IsFractionRing.finrank_right_eq`, about
+  modules over the fraction field, not matrices.
+- **Absent.** `Matrix.rank_map`, any lemma relating `Matrix.rank A` to
+  `Matrix.rank (A.map (algebraMap R K))`, any "rank equals the largest
+  nonzero minor" lemma, any rank lemma parameterised over a `RingHom`,
+  and any statement about the generic rank of a polynomial matrix.
+  `rank_map_eq` and `checkRank_sound_map` are therefore new, and if
+  Mathlib gains either, this library should state agreement with it
+  rather than a second copy.
+
+An implementer must re-run these searches when the Mathlib pin moves.
+
+## Tests
+
+`HexRankMathlib/Tests.lean`, build-only:
+
+- `checkRank_sound` on a closed `Hex.Matrix ℤ 3 4` of rank `2` with a
+  hand-written certificate, the check discharged by `decide +kernel`,
+  concluding `(e A).rank = 2`;
+- `rank_eq` on the same matrix through `Hex.Matrix.rank`, and the
+  `Decidable (A.rank = r)` instance on its Mathlib form by `decide`;
+- `rank_map_eq` instantiated at `IsFractionRing ℤ ℚ` and at
+  `IsFractionRing ℚ[X] (RatFunc ℚ)`, to check the instances resolve
+  without going through `FractionRing`;
+- `exists_decomposition_of_checkRank` and
+  `exists_rankCert_of_decomposition` on a `2 × 2` matrix of rank `1`, to
+  check that the hypotheses are stated in the form a consumer has.
+
+These are not an independent oracle. The conformance stream of `HexRank`
+is.

--- a/SPEC/Libraries/hex-rank-mathlib.md
+++ b/SPEC/Libraries/hex-rank-mathlib.md
@@ -38,15 +38,16 @@ theorem matrixEquiv_selectCols (A : Hex.Matrix R n m) (cols : Vector (Fin m) k) 
 theorem matrixEquiv_selectedSubmatrix (A : Hex.Matrix R n m)
     (rows : Vector (Fin n) k) (cols : Vector (Fin m) k) :
     e (Hex.Matrix.selectedSubmatrix A rows cols) = (e A).submatrix rows.get cols.get
-theorem matrixEquiv_smul (c : R) (A : Hex.Matrix R n m) : e (c • A) = c • e A
-theorem matrixEquiv_identity : e (Hex.Matrix.identity (R := R) n) = 1
 ```
 
-`matrixEquiv_selectedSubmatrix` is also specified by
-[hex-determinantal-ideal-mathlib](hex-determinantal-ideal-mathlib.md).
-These belong in `HexMatrixMathlib` (released, regenerated from this
-monorepo) beside `matrixEquiv_mul`, and whichever of the two planned
-companions lands first adds them there.
+together with the existing `matrixEquiv_smul` and `matrixEquiv_one` in
+`HexMatrixMathlib/Algebra.lean`. The two selection lemmas belong in
+`HexMatrixMathlib` (released, regenerated from this monorepo) beside
+`matrixEquiv_mul`. `matrixEquiv_selectedSubmatrix` cannot, because
+`selectedSubmatrix` is defined in `HexDeterminant/Minor.lean`, above
+`HexMatrix`; it belongs in `HexDeterminantMathlib`, is also specified by
+[hex-determinantal-ideal-mathlib](hex-determinantal-ideal-mathlib.md),
+and whichever of the two planned companions lands first adds it there.
 
 With these, `checkRank A c = true` transports to three facts about
 `M := e A : Matrix (Fin n) (Fin m) R`:
@@ -80,8 +81,9 @@ Proof, from the pinned Mathlib's `Mathlib/LinearAlgebra/Matrix/Rank.lean`:
   `(d • M).rank ≤ (M.submatrix id c.cols.get).rank`, and
   `Matrix.rank_le_card_width` bounds that by `Fintype.card (Fin r) = r`.
   The strong rank condition these lemmas assume is
-  `commRing_strongRankCondition` (`Mathlib/LinearAlgebra/InvariantBasisNumber.lean`)
-  from `IsDomain.toNontrivial`.
+  `commRing_strongRankCondition`
+  (`Mathlib/LinearAlgebra/FreeModule/StrongRankCondition.lean`) from
+  `IsDomain.toNontrivial`.
 
 The boundary cases need no separate treatment. At `r = 0` the lower bound
 is `0 ≤ rank` and the upper bound is `Matrix.rank_le_card_width` at width
@@ -175,18 +177,30 @@ theorem rankWith_eq (A : Hex.Matrix R n m) :
     Hex.Matrix.rankWith quot A = (e A).rank
 theorem rank_eq (A : Hex.Matrix Int n m) :
     Hex.Matrix.rank A = (e A).rank
+theorem exists_rankCert [CommRing R] [IsDomain R] [DecidableEq R] (A : Hex.Matrix R n m) :
+    ∃ c : Hex.Matrix.RankCert R n m, Hex.Matrix.checkRank A c = true
 ```
+
+`exists_rankCert` is completeness with no quotient hypothesis: the
+classical exact quotient of [Scalar extension](#scalar-extension) and
+`rankCertWith_check` supply the witness. The adjugate argument of
+[hex-rank §Completeness](hex-rank.md#completeness) is an alternative proof
+that does not go through the producer.
 
 `rowReduceWith_spec` is proved by induction along the column loop with the
 invariant of
 [hex-rank §Exactness and producer correctness](hex-rank.md#exactness-and-producer-correctness):
 after `k` pivots with block `B_k` and `p = B_k.det`, the pivot rows of the
 state are `B_k.adjugate * P_k` and each non-pivot row `i` is
-`p • A[i, :] − A[i, cols] * (B_k.adjugate * P_k)`. The pivot step
+`p • A[i, :] − A[i, cols] * (B_k.adjugate * P_k)`. The pivot step first
+identifies the new pivot with `B_{k+1}.det` by the bordered-determinant
+identity `det [[B_k, u], [vᵀ, x]] = x · det B_k − vᵀ * B_k.adjugate * u`
+(Laplace expansion along the last row, `Matrix.det_succ_row` and
+`Matrix.adjugate_apply`), so that `B_{k+1}` is nonsingular, and then
 verifies the update against the invariant by left-multiplying by
 `B_{k+1}` and cancelling the nonzero scalar `B_{k+1}.det` in a domain,
-using `Matrix.mul_adjugate` (`Mathlib/LinearAlgebra/Matrix/Adjugate.lean`)
-and nothing else about determinants. That equality is what turns each
+using `Matrix.mul_adjugate` (`Mathlib/LinearAlgebra/Matrix/Adjugate.lean`).
+Those are the only determinant facts used. That equality is what turns each
 `quot (…) prev` into the primed invariant value through `hquot`, so
 exactness of every division is a consequence of the invariant and not a
 separate hypothesis. The skip step changes nothing. `denom = B.det` is the
@@ -269,12 +283,29 @@ transform and no minor; the Hex certificate carries an `r × r` adjugate
 and no transform. Neither is a projection of the other, and the two
 conversions below each compute one `r × r` object.
 
-**From a Hex certificate.** Given `checkRank A c = true` and a lower
-triangular `T : Matrix (Fin r) (Fin r) R` with nonzero diagonal such that
-`T * B` is upper triangular with nonzero diagonal (a fraction-free
-Gaussian transform of `B`, which exists because every leading principal
-minor of `B` in elimination row order is a pivot of the run, hence
-nonzero), set
+**From a Hex certificate.** A checked certificate alone does not
+determine a `Decomposition`, because `checkRank` accepts index sets that
+no echelon form has: on `A = [[1, 1]]` the certificate
+`rows = [0], cols = [1], denom = 1, adj = [[1]]` checks, but no echelon
+form of `A` has its pivot in column `1`; and on `B = [[0, 1], [1, 0]]`
+(the canonical certificate of that matrix) no lower triangular `T` with
+nonzero diagonal makes `T * B` upper triangular with nonzero diagonal,
+since the `(1, 0)` entry of `T * B` is the `(1, 1)` entry of `T`. The
+adapter therefore takes, besides the certificate, a lower triangular
+transform `T` of the pivot block together with the echelon condition it
+has to produce:
+
+```lean
+def RankCert.toDecomposition (h : Hex.Matrix.checkRank A c = true)
+    (T : Matrix (Fin c.rank) (Fin c.rank) R) (hT : T.IsLowerTriangular)
+    (hTd : ∀ i, T.diag i ≠ 0)
+    (hTP : (T * (e A).submatrix c.rows.get id).IsPivotedBy (fun k => ↑(c.cols.get k))) :
+    Echelon.Decomposition (e A)
+theorem RankCert.toDecomposition_pivot_card (h T hT hTd hTP) :
+    #{i | (RankCert.toDecomposition h T hT hTd hTP).pivot i ≠ ⊤} = c.rank
+```
+
+with
 
 ```text
 σ     := the permutation moving c.rows to positions 0 … r - 1 in order
@@ -284,32 +315,34 @@ pivot := fun i => if i < r then ↑(c.cols.get i) else ⊤
 
 `L` is block lower triangular with triangular diagonal blocks and diagonal
 entries the diagonal of `T` and `d`, all nonzero. The first `r` rows of
-`L * M.submatrix σ id` are `T * (M.submatrix c.rows.get id)`, in echelon
-form with pivots at `c.cols` because the columns between pivot columns
-are zero in every non-pivot row at the moment they were skipped. The
+`L * M.submatrix σ id` are `T * (M.submatrix c.rows.get id)`, pivoted at
+`c.cols` by `hTP` (which forces `c.cols` strictly increasing). The
 remaining rows are `d • M[i, :] − M[i, cols] * (e c.adj * P)`, which is
-`0` by identity 3. So:
+`0` by identity 3. Existence is then a statement about the producer's
+certificates, not about arbitrary checked ones:
 
 ```lean
-def RankCert.toDecomposition (h : Hex.Matrix.checkRank A c = true)
-    (T : Matrix (Fin c.rank) (Fin c.rank) R) (hT : T.IsLowerTriangular)
-    (hTd : ∀ i, T.diag i ≠ 0) (hTB : (T * (e A).submatrix c.rows.get c.cols.get).IsUpperTriangular)
-    (hTBd : ∀ i, (T * (e A).submatrix c.rows.get c.cols.get).diag i ≠ 0) :
-    Echelon.Decomposition (e A)
-theorem RankCert.toDecomposition_pivot_card … :
-    #{i | (RankCert.toDecomposition h T …).pivot i ≠ ⊤} = c.rank
+theorem nonempty_decomposition [CommRing R] [IsDomain R] (A : Hex.Matrix R n m) :
+    Nonempty (Echelon.Decomposition (e A))
 theorem exists_decomposition_of_checkRank (h : Hex.Matrix.checkRank A c = true) :
     ∃ D : Echelon.Decomposition (e A), #{i | D.pivot i ≠ ⊤} = c.rank
 ```
 
-The transform `T` is an input because this library does not compute it:
-it is the transform of a below-only fraction-free pass over `B`, which
-`bareissNoPivotWith` performs without reporting. The existence theorem
-supplies `T` by the fraction-free LU factorisation of a matrix whose
-leading principal minors are nonzero (Bareiss 1968; the explicit
-entries are minors of `B`, so `T` is over `R`). The executable adapter
-that produces `T`, and the `bareiss_ext` model that lets Hex's producer
-feed `norm_rank` directly, are hex-matrix-tactic's
+The first is proved on `rankCertWith quot A` for the classical quotient:
+its `rows` are in elimination order and its `cols` strictly increasing,
+every leading principal minor of its `B` is a pivot of the run and so
+nonzero, and the below-only fraction-free elimination of `B` in that
+order (Bareiss 1968) supplies `T` over `R` with `T * P` in echelon form
+at `cols`, the columns between pivot columns being zero in every
+non-pivot row at the moment they were skipped. The second is the first
+together with `Decomposition.rank_eq` and `checkRank_sound`, and does
+not go through the given certificate's index sets.
+
+`T` is an input because this library does not compute it: it is the
+transform of a below-only fraction-free pass over `B`, which
+`Hex.Matrix.bareissNoPivotWith` performs without reporting. The
+executable adapter that produces `T`, and the `bareiss_ext` model that
+lets Hex's producer feed `norm_rank` directly, are hex-matrix-tactic's
 (https://github.com/kim-em/hex-dev/issues/10151), which names both.
 
 **From a Decomposition.** Given `D : Echelon.Decomposition (e A)` with

--- a/SPEC/Libraries/hex-rank.md
+++ b/SPEC/Libraries/hex-rank.md
@@ -257,8 +257,10 @@ implementation.
   certificate of positive rank does, since `Vector (Fin 0) rank` is empty
   for `rank > 0`.
 - **`rank > min n m`.** A passing check forces the entries of `rows` and
-  of `cols` to be distinct, so `rank ≤ n` and `rank ≤ m`. No certificate
-  of larger rank checks.
+  of `cols` to be distinct (a repeated index gives `det B = 0` by
+  `det_eq_zero_of_row_eq` in `HexDeterminant/ColumnLinear.lean` and its
+  column form), so `rank ≤ n` and `rank ≤ m`. No certificate of larger
+  rank checks.
 
 The general soundness and completeness proofs below cover all three
 without a case split. They are listed so that the conformance suite tests
@@ -380,11 +382,13 @@ Let `r` be the largest size of a nonzero minor of `A`, and let
   `d • A[i, :] = B[i-block] * adj * P = d • P[i-block]`, the adjugate
   identity again. For a row index `i ∉ rows`, the `(r + 1) × (r + 1)`
   minor on rows `rows ++ [i]` and columns `cols ++ [j]` vanishes for every
-  `j` (by maximality of `r`), and Laplace expansion of that bordered minor
-  along its last row (`det_eq_foldl_laplace_col` transposed, or
-  `HexDeterminant/LastRow.lean`) reads
-  `d · A[i, j] = Σ_k A[i, cols[k]] · (adj * P)[k, j]`, which is entry
-  `(i, j)` of identity 3.
+  `j` (by maximality of `r`), and the bordered-determinant identity
+  `det [[B, u], [vᵀ, x]] = x · det B − vᵀ * adjugate B * u` (Laplace
+  expansion along the last row, `HexDeterminant/LastRow.lean`, followed by
+  the cofactor expansion of each minor, which is the definition of
+  `adjugate`) reads `d · A[i, j] = Σ_k A[i, cols[k]] · (adj * P)[k, j]`,
+  which is entry `(i, j)` of identity 3. For `j ∈ cols` the minor has a
+  repeated column and the identity is `d · A[i, j] = d · A[i, j]`.
 
 At `r = 0` the maximal nonzero minor is the empty one (`det` of the
 `0 × 0` matrix is `1`), every entry of `A` is a vanishing `1 × 1` minor,
@@ -876,8 +880,9 @@ Fixtures follow [SPEC/testing.md](../testing.md). Lean drivers at
 "HexRank|hexrank_emit_fixtures|scripts/oracle/rank_carriers.py|conformance-fixtures/HexRank/rank.jsonl"
 ```
 
-The driver follows `scripts/oracle/matrix_carriers.py` in shape:
-python-flint for `Int` (`fmpz_mat`), `Rat` (`fmpq_mat`) and `ZMod64 p`
+The driver has the shape hex-bareiss's carrier SPEC gives its
+`scripts/oracle/matrix_carriers.py`, and shares code with it once that
+lands: python-flint for `Int` (`fmpz_mat`), `Rat` (`fmpq_mat`) and `ZMod64 p`
 (`nmod_mat`) records, SymPy for `DensePoly` and `MvPoly` records with the
 exact domain (`ZZ[x]`, `QQ[x]`, `GF(p)[x]`, `ZZ[x0, …]`, `QQ[x0, …]`)
 stated explicitly. Both are already installed and preflighted by the

--- a/SPEC/Libraries/hex-rank.md
+++ b/SPEC/Libraries/hex-rank.md
@@ -38,7 +38,7 @@ Nothing computes the rank of a matrix over `MvPoly`, over `ZPoly`, or over
 an arbitrary domain, and none of the three above returns a witness a
 consumer can re-check.
 
-`HexBareiss.bareissWith` is generic (any `quot : R → R → R` satisfying
+`Hex.Matrix.bareissWith` (library hex-bareiss) is generic (any `quot : R → R → R` satisfying
 `quot (a * b) b = a` for `b ≠ 0`, with laws over
 `[Lean.Grind.CommRing R] [DecidableEq R]`), but it is square in its types
 and it records an early singular stop: on `[[0, 1], [0, 0]]` the pivot search
@@ -178,8 +178,10 @@ For `A : Matrix R n m` (`n` rows, `m` columns, the `Hex.Matrix` convention):
 ```lean
 namespace Hex.Matrix
 
-/-- A two-sided rank certificate: an `rank × rank` submatrix of `A` at
-`rows × cols`, its adjugate `adj`, and its determinant `denom`. -/
+/-- A two-sided rank certificate: a `rank × rank` submatrix `B` of `A` at
+`rows × cols`, and a matrix `adj` and scalar `denom ≠ 0` with
+`B * adj = denom • 1`. The producer fills them with `adjugate B` and
+`det B`; the checker requires only the identity. -/
 structure RankCert (R : Type u) (n m : Nat) where
   rank : Nat
   rows : Vector (Fin n) rank
@@ -202,6 +204,16 @@ all-column identity `d • A = C * U` that the certificate establishes. It
 is derived by the checker rather than stored, see
 [Why the certificate stores the adjugate](#why-the-certificate-stores-the-adjugate-and-not-the-coefficients).
 
+The three identities are the whole contract. A passing check does not
+establish that `denom` is `det B` or that `adj` is `adjugate B`: for
+`A = B = 2 • identity 2`, the fields `denom = 2`, `adj = identity 2` pass
+all three tests, while `det B = 4` and `adjugate B = 2 • identity 2`. What
+a checked certificate carries is a denominator and numerator for `B⁻¹`,
+and that is all soundness needs. The producer's fields are `det B` and
+`adjugate B`, which is the companion's normalisation theorem
+`rowReduceWith_spec`, not a checker property, and the field names are
+chosen for the producer's values.
+
 The vectors `rows` and `cols` are index selections, not sets: they may be
 in any order, and the checker imposes no ordering or distinctness
 condition on them. None is needed. A repeated row or column index makes
@@ -213,9 +225,13 @@ indexing forced a strictly-increasing check.
 
 The producer returns `rows` in elimination order and `cols` strictly
 increasing, and `denom` is the determinant of `B` with its rows in that
-order. A consumer that sorts `rows` must negate `denom` and `adj` by the
-sign of the sorting permutation, or simply not sort: nothing in the
-checker cares.
+order. A consumer that reorders `rows` by a permutation `S` (so `B`
+becomes `S * B`) must replace `adj` by `adj * S⁻¹`, since
+`(S * B) * (adj * S⁻¹) = denom • 1`; `denom` may stay as it is, and
+becomes the determinant of the reordered block only after both fields
+are also multiplied by `sign S`. Negating `denom` alone is wrong, because
+`adjugate (S * B) = sign S • adjugate B * S⁻¹`. Or simply do not sort:
+nothing in the checker cares.
 
 ### The checker
 
@@ -308,12 +324,12 @@ Both statements are Mathlib-free and live in `HexRank/Check.lean`, over
 `B`, `C`, `P`, `U` as above and `d := c.denom`, `r := c.rank`.
 
 ```lean
-theorem checkRank_minor_ne_zero (h : checkRank A c = true) :
+theorem RankCert.det_ne_zero (h : checkRank A c = true) :
     det (selectedSubmatrix A c.rows c.cols) ≠ 0
-theorem checkRank_minor_succ_eq_zero (h : checkRank A c = true)
+theorem RankCert.det_succ_eq_zero (h : checkRank A c = true)
     (rows : Vector (Fin n) (c.rank + 1)) (cols : Vector (Fin m) (c.rank + 1)) :
     det (selectedSubmatrix A rows cols) = 0
-theorem checkRank_eq_zero_of_rank_zero (h : checkRank A c = true) (hr : c.rank = 0) :
+theorem RankCert.matrix_eq_zero (h : checkRank A c = true) (hr : c.rank = 0) :
     A = Matrix.zero n m
 ```
 
@@ -324,7 +340,7 @@ that a Mathlib-free library can state. The companion turns them into
 characterisation for `rowReduce_rank` over a field, and a consumer holding
 both gets `rowReduce_rank A = c.rank` over a field with no new proof.
 
-**Lower bound (`checkRank_minor_ne_zero`).** From identity 2,
+**Lower bound (`RankCert.det_ne_zero`).** From identity 2,
 `det (B * adj) = det (d • identity r)`. The left side is `det B · det adj`
 by `det_mul`. The right side is `d ^ r` by `det_rowScale` applied `r`
 times to `det_identity` (a lemma `det_smul : det (c • M) = c ^ k * det M`
@@ -333,11 +349,10 @@ for `M : Matrix R k k`, new in `HexDeterminant/RowOps.lean` if absent).
 and then `det B ≠ 0`. At `r = 0` the right side is `1`, and `1 ≠ 0` is
 `DomainLaws.one_ne_zero`; nothing else changes.
 
-**Upper bound (`checkRank_minor_succ_eq_zero`).** Fix `rows`, `cols` of
-length `r + 1`. From identity 3 and `selectedSubmatrix` commuting with
-scalar multiplication and with products of the shape `C * U`
-(`selectedSubmatrix (C * U) rows cols = selectRows C rows * selectCols U cols`,
-entrywise),
+**Upper bound (`RankCert.det_succ_eq_zero`).** Fix `rows`, `cols` of
+length `r + 1`. From identity 3, `selectedSubmatrix_smul`, and `selectedSubmatrix_mul`
+(`HexDeterminant/Gram.lean`:
+`selectedSubmatrix (C * U) rows cols = selectRows C rows * selectCols U cols`),
 
 ```text
 d ^ (r + 1) · det (selectedSubmatrix A rows cols)
@@ -354,7 +369,7 @@ Hence `d ^ (r + 1) · det (…) = 0`, and `d ^ (r + 1) ≠ 0` gives
 `det (…) = 0`. This is the same "empty middle sum" step that
 hex-determinantal-ideal's vanishing direction uses.
 
-**`rank = 0` (`checkRank_eq_zero_of_rank_zero`).** Identity 3 is
+**`rank = 0` (`RankCert.matrix_eq_zero`).** Identity 3 is
 `d • A = 0` entrywise, `d ≠ 0`, and `no_zero_div`. This is the upper bound
 at `r = 0` read directly, since `minors 1 A` are the entries.
 
@@ -400,7 +415,18 @@ zero divisors (so that "largest size of a nonzero minor" is a rank). It
 does not need an exact quotient: `adjugate` is polynomial in the entries.
 That is why the certificate is complete over every nontrivial domain even
 though the producer below is only defined over carriers with an executable
-exact quotient.
+exact quotient. The statement is a theorem of the companion,
+
+```lean
+theorem exists_rankCert [CommRing R] [IsDomain R] [DecidableEq R] (A : Hex.Matrix R n m) :
+    ∃ c : Hex.Matrix.RankCert R n m, Hex.Matrix.checkRank A c = true
+```
+
+with no quotient hypothesis. Its shortest proof is not the argument
+above but the producer's: every domain has an exact quotient classically,
+and `rankCertWith_check` then supplies the witness. The adjugate argument
+is recorded so that completeness is seen to hold for the certificate
+shape itself, independently of any elimination.
 
 ## The producer
 
@@ -438,16 +464,25 @@ Columns are scanned from `0` to `m - 1`. At column `j`:
    the coefficients the reduced form reports for that column.
 3. **Eliminate.** Otherwise `p` is appended to the pivot rows and `j` to
    the pivot columns, `pivot := M[p, j]`, and every row `i ≠ p` is updated
-   in the columns `j' > j`:
+   in every column `j' ≠ j`:
 
    ```text
    M[i, j'] ← quot (pivot · M[i, j'] − M[i, j] · M[p, j']) prev
    ```
 
-   after which `M[i, j] ← 0` for `i ≠ p`. Columns before `j` are
-   untouched: in a pivot row they hold earlier reduced entries, in a
-   non-pivot row they are already zero at pivot columns and are never
-   read again at skipped columns. Then `prev := pivot`.
+   after which `M[i, j] ← 0` for `i ≠ p`. The pivot row itself is not
+   changed. Then `prev := pivot`.
+
+   The columns before `j` are not exempt. In the pivot row `p` they are
+   zero (row `p` was a non-pivot row until now, so it is zero at every
+   earlier pivot column and at every earlier skipped column), so there
+   the formula is `quot (pivot · M[i, j']) prev`: in an earlier pivot row
+   it rescales the reduced entry from denominator `prev` to denominator
+   `pivot`, and in a non-pivot row it maps `0` to `0`. An implementation
+   may special-case the two shapes, but the reduced-form contract below
+   depends on the rescaling of the earlier pivot rows: on
+   `[[2, 0], [0, 3]]` the pass must end with `[[6, 0], [0, 6]]` and
+   `denom = 6`, not `[[2, 0], [0, 6]]`.
 
 **Rows are not moved.** The pivot row stays where it is, the search order
 in step 1 is the original row order, and the state records which rows are
@@ -475,9 +510,12 @@ returned: `denom = 1` and `matrix = A`, which is the zero matrix.
 The pass takes `[Zero R] [One R] [Sub R] [Mul R] [DecidableEq R]` and
 `quot`, the same operation classes as `bareissWith`. `One R` is for the
 seed. There is an in-place `rowReduceWithImpl` on `Array (Array R)`
-registered by `@[csimp]`, reusing `matrixToRows`, `rowsToMatrix` and
-`getEntry` from `HexBareiss/Bareiss.lean`; the public definition is the
-kernel-facing one, per design principle 11.
+registered by `@[csimp]`, reusing `getEntry` from
+`HexBareiss/Bareiss.lean` and rectangular forms of its `matrixToRows` and
+`rowsToMatrix` (the existing ones are `Matrix R n n` only; the
+`Matrix R n m` forms with their round-trip lemmas are listed under
+[Prerequisite changes](#prerequisite-changes-in-other-libraries)); the
+public definition is the kernel-facing one, per design principle 11.
 
 ### The rank profile
 
@@ -556,9 +594,10 @@ obligation are the same. Everything in the left column that concerns the
 determinant (`sign`, `lastDiag?`, `singularStep`, `BareissData.det`) has
 no counterpart here, and nothing here is a field added to `BareissData`.
 `bareissWith` stays the determinant algorithm: on a square full-rank
-matrix `rowReduceWith` does about half again the work of `bareissWith`
-(it updates rows above the pivot and never stops early), and a consumer
-that wants a determinant should not call it.
+matrix `rowReduceWith` does about three times the work of `bareissWith`
+(`(n − 1)(m − 1)` entries per step against `(n − 1 − k)²`, since it
+updates every row in every other column and never stops early), and a
+consumer that wants a determinant should not call it.
 
 `findPivot?` is not reused, because it scans a contiguous row range and
 the producer scans a filtered one. The array-storage layer is reused.
@@ -586,9 +625,18 @@ above, is:
 Under the invariant, the entry the update produces at a pivot row is
 `p · U'` and at a non-pivot row is `p · (p' • A[i,:] − A[i, cols'] * U')`
 where primes denote the next block, so `hquot` returns the primed value.
-The two identities are verified by left-multiplying by the nonsingular
-`B_{k+1}` and cancelling, using only `B_k * U = p • P_k` and
-`Matrix.mul_adjugate`. No Desnanot-Jacobi or Sylvester identity is used:
+The two identities are verified by left-multiplying by `B_{k+1}` and
+cancelling, using `B_k * U = p • P_k` and `Matrix.mul_adjugate`. The
+cancellation needs `B_{k+1}` nonsingular, and that is the one further
+step the induction establishes first: the pivot entry of the eliminated
+row, `p · A[rows[k], cols[k]] − A[rows[k], cols] * U[:, cols[k]]`, equals
+`det B_{k+1}` by the bordered-determinant identity
+`det [[B_k, u], [vᵀ, x]] = x · det B_k − vᵀ * adjugate B_k * u` (Laplace
+expansion along the last row, the identity
+[Completeness](#completeness) also uses), so the new pivot is a nonzero
+determinant and `prev` remains `det B_{k+1}`. That identity and
+`mul_adjugate` are the only determinant facts used. No Desnanot-Jacobi or
+Sylvester identity is used:
 characterising the pivot rows as the unique solution of a linear system
 over a domain replaces the bordered-minor recurrence that
 hex-bareiss-mathlib proves. This is a proof-route choice, not a claim that
@@ -654,13 +702,18 @@ second pass, so the pair is consistent whatever `π` is. (`rankCertWith`
 does not use the first pass's `denom`; it is reported by `rowReduceWith`
 for consumers that want `det B` without the adjugate.)
 
-The two-pass shape costs `O(n · r · m + r³)`. One pass over
-`[A | identity n]` also yields `adj B` (as the `rows × rows` block of the
-right half's pivot rows) and, in addition, the whole fraction-free
-transform, at `O(n · r · (m + n))`. It is never asymptotically cheaper
-and is worse for tall low-rank input, so it is not the default; a
-consumer that wants the transform (the `Decomposition` adapter in the
-companion is one) calls `rowReduceWith` on the augmented matrix itself.
+The two-pass shape costs `O(n · r · m + r³)`. A single pass over
+`[A | identity n]` would also yield `adj B` (as the `rows × rows` block
+of the right half's pivot rows) and the whole fraction-free transform,
+at `O(n · r · (m + n))`, but not by calling `rowReduceWith` on the
+augmented matrix: the loop would go on to find pivots in the identity
+block once the columns of `A` are exhausted, so the profile, `denom` and
+the right block would describe `[A | identity n]` (rank `n`) rather than
+`A`. Such a pass needs a pivot-search boundary at column `m`, with the
+row updates still applied to every column. It is never asymptotically
+cheaper than two passes and is worse for tall low-rank input, so this
+SPEC does not provide it; if a consumer wants the transform, the
+boundary parameter is the addition to make, not a second loop.
 
 `rankWith` and `rankProfileWith` are unchecked and fast, like `bareiss`;
 their correctness is `rankCertWith_check` plus soundness, in the
@@ -857,11 +910,17 @@ regenerated from this monorepo.
   moves down when a second consumer appears.
 - **`det_smul` in `HexDeterminant/RowOps.lean`**,
   `det (c • M) = c ^ k * det M` for `M : Matrix R k k`, by `det_rowScale`
-  iterated, and `selectedSubmatrix_smul`,
-  `selectedSubmatrix_mul_eq_selectRows_mul_selectCols` in
-  `HexDeterminant/Minor.lean`, both entrywise. hex-determinantal-ideal
-  asks for the column analogue `selectCols_mul`; these are of the same
-  kind and whichever library lands first adds them.
+  iterated, and `selectedSubmatrix_smul` in `HexDeterminant/Minor.lean`,
+  entrywise. (`selectedSubmatrix_mul` in `HexDeterminant/Gram.lean`
+  already exists and is what the upper bound uses.)
+- **`selectedColumnTuples_eq_nil_of_lt` in `HexDeterminant/Gram.lean`**,
+  `n < r → selectedColumnTuples r n = []`. hex-determinantal-ideal
+  specifies the same lemma and neither library imports the other, so it
+  lives in hex-determinant and whichever library lands first adds it.
+- **Rectangular `matrixToRows` and `rowsToMatrix`** for `Matrix R n m`,
+  with the round-trip lemmas, either generalised in place in
+  `HexBareiss/Bareiss.lean` (the square forms become the `n = m` case)
+  or added in `HexRank/Reduce.lean`.
 - **hex-modular-matrix SPEC amendment**, as listed under [Int](#int).
 - **`HexHermite`** may later return this certificate from its modular
   path; nothing is required now.
@@ -883,10 +942,17 @@ Fixtures follow [SPEC/testing.md](../testing.md). Lean drivers at
 The driver has the shape hex-bareiss's carrier SPEC gives its
 `scripts/oracle/matrix_carriers.py`, and shares code with it once that
 lands: python-flint for `Int` (`fmpz_mat`), `Rat` (`fmpq_mat`) and `ZMod64 p`
-(`nmod_mat`) records, SymPy for `DensePoly` and `MvPoly` records with the
-exact domain (`ZZ[x]`, `QQ[x]`, `GF(p)[x]`, `ZZ[x0, …]`, `QQ[x0, …]`)
-stated explicitly. Both are already installed and preflighted by the
-single oracle job; no install line changes.
+(`nmod_mat`) records, and SymPy's `DomainMatrix`
+(`sympy.polys.matrices`) for `DensePoly` and `MvPoly` records, constructed
+over the exact polynomial domain (`ZZ[x]`, `QQ[x]`, `GF(p)[x]`,
+`ZZ[x0, …]`, `QQ[x0, …]`) and converted with `to_field()` where a rank or
+reduced form is wanted. The ordinary `sympy.Matrix.rank()` and `rref()`
+are not used: they take no coefficient domain, so residues that were
+normalised entrywise are still added and multiplied in characteristic
+zero, and `[[1, 1], [1, 3]]` comes out of rank `2` where its rank over
+`GF(2)` is `1`. The same domain discipline applies to the certificate
+products the driver forms. Both packages are already installed and
+preflighted by the single oracle job; no install line changes.
 
 **Record format and operations.** A record carries the carrier, the
 matrix (integers, rationals, residues normalised to `[0, p)`, ascending
@@ -895,11 +961,11 @@ coefficient arrays for `DensePoly`, ordered exponent-vector terms for
 
 | `op` | Lean value | oracle recomputation and comparison |
 |---|---|---|
-| `rank` | `rankWith quot A` | `fmpz_mat.rank()` / `fmpq_mat.rank()` / `nmod_mat.rank()`; SymPy `Matrix.rank()` over the exact domain, compared as integers |
-| `colProfile` | `(rankProfileWith quot A).cols` | the pivot columns of the oracle's own reduced row echelon form (`fmpz_mat.rref()`, `fmpq_mat.rref()`, SymPy `Matrix.rref()`), compared as lists |
+| `rank` | `rankWith quot A` | `fmpz_mat.rank()` / `fmpq_mat.rank()` / `nmod_mat.rank()`; `DomainMatrix.rank()` over the exact domain, compared as integers |
+| `colProfile` | `(rankProfileWith quot A).cols` | the pivot columns of the oracle's own reduced row echelon form (`fmpz_mat.rref()`, `fmpq_mat.rref()`, `DomainMatrix.rref()` over the fraction field), compared as lists |
 | `rowProfile` | `(rankProfileWith quot A).rows` sorted | the rows `i` with `rank(A[0..i]) = rank(A[0..i-1]) + 1`, recomputed by the oracle with its own rank on row prefixes, compared as sorted lists |
 | `denom` | `(rowReduceWith quot A).denom` | the determinant of the oracle's submatrix at the Lean-reported `rows × cols`, compared exactly (this re-uses Lean's index selection, which is permitted canonicalisation: the value compared is the oracle's determinant) |
-| `cert` | `rankCertWith quot A`, with `checkRank A c` asserted `true` by `#guard` in `Conformance.lean` | the oracle re-verifies identities 1 to 3 with its own arithmetic (`fmpz_mat`/`fmpq_mat`/SymPy products) and re-checks `rank` against its own rank; a certificate that passes `checkRank` but fails the oracle's identities is a checker bug |
+| `cert` | `rankCertWith quot A`, with `checkRank A c` asserted `true` by `#guard` in `Conformance.lean` | the oracle re-verifies identities 1 to 3 with its own arithmetic (`fmpz_mat`/`fmpq_mat`/`DomainMatrix` products) and re-checks `rank` against its own rank; a certificate that passes `checkRank` but fails the oracle's identities is a checker bug |
 
 The `cert` row is the requirement that the certificate be checked by the
 oracle-independent checker: `checkRank` is asserted in Lean on every
@@ -912,7 +978,7 @@ implementation gets wrong:
 - `0 × 0`, `0 × m`, `n × 0`: rank `0`, `denom = 1`, empty profile, and
   the certificate checks;
 - the zero matrix at several shapes: rank `0`, `denom = 1`, and
-  `checkRank_eq_zero_of_rank_zero` by `decide` in `Conformance.lean`;
+  `RankCert.matrix_eq_zero` by `decide` in `Conformance.lean`;
 - `1 × 1` `[0]` and `[c]` for `c ≠ 0`, including negative `c` (so
   `denom = c` and `adj = [1]`);
 - `[[0, 1], [0, 0]]`: rank `1`, `cols = [1]`, `rows = [0]`, the matrix
@@ -975,15 +1041,33 @@ hoisted into `prep`) are separate `setup_benchmark` targets on every
 family, so that the ratio between producer and checker is a recorded
 number and not an assumption of the tactic SPEC.
 
-**Complexity claim**, mode 1 (two-sided parametric): on
-`low-rank-large-coefficients` at fixed `r`, `rowReduceWith` and
-`checkRank` are `Θ(n²)` big-integer operations at an entry size that does
-not grow with `n`, so the declared scaling is `n²` in `n`. On
-`dense-full-rank`, the declared scaling is the one hex-bareiss declares
-for `bareiss` on its dense family (cubic count at Hadamard-bounded entry
-size), because the operation count differs by a constant. The
-derivations are the operation counts in [Complexity](#complexity); they
-are written before measurement and are not fitted.
+**Complexity claims**, chosen per
+[SPEC/benchmarking.md §Choosing the complexity claim](../benchmarking.md#choosing-the-complexity-claim):
+
+- `low-rank-large-coefficients` and `rank-deficient-by-construction` at
+  fixed `r`: **mode 1**, two-sided parametric, declared scaling `n²`.
+  The count is `Θ(r · n · n)` operations, and every operand is a minor
+  of size at most `r` of a matrix whose entries have a fixed bit size,
+  so the operand size is bounded independently of `n` and the time model
+  is the operation count.
+- `dense-full-rank`: **mode 2**, one-sided upper bound, declared bound
+  `n⁵ · (log n + log B)²`. Mode 1 does not apply, because the operand
+  size grows with `n` (entries are minors of size up to `n`, of
+  `O(n · (log n + log B))` bits by Hadamard's bound, Bareiss 1968) and
+  GMP's multiplication cost is not one power law across the ladder, so
+  no tight family-specific time model can be derived. The bound is the
+  `Θ(n³)` operation count times the schoolbook cost `b²` of multiplying
+  or exactly dividing `b`-bit operands at the Hadamard size; GMP is
+  never slower than schoolbook, so a faster observation is expected and
+  is reported as *within declared upper bound (observed faster)*. The
+  same bound and reasoning apply to `bareiss` on this family, whose own
+  SPEC registers a structured tridiagonal family rather than a dense one.
+- `polynomial`: **mode 3**, a fixed registration with a ceiling taken
+  from the SymPy comparator, since the cost of a polynomial minor depends
+  on the support and no one-parameter model is claimed.
+
+The derivations are the operation counts in [Complexity](#complexity);
+they are written before measurement and are not fitted.
 
 **Comparators**, all `informational`, with the rationale recorded here
 and in `libraries.yml`:
@@ -992,7 +1076,7 @@ and in `libraries.yml`:
 |---|---|---|
 | python-flint `fmpz_mat.rank()` | `Int` families | FLINT selects between fraction-free and multi-modular rank by size, so the ratio compares algorithms, and no shared fixture history anchors a required ratio |
 | python-flint `fmpq_mat.rank()` | `Rat` variants of the `Int` families | as above, over `ℚ` |
-| SymPy `Matrix.rank()` over the exact polynomial domain | `polynomial` family | SymPy's rank chooses its own elimination and includes Python overhead |
+| SymPy `DomainMatrix.rank()` over the exact polynomial domain | `polynomial` family | SymPy's rank chooses its own elimination and includes Python overhead |
 
 Wired as persistent-subprocess drivers following `Hex.BenchOracle.Flint`,
 with trivial-request overhead recorded in
@@ -1007,7 +1091,7 @@ verify path at the smallest rung of each family.
 HexRank.lean                     umbrella
 HexRank/
   Cert.lean        RankCert, checkRank
-  Check.lean       checkRank_minor_ne_zero, checkRank_minor_succ_eq_zero, checkRank_eq_zero_of_rank_zero
+  Check.lean       RankCert.det_ne_zero, RankCert.det_succ_eq_zero, RankCert.matrix_eq_zero
   Reduce.lean      RankProfile, ReducedForm, rowReduceWith, rowReduceWithImpl, loop-step lemmas
   Produce.lean     rankProfileWith, rankCertWith, certifyRankWith, rankWith
   Int.lean         rowReduceFF, rankProfile, rankCert, certifyRank, rank
@@ -1035,7 +1119,7 @@ bench/HexRank/Bench.lean
         - tool: FLINT fmpq_mat.rank via python-flint
           class: informational
           rationale: the same over the rationals.
-        - tool: SymPy Matrix.rank over the exact polynomial domain
+        - tool: SymPy DomainMatrix.rank over the exact polynomial domain
           class: informational
           rationale: SymPy chooses its own elimination and includes interpreter overhead; it orients the polynomial carriers only.
       input_families:
@@ -1066,8 +1150,9 @@ bench/HexRank/Bench.lean
    the entry points. Conformance against the oracle for `rank`,
    `colProfile`, `rowProfile`, `denom` and `cert`.
 3. **The `Int` layer and the amendment to hex-modular-matrix.**
-4. **The companion.** `checkRank_sound`, `rankCertWith_check`, the
-   profile theorems, `rank_map_eq`, and the `Decomposition` adapters.
+4. **The companion.** `checkRank_sound`, `rankCertWith_check`,
+   `exists_rankCert`, the profile theorems, `rank_map_eq`, and the
+   `Decomposition` adapters and existence theorems.
    Begins after milestone 1.
 5. **Carriers and benchmarks.** The polynomial instantiations in the
    conformance and bench modules, the families above, and the headline

--- a/SPEC/Libraries/hex-rank.md
+++ b/SPEC/Libraries/hex-rank.md
@@ -1,0 +1,1090 @@
+# hex-rank (rank over an integral domain with a two-sided certificate)
+
+The rank of a matrix over any nontrivial integral domain, with a certificate
+that bounds the rank from both sides and a checker that needs only ring
+arithmetic and equality tests. The certificate names an `r × r` submatrix `B`
+of `A` and carries the adjugate of `B` together with `d = det B`. From those
+the checker verifies that `B` is nonsingular (so the rank is at least `r`)
+and that `d • A` is a combination of the `r` selected columns of `A` (so the
+rank is at most `r`). The producer is rectangular fraction-free Gauss-Jordan
+elimination with column pivoting and skipped columns, which also returns the
+row and column rank profiles. Mathlib-free. The companion
+[hex-rank-mathlib](hex-rank-mathlib.md) proves that a checked certificate
+determines `Matrix.rank` over the domain itself and over any fraction field,
+proves that the producer's certificate checks, and relates the certificate
+to Mathlib's `Echelon.Decomposition`.
+
+This is the shared foundation for certified integer rank in
+[hex-modular-matrix](hex-modular-matrix.md), for the generic rank of
+polynomial matrices, and for the symbolic `rank` tactic of the planned
+`hex-matrix-tactic` (https://github.com/kim-em/hex-dev/issues/10151).
+
+## Why this library exists
+
+Rank is executable in the tree in exactly three settings, and none of them
+is a general domain:
+
+- Over a field, `Hex.Matrix.rowReduce` (Gauss-Jordan to reduced row
+  echelon form, `[Lean.Grind.Field R]`) with `rowReduce_rank`, and the
+  companion theorem `HexMatrixMathlib.rank_eq` against `Matrix.rank`.
+- Over `Int`, through the Hermite form (`hnfRank`, with `hnfRank_eq_rank` in
+  `HexHermiteMathlib/Rank.lean`) and the Smith form (`snfRank`, with
+  `snfRank_eq_hnfRank` in `HexSmith/Structure.lean`).
+- Over `F[x]`, `Hex.PolyMatrix.snfRank` in hex-poly-smith, with
+  `HexPolySmithMathlib.rank_eq_ratFunc_rank` identifying it with the rank
+  over `RatFunc F`.
+
+Nothing computes the rank of a matrix over `MvPoly`, over `ZPoly`, or over
+an arbitrary domain, and none of the three above returns a witness a
+consumer can re-check.
+
+`HexBareiss.bareissWith` is generic (any `quot : R → R → R` satisfying
+`quot (a * b) b = a` for `b ≠ 0`, with laws over
+`[Lean.Grind.CommRing R] [DecidableEq R]`), but it is square in its types
+and it records an early singular stop: on `[[0, 1], [0, 0]]` the pivot search
+in column `0` finds nothing, `singularStep := some 0` is recorded, and the
+run ends. That is the right behaviour for a determinant and the wrong one
+for a rank, whose answer here is `1` with pivot column `1`. Rectangular
+elimination that skips an empty column and continues is a new algorithmic
+contract, not an extra return field on `BareissData`. The section
+[What is new relative to hex-bareiss](#what-is-new-relative-to-hex-bareiss)
+lists the differences against `bareissDataWith` and `pivotLoopWith`.
+
+[hex-modular-matrix](hex-modular-matrix.md) specifies a two-sided rank
+certificate over `Int` for its multi-modular route. That certificate is the
+`Int` instance of the one here, and the section
+[Int](#int) records the amendment that makes the two coincide.
+
+The pinned Mathlib proves `Echelon.Decomposition.rank_eq` in
+`Mathlib/LinearAlgebra/Matrix/Echelon/Decomposition.lean` directly over
+`[CommRing R] [IsDomain R]`, and `norm_rank` is built on it. Mathlib's
+certificate is an echelon transform, and its checker is `decide` on a
+matrix product and an echelon predicate. The certificate here is a
+different object with a smaller checker, and the companion states how to
+pass between them.
+
+## Scope and dependencies
+
+`HexRank` is Mathlib-free. Its dependency list is `HexBareiss`,
+`HexDeterminant`, `HexMatrix`, `HexArith`, `HexBasic`:
+
+- `HexMatrix` for `Matrix`, `selectRows`, `selectCols`, `identity`, scalar
+  multiplication and the linear-buffer discipline;
+- `HexDeterminant` for `selectedSubmatrix`, `det`, `det_mul`,
+  `det_identity`, `det_rowScale`, and the rectangular Cauchy-Binet
+  expansion `det_minor_mul` in `HexDeterminant/Gram.lean`, which is what
+  the Mathlib-free upper-bound proof uses;
+- `HexBareiss` for the array-storage layer (`matrixToRows`, `rowsToMatrix`,
+  `getEntry`) that the producer's in-place implementation reuses, and so
+  that this library sits above the square determinant algorithm in the
+  graph, as the companion sits above `HexBareissMathlib`;
+- `HexArith` for `HexArith.Int.exactDiv`, the GMP-backed exact quotient
+  that the `Int` instantiation passes as `quot`;
+- `HexBasic` for `Hex.ExactDivLaws`, `Hex.exactDiv` and the domain law
+  package below.
+
+It does not depend on `hex-row-reduce`: the field algorithm is a different
+algorithm, and the rank-versus-minors theorem that would identify the two
+over a field is [hex-determinantal-ideal](hex-determinantal-ideal.md)'s.
+It does not depend on `hex-determinantal-ideal` either. That SPEC states
+the relationship: the two are independent siblings, and this library's
+certificate is an instance of the nonzero-minor direction proved there,
+not a dependency of it. It does not depend on `hex-mv-poly`, `hex-poly`
+or `hex-mv-gcd`: the polynomial carriers are instantiated outside the
+production library, see [Placement](#placement).
+
+In scope: the certificate and its checker, the soundness and completeness
+statements, the rectangular fraction-free producer, the rank profile, the
+`Int` specialisation, and the carrier instantiations named below.
+
+Not in scope: a rational or integer kernel basis (hex-modular-matrix and
+hex-hermite), the rank of a specialised polynomial matrix at a point and
+the rank-drop locus (hex-determinantal-ideal), a modular or multi-modular
+rank over `Int` (hex-modular-matrix, which will produce this library's
+certificate by a faster route), and any tactic frontend
+(hex-matrix-tactic).
+
+The namespace is `Hex.Matrix`, beside `det`, `bareissWith` and
+`rowReduce`.
+
+## Coefficient contract
+
+Operations and laws are kept apart, exactly as in
+[hex-bareiss](../../HexBareiss/SPEC/hex-bareiss.md).
+
+**Operations.** The checker takes `[Lean.Grind.CommRing R] [DecidableEq R]`
+and nothing else: it multiplies, subtracts and compares. The producer takes
+the unbundled operation classes its loop calls
+(`[Zero R] [One R] [Sub R] [Mul R] [DecidableEq R]`) and the exact quotient
+as a plain function argument `quot : R → R → R`, never as a `Div R`. The
+reasons are those of
+[hex-bareiss §Exact quotients](../../HexBareiss/SPEC/hex-bareiss.md#exact-quotients-obligation-totality-and-the-int-fast-path):
+`Int` passes its GMP-backed `HexArith.Int.exactDiv`, every other carrier
+passes `Hex.exactDiv`, and no generic `Div`-derived alias is introduced.
+
+**Laws for the checker.** Soundness needs that `R` has no zero divisors.
+Lean core has no such class, and neither does `HexBasic`, so this SPEC adds
+one beside `Hex.ExactDivLaws` in `HexBasic/ExactDiv.lean`:
+
+```lean
+namespace Hex
+
+/-- A nontrivial ring without zero divisors. Proof-only. -/
+class DomainLaws (R : Type u) [Zero R] [One R] [Mul R] : Prop where
+  one_ne_zero : (1 : R) ≠ 0
+  no_zero_div : ∀ a b : R, a * b = 0 → a = 0 ∨ b = 0
+
+instance : DomainLaws Int
+instance [Lean.Grind.Field K] : DomainLaws K
+theorem DomainLaws.of_exactDivLaws [Lean.Grind.CommRing R] [Div R] [ExactDivLaws R]
+    (h1 : (1 : R) ≠ 0) : DomainLaws R
+```
+
+The field instance is `Lean.Grind.Field.of_mul_eq_zero` and
+`Lean.Grind.Field.zero_ne_one`. The last theorem is
+`Hex.ExactDivLaws.mul_ne_zero` and is how every carrier with an exact
+quotient discharges the class. It is a theorem, not an instance, because
+`ExactDivLaws` does not imply nontriviality: the trivial ring satisfies it
+vacuously.
+
+`DomainLaws` is deliberately not `ExactDivLaws`. **Exact division is a
+producer requirement, never a checker requirement.** A consumer that only
+re-checks a certificate (a tactic replaying it in the kernel, an oracle
+verifying a stored witness) must not need a quotient operation on `R`, and
+the soundness theorems must not name one.
+
+**Laws for the producer.** Producer correctness takes
+`[Lean.Grind.CommRing R] [DecidableEq R]`, `(1 : R) ≠ 0`, and the single
+hypothesis
+
+```lean
+(quot : R → R → R) (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+```
+
+The no-zero-divisor and cancellation facts it needs are consequences of
+`hquot`, through `Hex.ExactDivLaws.mul_ne_zero` and `mul_right_cancel`
+after the local `letI : Div R := ⟨quot⟩` that hex-bareiss also uses.
+Nontriviality is a genuine extra hypothesis: over the trivial ring no
+certificate checks (`denom ≠ 0` is unsatisfiable), so the producer cannot
+emit one. Over `Int` and over every polynomial carrier it is `decide` or
+a coefficient fact.
+
+## The certificate
+
+### Shape
+
+For `A : Matrix R n m` (`n` rows, `m` columns, the `Hex.Matrix` convention):
+
+```lean
+namespace Hex.Matrix
+
+/-- A two-sided rank certificate: an `rank × rank` submatrix of `A` at
+`rows × cols`, its adjugate `adj`, and its determinant `denom`. -/
+structure RankCert (R : Type u) (n m : Nat) where
+  rank : Nat
+  rows : Vector (Fin n) rank
+  cols : Vector (Fin m) rank
+  denom : R
+  adj : Matrix R rank rank
+```
+
+Writing `B := selectedSubmatrix A c.rows c.cols` (`rank × rank`),
+`C := selectCols A c.cols` (`n × rank`) and `P := selectRows A c.rows`
+(`rank × m`), the certificate asserts three things:
+
+1. `c.denom ≠ 0`;
+2. `B * c.adj = c.denom • identity c.rank`, so `B` is nonsingular;
+3. `c.denom • A = C * (c.adj * P)`, so every column of `A` is, after
+   clearing the denominator, a combination of the columns of `C`.
+
+The matrix `U := c.adj * P` (`rank × m`) is the coefficient matrix of the
+all-column identity `d • A = C * U` that the certificate establishes. It
+is derived by the checker rather than stored, see
+[Why the certificate stores the adjugate](#why-the-certificate-stores-the-adjugate-and-not-the-coefficients).
+
+The vectors `rows` and `cols` are index selections, not sets: they may be
+in any order, and the checker imposes no ordering or distinctness
+condition on them. None is needed. A repeated row or column index makes
+`B` have two equal rows or columns, hence `det B = 0`, hence identity 2
+fails (`det B · det adj = d ^ rank ≠ 0`). Distinctness is a consequence of
+a passing check, not a precondition of it. This is one difference from
+the certificate in hex-modular-matrix, whose complement-of-`cols`
+indexing forced a strictly-increasing check.
+
+The producer returns `rows` in elimination order and `cols` strictly
+increasing, and `denom` is the determinant of `B` with its rows in that
+order. A consumer that sorts `rows` must negate `denom` and `adj` by the
+sign of the sorting permutation, or simply not sort: nothing in the
+checker cares.
+
+### The checker
+
+```lean
+/-- Check a rank certificate. Ring arithmetic and equality tests only. -/
+def checkRank [Lean.Grind.CommRing R] [DecidableEq R]
+    (A : Matrix R n m) (c : RankCert R n m) : Bool :=
+  let B := selectedSubmatrix A c.rows c.cols
+  let C := selectCols A c.cols
+  let P := selectRows A c.rows
+  decide (c.denom ≠ 0) &&
+  decide (B * c.adj = c.denom • Matrix.identity c.rank) &&
+  decide (c.denom • A = C * (c.adj * P))
+```
+
+Cost, in ring multiplications: `rank³` for `B * adj`, `rank² · m` for
+`adj * P`, `n · rank · m` for `C * U`, and `n · m` scalar products for
+`denom • A`. No division, no determinant, no search. The dominant term
+`n · rank · m` is one matrix product, which is what a consumer replaying
+the certificate in the kernel pays. `Matrix` derives `DecidableEq`, so
+the two matrix equalities are entrywise comparisons.
+
+`checkRank` is `@[expose]` and kernel-reducible on closed inputs, per
+design principle 11, because the kernel is one of its two intended
+callers. The compiled path uses `Matrix.mul`'s existing `@[csimp]`
+implementation.
+
+### Boundary cases
+
+- **`rank = 0`.** `rows` and `cols` are empty, `adj` is the `0 × 0`
+  matrix, `B * adj` and `denom • identity 0` are both the empty matrix,
+  so identity 2 holds for any `denom`. `C` is `n × 0` and `U` is `0 × m`,
+  so `C * U` is the `n × m` zero matrix and identity 3 reads
+  `denom • A = 0`. With `denom ≠ 0` and no zero divisors, a certificate of
+  rank `0` checks exactly when `A = 0`. The canonical such certificate
+  has `denom = 1`.
+- **`n = 0` or `m = 0`.** `A` has no entries and is the zero matrix of its
+  shape. The rank-`0` certificate with `denom = 1` checks, and no
+  certificate of positive rank does, since `Vector (Fin 0) rank` is empty
+  for `rank > 0`.
+- **`rank > min n m`.** A passing check forces the entries of `rows` and
+  of `cols` to be distinct, so `rank ≤ n` and `rank ≤ m`. No certificate
+  of larger rank checks.
+
+The general soundness and completeness proofs below cover all three
+without a case split. They are listed so that the conformance suite tests
+them and so that an implementation which special-cases any of them is seen
+to be unnecessary.
+
+### Why the certificate stores the adjugate and not the coefficients
+
+The directive for this SPEC described the upper bound as the all-column
+identity `d • A = C * U` and the lower bound as a nonzero `r × r` minor of
+`C`, with `U` read off `adj B`. That is exactly what is checked. The
+question is what the certificate *stores*, and the answer is `adj B`
+alone, for three reasons.
+
+**The checker must not compute a determinant.** Establishing that the
+minor is nonzero by evaluating it means choosing a determinant algorithm
+for the checker. Over a general domain the division-free options are the
+Leibniz `det` (`r!` terms) and Berkowitz (`O(r⁴)`, and a dependency on
+hex-char-poly for a constant coefficient); Bareiss needs the exact
+quotient that the checker must not require. Carrying the adjugate turns
+the nonsingularity test into one `r × r` matrix product, and its
+soundness into `det B · det (adj B) = d ^ r ≠ 0`.
+
+**Given `adj B`, `U` is one small product.** `U = adj B · P` costs
+`r² · m` multiplications to form, against the `n · r · m` of the main
+identity, so storing `U` would enlarge the certificate by `r · m` entries
+to save a lower-order term. A certificate is embedded in a proof term by
+the tactic consumer, where size is the cost that matters.
+
+**`d` and `adj B` are what the producer has.** Fraction-free Gauss-Jordan
+on `[B | identity r]` produces `[d • identity r | adj B]` directly. The
+alternative producer that solves for `U` column by column (the shape the
+hex-modular-matrix draft took) does `m - r` solves where this one does
+`r`.
+
+Storing `U` as well as `adj B` is sound and was considered. It is not
+adopted because the checker would then either trust the stored `U` (and
+verify the identity with it, at no saving) or recompute it (and never read
+the stored one).
+
+## Soundness
+
+Both statements are Mathlib-free and live in `HexRank/Check.lean`, over
+`[Lean.Grind.CommRing R] [DecidableEq R] [Hex.DomainLaws R]`. Write
+`B`, `C`, `P`, `U` as above and `d := c.denom`, `r := c.rank`.
+
+```lean
+theorem checkRank_minor_ne_zero (h : checkRank A c = true) :
+    det (selectedSubmatrix A c.rows c.cols) ≠ 0
+theorem checkRank_minor_succ_eq_zero (h : checkRank A c = true)
+    (rows : Vector (Fin n) (c.rank + 1)) (cols : Vector (Fin m) (c.rank + 1)) :
+    det (selectedSubmatrix A rows cols) = 0
+theorem checkRank_eq_zero_of_rank_zero (h : checkRank A c = true) (hr : c.rank = 0) :
+    A = Matrix.zero n m
+```
+
+Together the first two say that `r` is the largest size of a nonzero
+minor of `A`, which is the meaning of "rank over the fraction field"
+that a Mathlib-free library can state. The companion turns them into
+`Matrix.rank`; hex-determinantal-ideal's `rank_eq_iff_minors` is the same
+characterisation for `rowReduce_rank` over a field, and a consumer holding
+both gets `rowReduce_rank A = c.rank` over a field with no new proof.
+
+**Lower bound (`checkRank_minor_ne_zero`).** From identity 2,
+`det (B * adj) = det (d • identity r)`. The left side is `det B · det adj`
+by `det_mul`. The right side is `d ^ r` by `det_rowScale` applied `r`
+times to `det_identity` (a lemma `det_smul : det (c • M) = c ^ k * det M`
+for `M : Matrix R k k`, new in `HexDeterminant/RowOps.lean` if absent).
+`d ≠ 0` and `DomainLaws.no_zero_div` give `d ^ r ≠ 0` by induction on `r`,
+and then `det B ≠ 0`. At `r = 0` the right side is `1`, and `1 ≠ 0` is
+`DomainLaws.one_ne_zero`; nothing else changes.
+
+**Upper bound (`checkRank_minor_succ_eq_zero`).** Fix `rows`, `cols` of
+length `r + 1`. From identity 3 and `selectedSubmatrix` commuting with
+scalar multiplication and with products of the shape `C * U`
+(`selectedSubmatrix (C * U) rows cols = selectRows C rows * selectCols U cols`,
+entrywise),
+
+```text
+d ^ (r + 1) · det (selectedSubmatrix A rows cols)
+  = det (selectedSubmatrix (d • A) rows cols)
+  = det (selectRows C rows * selectCols U cols).
+```
+
+The last matrix is a product of an `(r + 1) × r` and an `r × (r + 1)`
+matrix. `det_minor_mul` (`HexDeterminant/Gram.lean`) expands its
+determinant as a sum over `middle ∈ selectedColumnTuples (r + 1) r`, and
+that list is empty (`selectedColumnTuples_eq_nil_of_lt`, a strictly
+increasing `(r + 1)`-tuple in `Fin r` does not exist), so the sum is `0`.
+Hence `d ^ (r + 1) · det (…) = 0`, and `d ^ (r + 1) ≠ 0` gives
+`det (…) = 0`. This is the same "empty middle sum" step that
+hex-determinantal-ideal's vanishing direction uses.
+
+**`rank = 0` (`checkRank_eq_zero_of_rank_zero`).** Identity 3 is
+`d • A = 0` entrywise, `d ≠ 0`, and `no_zero_div`. This is the upper bound
+at `r = 0` read directly, since `minors 1 A` are the entries.
+
+Neither proof mentions `quot`, `ExactDivLaws`, or how the certificate was
+produced.
+
+## Completeness
+
+Every matrix over a nontrivial integral domain has a certificate that
+checks. The constructive form is
+[producer correctness](#exactness-and-producer-correctness); the
+existence argument is recorded here so that the certificate shape is seen
+to be complete independently of the elimination.
+
+Let `r` be the largest size of a nonzero minor of `A`, and let
+`rows`, `cols` index one such minor, `B := selectedSubmatrix A rows cols`,
+`d := det B ≠ 0`, and `adj := adjugate B`. Then:
+
+- Identity 1: `d ≠ 0` by choice.
+- Identity 2: `B * adjugate B = det B • identity r` is the adjugate
+  identity (`Hex.Matrix.mul_adjugate` in `HexDeterminant/Adjugate.lean`
+  for `r = k + 1`; Mathlib's `Matrix.mul_adjugate` at every `r` including
+  `0`).
+- Identity 3: `d • A = C * (adj * P)`. For a row index `i ∈ rows` this is
+  `d • A[i, :] = B[i-block] * adj * P = d • P[i-block]`, the adjugate
+  identity again. For a row index `i ∉ rows`, the `(r + 1) × (r + 1)`
+  minor on rows `rows ++ [i]` and columns `cols ++ [j]` vanishes for every
+  `j` (by maximality of `r`), and Laplace expansion of that bordered minor
+  along its last row (`det_eq_foldl_laplace_col` transposed, or
+  `HexDeterminant/LastRow.lean`) reads
+  `d · A[i, j] = Σ_k A[i, cols[k]] · (adj * P)[k, j]`, which is entry
+  `(i, j)` of identity 3.
+
+At `r = 0` the maximal nonzero minor is the empty one (`det` of the
+`0 × 0` matrix is `1`), every entry of `A` is a vanishing `1 × 1` minor,
+`d = 1` and identity 3 is `A = 0`. At `n = 0` or `m = 0` there are no
+entries and the same certificate applies.
+
+The argument needs `1 ≠ 0` (so that the empty minor is nonzero) and no
+zero divisors (so that "largest size of a nonzero minor" is a rank). It
+does not need an exact quotient: `adjugate` is polynomial in the entries.
+That is why the certificate is complete over every nontrivial domain even
+though the producer below is only defined over carriers with an executable
+exact quotient.
+
+## The producer
+
+### Fraction-free Gauss-Jordan with column pivoting
+
+```lean
+/-- The pivot rows, in elimination order, and the pivot columns, strictly
+increasing. -/
+structure RankProfile (n m : Nat) where
+  rank : Nat
+  rows : Vector (Fin n) rank
+  cols : Vector (Fin m) rank
+
+/-- Output of one fraction-free Gauss-Jordan pass. -/
+structure ReducedForm (R : Type u) (n m : Nat) where
+  profile : RankProfile n m
+  denom : R
+  matrix : Matrix R n m
+
+def rowReduceWith [Zero R] [One R] [Sub R] [Mul R] [DecidableEq R]
+    (quot : R → R → R) (A : Matrix R n m) : ReducedForm R n m
+```
+
+The state carries the current matrix, the previous pivot `prev` (seed
+`1`), the pivot rows found so far, and the pivot columns found so far.
+Columns are scanned from `0` to `m - 1`. At column `j`:
+
+1. **Search.** Among the rows that are not yet pivot rows, in increasing
+   index order, find the first row `p` with `M[p, j] ≠ 0`. This is a
+   membership test on the pivot-row list and an equality test on entries,
+   and needs `[Zero R] [DecidableEq R]`.
+2. **Skip.** If there is none, column `j` is not a pivot column. Nothing
+   in the matrix changes, `prev` does not change, and the scan moves to
+   `j + 1`. The entries of the pivot rows in column `j` are kept: they are
+   the coefficients the reduced form reports for that column.
+3. **Eliminate.** Otherwise `p` is appended to the pivot rows and `j` to
+   the pivot columns, `pivot := M[p, j]`, and every row `i ≠ p` is updated
+   in the columns `j' > j`:
+
+   ```text
+   M[i, j'] ← quot (pivot · M[i, j'] − M[i, j] · M[p, j']) prev
+   ```
+
+   after which `M[i, j] ← 0` for `i ≠ p`. Columns before `j` are
+   untouched: in a pivot row they hold earlier reduced entries, in a
+   non-pivot row they are already zero at pivot columns and are never
+   read again at skipped columns. Then `prev := pivot`.
+
+**Rows are not moved.** The pivot row stays where it is, the search order
+in step 1 is the original row order, and the state records which rows are
+pivot rows. This is the one choice that makes the row profile canonical,
+see [The rank profile](#the-rank-profile). It costs nothing: Gauss-Jordan
+eliminates every other row anyway, so a pivot row has no reason to be at a
+particular position.
+
+**Every row, not only the rows below.** Step 3 updates the earlier pivot
+rows as well as the non-pivot rows. This is what makes the pass
+Gauss-Jordan rather than Gaussian, and it is what makes the reported
+`matrix` a reduced form. After the pass, with `B` the `rank × rank` block
+at `rows × cols` in elimination order and `d` the last pivot:
+
+- `denom = d = det B`;
+- for each `k`, row `rows[k]` of `matrix` is row `k` of `adjugate B * P`,
+  where `P = selectRows A rows`; in particular
+  `matrix[rows[k], cols[l]] = if k = l then d else 0`;
+- every non-pivot row of `matrix` is zero.
+
+So `matrix` is `d` times the reduced row echelon form of `A` over the
+fraction field, with its rows left in place. At `rank = 0` the seed is
+returned: `denom = 1` and `matrix = A`, which is the zero matrix.
+
+The pass takes `[Zero R] [One R] [Sub R] [Mul R] [DecidableEq R]` and
+`quot`, the same operation classes as `bareissWith`. `One R` is for the
+seed. There is an in-place `rowReduceWithImpl` on `Array (Array R)`
+registered by `@[csimp]`, reusing `matrixToRows`, `rowsToMatrix` and
+`getEntry` from `HexBareiss/Bareiss.lean`; the public definition is the
+kernel-facing one, per design principle 11.
+
+### The rank profile
+
+Two canonical index sets are attached to a matrix over a field, and this
+producer computes both.
+
+- The **column rank profile** is the set of `j` such that column `j` is
+  not in the span of columns `0 … j - 1`: the pivot columns of the reduced
+  row echelon form.
+- The **row rank profile** is the set of `i` such that row `i` is not in
+  the span of rows `0 … i - 1`.
+
+Each is a lexicographically first independent set, and each is an
+invariant of the matrix.
+
+**What the producer guarantees.** `cols` is the column rank profile. This
+holds for any pivot-row rule: whether column `j` gains a pivot depends
+only on whether some non-pivot row has a nonzero entry there after
+elimination, which is whether column `j` lies outside the span of the
+earlier pivot columns. `rows`, as a set, is the row rank profile. This
+holds *because* step 1 searches the original row order among non-pivot
+rows and rows are never moved: if a dependent row `i'` had a nonzero
+eliminated entry at column `j`, that entry is a combination of the
+eliminated entries of the non-pivot rows below `i'` in index order, so
+some smaller-index non-pivot row also has a nonzero entry there and is
+chosen first. The row chosen is therefore always a profile row, and since
+`rank` rows are chosen, all profile rows are.
+
+**What swapping loses.** With `findPivot?`-style row swaps, the search
+order is the permuted order and the row set is *some* set of independent
+rows, not the profile. On
+
+```text
+[[0, 1, 0],
+ [0, 2, 0],
+ [1, 0, 0]]
+```
+
+the row rank profile is `{0, 2}`. Column `0`: the first nonzero row is
+`2`. With a swap of rows `0` and `2`, the search at column `1` runs over
+the swapped order and finds original row `1` first, giving `{2, 1}`.
+Without a swap, the search at column `1` runs over the non-pivot rows
+`0, 1` in index order and finds row `0`, giving `{2, 0}`. The order
+`rows = [2, 0]` is elimination order and is what the certificate uses; the
+set is the profile.
+
+The producer therefore guarantees the canonical profile in both
+directions, and the companion states both facts as theorems
+(`rowReduceWith_cols_eq_colProfile`, `rowReduceWith_rows_eq_rowProfile`).
+A consumer that wants "some nonsingular `r × r` block" gets it from
+`rows`, `cols`; a consumer that wants the profile gets it from the same
+fields. This SPEC does not promise the full rank profile matrix of
+Dumas, Pernet and Sultan ("Computing the rank profile matrix", ISSAC
+2015), which records more than the two sets, and no consumer asks for it.
+
+### What is new relative to hex-bareiss
+
+Checked against `bareissDataWith` and `pivotLoopWith` in
+`HexBareiss/Bareiss.lean`:
+
+| aspect | `pivotLoopWith` / `bareissDataWith` | `rowReduceWith` |
+|---|---|---|
+| shape | `Matrix R n n`, square in the types | `Matrix R n m` |
+| loop | `n - 1` steps, one per diagonal position | one step per column `0 … m - 1` |
+| pivot column | the diagonal column `k` | the current column `j`, if any non-pivot row is nonzero there |
+| empty pivot column | `singularStep := some k`, run stops | column skipped, run continues |
+| pivot row | first nonzero at or below the diagonal, moved by `rowSwap` | first nonzero non-pivot row in index order, not moved |
+| rows updated | rows below the pivot (Gaussian) | every row but the pivot row (Gauss-Jordan) |
+| bookkeeping | `rowSwaps : Nat`, `singularStep : Option Nat` | `rows : Vector (Fin n) rank`, `cols : Vector (Fin m) rank` |
+| output | terminal matrix, sign, last diagonal entry | `profile`, `denom = det B`, `d ·` reduced echelon form |
+| determinant | `sign * lastDiag` | `denom` is `det B`, with `B` in elimination row order; on a square full-rank input this is `det A` up to the sign of the row order |
+
+The update formula in step 3 is the Bareiss recurrence of
+`stepMatrixWith`, so the fraction-free property and the exact-quotient
+obligation are the same. Everything in the left column that concerns the
+determinant (`sign`, `lastDiag?`, `singularStep`, `BareissData.det`) has
+no counterpart here, and nothing here is a field added to `BareissData`.
+`bareissWith` stays the determinant algorithm: on a square full-rank
+matrix `rowReduceWith` does about half again the work of `bareissWith`
+(it updates rows above the pivot and never stops early), and a consumer
+that wants a determinant should not call it.
+
+`findPivot?` is not reused, because it scans a contiguous row range and
+the producer scans a filtered one. The array-storage layer is reused.
+
+### Exactness and producer correctness
+
+Every division in step 3 is by `prev`, which is `1` or a pivot already
+tested nonzero, and every numerator is an exact multiple of `prev`.
+Exactness is not tested at run time and is not a hypothesis on the input.
+The invariant that establishes it, and with it the reduced-form contract
+above, is:
+
+> After the pivots `(rows[0], cols[0]) … (rows[k-1], cols[k-1])` have been
+> processed, with `B_k := selectedSubmatrix A rows cols` (the `k × k`
+> block, rows in elimination order) and `p := det B_k` (`p = 1` at
+> `k = 0`):
+>
+> - the pivot rows of the state are the rows of `adjugate B_k * P_k`,
+>   where `P_k := selectRows A rows`, equivalently the unique `U` with
+>   `B_k * U = p • P_k`;
+> - every non-pivot row `i` of the state is
+>   `p • A[i, :] − A[i, cols] * U`;
+> - `prev = p`.
+
+Under the invariant, the entry the update produces at a pivot row is
+`p · U'` and at a non-pivot row is `p · (p' • A[i,:] − A[i, cols'] * U')`
+where primes denote the next block, so `hquot` returns the primed value.
+The two identities are verified by left-multiplying by the nonsingular
+`B_{k+1}` and cancelling, using only `B_k * U = p • P_k` and
+`Matrix.mul_adjugate`. No Desnanot-Jacobi or Sylvester identity is used:
+characterising the pivot rows as the unique solution of a linear system
+over a domain replaces the bordered-minor recurrence that
+hex-bareiss-mathlib proves. This is a proof-route choice, not a claim that
+the entries are not minors (they are: the invariant says each non-pivot
+entry is a bordered minor and each pivot-row entry is a minor with one
+column replaced).
+
+The route uses the adjugate and cancellation over a domain, which per
+[hex-bareiss §Mathlib-free vs. Mathlib-bridge proof surface](../../HexBareiss/SPEC/hex-bareiss.md#mathlib-free-vs-mathlib-bridge-proof-surface)
+places the invariant proof in the companion, not here. The Mathlib-free
+layer ships the definitions, the loop-step equations
+(`rowReduceWith_step_pivot`, `rowReduceWith_step_skip`, structural, no
+`hquot`), and the checker theorems. The companion proves:
+
+```lean
+theorem rankCertWith_check [CommRing R] [DecidableEq R] [Nontrivial R]
+    (quot : R → R → R) (hquot : ∀ a b : R, b ≠ 0 → quot (a * b) b = a)
+    (A : Hex.Matrix R n m) :
+    Hex.Matrix.checkRank A (Hex.Matrix.rankCertWith quot A) = true
+```
+
+This is producer correctness in the form the issue asks for: the producer
+emits a certificate that checks. Everything about `Matrix.rank` then
+follows from soundness and is stated in the companion.
+
+### Entry points
+
+```lean
+/-- The rank profile. -/
+def rankProfileWith (quot : R → R → R) (A : Matrix R n m) : RankProfile n m :=
+  (rowReduceWith quot A).profile
+
+/-- The certificate: the profile and denominator of one pass over `A`,
+and the adjugate of the pivot block from one pass over `[B | identity]`. -/
+def rankCertWith (quot : R → R → R) (A : Matrix R n m) : RankCert R n m
+
+/-- The certificate, checked. -/
+def certifyRankWith [Lean.Grind.CommRing R] [DecidableEq R]
+    (quot : R → R → R) (A : Matrix R n m) : Option (RankCert R n m) :=
+  let c := rankCertWith quot A
+  if checkRank A c then some c else none
+
+/-- The rank. -/
+def rankWith (quot : R → R → R) (A : Matrix R n m) : Nat :=
+  (rankProfileWith quot A).rank
+
+-- Int specialisations, all through HexArith.Int.exactDiv.
+def rowReduceFF (A : Matrix Int n m) : ReducedForm Int n m
+def rankProfile (A : Matrix Int n m) : RankProfile n m
+def rankCert (A : Matrix Int n m) : RankCert Int n m
+def certifyRank (A : Matrix Int n m) : Option (RankCert Int n m)
+def rank (A : Matrix Int n m) : Nat
+```
+
+`rankCertWith` runs `rowReduceWith` on `A` to obtain `rows`, `cols` and
+`denom`, forms `[B | identity rank]` (`rank × 2·rank`, by `ofFn`), runs
+`rowReduceWith` on it, and reads `adj` off the right block of the pivot
+rows. The second pass finds every column of `B` a pivot column and every
+row a pivot row, in some order `π`; its pivot rows, restricted to the
+right block and taken in the order of `π`, are `sign π · adjugate B`, and
+its `denom` is `sign π · det B`. The certificate takes both from the
+second pass, so the pair is consistent whatever `π` is. (`rankCertWith`
+does not use the first pass's `denom`; it is reported by `rowReduceWith`
+for consumers that want `det B` without the adjugate.)
+
+The two-pass shape costs `O(n · r · m + r³)`. One pass over
+`[A | identity n]` also yields `adj B` (as the `rows × rows` block of the
+right half's pivot rows) and, in addition, the whole fraction-free
+transform, at `O(n · r · (m + n))`. It is never asymptotically cheaper
+and is worse for tall low-rank input, so it is not the default; a
+consumer that wants the transform (the `Decomposition` adapter in the
+companion is one) calls `rowReduceWith` on the augmented matrix itself.
+
+`rankWith` and `rankProfileWith` are unchecked and fast, like `bareiss`;
+their correctness is `rankCertWith_check` plus soundness, in the
+companion. `certifyRankWith` is for a consumer that wants the witness and
+the check in one call, and its `none` branch is
+`unreachable-by-pipeline-invariant` under design principle 8, with
+`rankCertWith_check` as the witness theorem; the compiled `rank` does not
+route through it, so no fallback value is ever chosen. A caller that
+wants both the profile and the certificate calls `rankCertWith` once: the
+certificate's `rows`, `cols` *are* the profile.
+
+## Carriers
+
+The producer is one function. Each carrier supplies its quotient and its
+law term, exactly as in
+[hex-bareiss §Supported coefficient carriers](../../HexBareiss/SPEC/hex-bareiss.md#supported-coefficient-carriers):
+
+| carrier | quotient | law term for `hquot` | `DomainLaws` |
+|---|---|---|---|
+| `Int` | `HexArith.Int.exactDiv` | `Int.mul_ediv_cancel` | `instance` |
+| `Rat`, `ZMod64 p` (field) | `Hex.exactDiv` | `fun a b hb => Hex.exactDiv_mul_right a hb` via `Hex.instExactDivLawsField` | field instance |
+| `DensePoly F`, `[Lean.Grind.Field F] [DecidableEq F]` | `Hex.exactDiv` with `HexResultant.ExactDiv`'s `Hex.instExactDivLawsDensePoly` | same | `of_exactDivLaws` |
+| `ZPoly` (`DensePoly Int`) | `Hex.exactDiv` with the same recursive instance over `Hex.instExactDivLawsInt` | same | `of_exactDivLaws` |
+| `MvPoly n R cmp` under the `HexMvGcd.Divide` context | `Hex.exactDiv` with `Hex.MvPoly.instDiv` and `Hex.MvPoly.instExactDivLaws` | same | `of_exactDivLaws` |
+
+### Int
+
+`Int` is the production instantiation and lives in `HexRank/Int.lean`,
+through `HexArith.Int.exactDiv` (which `Hex.Matrix.exactDiv` in
+hex-bareiss now aliases). The names `rank`, `rankProfile`, `rankCert`,
+`certifyRank` are the `Int` forms.
+
+**Coincidence with hex-modular-matrix.** The certificate there
+(`RankCert n m` with `rows`, `cols`, `modulus`, `coeffs : Matrix Int r (m - r)`,
+`denom`) is amended to *be* `Hex.Matrix.RankCert Int n m`, and its
+`checkRank` to be this library's, with these consequences, recorded in
+[hex-modular-matrix §Rank](hex-modular-matrix.md#rank):
+
+- the `modulus` field and the "minor nonzero modulo `modulus`" test go
+  away, replaced by the adjugate identity, which is a big-integer product
+  the multi-modular route also has to produce; the completeness argument
+  that motivated a bare `Nat` modulus there (the `1 × 1` matrix `[L]`) is
+  moot, because the adjugate certificate is complete over `Int` with no
+  modulus at all;
+- the strictly-increasing check on `rows`, `cols` goes away, since the
+  all-column identity does not index a complement;
+- the producer there (`rankCert?`) keeps its modular route for finding
+  `rows`, `cols`, and obtains `adj B` and `det B` by Dixon solves of
+  `B * X = det B • identity r` (`r` solves, against the `m - r` the draft
+  did), with the whole certificate then passed to `checkRank`;
+- `checkRank_sound` there is this library's soundness, and its
+  `rank_eq` in the companion is this library's `checkRank_sound` at
+  `R = Int`, so hex-modular-matrix-mathlib inherits rather than reproves
+  it;
+- its unchecked `rank : Matrix Int n m → Nat` is renamed
+  `rankModular`, since `Hex.Matrix.rank` is this library's `Int`
+  entry point and both libraries are imported together by
+  hex-matrix-tactic.
+
+hex-modular-matrix is unimplemented, so this is a SPEC amendment with no
+code to migrate.
+
+### `DensePoly F` and `ZPoly`
+
+Over `F[x]` the certificate's `denom` is a polynomial and `adj` a
+polynomial matrix. The rank it certifies is the rank over `F(x)`, and the
+companion's `rank_map_eq` at `IsFractionRing (Polynomial F) (RatFunc F)`
+is the statement `HexPolySmithMathlib.rank_eq_ratFunc_rank` already makes
+for `snfRank`, now with a witness. `ZPoly` is `DensePoly Int` through the
+recursive exact-division instance; its rank is over `ℚ(x)`.
+
+### `MvPoly`
+
+Over `MvPoly k R cmp` with `R` a domain, the rank is the rank over the
+fraction field `Frac(R)(x_1, …, x_k)`, the *generic rank* of the
+polynomial matrix. The certificate's `denom` is a polynomial `d` with
+`d ≠ 0`, and `adj` is a polynomial matrix.
+
+### Generic rank is not a specialised rank
+
+A polynomial matrix `A` of generic rank `r` specialised at a point `p`
+has rank at most `r` (hex-determinantal-ideal-mathlib's
+`rank_map_le_rank_fractionRing`), and has rank exactly `r` at every `p`
+where the certificate's `denom` does not vanish, since then `det B (p) ≠ 0`
+and the lower bound survives specialisation. Nothing says such a `p`
+exists. Over a finite field it need not: the `1 × 1` matrix `[X^q − X]`
+over `𝔽_q[X]` has generic rank `1`, and `X^q − X` vanishes at every
+`a ∈ 𝔽_q`, so the specialised rank is `0` at every base-field point.
+The same happens for any polynomial in the ideal of the finite point set.
+
+A downstream tactic must therefore treat the generic rank as one of three
+distinct outputs and never present it as an unconditional specialised
+rank:
+
+1. **Generic rank**: `rank = r` as a statement about `A` over `R` or over
+   its fraction field. Unconditional. This library.
+2. **Conditional rank**: `rank (A.map (eval p)) = r` under the hypothesis
+   `eval p denom ≠ 0`, or more generally under a nonvanishing hypothesis
+   on the minor the certificate names. The hypothesis is a `Condition`
+   in the sense of [hex-reflect §Shared results and conditions](hex-reflect.md#shared-results-and-conditions),
+   returned to the caller rather than discharged. The certificate supplies
+   the condition as data: it is `denom`.
+3. **Rank locus**: the set of points where the rank drops below `r`, the
+   zero set of the determinantal ideal `I_r(A)`, from
+   hex-determinantal-ideal. The tactic that produces it is `rank_locus`,
+   and it takes `r` from this library only when the user asks for the
+   generic rank as the default `r`.
+
+### Placement
+
+`scripts/check_dag.py` enforces the production graph from
+`libraries.yml`, and `HexBareiss`, hence `HexRank`, cannot depend on
+`HexMvPoly`, `HexPoly` or `HexMvGcd`. So:
+
+- the `Int` instantiation is production code in `HexRank/Int.lean`;
+- the `Rat`, `ZMod64 p`, `DensePoly F`, `ZPoly` and `MvPoly`
+  instantiations live in `conformance/HexRank/Conformance.lean`, the
+  emitter `conformance/HexRank/EmitFixtures.lean` and
+  `bench/HexRank/Bench.lean`, which may import `HexPolyFp.PrimeField`,
+  `HexResultant.ExactDiv` and `HexMvGcd.Divide` and have no production
+  owner under `check_dag.py`, exactly as hex-bareiss's carrier table
+  places its own instantiations;
+- a production consumer that wants a named `MvPoly` rank defines it
+  itself, as `rankWith Hex.exactDiv` under the `HexMvGcd.Divide` context,
+  in a library already above `HexMvGcd`. The `rank_locus` and symbolic
+  `rank` tactics are the expected first such consumers, through
+  hex-matrix-tactic, and that one-line instantiation is theirs to make.
+  Nothing carrier-specific is added to `HexRank/*`.
+
+## Complexity
+
+`A` is `n × m` of rank `r`; counts are ring operations.
+
+| operation | multiplications | exact divisions | notes |
+|---|---|---|---|
+| `rowReduceWith` | `≤ 2 · r · n · m` | `≤ r · n · m` | one Gauss-Jordan step per pivot column, every row updated; skipped columns cost `O(n)` zero tests each |
+| `rankCertWith` | `rowReduceWith` plus `O(r³)` | plus `O(r³)` | the second pass on `[B \| identity r]` |
+| `checkRank` | `n · r · m + r² · m + r³ + n · m` | none | one product dominates; no determinant |
+| `rankWith`, `rankProfileWith` | as `rowReduceWith` | | |
+
+**Growth.** The invariant says every stored entry is a minor of `A` (a
+bordered `(k + 1) × (k + 1)` minor in a non-pivot row, a `k × k` minor with
+one column replaced in a pivot row), and every certificate entry is a
+minor (`denom` an `r × r` minor, `adj` entries `(r − 1) × (r − 1)` minors).
+Over `Int` with `‖A‖∞ ≤ B` Hadamard's bound gives `O(r · (log r + log B))`
+bits per entry, so `rowReduceWith` costs `O(r · n · m)` operations on
+integers of that size and `checkRank` costs `O(n · r · m)` multiplications
+of numbers of that size. This is the fraction-free contract of
+[hex-bareiss §Complexity](../../HexBareiss/SPEC/hex-bareiss.md#complexity),
+with `n³/3` replaced by `r · n · m`: on a low-rank matrix the run is short
+in the rank, not in the dimension. Over a polynomial carrier there is no
+bit bound; the minor identity is the only size statement, and expression
+swell in a minor is outside this SPEC as it is outside hex-bareiss's.
+
+The checker's `n · r · m` is the number a kernel replay pays. It is not
+smaller than the producer's count in the worst case (`r = min n m`), and
+this SPEC does not claim it is; what the certificate saves the kernel is
+the search, the divisions, and any determinant.
+
+## Relationship to the other rank computations in the tree
+
+- **`rowReduce` (hex-row-reduce).** Over a field both compute the reduced
+  row echelon form; `rowReduce` divides by the pivot and `rowReduceWith`
+  multiplies through and divides by the previous pivot. Over a field a
+  consumer should use `rowReduce`. This library does not import
+  hex-row-reduce, and the theorem that the two ranks agree over a field is
+  a corollary of hex-determinantal-ideal's `rank_eq_iff_minors` and the
+  two soundness theorems here, to be stated wherever both are imported.
+- **`hnfRank`, `snfRank` over `Int`** compute the rank as a by-product of a
+  normal form and carry no witness. `rank` here is the direct algorithm.
+  hex-hermite's modular route and hex-modular-matrix's multi-modular
+  route are the fast paths at large size, and both should return this
+  certificate.
+- **`Hex.PolyMatrix.snfRank` over `F[x]`** is the polynomial Smith form's
+  rank. `rankWith Hex.exactDiv` over `DensePoly F` is the direct
+  algorithm with a witness, and the two agree through the companion's
+  `rank_map_eq` and `rank_eq_ratFunc_rank`.
+- **hex-determinantal-ideal** enumerates all `r × r` minors and proves
+  the rank-versus-minors theorem for every `r`; it takes `r` as an input.
+  This library finds one nonzero `r × r` minor and its adjugate. The two
+  are independent, and the soundness theorems here are the instance of
+  the nonzero-minor direction at the certificate's minor.
+- **`Echelon.Decomposition` (Mathlib)**, see the companion.
+
+## Prerequisite changes in other libraries
+
+None blocks starting work here; each is an ordinary change to a repo
+regenerated from this monorepo.
+
+- **`Hex.DomainLaws` in `HexBasic/ExactDiv.lean`**, with the `Int` and
+  field instances and `DomainLaws.of_exactDivLaws`, as specified under
+  [Coefficient contract](#coefficient-contract). If landing it in
+  hex-basic is deferred, the class starts in `HexRank/Domain.lean` and
+  moves down when a second consumer appears.
+- **`det_smul` in `HexDeterminant/RowOps.lean`**,
+  `det (c • M) = c ^ k * det M` for `M : Matrix R k k`, by `det_rowScale`
+  iterated, and `selectedSubmatrix_smul`,
+  `selectedSubmatrix_mul_eq_selectRows_mul_selectCols` in
+  `HexDeterminant/Minor.lean`, both entrywise. hex-determinantal-ideal
+  asks for the column analogue `selectCols_mul`; these are of the same
+  kind and whichever library lands first adds them.
+- **hex-modular-matrix SPEC amendment**, as listed under [Int](#int).
+- **`HexHermite`** may later return this certificate from its modular
+  path; nothing is required now.
+
+## Conformance
+
+Fixtures follow [SPEC/testing.md](../testing.md). Lean drivers at
+`conformance/HexRank/Conformance.lean` and
+`conformance/HexRank/EmitFixtures.lean`, the latter exposed as
+`lean_exe hexrank_emit_fixtures`, a committed snapshot at
+`conformance-fixtures/HexRank/rank.jsonl`, and an oracle driver at
+`scripts/oracle/rank_carriers.py`. One tuple appended to `ORACLES` in
+`scripts/ci/run_oracles.sh`:
+
+```
+"HexRank|hexrank_emit_fixtures|scripts/oracle/rank_carriers.py|conformance-fixtures/HexRank/rank.jsonl"
+```
+
+The driver follows `scripts/oracle/matrix_carriers.py` in shape:
+python-flint for `Int` (`fmpz_mat`), `Rat` (`fmpq_mat`) and `ZMod64 p`
+(`nmod_mat`) records, SymPy for `DensePoly` and `MvPoly` records with the
+exact domain (`ZZ[x]`, `QQ[x]`, `GF(p)[x]`, `ZZ[x0, …]`, `QQ[x0, …]`)
+stated explicitly. Both are already installed and preflighted by the
+single oracle job; no install line changes.
+
+**Record format and operations.** A record carries the carrier, the
+matrix (integers, rationals, residues normalised to `[0, p)`, ascending
+coefficient arrays for `DensePoly`, ordered exponent-vector terms for
+`MvPoly`), and one of:
+
+| `op` | Lean value | oracle recomputation and comparison |
+|---|---|---|
+| `rank` | `rankWith quot A` | `fmpz_mat.rank()` / `fmpq_mat.rank()` / `nmod_mat.rank()`; SymPy `Matrix.rank()` over the exact domain, compared as integers |
+| `colProfile` | `(rankProfileWith quot A).cols` | the pivot columns of the oracle's own reduced row echelon form (`fmpz_mat.rref()`, `fmpq_mat.rref()`, SymPy `Matrix.rref()`), compared as lists |
+| `rowProfile` | `(rankProfileWith quot A).rows` sorted | the rows `i` with `rank(A[0..i]) = rank(A[0..i-1]) + 1`, recomputed by the oracle with its own rank on row prefixes, compared as sorted lists |
+| `denom` | `(rowReduceWith quot A).denom` | the determinant of the oracle's submatrix at the Lean-reported `rows × cols`, compared exactly (this re-uses Lean's index selection, which is permitted canonicalisation: the value compared is the oracle's determinant) |
+| `cert` | `rankCertWith quot A`, with `checkRank A c` asserted `true` by `#guard` in `Conformance.lean` | the oracle re-verifies identities 1 to 3 with its own arithmetic (`fmpz_mat`/`fmpq_mat`/SymPy products) and re-checks `rank` against its own rank; a certificate that passes `checkRank` but fails the oracle's identities is a checker bug |
+
+The `cert` row is the requirement that the certificate be checked by the
+oracle-independent checker: `checkRank` is asserted in Lean on every
+emitted certificate, and the oracle's verification of the same identities
+is the cross-check on `checkRank` itself, not a substitute for it.
+
+**Cases that must be present**, since these are what a plausible
+implementation gets wrong:
+
+- `0 × 0`, `0 × m`, `n × 0`: rank `0`, `denom = 1`, empty profile, and
+  the certificate checks;
+- the zero matrix at several shapes: rank `0`, `denom = 1`, and
+  `checkRank_eq_zero_of_rank_zero` by `decide` in `Conformance.lean`;
+- `1 × 1` `[0]` and `[c]` for `c ≠ 0`, including negative `c` (so
+  `denom = c` and `adj = [1]`);
+- `[[0, 1], [0, 0]]`: rank `1`, `cols = [1]`, `rows = [0]`, the matrix
+  on which `bareissDataWith` stops;
+- a matrix with a skipped column in the middle and a pivot after it;
+- the `3 × 3` example under [The rank profile](#the-rank-profile), whose
+  row profile `{0, 2}` differs from the swap-order set `{1, 2}`;
+- wide and tall matrices of every rank from `0` to `min n m`, built as
+  products of an `n × r` and an `r × m` matrix so that the rank is known
+  by construction;
+- a full-rank square matrix whose elimination order is not the identity
+  (so `denom = ± det A` with the sign determined by `rows`), checked
+  against the oracle's determinant of the reordered submatrix;
+- a matrix with entries of several hundred bits, where the minors in the
+  certificate are much larger than the input;
+- for every certificate case, a mutated certificate (wrong `rank`, one
+  entry of `adj` changed, `denom := 0`, a repeated index in `rows`) with
+  `checkRank` asserted `false` in `Conformance.lean`, so that the checker
+  is seen to reject as well as accept;
+- `DensePoly Rat` and `ZPoly` matrices whose second pivot is nonconstant,
+  so the exact division is by a nonconstant polynomial, and a singular one;
+- `DensePoly (ZMod64 p)`: the `1 × 1` matrix `[X^p − X]`, rank `1`, with
+  `checkRank` true, beside the `rankAt`-style observation (in the
+  docstring of the case, not as an oracle op) that it is `0` at every
+  point of `𝔽_p`;
+- `MvPoly` in two and three variables with mixed monomials, including a
+  generic `2 × 3` matrix of six indeterminates (rank `2`, `denom` one of
+  the classical `2 × 2` minors) and a rank-deficient one built as a
+  product.
+
+## Benchmarking
+
+Per [SPEC/benchmarking.md](../benchmarking.md), with drivers at
+`bench/HexRank/Bench.lean`, Mathlib-free, no import of any `Hex*Mathlib`
+module. The registrations extend the existing single bench job.
+
+**Input families**, each seeded and deterministic:
+
+- `dense-full-rank`: square `n × n` matrices of small random entries,
+  `n = 16 … 256`, rank `n` with overwhelming probability and checked at
+  generation. This is the family where the rank profile route does the
+  most work per row and is comparable to `bareiss`.
+- `low-rank-large-coefficients`: `n × n` matrices formed as a product of
+  an `n × r` and an `r × n` matrix with `r ∈ {2, 8}` fixed and entries of
+  `64` and `1024` bits, `n = 16 … 256`. The run should be linear in `n²`
+  at fixed `r`, and the coefficient size is where the fraction-free
+  growth is measured.
+- `rank-deficient-by-construction`: `n × n` matrices of rank `n − 1` and
+  of rank `n / 2`, built as products with small entries, `n = 16 … 256`,
+  including a variant whose pivot columns are not the first `r` columns,
+  so that the skip path is on the measured route.
+- `polynomial`: `DensePoly Rat` and `MvPoly 2 Int` matrices of dimension
+  `4 … 12` with entries of fixed small support, full rank and rank
+  deficient, for the carrier instantiations.
+
+**Registrations**, per the Attribution rule: `rowReduceWith` (the
+producer's first pass), `rankCertWith` (both passes), and `checkRank`
+(on the certificate the producer emitted, with certificate construction
+hoisted into `prep`) are separate `setup_benchmark` targets on every
+family, so that the ratio between producer and checker is a recorded
+number and not an assumption of the tactic SPEC.
+
+**Complexity claim**, mode 1 (two-sided parametric): on
+`low-rank-large-coefficients` at fixed `r`, `rowReduceWith` and
+`checkRank` are `Θ(n²)` big-integer operations at an entry size that does
+not grow with `n`, so the declared scaling is `n²` in `n`. On
+`dense-full-rank`, the declared scaling is the one hex-bareiss declares
+for `bareiss` on its dense family (cubic count at Hadamard-bounded entry
+size), because the operation count differs by a constant. The
+derivations are the operation counts in [Complexity](#complexity); they
+are written before measurement and are not fitted.
+
+**Comparators**, all `informational`, with the rationale recorded here
+and in `libraries.yml`:
+
+| comparator | scope | rationale |
+|---|---|---|
+| python-flint `fmpz_mat.rank()` | `Int` families | FLINT selects between fraction-free and multi-modular rank by size, so the ratio compares algorithms, and no shared fixture history anchors a required ratio |
+| python-flint `fmpq_mat.rank()` | `Rat` variants of the `Int` families | as above, over `ℚ` |
+| SymPy `Matrix.rank()` over the exact polynomial domain | `polynomial` family | SymPy's rank chooses its own elimination and includes Python overhead |
+
+Wired as persistent-subprocess drivers following `Hex.BenchOracle.Flint`,
+with trivial-request overhead recorded in
+`reports/hex-rank-performance.md §Comparator ratios`. The external rungs
+are scheduled-only; the Hex registrations build and verify in the ordinary
+bench target and stay under the `Bench verify` budget by registering the
+verify path at the smallest rung of each family.
+
+## File organisation
+
+```text
+HexRank.lean                     umbrella
+HexRank/
+  Cert.lean        RankCert, checkRank
+  Check.lean       checkRank_minor_ne_zero, checkRank_minor_succ_eq_zero, checkRank_eq_zero_of_rank_zero
+  Reduce.lean      RankProfile, ReducedForm, rowReduceWith, rowReduceWithImpl, loop-step lemmas
+  Produce.lean     rankProfileWith, rankCertWith, certifyRankWith, rankWith
+  Int.lean         rowReduceFF, rankProfile, rankCert, certifyRank, rank
+  SPEC/hex-rank.md
+  README.md
+conformance/HexRank/{Conformance,EmitFixtures}.lean
+conformance-fixtures/HexRank/rank.jsonl
+scripts/oracle/rank_carriers.py
+bench/HexRank/Bench.lean
+```
+
+`libraries.yml` gains:
+
+```yaml
+  HexRank:
+    deps: [HexBareiss, HexDeterminant, HexMatrix, HexArith, HexBasic]
+    mathlib: false
+    done_through: 0
+    status: planned
+    phase4:
+      comparators:
+        - tool: FLINT fmpz_mat.rank via python-flint
+          class: informational
+          rationale: FLINT selects fraction-free or multi-modular rank by size, so the ratio compares algorithms; no shared fixture history anchors a required ratio.
+        - tool: FLINT fmpq_mat.rank via python-flint
+          class: informational
+          rationale: the same over the rationals.
+        - tool: SymPy Matrix.rank over the exact polynomial domain
+          class: informational
+          rationale: SymPy chooses its own elimination and includes interpreter overhead; it orients the polynomial carriers only.
+      input_families:
+        - name: dense-full-rank
+          description: square matrices of small random entries at full rank, n = 16 to 256.
+        - name: low-rank-large-coefficients
+          description: products of n by r and r by n matrices at r = 2 and 8 with 64- and 1024-bit entries, n = 16 to 256.
+        - name: rank-deficient-by-construction
+          description: square products of rank n - 1 and n / 2 with small entries, including pivot columns that are not the leading columns.
+        - name: polynomial
+          description: DensePoly Rat and MvPoly 2 Int matrices of dimension 4 to 12 at fixed support, full rank and rank deficient.
+  HexRankMathlib:
+    deps: [HexRank, HexBareissMathlib, HexDeterminantMathlib, HexMatrixMathlib]
+    mathlib: true
+    correspondence_only: true
+    done_through: 0
+    status: planned
+```
+
+## Milestones
+
+1. **The certificate.** `Hex.DomainLaws`, `RankCert`, `checkRank`, and
+   the three soundness theorems with their `HexDeterminant` lemmas. At the
+   end of this milestone a hand-written certificate can be checked and
+   the checker is proved sound, with no producer.
+2. **The producer.** `RankProfile`, `ReducedForm`, `rowReduceWith`, the
+   in-place implementation and its `@[csimp]`, the loop-step lemmas, and
+   the entry points. Conformance against the oracle for `rank`,
+   `colProfile`, `rowProfile`, `denom` and `cert`.
+3. **The `Int` layer and the amendment to hex-modular-matrix.**
+4. **The companion.** `checkRank_sound`, `rankCertWith_check`, the
+   profile theorems, `rank_map_eq`, and the `Decomposition` adapters.
+   Begins after milestone 1.
+5. **Carriers and benchmarks.** The polynomial instantiations in the
+   conformance and bench modules, the families above, and the headline
+   report.
+
+## Open questions
+
+- **Whether `rowReduceWith`'s first pass should be Gaussian rather than
+  Gauss-Jordan.** `rankCertWith` uses only `rows`, `cols` from the first
+  pass, which a below-only elimination computes at a smaller constant. The
+  reduced form is what `rowReduceWith` is for, and a second, below-only
+  loop is a second loop to prove. Measure on `dense-full-rank` before
+  adding one.
+- **Whether `Hex.DomainLaws` should subsume `Hex.GcdDomainLaws`'s
+  `one_ne_zero` and `no_zero_div` fields** in hex-mv-gcd. The two classes
+  state the same two facts; making `GcdDomainLaws` extend `DomainLaws` is
+  a hex-mv-gcd change and is not required by this library.
+- **Whether the certificate should record the sign of the row order.**
+  The producer's `denom` is `det B` with rows in elimination order. A
+  consumer that wants `det` of the sorted block must compute the sign.
+  Adding a `sortedSign` field is cheap for the producer and not needed by
+  any consumer named here.
+- **The crossover with `hnfRank` and with the multi-modular route over
+  `Int`.** Both are expected to win at large size; the benchmark decides
+  the size, and this SPEC does not guess it.

--- a/libraries.yml
+++ b/libraries.yml
@@ -325,7 +325,7 @@ libraries:
         - tool: FLINT fmpq_mat.rank via python-flint
           class: informational
           rationale: The same comparison over the rationals.
-        - tool: SymPy Matrix.rank over the exact polynomial domain
+        - tool: SymPy DomainMatrix.rank over the exact polynomial domain
           class: informational
           rationale: SymPy chooses its own elimination and includes interpreter overhead; it orients the polynomial carriers only.
       input_families:

--- a/libraries.yml
+++ b/libraries.yml
@@ -312,6 +312,31 @@ libraries:
       input_families:
         - name: structured-bareiss-determinant
           description: Deterministic tridiagonal integer matrices for row-pivoted Bareiss determinant scaling without arbitrary coefficient blow-up.
+  HexRank:
+    deps: [HexBareiss, HexDeterminant, HexMatrix, HexArith, HexBasic]
+    mathlib: false
+    done_through: 0
+    status: planned
+    phase4:
+      comparators:
+        - tool: FLINT fmpz_mat.rank via python-flint
+          class: informational
+          rationale: FLINT selects fraction-free or multi-modular rank by size, so the ratio compares algorithms; no shared fixture history anchors a required ratio.
+        - tool: FLINT fmpq_mat.rank via python-flint
+          class: informational
+          rationale: The same comparison over the rationals.
+        - tool: SymPy Matrix.rank over the exact polynomial domain
+          class: informational
+          rationale: SymPy chooses its own elimination and includes interpreter overhead; it orients the polynomial carriers only.
+      input_families:
+        - name: dense-full-rank
+          description: Square matrices of small random entries at full rank, n = 16 to 256.
+        - name: low-rank-large-coefficients
+          description: Products of n by r and r by n matrices at r = 2 and 8 with 64- and 1024-bit entries, n = 16 to 256.
+        - name: rank-deficient-by-construction
+          description: Square products of rank n - 1 and n / 2 with small entries, including pivot columns that are not the leading columns.
+        - name: polynomial
+          description: DensePoly Rat and MvPoly 2 Int matrices of dimension 4 to 12 at fixed support, full rank and rank deficient.
   HexDeterminantalIdeal:
     deps: [HexBasic, HexMatrix, HexDeterminant, HexRowReduce, HexMvPoly]
     mathlib: false
@@ -980,6 +1005,12 @@ libraries:
     correspondence_only: true
     done_through: 3
     status: active
+  HexRankMathlib:
+    deps: [HexRank, HexBareissMathlib, HexDeterminantMathlib, HexMatrixMathlib]
+    mathlib: true
+    correspondence_only: true
+    done_through: 0
+    status: planned
   HexModArithMathlib:
     deps: [HexModArith]
     mathlib: true


### PR DESCRIPTION
This PR specifies `hex-rank` and `hex-rank-mathlib` in `SPEC/Libraries/`: matrix rank over any nontrivial integral domain with a two-sided certificate that names an `r × r` submatrix `B` of `A` and carries `adjugate B` and `det B`, so that the checker verifies `B * adj = d • 1` (rank at least `r`) and `d • A = C * (adj * P)` (rank at most `r`) with ring arithmetic and equality tests only, no division and no determinant. The SPEC writes out the Mathlib-free soundness proofs (`det_mul` and `det_smul` for the lower bound, the empty-middle-sum case of `det_minor_mul` for the upper bound) and the completeness argument (`d = det B`, `U` read off `adjugate B`) including `r = 0` and the empty shapes, and records why the certificate stores the adjugate rather than the coefficient matrix. The producer is rectangular fraction-free Gauss-Jordan elimination with column pivoting, skipped columns and unmoved rows, checked line by line against `bareissDataWith` and `pivotLoopWith` in `HexBareiss/Bareiss.lean`; it guarantees the canonical column rank profile and, because rows are never swapped, the canonical row rank profile, with a counterexample showing what swapping loses. Carriers are `Int` (production, and the `Int` instance that `hex-modular-matrix`'s certificate now coincides with, recorded as an amendment there), `DensePoly F`, `ZPoly` and `MvPoly`, placed in conformance and bench modules per `scripts/check_dag.py`, with the `[X^q − X]` over `𝔽_q[X]` example and the three distinct tactic outputs (generic, conditional, rank locus). The companion states `checkRank_sound` for `Matrix.rank` over any domain, the reusable `IsFractionRing` scalar-extension theorem, producer correctness through an adjugate invariant that needs no Desnanot-Jacobi identity, the rank-profile theorems, and both conversions with Mathlib's `Echelon.Decomposition`, with every cited declaration checked against the pinned Mathlib by file path. Both libraries are registered as `planned` in `libraries.yml` and the SPEC index; `check_dag.py` and `check_phase4.py` pass.

Closes #10153

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TE9BA8MbMrCmiptij3f96Q
