### PR TITLE
spec: determinant dispatch library

### DIFF
--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -18,6 +18,7 @@
 - **hex-row-reduce**: row reduction (RREF), rank, span, nullspace
 - **hex-determinant**: the Leibniz determinant and its cofactor/Cauchy-Binet/Plücker theory
 - **hex-bareiss**: the fraction-free Bareiss determinant algorithm
+- **[hex-det](hex-det.md)** (planned): production determinant dispatch with carrier policies, measured crossovers, and the completed algorithm reported for tactics
 - **[hex-rank](hex-rank.md)** (planned): matrix rank over any integral domain with a two-sided certificate (a nonsingular minor with its adjugate, and the identity expressing every column over the selected ones), the rectangular fraction-free producer, and the row and column rank profiles
 - **[hex-determinantal-ideal](hex-determinantal-ideal.md)** (planned): executable minors and determinantal-ideal generators of a matrix over a commutative ring, and the theorem that the rank over a field is below `r` exactly when every `r × r` minor vanishes
 - **hex-char-poly**: the characteristic polynomial by the division-free Samuelson-Berkowitz algorithm, over any commutative ring
@@ -86,6 +87,7 @@ Mathlib, and supplies correspondence proofs or Mathlib-facing APIs):
 - **hex-row-reduce-mathlib**: rank = `Matrix.rank`, nullspace = `LinearMap.ker`, span agreement
 - **hex-determinant-mathlib**: `det` agreement with `Matrix.det`, plus the Plücker / Desnanot-Jacobi assembly
 - **hex-bareiss-mathlib**: Bareiss determinant = `Matrix.det`, via the bordered-minor invariant
+- **[hex-det-mathlib](hex-det-mathlib.md)** (planned): determinant dispatch correctness and correspondence, including policy and fallback route laws
 - **[hex-rank-mathlib](hex-rank-mathlib.md)** (planned): certificate soundness for `Matrix.rank` over any domain, rank invariance under `IsFractionRing` scalar extension, producer correctness, and the conversions to and from Mathlib's `Echelon.Decomposition`
 - **[hex-determinantal-ideal-mathlib](hex-determinantal-ideal-mathlib.md)** (planned): minors as `Matrix.det` of a `submatrix`, the rank-versus-minors theorem for `Matrix.rank` under any ring homomorphism into a field, rank-drop loci as zero sets, and invariance of `I_r(A)` under invertible row and column operations
 - **hex-char-poly-mathlib**: agreement with `Matrix.charpoly`, Cayley-Hamilton, the trace and determinant coefficients, transpose and similarity invariance
@@ -138,6 +140,7 @@ Each library with its immediate dependencies:
 - **hex-row-reduce**: hex-matrix
 - **hex-determinant**: hex-matrix
 - **hex-bareiss**: hex-determinant, hex-matrix
+- **hex-det** (planned): hex-bareiss, hex-char-poly, hex-row-reduce, hex-poly-fp, hex-resultant, hex-mv-gcd (plus hex-modular-matrix when implemented)
 - **hex-rank** (planned): hex-bareiss, hex-determinant, hex-matrix, hex-arith, hex-basic
 - **hex-determinantal-ideal** (planned): hex-basic, hex-matrix, hex-determinant, hex-row-reduce, hex-mv-poly
 - **hex-char-poly**: hex-matrix, hex-poly
@@ -212,6 +215,7 @@ Mathlib companion libraries (each also depends on Mathlib):
 - **hex-row-reduce-mathlib**: hex-row-reduce, hex-matrix-mathlib
 - **hex-determinant-mathlib**: hex-determinant, hex-bareiss, hex-matrix-mathlib
 - **hex-bareiss-mathlib**: hex-determinant-mathlib
+- **hex-det-mathlib** (planned): hex-det, hex-bareiss-mathlib, hex-char-poly-mathlib, hex-determinant-mathlib, hex-poly-mathlib, hex-poly-fp-mathlib, hex-mv-poly-mathlib, Mathlib (plus hex-modular-matrix-mathlib when implemented)
 - **hex-rank-mathlib** (planned): hex-rank, hex-bareiss-mathlib, hex-determinant-mathlib, hex-matrix-mathlib
 - **hex-determinantal-ideal-mathlib** (planned): hex-determinantal-ideal, hex-determinant-mathlib, hex-row-reduce-mathlib, hex-mv-poly-mathlib
 - **hex-char-poly-mathlib**: hex-char-poly, hex-matrix-mathlib, hex-poly-mathlib, hex-determinant-mathlib
