### PR TITLE
spec: matrix tactic frontends, Mathlib adapters, and benchmarks

### DIFF
--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -20,8 +20,8 @@
 - **hex-bareiss**: the fraction-free Bareiss determinant algorithm
 - **[hex-rank](hex-rank.md)** (planned): matrix rank over any integral domain with a two-sided certificate (a nonsingular minor with its adjugate, and the identity expressing every column over the selected ones), the rectangular fraction-free producer, and the row and column rank profiles
 - **[hex-determinantal-ideal](hex-determinantal-ideal.md)** (planned): executable minors and determinantal-ideal generators of a matrix over a commutative ring, and the theorem that the rank over a field is below `r` exactly when every `r × r` minor vanishes
-- **[hex-matrix-tactic](hex-matrix-tactic.md)** (planned): proof-producing `det`, `rank`, and `char_poly` frontends, numeric entry models and certificate strategy
 - **hex-char-poly**: the characteristic polynomial by the division-free Samuelson-Berkowitz algorithm, over any commutative ring
+- **[hex-matrix-tactic](hex-matrix-tactic.md)** (planned): proof-producing `det`, `rank`, and `char_poly` frontends, numeric entry models and certificate strategy
 - **hex-min-poly**: the matrix minimal polynomial over a field, from Krylov sequences, with a certificate proving annihilation and minimality
 - **hex-hermite**: Hermite normal form over `Int`, unimodular transforms, integer lattice membership, integer kernel bases
 - **hex-smith**: Smith normal form over `Int`, invariant factors, and the structure of a finitely generated abelian group
@@ -78,7 +78,6 @@ Mathlib, and supplies correspondence proofs or Mathlib-facing APIs):
 - **hex-rational-fn-mathlib**: equivalence with `RatFunc K`, canonical numerator/denominator agreement and partial-evaluation semantics
 - **hex-sparse-poly-mathlib**: `SparsePoly R ≃+* Polynomial R`, and the identification of the stored term array with `Polynomial.support`
 - **hex-mv-poly-mathlib**: `MvPoly n R cmp ≃+* MvPolynomial (Fin n) R`, `aeval`, and operation correspondence
-- **[hex-matrix-tactic-mathlib](hex-matrix-tactic-mathlib.md)** (planned): Mathlib matrix literals, result transport and opt-in `norm_det` / `norm_rank` adapters
 - **hex-reflect-mathlib** (planned): Mathlib carrier translations and the `MvPolynomial` correspondence for reflected batches
 - **hex-mv-gcd-mathlib**: gcd maximality transported to `MvPolynomial (Fin n) R`, and decidable divisibility and squarefreeness
 - **hex-mv-hensel-mathlib**: the evaluation ideal and its residue ring as Mathlib objects, the lifted identities transported to `MvPolynomial (Fin (n+1)) ℤ`, and the factor-coefficient bound
@@ -91,6 +90,7 @@ Mathlib, and supplies correspondence proofs or Mathlib-facing APIs):
 - **[hex-rank-mathlib](hex-rank-mathlib.md)** (planned): certificate soundness for `Matrix.rank` over any domain, rank invariance under `IsFractionRing` scalar extension, producer correctness, and the conversions to and from Mathlib's `Echelon.Decomposition`
 - **[hex-determinantal-ideal-mathlib](hex-determinantal-ideal-mathlib.md)** (planned): minors as `Matrix.det` of a `submatrix`, the rank-versus-minors theorem for `Matrix.rank` under any ring homomorphism into a field, rank-drop loci as zero sets, and invariance of `I_r(A)` under invertible row and column operations
 - **hex-char-poly-mathlib**: agreement with `Matrix.charpoly`, Cayley-Hamilton, the trace and determinant coefficients, transpose and similarity invariance
+- **[hex-matrix-tactic-mathlib](hex-matrix-tactic-mathlib.md)** (planned): Mathlib matrix literals, result transport and opt-in `norm_det` / `norm_rank` adapters
 - **hex-min-poly-mathlib**: agreement with `minpoly`, the annihilator-generator statement for the vector order polynomial, divisibility into the characteristic polynomial, and the degree bound
 - **hex-hermite-mathlib**: row lattice = `Submodule.span ℤ`, integer rank = `Matrix.rank`, and an executable basis of the kernel submodule
 - **hex-smith-mathlib**: the executable output as `Module.Basis.SmithNormalForm`, the divisibility chain Mathlib's structure omits, and the quotient structure theorem

--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -20,6 +20,7 @@
 - **hex-bareiss**: the fraction-free Bareiss determinant algorithm
 - **[hex-rank](hex-rank.md)** (planned): matrix rank over any integral domain with a two-sided certificate (a nonsingular minor with its adjugate, and the identity expressing every column over the selected ones), the rectangular fraction-free producer, and the row and column rank profiles
 - **[hex-determinantal-ideal](hex-determinantal-ideal.md)** (planned): executable minors and determinantal-ideal generators of a matrix over a commutative ring, and the theorem that the rank over a field is below `r` exactly when every `r × r` minor vanishes
+- **[hex-matrix-tactic](hex-matrix-tactic.md)** (planned): proof-producing `det`, `rank`, and `char_poly` frontends, numeric entry models and certificate strategy
 - **hex-char-poly**: the characteristic polynomial by the division-free Samuelson-Berkowitz algorithm, over any commutative ring
 - **hex-min-poly**: the matrix minimal polynomial over a field, from Krylov sequences, with a certificate proving annihilation and minimality
 - **hex-hermite**: Hermite normal form over `Int`, unimodular transforms, integer lattice membership, integer kernel bases
@@ -77,6 +78,7 @@ Mathlib, and supplies correspondence proofs or Mathlib-facing APIs):
 - **hex-rational-fn-mathlib**: equivalence with `RatFunc K`, canonical numerator/denominator agreement and partial-evaluation semantics
 - **hex-sparse-poly-mathlib**: `SparsePoly R ≃+* Polynomial R`, and the identification of the stored term array with `Polynomial.support`
 - **hex-mv-poly-mathlib**: `MvPoly n R cmp ≃+* MvPolynomial (Fin n) R`, `aeval`, and operation correspondence
+- **[hex-matrix-tactic-mathlib](hex-matrix-tactic-mathlib.md)** (planned): Mathlib matrix literals, result transport and opt-in `norm_det` / `norm_rank` adapters
 - **hex-reflect-mathlib** (planned): Mathlib carrier translations and the `MvPolynomial` correspondence for reflected batches
 - **hex-mv-gcd-mathlib**: gcd maximality transported to `MvPolynomial (Fin n) R`, and decidable divisibility and squarefreeness
 - **hex-mv-hensel-mathlib**: the evaluation ideal and its residue ring as Mathlib objects, the lifted identities transported to `MvPolynomial (Fin (n+1)) ℤ`, and the factor-coefficient bound