@@ -689,6 +693,8 @@ for developments whose source-local move has not happened yet.
 - [hex-bareiss-mathlib](https://github.com/leanprover/hex-bareiss-mathlib/blob/main/SPEC/hex-bareiss-mathlib.md) (released): Bareiss determinant correctness
 - [hex-rank](hex-rank.md) (planned): rank over any integral domain with an adjugate-and-column-expression certificate, the rectangular fraction-free producer, and the rank profiles
 - [hex-rank-mathlib](hex-rank-mathlib.md) (planned): `Matrix.rank` soundness over any domain, `IsFractionRing` scalar extension, producer correctness, and `Echelon.Decomposition` conversions
+- [hex-det](hex-det.md) (planned): carrier-specific determinant dispatch and measured policies
+- [hex-det-mathlib](hex-det-mathlib.md) (planned): determinant dispatch value and route correctness
 - [hex-determinantal-ideal](hex-determinantal-ideal.md) (planned): executable minors, determinantal-ideal generators, and the rank-versus-minors theorem with a Mathlib-free proof
 - [hex-determinantal-ideal-mathlib](hex-determinantal-ideal-mathlib.md) (planned): `Matrix.rank` versus minors under any ring homomorphism into a field, rank-drop loci, and invariance of determinantal ideals
 - [hex-char-poly.md](hex-char-poly.md): the characteristic polynomial by the division-free Samuelson-Berkowitz algorithm, with Cayley-Hamilton and the `Matrix.charpoly` correspondence (the Mathlib companion is specified in the same file)

--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -154,7 +154,7 @@ Each library with its immediate dependencies:
 - **hex-mod-arith**: hex-arith
 - **hex-modular**: hex-arith
 - **hex-padics**: hex-arith, hex-modular, hex-primality, hex-basic
-- **hex-modular-matrix**: hex-modular, hex-matrix, hex-row-reduce, hex-determinant, hex-mod-arith, hex-arith, hex-basic
+- **hex-modular-matrix**: hex-modular, hex-matrix, hex-row-reduce, hex-determinant, hex-bareiss, hex-mod-arith, hex-arith, hex-basic
 - **hex-finite-field**: hex-arith, hex-mod-arith, hex-poly, hex-poly-fp, hex-matrix, hex-basic
 - **hex-gram-schmidt**: hex-row-reduce, hex-determinant, hex-bareiss
 - **hex-lll**: hex-gram-schmidt, hex-matrix, hex-basic

--- a/SPEC/Libraries/hex-det-mathlib.md
+++ b/SPEC/Libraries/hex-det-mathlib.md
@@ -61,16 +61,28 @@ theorem det_eq_mathlib [CommRing R] [DetOps R] [LawfulDetOps R]
 For each policy constructor, prove `LawfulPolicy` by splitting on its actual
 dispatch and fallback branches and using the arm theorems below. The
 exact-quotient constructor requires the cancellation law for its stored
-quotient. Field policies use the field operations and equality they carry.
-The modular constructor requires the lower bound law. Instantiate
+quotient. Field policies require the carried division's explicit law
+`∀ a b : R, b ≠ 0 → div (a * b) b = a` for the initial Bareiss arm, and
+field laws over the ambient commutative-ring operations for elimination.
+The field constructor's evidence supplies these laws, rather than a second
+ring on the same type.
+
+The integer recipe's constructor proof takes mutual inverse laws for
+`toInt` and `ofInt` and preservation of `0`, `1`, addition, negation, and
+multiplication. Prove the finite Leibniz sum commutes with these maps and
+transport the integer arm equality back to `R`. For the shipped `Int`
+instance the maps and this transport are identities. When the modular arm
+is enabled, the constructor proof additionally takes
+`[Hex.Matrix.LawfulDetBound]` from the lower library. Instantiate
 `LawfulDetOps` for each shipped default from these constructor proofs.
 Explicit test policies, including zero fuel, use `LawfulPolicy` directly.
 The theorem for an arbitrary `DetOps` always requires laws for that same
 instance's policy. A supplied quotient cannot be declared correct without
 its law.
 
-`det_eq` projects the default policy's `value_eq`. `det_eq_mathlib` composes
-it with `HexMatrixMathlib.det_eq`. Although the first law uses only
+`det_eq` unpacks `LawfulDetOps.lawful` and projects the default policy's
+`value_eq`. The `lawful` field is not itself a registered instance.
+`det_eq_mathlib` composes it with `HexMatrixMathlib.det_eq`. Although the first law uses only
 Mathlib-free types, it lives here and is not available to Mathlib-free
 consumers in the first version. In particular, the supplied proofs must not
 assume a Mathlib `CommRing` instance exists on every executable carrier.
@@ -165,8 +177,11 @@ a ring with zero divisors, and the trivial ring.
 
 Exercise `det_eq` and `det_eq_mathlib` at empty, one-by-one, two-by-two,
 row-swapped, and singular inputs. For integration, call `runWith` to force
-each enabled arm and each fallback transition and apply its
-`LawfulPolicy.route_sound` law. Tiny closed values
+each enabled non-small arm at `n > 2` and each available fallback transition, then
+apply its
+`LawfulPolicy.route_sound` law. Tiny-size cross-arm comparisons call the
+lower algorithms directly because dispatch always uses the small arm.
+Tiny closed values
 may be checked with kernel `decide`. Certificate replay and tactic
 performance belong to the downstream matrix-tactic libraries. This
 companion introduces neither a certificate format nor a trusted evaluator.

--- a/SPEC/Libraries/hex-det-mathlib.md
+++ b/SPEC/Libraries/hex-det-mathlib.md
@@ -26,14 +26,29 @@ instance resolution. They do not duplicate the owner's runtime conformance.
 ## Contract
 
 The following declarations are proposed obligations, not existing theorems.
-Use namespace `Hex.Det` for the dispatch laws. Under
-`[Lean.Grind.CommRing R] [DetOps R]`, define the companion-only law class:
+Use namespace `HexDetMathlib` for the companion declarations below, with
+`open Hex.Det` for the executable API. Define one relation
+`ValidRoute (policy : Policy R) (A : Hex.Matrix R n n) (result : Result R)`.
+It follows the constructors of `Policy` and the branches of `runWith`:
+selection obeys the policy, each route transition is justified by the actual
+failure equation of the attempted operation, and the returned value equals
+the completed arm's result with the policy's coefficient operations and
+parameters on the same input. A small completion additionally asserts
+`n ≤ 2`. Endpoint consistency and nonemptiness hold by construction of
+`Route`. This definition must not trust the reported tags or hide an
+unspecified per-producer predicate.
+
+The proposed law class for an explicit policy is:
 
 ```lean
-class LawfulDetOps (R : Type u) [Lean.Grind.CommRing R] [DetOps R] : Prop where
+class LawfulPolicy [Lean.Grind.CommRing R] (policy : Policy R) : Prop where
   value_eq : ∀ {n} (A : Hex.Matrix R n n),
-    (DetOps.run A).value = Hex.Matrix.det A
-  route_sound : ∀ {n} (A : Hex.Matrix R n n), ValidRoute A (DetOps.run A)
+    (runWith policy A).value = Hex.Matrix.det A
+  route_sound : ∀ {n} (A : Hex.Matrix R n n),
+    ValidRoute policy A (runWith policy A)
+
+class LawfulDetOps (R : Type u) [Lean.Grind.CommRing R] [DetOps R] : Prop where
+  lawful : LawfulPolicy (DetOps.policy (R := R))
 
 theorem det_eq [Lean.Grind.CommRing R] [DetOps R] [LawfulDetOps R]
     (A : Hex.Matrix R n n) : Hex.Det.det A = Hex.Matrix.det A
@@ -43,29 +58,22 @@ theorem det_eq_mathlib [CommRing R] [DetOps R] [LawfulDetOps R]
     Hex.Det.det A = Matrix.det (HexMatrixMathlib.matrixEquiv A)
 ```
 
-`ValidRoute` is a proposed companion relation over the producer's installed
-policy and algorithm parameters. It asserts that `attempts` is nonempty,
-its first and last entries are `selected` and `completed`, selection obeys
-the policy, each transition is justified by the actual failure branch of
-the attempted algorithm, and the value equals the completed arm's result
-on the same input. A small completion additionally asserts `n ≤ 2`.
-The relation is defined using the lower operations and their return
-equations, not by trusting the reported tags. Its definition and the law
-instances must be supplied together with each enabled producer.
+For each policy constructor, prove `LawfulPolicy` by splitting on its actual
+dispatch and fallback branches and using the arm theorems below. The
+exact-quotient constructor requires the cancellation law for its stored
+quotient. Field policies use the field operations and equality they carry.
+The modular constructor requires the lower bound law. Instantiate
+`LawfulDetOps` for each shipped default from these constructor proofs.
+Explicit test policies, including zero fuel, use `LawfulPolicy` directly.
+The theorem for an arbitrary `DetOps` always requires laws for that same
+instance's policy. A supplied quotient cannot be declared correct without
+its law.
 
-For each concrete instance and each generic constructor, prove these laws
-by splitting on its actual dispatch and fallback branches and using the
-arm theorems below. Exact-quotient constructors require their quotient law.
-Field constructors require the field operations and equality they use.
-The modular constructor requires the lower bound law. The theorem for an
-arbitrary `DetOps` instance always requires `LawfulDetOps` for that same
-instance. An unconstrained implementation cannot be declared correct.
-
-`det_eq` is projection of `value_eq`. `det_eq_mathlib` composes it with
-`HexMatrixMathlib.det_eq`. Although the first law uses only Mathlib-free
-types, it lives here and is not available to Mathlib-free consumers in the
-first version. In particular, the supplied proofs must not assume a
-Mathlib `CommRing` instance exists on every executable carrier.
+`det_eq` projects the default policy's `value_eq`. `det_eq_mathlib` composes
+it with `HexMatrixMathlib.det_eq`. Although the first law uses only
+Mathlib-free types, it lives here and is not available to Mathlib-free
+consumers in the first version. In particular, the supplied proofs must not
+assume a Mathlib `CommRing` instance exists on every executable carrier.
 
 ## Existing proof routes
 
@@ -124,8 +132,13 @@ explains. The existence of the generic Bareiss theorem does not close
 those carrier obligations.
 
 The implementation must supply compatible Mathlib algebraic structures in
-the appropriate coefficient companions, transported from their mathematical
-polynomial or residue types while retaining the executable operations.
+`HexPolyMathlib` for `DensePoly`/`ZPoly` and `HexPolyFpMathlib` for `ZMod64`,
+transported from the mathematical polynomial or residue types while retaining
+the executable operations. The private dense-polynomial structure in
+`HexResultantMathlib/Specialize.lean` is not a reusable dependency and uses
+`npowRec`. Follow the executable-power choices in
+`HexMvPolyMathlib/Equiv.lean` and `HexGFqMathlib/Basic.lean`: install the
+executable `npow`, rather than introduce a second power operation.
 Then the generic arm proofs apply with the same quotient law. Transport
 must preserve the exact `Zero`, `One`, `Add`, `Neg`, `Mul`, and `Pow`
 operations used by `Lean.Grind.CommRing`, rather than introducing a second
@@ -151,8 +164,9 @@ explicit custom quotient constructor, the generic Berkowitz default over
 a ring with zero divisors, and the trivial ring.
 
 Exercise `det_eq` and `det_eq_mathlib` at empty, one-by-one, two-by-two,
-row-swapped, and singular inputs. For integration, force each enabled arm
-and each fallback transition and apply its route law. Tiny closed values
+row-swapped, and singular inputs. For integration, call `runWith` to force
+each enabled arm and each fallback transition and apply its
+`LawfulPolicy.route_sound` law. Tiny closed values
 may be checked with kernel `decide`. Certificate replay and tactic
 performance belong to the downstream matrix-tactic libraries. This
 companion introduces neither a certificate format nor a trusted evaluator.

--- a/SPEC/Libraries/hex-det-mathlib.md
+++ b/SPEC/Libraries/hex-det-mathlib.md
@@ -1,0 +1,158 @@
+# hex-det-mathlib
+
+Correctness of [hex-det](hex-det.md)'s dispatch and correspondence with
+Mathlib's determinant. This is a `correspondence-only-layer`, registered
+with `correspondence_only: true`. It owns no runtime determinant, conformance
+driver, benchmark process, or tactic.
+
+Computational conformance owner: `HexDet`.
+
+Computational performance owner: `HexDet`.
+
+## Dependencies
+
+Direct dependencies are `HexDet`, `HexBareissMathlib`,
+`HexCharPolyMathlib`, `HexDeterminantMathlib`, `HexPolyMathlib`,
+`HexPolyFpMathlib`, and `HexMvPolyMathlib`, plus Mathlib. These provide
+algorithm correctness and coefficient transport without placing Mathlib
+imports in `HexDet`. Add `HexModularMatrixMathlib` when the modular arm is
+integrated. No dependency points back from those providers to dispatch.
+
+The intended files are `HexDetMathlib/{Basic,Small,Bareiss,Berkowitz,Field,Carriers}.lean`
+and the umbrella `HexDetMathlib.lean`. A modular correspondence module is
+added with that algorithm. Build-only examples exercise the laws and
+instance resolution. They do not duplicate the owner's runtime conformance.
+
+## Contract
+
+The following declarations are proposed obligations, not existing theorems.
+Use namespace `Hex.Det` for the dispatch laws. Under
+`[Lean.Grind.CommRing R] [DetOps R]`, define the companion-only law class:
+
+```lean
+class LawfulDetOps (R : Type u) [Lean.Grind.CommRing R] [DetOps R] : Prop where
+  value_eq : ∀ {n} (A : Hex.Matrix R n n),
+    (DetOps.run A).value = Hex.Matrix.det A
+  route_sound : ∀ {n} (A : Hex.Matrix R n n), ValidRoute A (DetOps.run A)
+
+theorem det_eq [Lean.Grind.CommRing R] [DetOps R] [LawfulDetOps R]
+    (A : Hex.Matrix R n n) : Hex.Det.det A = Hex.Matrix.det A
+
+theorem det_eq_mathlib [CommRing R] [DetOps R] [LawfulDetOps R]
+    (A : Hex.Matrix R n n) :
+    Hex.Det.det A = Matrix.det (HexMatrixMathlib.matrixEquiv A)
+```
+
+`ValidRoute` is a proposed companion relation over the producer's installed
+policy and algorithm parameters. It asserts that `attempts` is nonempty,
+its first and last entries are `selected` and `completed`, selection obeys
+the policy, each transition is justified by the actual failure branch of
+the attempted algorithm, and the value equals the completed arm's result
+on the same input. A small completion additionally asserts `n ≤ 2`.
+The relation is defined using the lower operations and their return
+equations, not by trusting the reported tags. Its definition and the law
+instances must be supplied together with each enabled producer.
+
+For each concrete instance and each generic constructor, prove these laws
+by splitting on its actual dispatch and fallback branches and using the
+arm theorems below. Exact-quotient constructors require their quotient law.
+Field constructors require the field operations and equality they use.
+The modular constructor requires the lower bound law. The theorem for an
+arbitrary `DetOps` instance always requires `LawfulDetOps` for that same
+instance. An unconstrained implementation cannot be declared correct.
+
+`det_eq` is projection of `value_eq`. `det_eq_mathlib` composes it with
+`HexMatrixMathlib.det_eq`. Although the first law uses only Mathlib-free
+types, it lives here and is not available to Mathlib-free consumers in the
+first version. In particular, the supplied proofs must not assume a
+Mathlib `CommRing` instance exists on every executable carrier.
+
+## Existing proof routes
+
+These are existing declarations, with the paths and hypotheses that the
+implementation may actually use:
+
+| Arm or transport | Existing source | Use |
+|---|---|---|
+| reference to Mathlib | `HexMatrixMathlib.det_eq`, `HexDeterminantMathlib/CoreTransport.lean`, `[CommRing R]` | `Hex.Matrix.det A = Matrix.det (matrixEquiv A)` |
+| Bareiss | `HexMatrixMathlib.bareissWith_eq_mathlib_det`, `HexBareissMathlib/Bareiss.lean`, `[CommRing R] [DecidableEq R]`, `quot`, and `∀ a b, b ≠ 0 → quot (a * b) b = a` | compose with the symmetric reference correspondence |
+| Bareiss directly to reference | `HexMatrixMathlib.bareissWith_eq_det`, same file and hypotheses | already packages that composition |
+| Berkowitz | `HexCharPolyMathlib.coeff_zero_charPoly`, `HexCharPolyMathlib/Coeff.lean`, `[CommRing R] [DecidableEq R]` | `(charPoly A).coeff 0 = (-1)^n * Hex.Matrix.det A` |
+| tiny characteristic polynomials | `Hex.Matrix.charPoly_empty`, `charPoly_one_by_one`, `charPoly_two_by_two`, `HexCharPoly/Small.lean`, `[Lean.Grind.CommRing R] [DecidableEq R]` | closed forms for the signed constant coefficient |
+| tiny determinants | `Hex.Matrix.det_principalSubmatrix_zero`, `det_one_by_one`, `det_two_by_two`, `HexDeterminant/Leibniz.lean` | reference equalities (the empty case is stated for a zero-sized principal submatrix), under `Lean.Grind.Ring` for sizes zero and one and `Lean.Grind.CommRing` for size two |
+| elimination steps | `Hex.Matrix.det_rowSwap`, `det_rowScale`, `det_rowAdd`, `HexDeterminant/RowOps.lean`, `[Lean.Grind.CommRing R]` | determinant effects of the actual row operations |
+
+For Berkowitz, multiply the coefficient theorem by `(-1)^n` and simplify
+`(-1)^n * (-1)^n = 1`. This yields the required determinant without a
+nontriviality, invertibility, or characteristic restriction. Both signs
+matter, particularly in odd dimensions. For the small arm, specialize the
+reference equalities or use the small characteristic-polynomial forms
+and this same coefficient argument. Neither route runs a full Berkowitz
+computation at runtime.
+
+The Bareiss equation is available through the companion, not as a
+Mathlib-free theorem merely because its conclusion mentions two executable
+definitions. No full Mathlib-free proof of the Berkowitz determinant
+identity is claimed. Such a proof is future work and must establish the
+same identity over `Lean.Grind.CommRing`, including rings with zero divisors.
+
+## Outstanding arm and carrier obligations
+
+**Field elimination.** There is no existing determinant result obtained by
+multiplying the diagonal of `rowReduce`. Prove correctness for the proposed
+forward-elimination operation with its accumulated pivot product and swap
+sign. The invariant relates that product, sign, and trailing determinant
+to the input determinant. Use the row-operation lemmas above. Prove the
+failed-pivot column branch yields determinant zero. Until the operation
+and its correctness are supplied, the installed field policy is Bareiss.
+
+**Modular and divisor arms.** The operations and correctness in
+[hex-modular-matrix](hex-modular-matrix.md) are planned, not declarations
+that can be imported today. Once implemented, compose their determinant
+equalities with the dispatch branches and discharge `LawfulDetBound` using
+the modular companion. The divisor route must also satisfy that library's
+certified solve and divisibility contracts. Modular exhaustion must use the
+Bareiss proof and report Bareiss completion. Never assume finite fuel always
+succeeds or replace the bound by a stabilization test.
+
+**Executable coefficient structures.** `Rat` and the supported `MvPoly`
+carriers already have the Mathlib structures needed for generic arm
+correspondence. Executable `DensePoly`/`ZPoly` and `ZMod64` do not currently
+have global Mathlib `CommRing` instances, as the
+[hex-bareiss companion](../../HexBareissMathlib/SPEC/hex-bareiss-mathlib.md#headline-correspondence-theorems)
+explains. The existence of the generic Bareiss theorem does not close
+those carrier obligations.
+
+The implementation must supply compatible Mathlib algebraic structures in
+the appropriate coefficient companions, transported from their mathematical
+polynomial or residue types while retaining the executable operations.
+Then the generic arm proofs apply with the same quotient law. Transport
+must preserve the exact `Zero`, `One`, `Add`, `Neg`, `Mul`, and `Pow`
+operations used by `Lean.Grind.CommRing`, rather than introducing a second
+unrelated ring on the type. It must leave computational division and
+decidable equality intact. `HexDetMathlib/Carriers.lean` assembles those
+instances and the dispatch laws above both dependency chains.
+
+For a custom commutative carrier with only `Lean.Grind.CommRing`, the same
+compatibility work or a direct proof of its dispatch law is required in the
+companion. The generic class does not manufacture Mathlib structures.
+These are implementation prerequisites for the advertised per-carrier
+correctness: computation and conformance alone do not complete them. Do
+not claim the first version's full correctness until all shipped carrier
+instances have laws. No new axiom or silent weakening of the carrier table
+is an acceptable substitute.
+
+## Verification
+
+Build-only examples must resolve both `DetOps` and its law for every carrier
+listed in the computational SPEC, using `Rat` and prime `ZMod64` for dense
+polynomials and `Int` and `Rat` for multivariate polynomials. Include an
+explicit custom quotient constructor, the generic Berkowitz default over
+a ring with zero divisors, and the trivial ring.
+
+Exercise `det_eq` and `det_eq_mathlib` at empty, one-by-one, two-by-two,
+row-swapped, and singular inputs. For integration, force each enabled arm
+and each fallback transition and apply its route law. Tiny closed values
+may be checked with kernel `decide`. Certificate replay and tactic
+performance belong to the downstream matrix-tactic libraries. This
+companion introduces neither a certificate format nor a trusted evaluator.

--- a/SPEC/Libraries/hex-det.md
+++ b/SPEC/Libraries/hex-det.md
@@ -20,13 +20,25 @@ The following is the proposed public surface, not existing declarations.
 `Policy R` is a typed recipe for the available algorithms and their parameters.
 Its constructors are Berkowitz with decidable equality, exact-quotient
 Bareiss with equality and `quot`, field selection with field operations and
-equality, and integer selection with its modular settings. Field and integer
-constructors admit only arms implemented for that carrier. Before modular
-integration, integer policies admit only Bareiss. Before field elimination
+equality, and integer selection with its modular settings. To call the
+integer backend from the generic interpreter, the integer recipe carries
+`toInt : R → Int` and `ofInt : Int → R`. It maps entries through `toInt`
+and the answer through `ofInt`. The companion requires these maps to be
+mutual inverses preserving the ring operations. The `Int` instance uses
+identity maps, so its runner has no representation conversion. No generic
+ring is assumed to be `Int` by a typeclass search or unchecked cast.
+Field and integer constructors admit only arms implemented for that carrier.
+Before modular integration, integer policies admit only Bareiss. Before field elimination
 exists, field policies admit only Bareiss. Small cases precede every recipe.
 
 Policies carry the dimension and coefficient-size selection regions, cutoff
-tie rules, and applicable fuel and seed settings. They also retain the
+tie rules, and applicable fuel and seed settings. A size-based recipe also
+carries its executable input statistic, for example
+`size : {n : Nat} → Hex.Matrix R n n → Nat`, with the report specifying
+its units and aggregation rule. Integer entries use maximum absolute bit
+length. Rational policies may use maximum numerator and denominator bit
+lengths as separate statistics. Carriers without a supplied statistic have
+dimension-only regions. `Lean.Grind.CommRing` supplies no size measure. They also retain the
 coefficient operations, including the quotient, that the runner uses. Field
 evidence must extend the ambient commutative-ring operations, not replace
 them with another ring structure. Thus
@@ -76,18 +88,22 @@ fuel and completes through Bareiss records `[modular, bareiss]`. A divisor
 attempt can record an intermediate modular attempt before Bareiss. The
 route records determinant algorithms only, not every modular image or
 subsidiary solve. Diagnostics retain the resolved policy alongside the
-result so fuel, seed, and selection settings remain reproducible.
+result so fuel, seed, and selection settings remain reproducible. For
+`DetOps.run` this is precisely `DetOps.policy`. For `runWith p` the caller
+retains `p`. Neither the runner nor `Result` stores a second resolved policy.
 
 Each producer sets the route in the branch that actually returns the value.
 In particular, a wrapper must not label the opaque result of a total modular
 routine `modular` when that routine may have used Bareiss internally. The
 modular integration requires either a result-with-route API below dispatch,
 or composition of its partial operations with the same documented total
-fallback. No determinant is computed twice to discover its route.
+fallback. The modular SPEC requires `Hex.ModularMatrix.detWith` with explicit
+fuel, seed, divisor selection, and the completion route. No determinant is
+computed twice to discover its route.
 
 Conformance and build-only examples call `runWith` with explicit policies
-to force each available arm and transition, including zero modular fuel.
-These use the production interpreter, not a separate test implementation.
+to force each available arm and transition, including zero modular fuel
+once modular integration exists. These use the production interpreter, not a separate test implementation.
 A policy cannot request an unavailable arm. Every explicit policy used in
 a proof must satisfy the same companion laws as an installed default.
 
@@ -107,7 +123,7 @@ with `Int` and the generic cases stated separately.
 
 | Carrier | Required operations and laws | Selection after the small cases | Instance module in `HexDet` |
 |---|---|---|---|
-| `Int` | existing integer operations and native `Hex.Matrix.exactDiv` | Bareiss below the measured crossover, modular above it once available and measured | `Int.lean` |
+| `Int` | existing integer operations and native `HexArith.Int.exactDiv` | Bareiss below the measured crossover, modular above it once available and measured | `Int.lean` |
 | `Rat` | core `Lean.Grind.Field` and decidable equality | Bareiss initially, then the measured choice with division elimination once available | `Field.lean` |
 | `ZMod64 p` | `[ZMod64.Bounds p] [ZMod64.PrimeModulus p]`, field instance from `HexPolyFp.PrimeField` | Bareiss initially, then a field policy measured separately from `Rat` once elimination is available | `Field.lean` |
 | `DensePoly F` | `[Lean.Grind.Field F] [DecidableEq F]`, polynomial division and `Hex.instExactDivLawsDensePoly` from `HexResultant.ExactDiv` | Bareiss with `Hex.exactDiv`, exercising both `F = Rat` and `F = ZMod64 p` | `Poly.lean` |
@@ -190,20 +206,31 @@ those dependencies. The carrier instance modules live here, above both
 matrix algorithms and quotient providers. Neither `HexBareiss` nor a
 quotient provider acquires a dependency on `HexDet`.
 
+For field recipes, the carried division `div` must obey
+`div (a * b) b = a` whenever `b ≠ 0`. Their field evidence supplies this
+law for the ambient multiplication. The companion must use this specific
+law for the initial Bareiss arm, and the same field evidence for forward
+elimination. An unrelated field dictionary is not accepted.
+
 The intended files are `HexDet/{Basic,Int,Field,Poly,MvPoly}.lean` and the
 `HexDet.lean` umbrella. `Basic` owns the public protocol, small cases,
 Berkowitz default, and generic exact-quotient constructor. The other modules
-own carrier policies and instances. Consumers may import `HexDet.Basic` or
-`HexDet.Int` directly without the multivariate instance modules. This issue
+own carrier policies and instances. The umbrella is the supported way to obtain all concrete carrier policies.
+An integer-only consumer may import `HexDet.Int` without multivariate
+instances. Importing only `HexDet.Basic` deliberately exposes the generic
+Berkowitz default: other carriers need their instance module or the umbrella
+to obtain their production policy. Partial imports can change the selected
+arm while preserving correctness. This issue
 creates only the SPECs and
 planned metadata, not these source files or Lake targets.
 
 When registered and implemented, add `HexModularMatrix` to `HexDet.deps`,
 and `HexModularMatrixMathlib` to the companion's dependencies. Neither
-modular library may depend on `HexDet`. The lower modular API must use a
-namespace distinct from the existing `Hex.Matrix.det` and new `Hex.Det.det`.
-The `det` signatures in its SPEC describe planned operations, not existing
-callable names. Adding these edges preserves the topological order because
+modular library may depend on `HexDet`. The lower determinant wrappers use `Hex.ModularMatrix.det` and
+`Hex.ModularMatrix.detViaDivisor`, distinct from `Hex.Matrix.det` and
+`Hex.Det.det`. Its image, bound, and partial reconstruction helpers may
+remain in `Hex.Matrix`. These signatures describe planned operations, not
+existing callable names. Adding these edges preserves the topological order because
 both modular libraries depend only on libraries below dispatch.
 
 `scripts/check_dag.py` checks registered dependencies and actual imports,
@@ -243,10 +270,12 @@ but cannot import these companion theorems as Mathlib-free correctness.
 ## Conformance and measured policies
 
 `HexDet` owns conformance and performance. Compare dispatch and every
-available forced arm on identical matrices, including empty and tiny
+available lower algorithm on identical matrices, including empty and tiny
 matrices, row swaps, singular matrices, zero pivot columns, odd and even
-sizes, and the trivial ring where `1 = 0`. Check both values and actual
-route transitions, especially forced modular exhaustion. Exercise each
+sizes, and the trivial ring where `1 = 0`. At `n ≤ 2`, call the lower algorithms directly to compare with dispatch's
+mandatory small arm. At larger sizes, use `runWith` to force the available
+arms. Check both values and actual route transitions, including forced
+modular exhaustion once that arm is enabled. Exercise each
 carrier in the table, nonconstant polynomial pivots, and a commutative ring
 with zero divisors through Berkowitz. Compare against Leibniz at small
 sizes only. Larger oracle comparisons use python-flint `fmpz_mat.det()`,
@@ -262,7 +291,7 @@ The required Phase-4 input families are:
 | `field` | dimension, rational numerator/denominator bit lengths, and prime modulus: forward elimination versus Bareiss, with Berkowitz as a reference on feasible sizes |
 | `dense-poly` | dimension, entry degree, and coefficient size over `Rat`, prime `ZMod64`, and `Int`: Bareiss versus Berkowitz, including exact division by nonconstant pivots |
 | `mv-poly` | dimension, variable count, total degree, support, and coefficient size over `Int` and `Rat`: Bareiss versus Berkowitz, including nonconstant pivots and expression growth |
-| `dispatch` | tiny dimensions, both sides of each measured cutoff, modular fallback, and rings with zero divisors: dispatch overhead versus its selected direct arm |
+| `dispatch` | tiny dimensions and rings with zero divisors, plus both sides of each measured cutoff and modular fallback when enabled: dispatch overhead versus its selected direct arm |
 
 Crossovers are benchmark outputs, never numerical SPEC constants. Record
 each enabled cutoff, coefficient-size region, tie rule, seed, and fuel

--- a/SPEC/Libraries/hex-det.md
+++ b/SPEC/Libraries/hex-det.md
@@ -1,0 +1,253 @@
+# hex-det
+
+One production determinant entry point for square `Hex.Matrix` values over
+supported commutative rings. `hex-det` chooses a computation from
+`hex-bareiss`, `hex-char-poly`, and eventually `hex-modular-matrix`.
+`hex-determinant` retains the Leibniz reference definition `Hex.Matrix.det`
+and its determinant identities. The short name `det` names the operation
+consumers request, while `determinant` names that existing foundational
+library. The new entry point is `Hex.Det.det`, so neither the library nor
+the Lean declaration replaces or overloads the reference definition.
+
+This is a specification, with a [Mathlib companion](hex-det-mathlib.md).
+It adds no determinant implementation. Noncommutative rings, approximate
+floating-point determinants, rank, and characteristic-polynomial dispatch
+are outside its scope.
+
+## API and selection evidence
+
+The following is the proposed public surface, not existing declarations:
+
+```lean
+namespace Hex.Det
+
+inductive Arm where
+  | small | bareiss | elimination | berkowitz | modular | divisor
+
+structure Result (R : Type u) where
+  value : R
+  selected : Arm
+  completed : Arm
+  attempts : List Arm
+
+class DetOps (R : Type u) [Lean.Grind.CommRing R] where
+  run : {n : Nat} → Hex.Matrix R n n → Result R
+
+def det [Lean.Grind.CommRing R] [DetOps R]
+    (A : Hex.Matrix R n n) : R := (DetOps.run A).value
+
+end Hex.Det
+```
+
+`DetOps.run` computes once and returns both the value and the route.
+`det` is its value projection, not an independently dispatched computation.
+`selected` is the initial choice, `completed` is the arm that supplies the
+answer, and `attempts` is a nonempty, ordered list starting at `selected`
+and ending at `completed`. An ordinary call records a singleton. A modular
+attempt that exhausts its fuel and completes through Bareiss records
+`[modular, bareiss]`. A divisor attempt can record an intermediate modular
+attempt before Bareiss. The route records determinant algorithms only, not
+every modular image or subsidiary solve.
+
+Each producer sets the route in the branch that actually returns the value.
+In particular, a wrapper must not label the opaque result of a total modular
+routine `modular` when that routine may have used Bareiss internally. The
+modular integration requires either a result-with-route API below dispatch,
+or composition of its partial operations with the same documented total
+fallback. No determinant is computed twice to discover its route.
+
+The companion states correctness for the value and for the completed arm.
+These laws are separate from `DetOps`: an arbitrary user-supplied instance
+is executable code, not a proof of correctness. Selection metadata is also
+ordinary data and cannot establish a determinant equation by itself.
+
+## Selection rule
+
+All rows first use `small` for `n = 0, 1, 2`, returning respectively `1`,
+`A[(0,0)]`, and `A[(0,0)] * A[(1,1)] - A[(0,1)] * A[(1,0)]`.
+This is a mathematical size case, not a tuned crossover. The following
+choices apply at larger sizes. The five carrier rows reproduce the surface
+of [hex-bareiss's carrier table](../../HexBareiss/SPEC/hex-bareiss.md#supported-coefficient-carriers),
+with `Int` and the generic cases stated separately.
+
+| Carrier | Required operations and laws | Selection after the small cases | Instance module in `HexDet` |
+|---|---|---|---|
+| `Int` | existing integer operations and native `Hex.Matrix.exactDiv` | Bareiss below the measured crossover, modular above it once available and measured | `Int.lean` |
+| `Rat` | core `Lean.Grind.Field` and decidable equality | measured choice between division elimination and Bareiss | `Field.lean` |
+| `ZMod64 p` | `[ZMod64.Bounds p] [ZMod64.PrimeModulus p]`, field instance from `HexPolyFp.PrimeField` | field policy measured separately from `Rat` | `Field.lean` |
+| `DensePoly F` | `[Lean.Grind.Field F] [DecidableEq F]`, polynomial division and `Hex.instExactDivLawsDensePoly` from `HexResultant.ExactDiv` | Bareiss with `Hex.exactDiv`, exercising both `F = Rat` and `F = ZMod64 p` | `Poly.lean` |
+| `ZPoly` (`DensePoly Int`) | recursive dense-polynomial exact division over `Hex.instExactDivLawsInt` | Bareiss with `Hex.exactDiv` | `Poly.lean` |
+| `MvPoly k R cmp` | the complete coefficient and order context below, with division from `HexMvGcd.Divide` | Bareiss with `Hex.exactDiv`, exercising `R = Int` and `R = Rat` | `MvPoly.lean` |
+| other fields `F` | `[Lean.Grind.Field F] [DecidableEq F]` | field constructor accepts a recorded policy choosing elimination or Bareiss | explicit constructor in `Field.lean` |
+| other exact-quotient commutative rings `R` | `[Lean.Grind.CommRing R] [DecidableEq R]`, `quot` and its cancellation law below | Bareiss | explicit constructor in `Basic.lean` |
+| remaining commutative rings `R` | `[Lean.Grind.CommRing R] [DecidableEq R]` | Berkowitz, `(-1 : R)^n * (Hex.Matrix.charPoly A).coeff 0` | low-priority default in `Basic.lean` |
+
+The `MvPoly` context is `[Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+[Lean.Grind.CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R] [Dvd R]
+[Hex.GcdOps R] [Hex.IsMonomialOrder cmp] [Hex.LawfulGcdOps R]`, as required
+by the provider. The exact quotient contract is
+`∀ a b : R, b ≠ 0 → quot (a * b) b = a`, not merely the presence of `Div R`.
+For the listed non-integer Bareiss instances it is supplied by
+`fun a b hb => Hex.exactDiv_mul_right a hb` from `HexBasic/ExactDiv.lean`.
+No nonzero-determinant or nonzero-leading-minors precondition is allowed.
+
+Concrete carrier instances take precedence over the Berkowitz default.
+Generic field and exact-quotient policies are explicit constructors of
+`DetOps`, installed locally or by a carrier's integration module. They are
+not competing blanket instances: importing a division provider must not
+silently change an existing carrier's policy. In particular, exact division
+over `Rat` does not override the measured field choice. The umbrella
+imports all listed concrete instances. A custom carrier can always use the
+Berkowitz default without a quotient. Decidable equality is needed by the
+current polynomial computation even on this division-free route.
+
+`ZPoly` shares the `DensePoly Int` instance and receives no second instance
+through the alias. A field of polynomial coefficients is not a field of
+polynomials. Composite-modulus rings lacking the prime-field assumptions
+use Berkowitz when their commutative-ring and equality instances exist.
+Zero divisors do not satisfy the exact-quotient law in general.
+
+### Field elimination
+
+The field arm uses forward elimination with row pivoting, accumulating the
+product of the unnormalized pivots and the sign of the row permutation.
+A failed pivot column returns zero. It does not compute a determinant of
+an auxiliary transform or recurse through dispatch.
+
+`Hex.Matrix.rowReduce` in `HexRowReduce/Loop.lean` computes full reduced row
+echelon form and a transform, but its result does not carry the determinant
+of that transform. Multiplying the normalized diagonal of that result is
+not a determinant algorithm. A determinant-specific elimination operation,
+including the pivot and sign bookkeeping, must be supplied below dispatch
+in `HexRowReduce` before this arm is enabled. Its determinant correctness
+belongs in this companion, which can import `HexDeterminant` through the
+appropriate dependency paths. This does not add an upward dependency from
+`HexRowReduce` to dispatch. Until this operation exists and has measurements,
+the field constructor uses Bareiss as its explicit initial policy.
+
+### Integer modular integration
+
+[hex-modular-matrix](hex-modular-matrix.md) specifies the modular and divisor
+algorithms but has no registered library or implementation today. Initial
+integer dispatch therefore uses Bareiss at every `n > 2`. Enable modular
+selection only after the lower algorithm, route reporting, correctness
+integration, and crossover measurement exist. This initial availability
+rule is not a claim that Bareiss wins for large matrices.
+
+The eventual policy selects Bareiss below a measured cutoff and modular
+at or above it. Dimension and input coefficient bit length may determine
+the measured region. `detViaDivisor` is an optional measured choice inside
+that region, not an unconditional extra solve on every input. Its seeds and
+fuel settings are deterministic, recorded policy parameters. The lower
+library owns reconstruction, its bound, and finite-fuel fallback. Dispatch
+must preserve those contracts, including the `LawfulDetBound` proof required
+for modular correctness in the companion. Stabilization of residues alone
+never certifies an answer.
+
+## Dependencies and files
+
+Register `HexDet` as planned, with direct dependencies on `HexBareiss`,
+`HexCharPoly`, `HexRowReduce`, `HexPolyFp`, `HexResultant`, and `HexMvGcd`.
+`HexMatrix`, `HexDeterminant`, `HexBasic`, and `HexPoly` are reachable through
+those dependencies. The carrier instance modules live here, above both
+matrix algorithms and quotient providers. Neither `HexBareiss` nor a
+quotient provider acquires a dependency on `HexDet`.
+
+The intended files are `HexDet/{Basic,Int,Field,Poly,MvPoly}.lean` and the
+`HexDet.lean` umbrella. `Basic` owns the public protocol, small cases,
+Berkowitz default, and generic exact-quotient constructor. The other modules
+own carrier policies and instances. This issue creates only the SPECs and
+planned metadata, not these source files or Lake targets.
+
+When registered and implemented, add `HexModularMatrix` to `HexDet.deps`,
+and `HexModularMatrixMathlib` to the companion's dependencies. Neither
+modular library may depend on `HexDet`. The lower modular API must use a
+namespace distinct from the existing `Hex.Matrix.det` and new `Hex.Det.det`.
+The `det` signatures in its SPEC describe planned operations, not existing
+callable names. Adding these edges preserves the topological order because
+both modular libraries depend only on libraries below dispatch.
+
+`scripts/check_dag.py` checks registered dependencies and actual imports,
+not Markdown arrows. The planned entries make the current graph checkable.
+The deferred modular edges must be registered and checked when their targets
+exist. `hex-matrix-tactic` is a downstream consumer, with no reverse edge.
+
+## Correctness and tactic use
+
+Every shipped arm must equal `Hex.Matrix.det A`. All dispatch correctness
+statements and proofs in the first version live in
+[hex-det-mathlib](hex-det-mathlib.md), including statements whose two sides
+are Mathlib-free expressions. A Mathlib-free executable is not thereby a
+Mathlib-free proof. A Mathlib-free proof of the Berkowitz determinant arm
+is future work. No axiom, `native_decide`, or invented lower-layer proof
+fills that gap.
+
+[hex-matrix-tactic (#10151)](https://github.com/kim-em/hex-dev/issues/10151)
+consumes `DetOps.run` and follows `completed`, retaining `selected` and
+`attempts` for diagnostics and reproducible strategy measurements. Small
+forms permit direct normalization, Bareiss and elimination permit their
+correspondence plus kernel replay or a separately proved certificate,
+and Berkowitz can use characteristic-polynomial certificate machinery.
+A modular answer requires the reconstruction and bound correctness route,
+or a separate verified recomputation. Dispatch promises no cheap modular
+determinant certificate. A tag or compiled value is never proof evidence.
+
+The tactic separately chooses between kernel replay and certificate
+construction, measuring coefficient size and symbolic growth as well as
+matrix dimension. It does not maintain a second table choosing the
+production determinant algorithm. If a proof strategy is unavailable for
+the completed arm, the tactic reports that limitation or explicitly checks
+the value by another sound strategy. It cannot pretend a Bareiss certificate
+was returned by a modular run. The Mathlib-free tactic can compute values
+but cannot import these companion theorems as Mathlib-free correctness.
+
+## Conformance and measured policies
+
+`HexDet` owns conformance and performance. Compare dispatch and every
+available forced arm on identical matrices, including empty and tiny
+matrices, row swaps, singular matrices, zero pivot columns, odd and even
+sizes, and the trivial ring where `1 = 0`. Check both values and actual
+route transitions, especially forced modular exhaustion. Exercise each
+carrier in the table, nonconstant polynomial pivots, and a commutative ring
+with zero divisors through Berkowitz. Compare against Leibniz at small
+sizes only. Larger oracle comparisons use python-flint for integers,
+rationals, and prime residues, and SymPy's explicit Berkowitz method over
+identical exact polynomial domains for polynomial carriers.
+
+The required Phase-4 input families are:
+
+| Family | Sweep and compared arms |
+|---|---|
+| `integer` | dimension and entry bit length on dense, tridiagonal, triangular, singular, low-rank, and unimodular matrices: Bareiss, modular, and divisor when available |
+| `field` | dimension, rational numerator/denominator bit lengths, and prime modulus: forward elimination versus Bareiss, with Berkowitz as a reference on feasible sizes |
+| `dense-poly` | dimension, entry degree, and coefficient size over `Rat`, prime `ZMod64`, and `Int`: Bareiss versus Berkowitz, including exact division by nonconstant pivots |
+| `mv-poly` | dimension, variable count, total degree, support, and coefficient size over `Int` and `Rat`: Bareiss versus Berkowitz, including nonconstant pivots and expression growth |
+| `dispatch` | tiny dimensions, both sides of each measured cutoff, modular fallback, and rings with zero divisors: dispatch overhead versus its selected direct arm |
+
+Crossovers are benchmark outputs, never numerical SPEC constants. Record
+each enabled cutoff, coefficient-size region, tie rule, seed, and fuel
+setting with the source revision, fixture identifiers, command, host context,
+raw measurements, and adjacent-arm ratios in
+`reports/hex-det-performance.md`. Register these families under
+`HexDet.phase4.input_families` in `libraries.yml`. When a policy is enabled
+or changed, update the corresponding family's `description` with the exact
+policy constant names and values and a reference to the report's policy
+table. This uses the existing `phase4` schema, which has no `crossovers`
+field. The report and executable policy must agree with that record.
+
+Use the shared-host discipline in [benchmarking](../benchmarking.md):
+automatically select and pin a CPU when supported, retain host context and
+all completed samples, use fixed trial-major schedules for scaling, and
+adjacent alternating AB/BA arms for comparisons. Allow at most one unchanged
+rerun of an inconclusive comparison. Never tune a cutoff without recorded
+measurements. An inconclusive comparison keeps the existing policy. The
+initial availability policies above must be labeled unmeasured until the
+first evidence is collected.
+
+Internal comparisons determine selection. External comparators are
+informational because their algorithm selection and process overhead differ.
+Ordinary Mathlib-free bench targets verify bounded fixture outputs and route
+agreement. Timing runs are manual, extending the existing benchmark setup
+under its CI wall-clock cap, with no new workflow jobs. Tactic elaboration,
+certificate construction, kernel checking, and proof-size measurements are
+owned by the tactic library, not substituted for these producer timings.

--- a/SPEC/Libraries/hex-det.md
+++ b/SPEC/Libraries/hex-det.md
@@ -16,7 +16,24 @@ are outside its scope.
 
 ## API and selection evidence
 
-The following is the proposed public surface, not existing declarations:
+The following is the proposed public surface, not existing declarations.
+`Policy R` is a typed recipe for the available algorithms and their parameters.
+Its constructors are Berkowitz with decidable equality, exact-quotient
+Bareiss with equality and `quot`, field selection with field operations and
+equality, and integer selection with its modular settings. Field and integer
+constructors admit only arms implemented for that carrier. Before modular
+integration, integer policies admit only Bareiss. Before field elimination
+exists, field policies admit only Bareiss. Small cases precede every recipe.
+
+Policies carry the dimension and coefficient-size selection regions, cutoff
+tie rules, and applicable fuel and seed settings. They also retain the
+coefficient operations, including the quotient, that the runner uses. Field
+evidence must extend the ambient commutative-ring operations, not replace
+them with another ring structure. Thus
+a policy determines an executable computation, rather than describing an
+arbitrary callback hidden in an instance. Quotient and algorithm correctness
+laws are supplied separately in the companion. The concrete carrier instances
+use the exact quotients and laws listed below.
 
 ```lean
 namespace Hex.Det
@@ -24,14 +41,22 @@ namespace Hex.Det
 inductive Arm where
   | small | bareiss | elimination | berkowitz | modular | divisor
 
+structure Route where
+  first : Arm
+  rest : List Arm
+
 structure Result (R : Type u) where
   value : R
-  selected : Arm
-  completed : Arm
-  attempts : List Arm
+  route : Route
 
 class DetOps (R : Type u) [Lean.Grind.CommRing R] where
-  run : {n : Nat} → Hex.Matrix R n n → Result R
+  policy : Policy R
+
+def runWith [Lean.Grind.CommRing R] (policy : Policy R)
+    (A : Hex.Matrix R n n) : Result R
+
+def DetOps.run [Lean.Grind.CommRing R] [DetOps R]
+    (A : Hex.Matrix R n n) : Result R := runWith DetOps.policy A
 
 def det [Lean.Grind.CommRing R] [DetOps R]
     (A : Hex.Matrix R n n) : R := (DetOps.run A).value
@@ -39,15 +64,19 @@ def det [Lean.Grind.CommRing R] [DetOps R]
 end Hex.Det
 ```
 
-`DetOps.run` computes once and returns both the value and the route.
-`det` is its value projection, not an independently dispatched computation.
-`selected` is the initial choice, `completed` is the arm that supplies the
-answer, and `attempts` is a nonempty, ordered list starting at `selected`
-and ending at `completed`. An ordinary call records a singleton. A modular
-attempt that exhausts its fuel and completes through Bareiss records
-`[modular, bareiss]`. A divisor attempt can record an intermediate modular
-attempt before Bareiss. The route records determinant algorithms only, not
-every modular image or subsidiary solve.
+`runWith` interprets the recipe by calling the lower algorithms, and
+`DetOps.run` uses the installed default. `det` is its value projection,
+not an independently dispatched computation. The public route accessors
+`selected`, `completed`, and `attempts` derive respectively the first arm,
+the last arm, and the list `first :: rest`. The route is nonempty by
+construction and stores its endpoints only once.
+
+An ordinary call records a singleton. A modular attempt that exhausts its
+fuel and completes through Bareiss records `[modular, bareiss]`. A divisor
+attempt can record an intermediate modular attempt before Bareiss. The
+route records determinant algorithms only, not every modular image or
+subsidiary solve. Diagnostics retain the resolved policy alongside the
+result so fuel, seed, and selection settings remain reproducible.
 
 Each producer sets the route in the branch that actually returns the value.
 In particular, a wrapper must not label the opaque result of a total modular
@@ -56,9 +85,15 @@ modular integration requires either a result-with-route API below dispatch,
 or composition of its partial operations with the same documented total
 fallback. No determinant is computed twice to discover its route.
 
+Conformance and build-only examples call `runWith` with explicit policies
+to force each available arm and transition, including zero modular fuel.
+These use the production interpreter, not a separate test implementation.
+A policy cannot request an unavailable arm. Every explicit policy used in
+a proof must satisfy the same companion laws as an installed default.
+
 The companion states correctness for the value and for the completed arm.
-These laws are separate from `DetOps`: an arbitrary user-supplied instance
-is executable code, not a proof of correctness. Selection metadata is also
+These laws are separate from `DetOps`: a user-supplied recipe is executable
+configuration, not a proof of correctness. Selection metadata is also
 ordinary data and cannot establish a determinant equation by itself.
 
 ## Selection rule
@@ -73,12 +108,12 @@ with `Int` and the generic cases stated separately.
 | Carrier | Required operations and laws | Selection after the small cases | Instance module in `HexDet` |
 |---|---|---|---|
 | `Int` | existing integer operations and native `Hex.Matrix.exactDiv` | Bareiss below the measured crossover, modular above it once available and measured | `Int.lean` |
-| `Rat` | core `Lean.Grind.Field` and decidable equality | measured choice between division elimination and Bareiss | `Field.lean` |
-| `ZMod64 p` | `[ZMod64.Bounds p] [ZMod64.PrimeModulus p]`, field instance from `HexPolyFp.PrimeField` | field policy measured separately from `Rat` | `Field.lean` |
+| `Rat` | core `Lean.Grind.Field` and decidable equality | Bareiss initially, then the measured choice with division elimination once available | `Field.lean` |
+| `ZMod64 p` | `[ZMod64.Bounds p] [ZMod64.PrimeModulus p]`, field instance from `HexPolyFp.PrimeField` | Bareiss initially, then a field policy measured separately from `Rat` once elimination is available | `Field.lean` |
 | `DensePoly F` | `[Lean.Grind.Field F] [DecidableEq F]`, polynomial division and `Hex.instExactDivLawsDensePoly` from `HexResultant.ExactDiv` | Bareiss with `Hex.exactDiv`, exercising both `F = Rat` and `F = ZMod64 p` | `Poly.lean` |
 | `ZPoly` (`DensePoly Int`) | recursive dense-polynomial exact division over `Hex.instExactDivLawsInt` | Bareiss with `Hex.exactDiv` | `Poly.lean` |
 | `MvPoly k R cmp` | the complete coefficient and order context below, with division from `HexMvGcd.Divide` | Bareiss with `Hex.exactDiv`, exercising `R = Int` and `R = Rat` | `MvPoly.lean` |
-| other fields `F` | `[Lean.Grind.Field F] [DecidableEq F]` | field constructor accepts a recorded policy choosing elimination or Bareiss | explicit constructor in `Field.lean` |
+| other fields `F` | `[Lean.Grind.Field F] [DecidableEq F]` | Bareiss initially; field constructor accepts measured elimination once available | explicit constructor in `Field.lean` |
 | other exact-quotient commutative rings `R` | `[Lean.Grind.CommRing R] [DecidableEq R]`, `quot` and its cancellation law below | Bareiss | explicit constructor in `Basic.lean` |
 | remaining commutative rings `R` | `[Lean.Grind.CommRing R] [DecidableEq R]` | Berkowitz, `(-1 : R)^n * (Hex.Matrix.charPoly A).coeff 0` | low-priority default in `Basic.lean` |
 
@@ -103,7 +138,9 @@ current polynomial computation even on this division-free route.
 
 `ZPoly` shares the `DensePoly Int` instance and receives no second instance
 through the alias. A field of polynomial coefficients is not a field of
-polynomials. Composite-modulus rings lacking the prime-field assumptions
+polynomials. More general ring-coefficient dense polynomials use the explicit
+exact-quotient constructor. A future recursive instance must subsume the
+existing dense-polynomial cases with the same policy, not compete with them. Composite-modulus rings lacking the prime-field assumptions
 use Berkowitz when their commutative-ring and equality instances exist.
 Zero divisors do not satisfy the exact-quotient law in general.
 
@@ -156,7 +193,9 @@ quotient provider acquires a dependency on `HexDet`.
 The intended files are `HexDet/{Basic,Int,Field,Poly,MvPoly}.lean` and the
 `HexDet.lean` umbrella. `Basic` owns the public protocol, small cases,
 Berkowitz default, and generic exact-quotient constructor. The other modules
-own carrier policies and instances. This issue creates only the SPECs and
+own carrier policies and instances. Consumers may import `HexDet.Basic` or
+`HexDet.Int` directly without the multivariate instance modules. This issue
+creates only the SPECs and
 planned metadata, not these source files or Lake targets.
 
 When registered and implemented, add `HexModularMatrix` to `HexDet.deps`,
@@ -210,9 +249,10 @@ sizes, and the trivial ring where `1 = 0`. Check both values and actual
 route transitions, especially forced modular exhaustion. Exercise each
 carrier in the table, nonconstant polynomial pivots, and a commutative ring
 with zero divisors through Berkowitz. Compare against Leibniz at small
-sizes only. Larger oracle comparisons use python-flint for integers,
-rationals, and prime residues, and SymPy's explicit Berkowitz method over
-identical exact polynomial domains for polynomial carriers.
+sizes only. Larger oracle comparisons use python-flint `fmpz_mat.det()`,
+`fmpq_mat.det()`, and `nmod_mat.det()` for integers, rationals, and prime
+residues. Polynomial carriers use SymPy `Matrix.det(method="berkowitz")`
+over identical exact polynomial domains.
 
 The required Phase-4 input families are:
 
@@ -246,6 +286,9 @@ first evidence is collected.
 
 Internal comparisons determine selection. External comparators are
 informational because their algorithm selection and process overhead differ.
+The dispatch-overhead and route-agreement surfaces have comparator-absence
+class `no-comparable-surface-in-named-comparator`: python-flint and SymPy do
+not expose Hex's arm selection or fallback route as callable operations.
 Ordinary Mathlib-free bench targets verify bounded fixture outputs and route
 agreement. Timing runs are manual, extending the existing benchmark setup
 under its CI wall-clock cap, with no new workflow jobs. Tactic elaboration,

--- a/SPEC/Libraries/hex-modular-matrix.md
+++ b/SPEC/Libraries/hex-modular-matrix.md
@@ -146,6 +146,21 @@ so rather than accepting `Rat` matrices and doing it silently.
 
 ## The determinant
 
+### Public names and dispatch integration
+
+The determinant API sketches below use local names. The production names of
+`det`, `detViaDivisor`, and their wrapper correspondence theorems belong in
+`Hex.ModularMatrix`, not `Hex.Matrix`: `Hex.Matrix.det` already denotes the
+Leibniz reference and cannot be redeclared. The shared production dispatcher
+is separately named `Hex.Det.det` in [hex-det](hex-det.md).
+
+The modular library stays below `HexDet`. It must expose either the actual
+completion route of its total determinant routines, including Bareiss
+fallback, or partial operations with explicit fuel and seed parameters that
+let `HexDet` compose the same branches and report that route. The latter
+must use the production code paths so zero-fuel conformance can exercise
+fallback. No upward import of `HexDet` is required for either form.
+
 ### One image
 
 ```lean

--- a/SPEC/Libraries/hex-modular-matrix.md
+++ b/SPEC/Libraries/hex-modular-matrix.md
@@ -148,18 +148,56 @@ so rather than accepting `Rat` matrices and doing it silently.
 
 ### Public names and dispatch integration
 
-The determinant API sketches below use local names. The production names of
-`det`, `detViaDivisor`, and their wrapper correspondence theorems belong in
+The executable wrappers `det` and `detViaDivisor` below belong in
 `Hex.ModularMatrix`, not `Hex.Matrix`: `Hex.Matrix.det` already denotes the
-Leibniz reference and cannot be redeclared. The shared production dispatcher
-is separately named `Hex.Det.det` in [hex-det](hex-det.md).
+Leibniz reference and cannot be redeclared. Their conditional correctness
+lemmas use that wrapper namespace. Mathlib correspondence remains in the
+companion namespace. Image, bound, and partial reconstruction operations
+remain in `Hex.Matrix`. The shared dispatcher is `Hex.Det.det` in
+[hex-det](hex-det.md), above this library.
 
-The modular library stays below `HexDet`. It must expose either the actual
-completion route of its total determinant routines, including Bareiss
-fallback, or partial operations with explicit fuel and seed parameters that
-let `HexDet` compose the same branches and report that route. The latter
-must use the production code paths so zero-fuel conformance can exercise
-fallback. No upward import of `HexDet` is required for either form.
+The total wrappers share this proposed executable interface:
+
+```lean
+namespace Hex.ModularMatrix
+
+inductive Method where
+  | modular | divisor | bareiss
+
+structure DetData where
+  value : Int
+  first : Method
+  rest : List Method
+
+def detWith (A : Hex.Matrix Int n n) (fuel seed : Nat)
+    (useDivisor : Bool) : DetData
+
+end Hex.ModularMatrix
+```
+
+`first :: rest` records attempted determinant methods in order. Its last
+entry is the method that supplied `value`. With `useDivisor = false`,
+`detWith` runs bounded modular reconstruction then Bareiss on exhaustion.
+With `useDivisor = true`, it first attempts the seeded divisor optimization,
+then ordinary modular reconstruction if the divisor attempt fails, and
+finally Bareiss if that reconstruction exhausts its budget. `fuel` bounds
+each attempted modular reconstruction and the divisor's bounded search.
+At zero fuel no modular or divisor attempt succeeds. Seed affects the
+divisor search only. The methods share the algorithm bodies described below.
+
+`det A` projects the value of `detWith A defaultFuel defaultSeed false`.
+`detViaDivisor A seed` projects `detWith A defaultFuel seed true`. The
+default fuel and seed are recorded implementation parameters. `HexDet`
+calls `detWith` with its own recorded parameters, converts this route to its
+public route type, and never guesses which fallback ran. Zero-fuel tests
+therefore exercise the production branches. The lower library never imports
+`HexDet`.
+
+The implementation owes `detWith_eq`, under
+`[Hex.Matrix.LawfulDetBound]`, asserting that every returned value equals
+`Hex.Matrix.det A`, and route equations for each success and failure branch.
+These are proposed obligations, not existing declarations. The correctness
+proofs of `det` and `detViaDivisor` project this shared result.
 
 ### One image
 
@@ -257,14 +295,23 @@ bound here as the fallback if a Mathlib-free consumer ever appears.
 moduli runs out before the bound is reached. -/
 def detModular? (A : Matrix Int n n) (fuel : Nat) : Option Int
 
-/-- The determinant. Falls back to `Hex.Matrix.bareiss` when the modular
-route does not finish. -/
-def det (A : Matrix Int n n) : Int
-
 theorem detModular?_eq [LawfulDetBound] (h : detModular? A fuel = some d) :
     d = Matrix.det A
-theorem det_eq [LawfulDetBound] (A : Matrix Int n n) :
-    det A = Matrix.det A
+```
+
+The total wrapper is in `Hex.ModularMatrix`:
+
+```lean
+namespace Hex.ModularMatrix
+
+/-- The determinant. Falls back to `Hex.Matrix.bareiss` when the modular
+route does not finish. -/
+def det (A : Hex.Matrix Int n n) : Int
+
+theorem det_eq [Hex.Matrix.LawfulDetBound] (A : Hex.Matrix Int n n) :
+    det A = Hex.Matrix.det A
+
+end Hex.ModularMatrix
 ```
 
 The loop folds one image per modulus into a `Crt` and stops when the
@@ -314,9 +361,13 @@ writes it, and it belongs in hex-basic rather than here. Then `d` divides
 that much smaller number.
 
 ```lean
+namespace Hex.ModularMatrix
+
 /-- The determinant, computed as a divisor found by lifting times a
 cofactor found by Chinese remaindering. -/
-def detViaDivisor (A : Matrix Int n n) : Int
+def detViaDivisor (A : Hex.Matrix Int n n) (seed : Nat) : Int
+
+end Hex.ModularMatrix
 ```
 
 Three things make this rigorous rather than heuristic, and the middle one
@@ -786,7 +837,8 @@ results. Writing `e` for hex-matrix-mathlib's `matrixEquiv`:
 ```lean
 instance : LawfulDetBound        -- from Matrix.norm_det_le_prod_norm_column
 
-theorem det_eq (A : Matrix Int n n) : det A = Matrix.det (e A)
+theorem det_eq (A : Hex.Matrix Int n n) :
+    Hex.ModularMatrix.det A = Matrix.det (e A)
 theorem rank_eq (A : Matrix Int n m) : rank A = Matrix.rank (e A)
 
 theorem solve_eq (h : solve? A b fuel = some (y, d)) :
@@ -869,7 +921,7 @@ HexModularMatrixMathlib.lean
 
 ```yaml
   HexModularMatrix:
-    deps: [HexModular, HexMatrix, HexRowReduce, HexDeterminant, HexModArith, HexArith, HexBasic]
+    deps: [HexModular, HexMatrix, HexRowReduce, HexDeterminant, HexBareiss, HexModArith, HexArith, HexBasic]
     mathlib: false
     done_through: 0
     status: planned
@@ -904,6 +956,7 @@ HexModularMatrixMathlib.lean
 
 `HexDeterminant` is a dependency for the row-operation determinant
 lemmas, not for the Leibniz determinant, which nothing here calls.
+`HexBareiss` supplies the total determinant fallback.
 `HexBasic` is for the random generator the determinant divisor draws
 its right-hand side from.
 

--- a/libraries.yml
+++ b/libraries.yml
@@ -397,7 +397,7 @@ libraries:
         - name: mv-poly
           description: Dimension, variable count, degree, support, and coefficient size over Int and Rat; Bareiss versus Berkowitz with nonconstant pivots.
         - name: dispatch
-          description: Tiny cases, both sides of measured cutoffs, modular fallback, and rings with zero divisors; dispatch versus its selected direct arm.
+          description: Tiny cases and rings with zero divisors, plus both sides of measured cutoffs and modular fallback when enabled; dispatch versus its selected direct arm.
   HexDetMathlib:
     deps: [HexDet, HexBareissMathlib, HexCharPolyMathlib, HexDeterminantMathlib, HexPolyMathlib, HexPolyFpMathlib, HexMvPolyMathlib]
     mathlib: true

--- a/libraries.yml
+++ b/libraries.yml
@@ -368,6 +368,36 @@ libraries:
     correspondence_only: true
     done_through: 0
     status: planned
+  HexDet:
+    deps: [HexBareiss, HexCharPoly, HexRowReduce, HexPolyFp, HexResultant, HexMvGcd]
+    mathlib: false
+    done_through: 0
+    status: planned
+    phase4:
+      comparators:
+        - tool: FLINT integer, rational, and prime-residue determinants via python-flint
+          class: informational
+          rationale: FLINT uses its own determinant selection and process protocol; internal adjacent-arm comparisons determine Hex dispatch policies.
+        - tool: SymPy Berkowitz determinant over exact polynomial domains
+          class: informational
+          rationale: Independent polynomial recurrence and Python process overhead provide conformance and timing context, not a dispatch cutoff.
+      input_families:
+        - name: integer
+          description: Dimension and coefficient-bit sweeps on dense, tridiagonal, triangular, singular, low-rank, and unimodular inputs; Bareiss, modular, and divisor comparisons. Initial Bareiss policy is unmeasured; record enabled constants and evidence in reports/hex-det-performance.md.
+        - name: field
+          description: Dimension, rational numerator and denominator size, and prime modulus; elimination versus Bareiss. Initial Bareiss policy is unmeasured; record enabled constants and evidence in reports/hex-det-performance.md.
+        - name: dense-poly
+          description: Dimension, degree, and coefficient size over Rat, prime ZMod64, and Int; Bareiss versus Berkowitz with nonconstant pivots.
+        - name: mv-poly
+          description: Dimension, variable count, degree, support, and coefficient size over Int and Rat; Bareiss versus Berkowitz with nonconstant pivots.
+        - name: dispatch
+          description: Tiny cases, both sides of measured cutoffs, modular fallback, and rings with zero divisors; dispatch versus its selected direct arm.
+  HexDetMathlib:
+    deps: [HexDet, HexBareissMathlib, HexCharPolyMathlib, HexDeterminantMathlib, HexPolyMathlib, HexPolyFpMathlib, HexMvPolyMathlib]
+    mathlib: true
+    correspondence_only: true
+    done_through: 0
+    status: planned
   HexCharPoly:
     deps: [HexMatrix, HexPoly]
     mathlib: false

--- a/libraries.yml
+++ b/libraries.yml
@@ -375,10 +375,16 @@ libraries:
     status: planned
     phase4:
       comparators:
-        - tool: FLINT integer, rational, and prime-residue determinants via python-flint
+        - tool: FLINT fmpz_mat.det() via python-flint
           class: informational
           rationale: FLINT uses its own determinant selection and process protocol; internal adjacent-arm comparisons determine Hex dispatch policies.
-        - tool: SymPy Berkowitz determinant over exact polynomial domains
+        - tool: FLINT fmpq_mat.det() via python-flint
+          class: informational
+          rationale: FLINT uses its own rational determinant selection; internal elimination versus Bareiss comparisons determine the field policy.
+        - tool: FLINT nmod_mat.det() via python-flint
+          class: informational
+          rationale: FLINT uses its own modular determinant selection; internal comparisons at the identical prime determine the field policy.
+        - tool: SymPy Matrix.det(method="berkowitz") over exact polynomial domains
           class: informational
           rationale: Independent polynomial recurrence and Python process overhead provide conformance and timing context, not a dispatch cutoff.
       input_families:


### PR DESCRIPTION
Consumers currently choose a determinant algorithm themselves. Specify `hex-det` as the production entry point, with tiny closed forms, carrier-specific policies, measured field and integer crossovers, and reporting of the algorithm that actually completed so matrix tactics can choose a proof strategy.

Policies explicitly carry algorithm parameters. The same `runWith` interpreter supports production defaults and forced-arm/fallback verification. The companion specifies value and route correctness, verifies the existing Bareiss/Berkowitz theorem paths, and identifies field-elimination, modular, and coefficient-structure prerequisites.

Register both libraries as planned with dependency and Phase-4 metadata and add them to the library index. Amend the modular-matrix SPEC to resolve its proposed `Hex.Matrix.det` collision with the existing Leibniz definition and specify the route-reporting interface needed by dispatch. This is specification only; no Lean implementation or Lake targets are added.

Validation: dependency DAG checker and its 12 tests, Phase-4 checker, release manifest checker, status parser, local Markdown links, all 14 cited theorem declarations, and `git diff --check`.

Closes #10180.