--- a/SPEC/Libraries/hex-matrix-tactic-mathlib.md
+++ b/SPEC/Libraries/hex-matrix-tactic-mathlib.md
@@ -1,0 +1,267 @@
+# hex-matrix-tactic-mathlib
+
+Mathlib matrix literal conversion, correspondence proofs, and adapters for
+[hex-matrix-tactic](hex-matrix-tactic.md). The companion implements the
+Mathlib-facing `det`, `rank`, and `char_poly` operations while leaving the
+numeric producers and generic frontend protocol in the Mathlib-free library.
+This is a specification; adapter names below are proposed unless explicitly
+listed as existing in the source inventory.
+
+## Dependencies and ownership
+
+`HexMatrixTacticMathlib` depends on `HexMatrixTactic`, `HexMatrixMathlib`,
+`HexBareissMathlib`, `HexRowReduceMathlib`, `HexCharPolyMathlib`, and the
+planned `HexRankMathlib`, plus Mathlib. `HexDeterminantMathlib` and
+`HexPolyMathlib` are transitive dependencies. Numeric support has no
+`HexReflect` dependency. A future symbolic integration library sits above
+both frontend and reflection companions; no reverse edge is permitted.
+
+The namespace is `HexMatrixTacticMathlib`, with proposed modules
+`Literal`, `Model`, `Det`, `Rank`, `CharPoly`, and opt-in `MathlibAdapters`.
+The umbrella imports the ordinary frontends. Importing the explicit adapter
+module enables Hex in Mathlib's machinery without changing the baseline
+comparison by accident. This companion is not `correspondence_only`: it owns
+literal recognition, Meta registrations, conformance and fresh-module proof
+probes. Its benchmark contract and fixtures are specified in the base SPEC.
+It has no Mathlib-importing compiled bench executable.
+
+## Literal reconstruction
+
+Enumerate every `(i,j)` in row-major order for concrete `Fin n`, `Fin m`:
+
+- `!![…]` matrix notation;
+- `Matrix.of ![…]` with each row a concrete vector;
+- `fun i j => …` when evaluation at each concrete index is supported;
+- `Matrix.ofArray xs h`, with the exact size witness.
+
+Unfold reducible wrappers and let bindings within a documented budget.
+Do not require that enumeration itself is definitionally equal to a literal:
+prove each interpreted Hex entry equals the original `A i j`. Symbolic
+entries use one downstream reflection session; closed entries use the numeric
+model. Failure reports its row and column. Shape checks include empty rows and
+columns and must not infer the width of a zero-row matrix from its first row.
+
+Let `e := HexMatrixMathlib.matrixEquiv`. The reconstruction API includes the
+following **new** theorem shapes, using public Hex accessors:
+
+```text
+ofArray_eq (B : Hex.Matrix R n m) (xs : Array R)
+  (hsize : xs.size = n*m)
+  (hentries : ∀ i : Fin n, ∀ j : Fin m,
+    (Matrix.ofArray xs hsize) i j = B[(i,j)]) :
+  Matrix.ofArray xs hsize = e B
+
+matrix_eq (B : Hex.Matrix C n m) (φ : C →+* R)
+  (hentries : ∀ i j, φ (B[(i,j)]) = A i j) :
+  (e B).map φ = A
+```
+
+The first also gets an entry-array specialization whose hypothesis reads the
+flat offset `i.val*m+j.val`, with its bound derived from `hsize`; the second
+has a same-carrier identity specialization. `Matrix.ofArray` is a constructor,
+not an equivalence. Reuse its entry lemma and `ofArray_ofFn`; never introduce
+an `ofArray`-to-Hex `Equiv` that forgets a length condition. The shared batch
+certificate replaces the characteristic-polynomial-specific inductive literal
+witnesses and works for rectangular matrices too.
+
+## Statements and scalar domains
+
+The goal forms accept:
+
+```text
+by det        : Matrix.det A = e
+by rank       : A.rank = r        (also A.rank ≤ r and r ≤ A.rank)
+by char_poly  : A.charpoly = p
+```
+
+The corresponding term forms return `{ value, proof }` with proof types
+`A.det = value`, `A.rank = value`, and `A.charpoly = value`.
+Names have no `hex_` prefix. Result reconstruction proves agreement with the
+user's expression, not merely a printed numeral or polynomial. Preserve
+existing `char_poly` compatibility as described in the base SPEC.
+
+For an integer matrix, integer rank means rank after the injective cast to
+`Rat`. To close a target using Mathlib's integer `A.rank`, compose with the
+domain-to-fraction-field rank preservation theorem specified by
+[hex-rank-mathlib](hex-rank-mathlib.md#scalar-extension). That theorem is
+planned; existing `hnfRank_eq_rank` concerns module rank over `Int` and alone
+does not establish the cast convention. A first field-only path can certify
+the explicitly cast rational matrix using existing row-reduction correctness;
+the direct integer target needs the scalar-extension bridge.
+
+For rational literals in `ℝ` or `ℂ`, prove entry equalities to the image of a
+rational matrix using `norm_num`, check its certificate in `Rat`, and transport
+through the injective rational embedding. For determinant/characteristic
+polynomial the operation-preserving map suffices; rank uses injectivity and
+minor/column soundness. This avoids kernel reduction of classical equality.
+It is support of a fixed closed literal fragment, not arbitrary real or
+complex computation.
+
+## Certificate adapters
+
+**Determinant value.** A proposed `det_eq_of_check` adapter composes an input
+reconstruction with a checked Hex determinant value and operation
+correspondence. For direct Bareiss replay its premises include
+`[CommRing C] [DecidableEq C]`, a quotient `q`,
+`∀ a b, b ≠ 0 → q (a*b) b = a`, and the kernel-proved equality
+`Hex.Matrix.bareissWith q B = d`. Its conclusion is `A.det = φ d` when
+`(e B).map φ = A`. A certificate path instead uses the relevant check's
+soundness theorem. A Berkowitz constant-coefficient adapter includes the
+`(-1)^n` sign for Mathlib's `det(X I - A)` convention.
+
+`HexMatrixMathlib.bareissWith_eq_mathlib_det` is **producer correctness**
+for any `CommRing` with `DecidableEq` and the stated exact-quotient law; it
+does not assume `IsDomain` or `Nontrivial` explicitly. The trivial ring is
+handled separately, and in a nontrivial ring the quotient law implies the
+needed cancellation. Mathlib's `Echelon.Decomposition.rank_eq` is instead
+**certificate soundness** over a domain. It makes no claim that a particular
+Bareiss producer returns a valid certificate. These are different theorems,
+and neither is a replacement for the other.
+
+**Rank certificate.** A proposed `rank_eq_of_check` consumes the two-sided
+certificate of `HexRank`: a selected nonzero minor (certified via its scaled
+inverse/adjugate) and an identity expressing all columns through the selected
+columns. Reuse the planned `HexRankMathlib.checkRank_sound` and
+`checkRank_sound_map` adapters with their domain and injective-map hypotheses;
+do not implement a second rank checker here. Expose lower-bound and
+upper-bound adapters for clients that hold only the corresponding witness.
+These prove Mathlib `Matrix.rank` equalities/inequalities without reconstructing
+Mathlib's full elimination matrix.
+
+**Echelon predicates.** For `E : Hex.Matrix.IsEchelonForm B D`, define the
+pivot function to be `D.pivotCols[i]` on the first `D.rank` rows and `⊤`
+afterwards. A proposed `isPivotedBy_of_echelon` requires both:
+
+1. `E.HasNonzeroPivots`;
+2. every entry strictly before the named pivot in each pivot row is zero.
+
+Then `(e D.echelon).IsPivotedBy pivot` follows from these, sorted pivots and
+zero trailing rows. `IsRowReduced` provides nonzero pivots over a nontrivial
+ring, but still needs condition 2. For example `B = D.echelon = [1,1]` with
+identity transform and the sole pivot named in column 1 satisfies the Hex
+RREF fields yet is not pivoted in Mathlib's sense at column 1.
+Conversely, `IsPivotedBy` and a sorted list of its finite pivots supply the
+entry-shape fields; Hex's transform and inverse witnesses must be provided
+separately. It does not assert reduced pivots or zero entries above them.
+
+**Decomposition.** A proposed `decomposition_of_check` takes the original
+matrix, a row permutation `σ`, a lower-triangular `L` with nonzero diagonal,
+and a checked equation `L * A.submatrix σ id = e D.echelon`, together with
+the preceding pivot proof. It builds the pinned `Echelon.Decomposition A`;
+its `rank_eq` yields the pivot count. Do not pass `D.transform` as `L`
+unconditionally: Hex's invertible transform can contain swaps and operations
+above pivots and need not be lower triangular. Conversely, a domain
+`Decomposition` need not have a ring-invertible transform (its diagonal is
+nonzero, not necessarily a unit); conversion to Hex field row-reduction data
+needs scalar extension/invertibility and extra reduction work. General
+rank-certificate/decomposition conversions belong to `HexRankMathlib`, as
+specified there; this frontend consumes them rather than asserting that the
+data structures are definitionally interchangeable.
+
+## Mathlib integration
+
+The opt-in `@[bareiss_ext]` declaration has the actual pinned type
+`Mathlib.Tactic.Echelon.BareissExt`, whose sole field is
+`producer? : Expr → MetaM (Option Producer)`. A `Producer` takes
+`Array (Array Expr)` and returns `BareissData Expr` containing `L`, ordered
+row swaps, and pivot columns. Implement a Hex-backed producer returning that
+shape, including the lower-triangular transform and restoration of any row
+scaling. The determinant-only `Hex.Matrix.bareiss` result cannot supply it;
+use or extend the rectangular producer to retain the needed transform, with
+these obligations verified by Mathlib's certificate builder.
+
+Reuse the same computation model and quotation used by Hex's own frontend.
+Unsupported carriers return `none`. Mathlib then checks the pivot condition
+of `L * A.submatrix σ id`, triangularity and nonzero diagonal by kernel
+`decide`. A faster producer alone does not remove its documented matrix
+multiplication bottleneck. The independent Hex `rank` can use the smaller
+certificate, but `bareiss_ext` cannot replace Mathlib's certificate checker.
+
+The pinned `norm_rank` calls `checkBareissApplicable` before model selection:
+`CommRing`, `IsDomain`, and reduction of the decidable test `1 = 0` to false.
+This is a probe for kernel-decidable zero equality, not a proof that every
+entry equality reduces. All actual conditions still have to check. Registering
+a model therefore does not enable `norm_rank` on classical `ℝ`/`ℂ`, composite
+moduli, or arbitrary symbolic atoms. Those supported Hex cases use the
+independent frontend and proved interpretation instead.
+
+The pinned `norm_det` has no analogous producer registry. Supply an opt-in
+Hex determinant simproc/Meta adapter that returns a `Simp.Result` with the
+same `Matrix.det` rewrite contract, using `det_eq_of_check`. Compose it in an
+explicit simp set with `norm_det` as fallback (try Hex first, then the stock
+simproc on decline). Preserve unmodified `norm_det`/`eval_det` for standalone
+use and comparison; do not claim `bareiss_ext` extends determinant or replace
+Mathlib's declaration by a same-named declaration. Test both fallback and
+Hex-selected paths.
+
+## Closed algebraic benchmark
+
+Use `α = √2` in the real embedding of `Q(√2)` and
+`A = !![α, 1; 1, α]`. Its determinant is `1`, rank is `2`, and characteristic
+polynomial is `X² - 2α X + 1`. Repeat as diagonal blocks, then add fixed
+rational off-block couplings to exercise full computation. The computable
+model represents `a + bα` as a rational pair, multiplies modulo `α² = 2`,
+and proves its embedding using `Real.sq_sqrt` with `0 ≤ 2` and the
+irreducibility/injectivity evidence needed for field operations and rank.
+Use both an explicit number-field presentation and its real-algebraic image;
+the registered provider must prove the relation, not infer it from spelling.
+
+`norm_det` normalizes the determinant as a ring expression, treating `√2`
+as an atom; its ring normalizer does not by itself use the algebraic relation.
+Measure raw `norm_det` output and whether it closes the target. For a complete
+proof comparator also measure `eval_det` followed by the explicitly supplied
+`α² = 2` normalization, including that normalization's cost. Raw `norm_rank`
+on `ℝ` is inapplicable at the equality check: record that result, and compare
+rank on the computable number-field model when its kernel equality is
+supported. Do not turn inapplicability into an infinite speedup. Run the Hex
+standalone real frontend and the computable-carrier comparator as separately
+labelled arms. This family tests closed algebraic reduction without waiting
+for `hex-reflect`.
+
+## Verified source inventory
+
+Paths below are relative to the repository, or to `.lake/packages/mathlib/`
+for Mathlib. The pin in `lake-manifest.json` is
+`85e3a25e006c35636f0e53b0e9296caca2685bc0`. These existing declarations were
+checked in that source; proposed adapters elsewhere in this SPEC are not
+claims about the current API.
+
+| Existing Mathlib declaration | File and checked contract |
+|---|---|
+| `Matrix.ofArray`, `ofArray_apply`, `ofArray_ofFn` | `Mathlib/LinearAlgebra/Matrix/Defs.lean`: flat array plus `size = m*n`, row-major access, reconstruction of a `Fin` matrix; no ring assumptions. |
+| `Mathlib.Tactic.Echelon.BareissExt`, `Producer`, `BareissData`, `RingOps`, `mkProducer`, `bareiss_ext` | `Mathlib/Tactic/Echelon/Core.lean`: model lookup, nested-array producer, transform/swaps/pivots, arithmetic/preparation/restoration/quotation, and Meta registration attribute. |
+| `checkBareissApplicable`, `checkKernelDecide`, `mkCertificate`, `producerFor` | `Mathlib/Tactic/Echelon/Bareiss.lean`: domain applicability before dispatch; three kernel-decided certificate conditions; first supported extension then rational fallback. |
+| `Echelon.Decomposition`, `Echelon.Decomposition.rank_eq` | `Mathlib/LinearAlgebra/Matrix/Echelon/Decomposition.lean`: namespace is root `Echelon`, not `Matrix.Echelon`; `[CommRing R] [IsDomain R]`, finite linearly ordered indices; rank equals the number of finite pivots. |
+| `Matrix.IsPivotedBy` | `Mathlib/LinearAlgebra/Matrix/Echelon/Pivot.lean`: `[Zero R]`, ordered indices, row-echelon shape and leading nonzero entries; its rank theorem additionally assumes a domain and finite indices. |
+| `norm_det`, `eval_det` | `Mathlib/Tactic/NormDet.lean`: concrete square `Fin` matrix literals over `CommRing`, Bird determinant and certificate-chain normalization from `Mathlib/Tactic/Determinant/Bird/Cert.lean`; symbolic ring entries allowed. |
+| `norm_rank`, `eval_rank` | `Mathlib/Tactic/NormRank.lean`: non-symbolic literal matrices, applicability check then Bareiss certificate; supporting parsing and numeric models in `Mathlib/Tactic/Echelon/{Parsing,Rat,Zsqrtd}.lean`; certificate construction is in `Bareiss.lean`, not a separate `Echelon/Cert.lean` file. |
+| `Real.sq_sqrt` | `Mathlib/Analysis/Real/Sqrt.lean`: `(√x)^2 = x` requires `0 ≤ x`. |
+
+| Existing Hex declaration | File and checked contract |
+|---|---|
+| `HexMatrixMathlib.matrixEquiv` | `HexMatrixMathlib/Basic.lean`: Hex/Mathlib `Fin` matrix equivalence, no ring assumptions. |
+| `HexMatrixMathlib.det_eq` | `HexDeterminantMathlib/CoreTransport.lean`: `[CommRing R]`, `Hex.Matrix.det B = Matrix.det (matrixEquiv B)`. |
+| `HexMatrixMathlib.bareissWith_eq_mathlib_det` | `HexBareissMathlib/Bareiss.lean`: `[CommRing R] [DecidableEq R]` and `∀ a b, b ≠ 0 → quot (a*b) b = a`; arbitrary square Hex matrix. |
+| `HexMatrixMathlib.bareiss_eq_mathlib_det` | Same file: specialization to `Int` and exact integer quotient. |
+| `HexMatrixMathlib.rank_eq` | `HexRowReduceMathlib/RankSpanNullspace.lean`: `[Field R]`, `E : Hex.Matrix.IsRowReduced M D` implies `D.rank = (matrixEquiv M).rank`; not a theorem about arbitrary echelon data or arbitrary rings. |
+| `hnfRank_eq_rank` in namespace `HexHermiteMathlib` | `HexHermiteMathlib/Rank.lean`: integer HNF rank equals Mathlib module rank over `Int`; contextual inventory, not an added Hermite dependency. |
+| `HexCharPolyMathlib.equiv_charPoly` | `HexCharPolyMathlib/Basic.lean`: `[CommRing R] [DecidableEq R]`, dense-polynomial equivalence sends `Hex.Matrix.charPoly B` to `(matrixEquiv B).charpoly`. |
+| `Hex.Matrix.RowEchelonData`, `IsEchelonForm`, `IsRowReduced`, `IsEchelonForm.HasNonzeroPivots` | `HexRowReduce/RowEchelon/Contracts.lean`: transform witnesses, sorted columns, zeros below pivots/trailing rows; nonzero pivots and leading-entry conditions must be distinguished as above. |
+
+## Verification obligations
+
+- Build the numeric base without Mathlib or reflection; check the import DAG.
+- Check every literal syntax and empty/rectangular boundary; alter an entry,
+  dimension, modulus and interpretation instance to test rejection.
+- Prove all new reconstruction and certificate adapters with their stated
+  hypotheses; test the nonleading-pivot counterexample and a nontriangular
+  transform so the echelon adapter cannot silently assume stronger contracts.
+- Test determinant signs in odd and even dimensions, rank inequalities in both
+  directions, integer/rational cast agreement, real/complex rational literals,
+  finite prime and composite carriers, and characteristic polynomials beyond
+  `Int`. Negative targets and unresolved conditions must not close.
+- Verify the shared model through both the standalone Hex frontend and the
+  `bareiss_ext` adapter. Record stock comparator, adapter and standalone costs
+  separately under the base SPEC's Phase-4 fixtures and ceilings.
+- Preserve existing `char_poly` numeric examples and proof strategy, migrate
+  import paths without cycles or duplicate elaborators, and audit axiom sets.

--- a/SPEC/Libraries/hex-matrix-tactic-mathlib.md
+++ b/SPEC/Libraries/hex-matrix-tactic-mathlib.md
@@ -13,8 +13,9 @@ listed as existing in the source inventory.
 `HexBareissMathlib`, `HexRowReduceMathlib`, `HexCharPolyMathlib`, and the
 planned `HexRankMathlib`, plus Mathlib. `HexDeterminantMathlib` and
 `HexPolyMathlib` are transitive dependencies. Numeric support has no
-`HexReflect` dependency. A future symbolic integration library sits above
-both frontend and reflection companions; no reverse edge is permitted.
+`HexReflect` dependency. The future `HexMatrixReflectMathlib` integration sits above
+`HexMatrixReflect` and both frontend and reflection companions; no reverse
+edge is permitted.
 
 The namespace is `HexMatrixTacticMathlib`, with proposed modules
 `Literal`, `Model`, `Det`, `Rank`, `CharPoly`, and opt-in `MathlibAdapters`.
@@ -23,7 +24,7 @@ module enables Hex in Mathlib's machinery without changing the baseline
 comparison by accident. This companion is not `correspondence_only`: it owns
 literal recognition, Meta registrations, conformance and fresh-module proof
 probes. Its benchmark contract and fixtures are specified in the base SPEC.
-It has no Mathlib-importing compiled bench executable.
+It has no compiled bench executable.
 
 ## Literal reconstruction
 
@@ -74,9 +75,12 @@ by rank       : A.rank = r        (also A.rank ≤ r and r ≤ A.rank)
 by char_poly  : A.charpoly = p
 ```
 
-The corresponding term forms return `{ value, proof }` with proof types
+The corresponding term forms `det% A`, `rank% A`, and `char_poly A` return `{
+value, proof }` with proof types
 `A.det = value`, `A.rank = value`, and `A.charpoly = value`.
-Names have no `hex_` prefix. Result reconstruction proves agreement with the
+Tactic names have no `hex_` prefix; `%` in the first two term forms avoids
+collisions with ordinary determinant/rank function applications. Result
+reconstruction proves agreement with the
 user's expression, not merely a printed numeral or polynomial. Preserve
 existing `char_poly` compatibility as described in the base SPEC.
 
@@ -206,7 +210,20 @@ irreducibility/injectivity evidence needed for field operations and rank.
 Use both an explicit number-field presentation and its real-algebraic image;
 the registered provider must prove the relation, not infer it from spelling.
 
-`norm_det` normalizes the determinant as a ring expression, treating `√2`
+Also require a matched integral subfamily over `Zsqrtd (2 : ℤ)`, with
+`α := ⟨0,1⟩`. The pinned `Mathlib.Tactic.Echelon.zsqrtdExt` already supplies a
+Bareiss computation model for this quadratic ring. Compare Hex with stock
+`norm_det` and stock `norm_rank` on the same `Zsqrtd` matrices; supply a
+locally proved `Zsqrtd.Nonsquare (2 : ℕ)` instance to synthesize the domain
+needed by `norm_rank`. This is an integral subring of the number field, so it
+covers the integer-coefficient block family and integer couplings, not every
+rational-pair input. Retain the rational number-field and real-embedding arms
+as distinct coverage. `norm_det` accepts the ring but may still need explicit
+algebraic normalization to close a chosen scalar target; record its actual
+output and the cost of completing that proof.
+
+On the real-embedding arm, `norm_det` normalizes the determinant as a ring
+expression, treating `√2`
 as an atom; its ring normalizer does not by itself use the algebraic relation.
 Measure raw `norm_det` output and whether it closes the target. For a complete
 proof comparator also measure `eval_det` followed by the explicitly supplied
@@ -231,10 +248,11 @@ claims about the current API.
 | `Matrix.ofArray`, `ofArray_apply`, `ofArray_ofFn` | `Mathlib/LinearAlgebra/Matrix/Defs.lean`: flat array plus `size = m*n`, row-major access, reconstruction of a `Fin` matrix; no ring assumptions. |
 | `Mathlib.Tactic.Echelon.BareissExt`, `Producer`, `BareissData`, `RingOps`, `mkProducer`, `bareiss_ext` | `Mathlib/Tactic/Echelon/Core.lean`: model lookup, nested-array producer, transform/swaps/pivots, arithmetic/preparation/restoration/quotation, and Meta registration attribute. |
 | `checkBareissApplicable`, `checkKernelDecide`, `mkCertificate`, `producerFor` | `Mathlib/Tactic/Echelon/Bareiss.lean`: domain applicability before dispatch; three kernel-decided certificate conditions; first supported extension then rational fallback. |
+| `Mathlib.Tactic.Echelon.zsqrtdExt` | `Mathlib/Tactic/Echelon/Zsqrtd.lean`: existing `bareiss_ext` model for `Zsqrtd d`, using exact division by conjugation. `Mathlib/NumberTheory/Zsqrtd/Basic.lean` supplies the domain instance for natural `d` under `Zsqrtd.Nonsquare d`. |
 | `Echelon.Decomposition`, `Echelon.Decomposition.rank_eq` | `Mathlib/LinearAlgebra/Matrix/Echelon/Decomposition.lean`: namespace is root `Echelon`, not `Matrix.Echelon`; `[CommRing R] [IsDomain R]`, finite linearly ordered indices; rank equals the number of finite pivots. |
 | `Matrix.IsPivotedBy` | `Mathlib/LinearAlgebra/Matrix/Echelon/Pivot.lean`: `[Zero R]`, ordered indices, row-echelon shape and leading nonzero entries; its rank theorem additionally assumes a domain and finite indices. |
-| `norm_det`, `eval_det` | `Mathlib/Tactic/NormDet.lean`: concrete square `Fin` matrix literals over `CommRing`, Bird determinant and certificate-chain normalization from `Mathlib/Tactic/Determinant/Bird/Cert.lean`; symbolic ring entries allowed. |
-| `norm_rank`, `eval_rank` | `Mathlib/Tactic/NormRank.lean`: non-symbolic literal matrices, applicability check then Bareiss certificate; supporting parsing and numeric models in `Mathlib/Tactic/Echelon/{Parsing,Rat,Zsqrtd}.lean`; certificate construction is in `Bareiss.lean`, not a separate `Echelon/Cert.lean` file. |
+| `norm_det`, `eval_det` | `Mathlib/Tactic/NormDet.lean`: `!![…]` / `Matrix.of` vector-chain square literals over `CommRing`, not general lambdas or `ofArray`; Bird determinant and certificate-chain normalization from `Mathlib/Tactic/Determinant/Bird/Cert.lean`; symbolic ring entries allowed. |
+| `norm_rank`, `eval_rank` | `Mathlib/Tactic/NormRank.lean`: `!![…]` / `Matrix.of` vector-chain matrices without free variables or metavariables, not general lambdas or `ofArray`; applicability check then Bareiss certificate; supporting parsing and numeric models in `Mathlib/Tactic/Echelon/{Parsing,Rat,Zsqrtd}.lean`; certificate construction is in `Bareiss.lean`, not a separate `Echelon/Cert.lean` file. |
 | `Real.sq_sqrt` | `Mathlib/Analysis/Real/Sqrt.lean`: `(√x)^2 = x` requires `0 ≤ x`. |
 
 | Existing Hex declaration | File and checked contract |
@@ -263,5 +281,7 @@ claims about the current API.
 - Verify the shared model through both the standalone Hex frontend and the
   `bareiss_ext` adapter. Record stock comparator, adapter and standalone costs
   separately under the base SPEC's Phase-4 fixtures and ceilings.
+- Check that term result syntax does not alter ordinary `det`/`rank` function
+  applications; test namespace opens and qualified names with both umbrellas.
 - Preserve existing `char_poly` numeric examples and proof strategy, migrate
   import paths without cycles or duplicate elaborators, and audit axiom sets.

--- a/SPEC/Libraries/hex-matrix-tactic.md
+++ b/SPEC/Libraries/hex-matrix-tactic.md
@@ -1,0 +1,279 @@
+# hex-matrix-tactic
+
+Proof-producing `det`, `rank`, and `char_poly` frontends for executable Hex
+matrices. The [Mathlib companion](hex-matrix-tactic-mathlib.md) accepts
+Mathlib matrices and integrates with `norm_det` and `norm_rank`. These are
+independent tactics with plain names; duplicating a Mathlib tactic is allowed.
+The performance objective is a measured, reproducible speedup on named
+families, with slower cases driving optimisation. Benchmarking determines
+strategy and documents coverage; it does not decide whether a tactic may ship.
+
+This SPEC specifies future implementation, not an implemented API. It follows
+[the matrix design in PR #9437](https://github.com/kim-em/hex-dev/pull/9437),
+with numeric support independent of the separately specified
+[hex-reflect](hex-reflect.md).
+
+## Boundary and dependencies
+
+`HexMatrixTactic` owns Hex literal recognition, entry-model selection, matrix
+batch conversion, algorithm selection, result reconstruction, and syntax.
+It accepts `Hex.Matrix R n m`, with concrete natural dimensions, through the
+public `ofFn`, `ofRows`, row and entry APIs and the library's notation. It
+must not access the private backing buffer or recognize Mathlib syntax.
+
+Its direct dependencies are `HexMatrix`, `HexBareiss`, `HexRowReduce`,
+`HexCharPoly`, and the planned `HexRank`. `HexDeterminant`, `HexPoly`,
+`HexArith`, and `HexBasic` are available transitively. It imports Lean's
+elaborator API, but no Mathlib. The companion sits above this library and the
+corresponding Mathlib bridges. Neither numeric library imports `HexReflect`
+or `HexReflectMathlib`.
+
+The `libraries.yml` entries are `status: planned`, `done_through: 0`, with no
+Lake targets or umbrella files until activation. These edges follow
+`scripts/check_dag.py` and its `libgraph.may_import` dependency closure.
+The existing lower libraries must never import either frontend. Symbolic
+integration will live in a separately registered downstream library depending
+on both this frontend and reflection (and their companions where needed).
+It cannot be an optional file in the numeric library whose import would
+silently expand that library's dependency closure.
+
+## Entry models and conversion
+
+A computation model mirrors `Mathlib.Tactic.Echelon.BareissExt`: a Meta-level
+lookup on the carrier returns a producer or declines. The executable value
+type, arithmetic, preparation/restoration and quotation are separate pieces.
+A model records zero, one, multiplication, subtraction, a zero test and,
+when available, an exact quotient. It also supplies the addition and
+interpretation laws needed by Hex algorithms. Preparation converts a whole
+matrix, retaining dimensions, row-major order, original entry expressions,
+and one proof of each entry's interpretation. Restoration accounts for every
+row scale or coefficient conversion, not just the returned scalar.
+
+Lookup and caches include the exact carrier, algebraic instances,
+interpretation map, configuration and, for symbolic input, sealed variable
+environment. Matching only a type name is insufficient. Discovery and
+quotation are untrusted; an executable zero test is not a proof of its answer.
+
+| Entry model | Accepted fragment and proof obligation |
+|---|---|
+| Closed `Int`, `Rat` | Kernel-transparent arithmetic and equality; rational denominators are nonzero and any denominator clearing has a proved restoration. |
+| Closed `ZMod n`, `Fin n` | Literal modulus, kernel-decidable equality and lawful ring operations. `ZMod` recognition belongs in the companion; `Fin n` requires positive `n` for its modular ring. Determinant and characteristic polynomial allow composite moduli; rank requires a domain/field model, normally prime modulus, and cannot assume primality. `ZMod 0` follows its integer model. |
+| Literals in `ℝ`, `ℂ` | The companion proves entries equal to images of computable values using `norm_num` and registered interpretation lemmas. Rational-valued literals use `Rat`; complex literals involving `I` need an explicit computable extension. Never run kernel equality on classical real or complex instances. |
+| Closed algebraic entries | A registered computable number-field or real-algebraic carrier and certified embedding, with nonzero preservation for rank. This is a numeric provider extension, independent of symbolic reflection. |
+| Symbolic entries | A later `hex-reflect` provider converts the entire matrix in one batch, seals variables once and supplies interpretation equalities. Intermediate polynomial matrices are not printed and reparsed. |
+
+Determinant and characteristic polynomial commute with a ring homomorphism;
+rank additionally needs injectivity or explicit proofs that the chosen minor
+remains nonzero under interpretation. A symbolic polynomial nonzero before
+specialization may become zero afterwards. Generic rank must name the
+polynomial domain or its fraction field; conditional specialized rank retains
+all nonvanishing conditions. Unconditional rank of arbitrary specializations
+is not promised. Piecewise rank and case splitting are later work.
+
+## Frontends and results
+
+The term forms `det A`, `rank A`, and `char_poly A` return dependent records
+with fields `value` and `proof`, the latter asserting that the requested
+operation on the original matrix equals `value`. Determinant values are in
+the source carrier, rank values in `Nat`, and characteristic-polynomial
+values in `Hex.DensePoly R` or the companion's `Polynomial R`.
+
+The goal forms close determinant equality, rank equality or either inequality,
+and characteristic-polynomial equality. On Hex inputs these refer to the
+selected executable determinant, field rank or explicitly interpreted integer
+rank, and `Hex.Matrix.charPoly`; the companion gives the exact Mathlib
+statements. Square shape is required for determinant and characteristic
+polynomial; rank supports rectangular and empty matrices. Empty square
+matrices have determinant `1`, rank `0`, and characteristic polynomial `1`.
+
+An equality tactic checks the requested right-hand side against the certified
+result, including coefficientwise polynomial equality. Rank inequalities use
+the certified equality followed by a checked natural-number comparison; a
+one-sided minor or spanning certificate may avoid computing the opposite bound
+when its soundness theorem suffices. A false target remains unproved.
+
+The common internal protocol distinguishes `notApplicable` (wrong fragment),
+`declined` (unsupported capability or exhausted budget), `success` (value and
+proof, or explicitly conditional result), and `failure` (malformed output or
+failed certificate). A tactic closes a goal only after every condition is
+proved. Programmatic conditional results expose an ordered condition list and
+a proof depending on it; unconditional term forms decline unresolved
+conditions. Diagnostics identify the operation, carrier, entry coordinate,
+missing capability or exceeded budget. No failure substitutes a weaker goal.
+
+## Algorithms and proof strategy
+
+Initial determinant selection is:
+
+| Input and laws | Producer |
+|---|---|
+| Closed `Int` | Row-pivoted fraction-free Bareiss |
+| Closed field with certified exact quotient | Bareiss, with denominator restoration when working integrally |
+| Commutative ring without exact quotient | Samuelson–Berkowitz, returning `(-1)^n` times the constant coefficient of `det(X I - A)` |
+| Symbolic polynomial entries with certified exact quotient | Polynomial Bareiss |
+| Symbolic polynomial entries without exact quotient | Samuelson–Berkowitz with the same sign correction |
+
+Characteristic polynomial uses Samuelson–Berkowitz. The characteristic
+variable stays separate from reflected entry variables, for example in
+`DensePoly (MvPoly k C cmp)`. Rank uses verified field row reduction or the
+two-sided domain certificate and fraction-free producer specified by
+[hex-rank](hex-rank.md). That certificate and its companion's soundness are
+planned dependencies, not existing declarations.
+
+There are two proof strategies:
+
+- **Transport and kernel evaluation.** Materialize a Hex input, transport by
+  correspondence, then prove a closed executable equality by kernel `decide`
+  (`Lean.Meta.mkDecideProof`, or `decide +kernel` in source examples).
+  For Bareiss the equality must mention `bareiss`/`bareissWith`; reducing
+  `Hex.Matrix.det` instead evaluates its Leibniz definition. Either way,
+  evaluating a producer equality in the kernel replays that producer.
+- **Certificates.** Compiled code proposes intermediate values; kernel checks
+  local equations or a smaller result certificate, and a soundness theorem
+  yields the result. Keep the existing Berkowitz certificate path. Rank's
+  nonzero minor and column-expression certificate can check in `O(n m r)`
+  arithmetic operations at fixed rank, avoiding full elimination. Determinant
+  step certificates still verify elimination arithmetic: no generally cheaper
+  determinant certificate is assumed.
+
+Selection is provisional until Phase 4 measures it. Record dimensions and
+rank, maximum coefficient numerator/denominator bit lengths, estimated minor
+bit growth, and predicted certificate size. For symbolic matrices also record
+variable count, degree, support and intermediate support growth. Small
+matrices with bounded coefficients initially use direct replay; larger
+coefficients, costly kernel division or repeated polynomial expansion favour
+local checks; low-rank inputs favour the two-sided certificate. Dimension
+alone is never a cutoff. Model-specific thresholds, proof-size and search
+budgets are fixed from the benchmark tables before claiming Phase 4 and
+reported with the chosen strategy. Provide a diagnostic strategy override for
+matched measurements and reproducibility.
+
+## Trust and migration
+
+No `native_decide`, new axioms or trusted runtime verdicts. Kernel `decide`
+proves transparent entry equalities, finite shape/index checks, arithmetic
+leaves, Boolean checker acceptance and direct producer equalities. Certificate
+soundness theorems prove the advertised operation from those checks.
+Transport lemmas prove input reconstruction, operation correspondence and
+coefficient interpretation. Noncomputable-source equalities use proved
+normalization and interpretation, never evaluation of classical equality.
+Audit accepted theorem axiom sets for unexpected dependencies.
+
+Move the frontend machinery from `HexCharPoly/CharPolyElab.lean` into this
+library, and its Mathlib literal enumeration, `RowCertificate` /
+`MatrixCertificate` construction and RHS recognition from
+`HexCharPolyMathlib/CharPolyElab.lean` into the companion's shared conversion
+layer. Keep `Hex.Matrix.charPoly`, Berkowitz computation, its local certificate
+checks and soundness, and `HexCharPolyMathlib.equiv_charPoly` in their owning
+algorithm libraries. Generalize or reuse those checks rather than replacing
+them by full kernel recomputation. Numeric polynomial reconstruction remains
+available without reflection; the symbolic adapter later supplies shared
+polynomial normalization instead of the bespoke structural matcher.
+
+Current result fields are `poly` and `charPoly_eq`, not literally `value` and
+`proof`. Preserve compatibility projections and the existing goal/term forms
+while introducing the uniform records. Compatibility imports must be
+restructured without a lower-library import of `HexMatrixTactic`: an old
+frontend import may need migration to the new umbrella. Importing both
+umbrellas must register each syntax handler only once.
+
+## Phase-4 evidence
+
+Follow [benchmarking](../benchmarking.md), especially fresh-module proof
+evidence and the headline report format. Reports are
+`reports/hex-matrix-tactic-performance.md` and
+`reports/hex-matrix-tactic-mathlib-performance.md`, with **Bench targets**,
+**Verdicts**, **Comparator ratios**, **Profile**, and **Concerns**
+sections. The companion owns its Mathlib proof probes; it is not a
+correspondence-only layer because it implements frontends and adapters.
+
+**Fixtures.** Commit deterministic seeds, exact entries, dimensions, expected
+results and hashes in `conformance-fixtures/HexMatrixTactic/matrices.jsonl`;
+companion notation/interpretation cases live in
+`conformance-fixtures/HexMatrixTacticMathlib/literals.jsonl`. Use these named
+families, also in the Phase-4 tables:
+
+| Family | Parameter ladder and purpose |
+|---|---|
+| `dense` | Seeded full-rank square `Int` matrices, dimensions `2,4,8,16,32`, entry bits `8,32`; rational variants with denominator bits `4,16`. |
+| `structured` | Tridiagonal and Vandermonde matrices on the same dimension ladder; include required pivot swaps. |
+| `singular` | Duplicate rows and products of certified rank `n-1`, including a late failed pivot, on that ladder. |
+| `low-rank` | Products of `n × r` and `r × m` factors with a known nonsingular `r`-minor, `n,m = 8,16,32,64`, `r = 1,2,4`; include nonleading pivot columns and rectangular shapes. |
+| `large-coefficients` | Dense and rank-2 inputs, dimensions `2,4,8,16`, entry bits `64,256,1024`; record intermediate bit lengths. |
+| `finite-carriers` | Corresponding small matrices over `ZMod 7`, `Fin 7`, and composite modulus `8`; composite cases test only determinant and characteristic polynomial. |
+| `closed-algebraic` | Blocks `[[α,1],[1,α]]` with `α²=2`, and block-coupled variants, dimensions `2,4,8,16`; see companion for exact embeddings and comparator obligations. |
+| `symbolic` (later) | Dimensions `2,4,8`, variables `1,2,4,8`, degree `1,2,4`, support `1,4,16`; include repeated subexpressions, generic full rank and known low rank. Record realized support, not just generation limits. |
+
+**Compiled registrations.** `bench/HexMatrixTactic/Bench.lean` remains
+Mathlib-free. Register producer, certificate construction and checker
+separately; checker preparation holds a precomputed certificate. Reuse the
+underlying libraries' complexity claims on identical families and parameters;
+frontend-specific irregular fixed workloads use mode 3 with a preregistered
+comparator-anchored ceiling, explaining why modes 1 and 2 do not apply. Do not
+claim one cubic time model across bit-size and symbolic-support ladders.
+
+**Proof probes.** Reserve `bench/HexMatrixTactic/ProofProbe` and
+`bench/HexMatrixTacticMathlib/ProofProbe` in each owner's `proof_probes` metadata.
+Use external fresh `lake build +<module>:olean` runs with warm dependencies,
+matched import-only and construction-only baselines, and variants for entry
+conversion, producer-only search, certificate construction, literal emission,
+replay and full elaboration. Separate construction from producer discovery;
+report matched differences as attribution estimates, not additive exact
+clocks. No clocks, timing loops, executables or LeanBench imports inside
+probes. Record producer time, certificate construction, kernel checking,
+proof-expression node count/serialized bytes, `.olean` size, and total
+elaboration separately. Include one representative compiled profile per declared numeric input family;
+proof-track attribution uses the matched builds above.
+
+**Comparators.** In the companion, unmodified pinned `norm_det`/`eval_det` and
+`norm_rank`/`eval_rank` are gating comparators: wiring, coverage and reported
+ratios are mandatory. Run them without the Hex extensions imported, alongside
+separate Hex-enabled adapter arms. Hex's current `char_poly` is the
+characteristic-polynomial regression comparator; no nonexistent Mathlib
+`norm_char_poly` is assumed. Compare identical literal inputs and targets;
+report additional notation conversion separately. Unsupported comparator
+fragments are recorded with the diagnostic and a matched supported subfamily,
+never fabricated timings.
+
+**Required checks and ceilings.** The external proof-runner manifest records
+these fixed smoke/regression obligations before measurement; they are
+operational limits, not portable scientific budgets:
+
+| Check | Canonical input | Ceiling / required result |
+|---|---|---|
+| `literal-roundtrip` | All four Mathlib syntaxes, `0 × 0`, `0 × 3`, `3 × 0`, and `2 × 2` | Exact shape and entry proofs; reject transposed/incorrect entries. |
+| `numeric-proof` | `dense` dimension 4, 8-bit entries, each operation and rank inequality | Full proof-build median ≤ 10 s per case; theorem axiom audit passes. |
+| `large-proof` | `large-coefficients` dimension 4, 256-bit entries | Full proof-build median ≤ 30 s per case; serialized proof ≤ 32 MiB. |
+| `certificate-rejection` | Wrong value, changed pivot/minor/column coefficient, wrong size or modulus | Rejection without a theorem; median ≤ 10 s per case. |
+| `algebraic-proof` | One `α²=2` block and rational literals in `ℝ`, `ℂ` | Kernel-checked transported result, median ≤ 30 s per case. |
+| `bench-verify` | Smallest rung of each compiled registration | Per-library `Bench verify` 30 s soft warning; stay within the existing combined hard cap and extend the existing script only. |
+
+Every fresh build has a 120 s cleanup timeout; timeout or incomplete pair
+invalidates that evidence. Scheduled larger rungs retain timeouts as outcomes
+and cannot be reported as passing samples. Recalibrate fixed ceilings only
+with documented evidence, not merely to make a failure pass. Keep required
+CI checks small; timing-sensitive scientific runs are manual on the shared
+host, with no extra CI jobs or workflows.
+
+Collect an even preregistered number of rounds (initially eight), adjacent
+comparator/Hex pairs, alternating AB/BA. Retain every completed sample,
+record host load, and automatically select one CPU when supported. Do not
+wait for quiet or reject busy-host samples; allow at most one unchanged
+rerun after inconclusive evidence. Record pristine commit and source hashes,
+toolchain and Mathlib pin, commands, options, seeds, CPU/OS, all raw timings,
+paired deltas and the exact strategy decision.
+
+The Phase-4 target is a reproducible total-elaboration speedup over **each**
+of `norm_det` and `norm_rank` on explicitly named families and eligible
+rungs, with a resolved paired effect rather than a universal speed claim.
+Tables contain every shared rung and list the selected strategy, each phase,
+proof size, both totals, ratio and uncertainty. Set a numerical improvement
+target from the baseline before optimisation; do not select only winning
+samples. If there is no measured win yet, report the unmet target and planned
+optimisation rather than prohibiting the frontend. Slower cases name evidence
+for the cause and a remedy: kernel elimination replay → local arithmetic
+certificates or a different producer; rank multiplication cost → the smaller
+minor/column certificate or blocked checks; certificate size → shared literals
+and coarser checked blocks; elaboration overhead → shared entry conversion and
+proof caches; symbolic expansion → certified exact quotients or representation
+changes. Revise the provisional strategy table from these measurements.

--- a/SPEC/Libraries/hex-matrix-tactic.md
+++ b/SPEC/Libraries/hex-matrix-tactic.md
@@ -32,10 +32,19 @@ The `libraries.yml` entries are `status: planned`, `done_through: 0`, with no
 Lake targets or umbrella files until activation. These edges follow
 `scripts/check_dag.py` and its `libgraph.may_import` dependency closure.
 The existing lower libraries must never import either frontend. Symbolic
-integration will live in a separately registered downstream library depending
-on both this frontend and reflection (and their companions where needed).
+integration will live in the future `HexMatrixReflect` library, depending on
+this frontend and reflection, with `HexMatrixReflectMathlib` above their
+companions. These extension libraries are outside the numeric activation.
 It cannot be an optional file in the numeric library whose import would
 silently expand that library's dependency closure.
+
+Activation must first make `HexRank` active, then activate `HexMatrixTactic`;
+the Mathlib path likewise requires active `HexRankMathlib` before
+`HexMatrixTacticMathlib`. Here active means the dependency's scaffolding and
+Lake registration exist, not that all its implementation phases are complete.
+Determinant and characteristic-polynomial work can then proceed while rank's
+certificate implementation is developed. No migration imports a planned
+library before this activation order is satisfied.
 
 ## Entry models and conversion
 
@@ -60,7 +69,7 @@ quotation are untrusted; an executable zero test is not a proof of its answer.
 | Closed `ZMod n`, `Fin n` | Literal modulus, kernel-decidable equality and lawful ring operations. `ZMod` recognition belongs in the companion; `Fin n` requires positive `n` for its modular ring. Determinant and characteristic polynomial allow composite moduli; rank requires a domain/field model, normally prime modulus, and cannot assume primality. `ZMod 0` follows its integer model. |
 | Literals in `ℝ`, `ℂ` | The companion proves entries equal to images of computable values using `norm_num` and registered interpretation lemmas. Rational-valued literals use `Rat`; complex literals involving `I` need an explicit computable extension. Never run kernel equality on classical real or complex instances. |
 | Closed algebraic entries | A registered computable number-field or real-algebraic carrier and certified embedding, with nonzero preservation for rank. This is a numeric provider extension, independent of symbolic reflection. |
-| Symbolic entries | A later `hex-reflect` provider converts the entire matrix in one batch, seals variables once and supplies interpretation equalities. Intermediate polynomial matrices are not printed and reparsed. |
+| Symbolic entries (future `HexMatrixReflect` extension) | A later `hex-reflect` provider converts the entire matrix in one batch, seals variables once and supplies interpretation equalities. Intermediate polynomial matrices are not printed and reparsed. |
 
 Determinant and characteristic polynomial commute with a ring homomorphism;
 rank additionally needs injectivity or explicit proofs that the chosen minor
@@ -72,17 +81,30 @@ is not promised. Piecewise rank and case splitting are later work.
 
 ## Frontends and results
 
-The term forms `det A`, `rank A`, and `char_poly A` return dependent records
+The term forms `det% A`, `rank% A`, and `char_poly A` return dependent records
 with fields `value` and `proof`, the latter asserting that the requested
 operation on the original matrix equals `value`. Determinant values are in
 the source carrier, rank values in `Nat`, and characteristic-polynomial
 values in `Hex.DensePoly R` or the companion's `Polynomial R`.
 
+The `%` distinguishes result-producing term syntax from ordinary `det A` and
+`rank A` function applications. The tactics remain plain `det`, `rank` and
+`char_poly`. Importing a frontend must not reserve bare `det` or `rank` as a
+term keyword or change existing name resolution; opening both matrix
+namespaces can already require qualifying their identically named functions.
+
 The goal forms close determinant equality, rank equality or either inequality,
-and characteristic-polynomial equality. On Hex inputs these refer to the
-selected executable determinant, field rank or explicitly interpreted integer
-rank, and `Hex.Matrix.charPoly`; the companion gives the exact Mathlib
-statements. Square shape is required for determinant and characteristic
+and characteristic-polynomial equality. On Hex inputs determinant goals name
+`Hex.Matrix.det`, `bareiss`, or
+`bareissWith` with its quotient law, and characteristic-polynomial goals name
+`Hex.Matrix.charPoly`. Field-rank goals name `Hex.Matrix.rowReduce_rank`
+(`[Lean.Grind.Field R] [DecidableEq R]`, `HexRowReduce/Api.lean`);
+domain-rank goals name the planned `Hex.Matrix.rankWith quot` with its exact
+quotient law, or its integer specialization `Hex.Matrix.rank`, from
+`hex-rank`. The integer result agrees with rank after casting to `Rat` via
+the companion's scalar-extension theorem. Each rank operation admits equality
+and the two inequality forms. The companion gives the Mathlib statements.
+Square shape is required for determinant and characteristic
 polynomial; rank supports rectangular and empty matrices. Empty square
 matrices have determinant `1`, rank `0`, and characteristic polynomial `1`.
 
@@ -110,8 +132,8 @@ Initial determinant selection is:
 | Closed `Int` | Row-pivoted fraction-free Bareiss |
 | Closed field with certified exact quotient | Bareiss, with denominator restoration when working integrally |
 | Commutative ring without exact quotient | Samuelson–Berkowitz, returning `(-1)^n` times the constant coefficient of `det(X I - A)` |
-| Symbolic polynomial entries with certified exact quotient | Polynomial Bareiss |
-| Symbolic polynomial entries without exact quotient | Samuelson–Berkowitz with the same sign correction |
+| Symbolic polynomial entries with certified exact quotient (future extension) | Polynomial Bareiss |
+| Symbolic polynomial entries without exact quotient (future extension) | Samuelson–Berkowitz with the same sign correction |
 
 Characteristic polynomial uses Samuelson–Berkowitz. The characteristic
 variable stays separate from reflected entry variables, for example in
@@ -177,6 +199,16 @@ restructured without a lower-library import of `HexMatrixTactic`: an old
 frontend import may need migration to the new umbrella. Importing both
 umbrellas must register each syntax handler only once.
 
+The migration change updates `HexCharPoly/SPEC/hex-char-poly.md` and
+`HexCharPolyMathlib/SPEC/hex-char-poly-mathlib.md` to name the new frontend
+imports; their current umbrella promises remain accurate until that change.
+Move `HexCharPoly/CharPolyElabTests.lean` and
+`HexCharPolyMathlib/CharPolyElabTests.lean` into the respective
+`HexMatrixTactic` and `HexMatrixTacticMathlib` directories, updating the
+`HexCharPolyTests` globs in `lakefile.lean` and the corresponding build-root
+allowlist. A build-only target does not exempt a test under a lower library's
+directory from that library's import boundary.
+
 ## Phase-4 evidence
 
 Follow [benchmarking](../benchmarking.md), especially fresh-module proof
@@ -190,8 +222,11 @@ correspondence-only layer because it implements frontends and adapters.
 **Fixtures.** Commit deterministic seeds, exact entries, dimensions, expected
 results and hashes in `conformance-fixtures/HexMatrixTactic/matrices.jsonl`;
 companion notation/interpretation cases live in
-`conformance-fixtures/HexMatrixTacticMathlib/literals.jsonl`. Use these named
-families, also in the Phase-4 tables:
+`conformance-fixtures/HexMatrixTacticMathlib/literals.jsonl`. The JSON records
+contain carrier-neutral entry data; base registrations use
+only Mathlib-free representations. Use the following named numeric fixture
+families in the Phase-4 tables. The symbolic row reserves an extension-owned
+family for later work, not a numeric Phase-4 obligation:
 
 | Family | Parameter ladder and purpose |
 |---|---|
@@ -200,9 +235,15 @@ families, also in the Phase-4 tables:
 | `singular` | Duplicate rows and products of certified rank `n-1`, including a late failed pivot, on that ladder. |
 | `low-rank` | Products of `n × r` and `r × m` factors with a known nonsingular `r`-minor, `n,m = 8,16,32,64`, `r = 1,2,4`; include nonleading pivot columns and rectangular shapes. |
 | `large-coefficients` | Dense and rank-2 inputs, dimensions `2,4,8,16`, entry bits `64,256,1024`; record intermediate bit lengths. |
-| `finite-carriers` | Corresponding small matrices over `ZMod 7`, `Fin 7`, and composite modulus `8`; composite cases test only determinant and characteristic polynomial. |
+| `finite-carriers` | Base cases use `Fin 7` and `Fin 8`; companion cases in `literals.jsonl` use `ZMod 7` and `ZMod 8`. Composite cases test only determinant and characteristic polynomial. |
 | `closed-algebraic` | Blocks `[[α,1],[1,α]]` with `α²=2`, and block-coupled variants, dimensions `2,4,8,16`; see companion for exact embeddings and comparator obligations. |
-| `symbolic` (later) | Dimensions `2,4,8`, variables `1,2,4,8`, degree `1,2,4`, support `1,4,16`; include repeated subexpressions, generic full rank and known low rank. Record realized support, not just generation limits. |
+| `symbolic` (future `HexMatrixReflect` fixtures) | Dimensions `2,4,8`, variables `1,2,4,8`, degree `1,2,4`, support `1,4,16`; include repeated subexpressions, generic full rank and known low rank. Record realized support, not just generation limits. |
+
+`symbolic` fixtures belong in
+`conformance-fixtures/HexMatrixReflect/matrices.jsonl` with Mathlib translations
+owned by `HexMatrixReflectMathlib`. Their later Phase-4 metadata and reports
+own the symbolic provider measurements; the numeric frontend does not acquire
+reflection imports or symbolic activation gates.
 
 **Compiled registrations.** `bench/HexMatrixTactic/Bench.lean` remains
 Mathlib-free. Register producer, certificate construction and checker
@@ -222,8 +263,24 @@ report matched differences as attribution estimates, not additive exact
 clocks. No clocks, timing loops, executables or LeanBench imports inside
 probes. Record producer time, certificate construction, kernel checking,
 proof-expression node count/serialized bytes, `.olean` size, and total
-elaboration separately. Include one representative compiled profile per declared numeric input family;
+elaboration separately. Include one representative compiled profile per
+declared numeric input family;
 proof-track attribution uses the matched builds above.
+
+The companion's metadata groups these probes as `literal-conversion`,
+`certificate-replay`, and `tactic-comparison`, each spanning the applicable
+numeric fixture families above. Its Profile section cites fresh-build
+attribution, not compiled timed-region sampling. With two declared
+comparators, it supplies the required plots
+`reports/figures/hex-matrix-tactic-mathlib-comparator-<family>.svg` for these
+three probe families, generated by
+`scripts/plots/hex-matrix-tactic-mathlib-comparator.py` from the retained raw
+samples. Here one invocation means one fresh module elaboration: plot total
+wall time and baseline-adjusted elaboration time on a log-y axis across each
+fixture ladder. Use separate panels for determinant and rank; component
+panels compare matched conversion/replay variants with the shared full-tactic
+references. Label the quantity as fresh-build time, never compiled call time.
+Retain ratios and inapplicability markers for every shared case.
 
 **Comparators.** In the companion, unmodified pinned `norm_det`/`eval_det` and
 `norm_rank`/`eval_rank` are gating comparators: wiring, coverage and reported
@@ -236,11 +293,12 @@ fragments are recorded with the diagnostic and a matched supported subfamily,
 never fabricated timings.
 
 **Required checks and ceilings.** The external proof-runner manifest records
-these fixed smoke/regression obligations before measurement; they are
+these fixed correctness/regression obligations before measurement; they are
 operational limits, not portable scientific budgets:
 
 | Check | Canonical input | Ceiling / required result |
 |---|---|---|
+| `syntax-compatibility` | Both frontend umbrellas, existing `det`/`rank` function names under each matrix namespace | Bare function application retains existing resolution; `det%`, `rank%`, `char_poly` return records. |
 | `literal-roundtrip` | All four Mathlib syntaxes, `0 × 0`, `0 × 3`, `3 × 0`, and `2 × 2` | Exact shape and entry proofs; reject transposed/incorrect entries. |
 | `numeric-proof` | `dense` dimension 4, 8-bit entries, each operation and rank inequality | Full proof-build median ≤ 10 s per case; theorem axiom audit passes. |
 | `large-proof` | `large-coefficients` dimension 4, 256-bit entries | Full proof-build median ≤ 30 s per case; serialized proof ≤ 32 MiB. |

--- a/SPEC/Libraries/hex-reflect.md
+++ b/SPEC/Libraries/hex-reflect.md
@@ -70,8 +70,11 @@ hex-basic ────┐
 hex-mv-poly ──┘
 ```
 
-The direction is deliberate. For example, `hex-matrix-tactic` may depend on
-`hex-reflect`, but `hex-reflect` does not know about matrices.
+The direction is deliberate. For example, the future `HexMatrixReflect`
+symbolic extension of
+[hex-matrix-tactic](hex-matrix-tactic.md) depends on `hex-reflect`, while the
+numeric frontend remains independent of reflection. `hex-reflect` does not
+know about matrices.
 
 ## Module and test layout
 
@@ -533,8 +536,9 @@ characteristic-polynomial, gcd, or factorization algorithm.
 
 ## First consumers and parser adoption
 
-The first symbolic consumers are `det` and `char_poly` in the planned
-`hex-matrix-tactic` library. They reify all entries in one batch, run the
+The first symbolic consumers are the `det` and `char_poly` providers in
+`HexMatrixReflect`, the future downstream symbolic extension of
+[hex-matrix-tactic](hex-matrix-tactic.md). They reify all entries in one batch, run the
 existing verified matrix algorithm over `Hex.MvPoly`, and interpret the result
 through this library's soundness theorem. The characteristic-polynomial
 variable remains the `DensePoly` variable. It is not added to the environment

--- a/libraries.yml
+++ b/libraries.yml
@@ -363,6 +363,32 @@ libraries:
     mathlib: false
     done_through: 0
     status: active
+  HexMatrixTactic:
+    deps: [HexMatrix, HexBareiss, HexRowReduce, HexCharPoly, HexRank]
+    mathlib: false
+    proof_probes: [bench/HexMatrixTactic/ProofProbe]
+    done_through: 0
+    status: planned
+    phase4:
+      comparators:
+        - tool: Existing Hex char_poly frontend
+          class: informational
+          rationale: Preserve the current numeric certificate path and record migration regressions on matching fixtures.
+      input_families:
+        - name: dense
+          description: Seeded full-rank integer and rational matrices, varying dimension and entry bit size.
+        - name: structured
+          description: Tridiagonal and Vandermonde matrices including pivot swaps.
+        - name: singular
+          description: Duplicate rows and rank n minus one products including late failed pivots.
+        - name: low-rank
+          description: Rectangular products of known rank with nonleading pivot columns.
+        - name: large-coefficients
+          description: Dense and rank-two matrices with 64-, 256- and 1024-bit entries.
+        - name: finite-carriers
+          description: Prime-modulus determinant, rank and characteristic polynomial, and composite-modulus determinant and characteristic polynomial.
+        - name: closed-algebraic
+          description: Rational-pair computations modulo alpha squared equals two, with number-field and real-algebraic interpretations.
   HexMinPoly:
     deps: [HexMatrix, HexRowReduce, HexPoly]
     mathlib: false
@@ -994,6 +1020,35 @@ libraries:
     mathlib: true
     done_through: 0
     status: active
+  HexMatrixTacticMathlib:
+    deps: [HexMatrixTactic, HexMatrixMathlib, HexBareissMathlib, HexRowReduceMathlib, HexCharPolyMathlib, HexRankMathlib]
+    mathlib: true
+    proof_probes: [bench/HexMatrixTacticMathlib/ProofProbe]
+    done_through: 0
+    status: planned
+    phase4:
+      comparators:
+        - tool: Mathlib norm_det / eval_det
+          class: gating
+          goal: Wire the unmodified pinned comparator and report all shared fixture ratios; target a reproducible total-elaboration speedup on named families and document slower cases.
+        - tool: Mathlib norm_rank / eval_rank
+          class: gating
+          goal: Wire the unmodified pinned comparator and report all shared fixture ratios; target a reproducible total-elaboration speedup on named families and document slower cases.
+      input_families:
+        - name: dense
+          description: Seeded full-rank integer and rational matrices, varying dimension and entry bit size.
+        - name: structured
+          description: Tridiagonal and Vandermonde matrices including pivot swaps.
+        - name: singular
+          description: Duplicate rows and rank n minus one products including late failed pivots.
+        - name: low-rank
+          description: Rectangular products of known rank with nonleading pivot columns.
+        - name: large-coefficients
+          description: Dense and rank-two matrices with 64-, 256- and 1024-bit entries.
+        - name: finite-carriers
+          description: Prime-modulus determinant, rank and characteristic polynomial, and composite-modulus determinant and characteristic polynomial.
+        - name: closed-algebraic
+          description: Rational-pair computations modulo alpha squared equals two, with number-field and real-algebraic interpretations.
   HexMinPolyMathlib:
     deps: [HexMinPoly, HexMatrixMathlib, HexPolyMathlib, HexCharPolyMathlib]
     mathlib: true

--- a/libraries.yml
+++ b/libraries.yml
@@ -386,7 +386,7 @@ libraries:
         - name: large-coefficients
           description: Dense and rank-two matrices with 64-, 256- and 1024-bit entries.
         - name: finite-carriers
-          description: Prime-modulus determinant, rank and characteristic polynomial, and composite-modulus determinant and characteristic polynomial.
+          description: Mathlib-free Fin 7 determinant, rank and characteristic polynomial, and Fin 8 determinant and characteristic polynomial.
         - name: closed-algebraic
           description: Rational-pair computations modulo alpha squared equals two, with number-field and real-algebraic interpretations.
   HexMinPoly:
@@ -1035,20 +1035,12 @@ libraries:
           class: gating
           goal: Wire the unmodified pinned comparator and report all shared fixture ratios; target a reproducible total-elaboration speedup on named families and document slower cases.
       input_families:
-        - name: dense
-          description: Seeded full-rank integer and rational matrices, varying dimension and entry bit size.
-        - name: structured
-          description: Tridiagonal and Vandermonde matrices including pivot swaps.
-        - name: singular
-          description: Duplicate rows and rank n minus one products including late failed pivots.
-        - name: low-rank
-          description: Rectangular products of known rank with nonleading pivot columns.
-        - name: large-coefficients
-          description: Dense and rank-two matrices with 64-, 256- and 1024-bit entries.
-        - name: finite-carriers
-          description: Prime-modulus determinant, rank and characteristic polynomial, and composite-modulus determinant and characteristic polynomial.
-        - name: closed-algebraic
-          description: Rational-pair computations modulo alpha squared equals two, with number-field and real-algebraic interpretations.
+        - name: literal-conversion
+          description: Fresh-module enumeration, interpretation and literal-emission probes for all numeric fixture families and supported Mathlib syntaxes.
+        - name: certificate-replay
+          description: Matched fresh-module certificate construction and kernel replay, including finite and closed-algebraic carriers.
+        - name: tactic-comparison
+          description: Full fresh-module det and rank comparisons with stock Mathlib tactics across all shared numeric ladders, including Zsqrtd 2 and separately labelled real embeddings.
   HexMinPolyMathlib:
     deps: [HexMinPoly, HexMatrixMathlib, HexPolyMathlib, HexCharPolyMathlib]
     mathlib: true


### PR DESCRIPTION
Specify proof-producing `det`, `rank`, and `char_poly` frontends, shared matrix conversion, Mathlib adapters, and the performance evidence needed to choose their proof strategies. Add the two library SPECs and planned DAG entries, and align reflection documentation with downstream symbolic integration; this change implements no tactics.

The contracts distinguish producer correctness from certificate soundness, state the extra hypotheses needed for echelon conversion, and keep numeric frontends independent of reflection. The benchmark specifies fixtures, separate producer/construction/kernel costs, stock Mathlib comparators, and required-check ceilings. Migration specifies test relocation and dependency activation. Term forms `det%` and `rank%` preserve existing bare function names; tactic names remain plain.

Checked declaration names and hypotheses against Hex sources and Mathlib pin `85e3a25e006c35636f0e53b0e9296caca2685bc0`. Corrected the issue's namespace/file descriptions: `Echelon.Decomposition` is in the root namespace, and rank certificate construction lives in `Tactic/Echelon/Bareiss.lean`.

Validation: `python3 scripts/check_dag.py`; all 12 `scripts/test_check_dag.py` tests; SPEC link checks; numeric dependency-closure assertions; `git diff --check`; `python3 scripts/check_phase4.py`; a scratch `lake build` parser check on the pinned Lean toolchain. No repository Lean source changed.

Closes #10151.
