### PR TITLE
spec: field inverse and linear solve with completeness contracts

### DIFF
--- a/HexRowReduce/SPEC/hex-row-reduce.md
+++ b/HexRowReduce/SPEC/hex-row-reduce.md
@@ -131,6 +131,7 @@ theorem inverse?_spec (A B : Matrix F n n) :
 theorem inverse?_isSome (A : Matrix F n n) :
     (inverse? A).isSome ↔ rowReduce_rank A = n
 
+/-- Convenience corollary of `inverse?_isSome`. -/
 theorem inverse?_eq_none (A : Matrix F n n) :
     inverse? A = none ↔ rowReduce_rank A ≠ n
 ```
@@ -150,6 +151,8 @@ The determinant form of completeness, `inverse? A = none ↔ det A = 0`,
 belongs to the companion, using `rank_eq` on `rowReduce_isRowReduced A`.
 The computational code decides only the rank test and does not evaluate a
 determinant. There is no fuel, search limit, or resource-failure return.
+This API exposes singularity through its completeness theorem. A separate
+witness-producing inverse operation is outside this extension's scope.
 
 ### Solve and inconsistency witness
 
@@ -176,6 +179,7 @@ theorem solve?_spec (A : Matrix F n m) (b : Vector F n) (s : SolveData A) :
 theorem solve?_isSome (A : Matrix F n m) (b : Vector F n) :
     (solve? A b).isSome ↔ ∃ x : Vector F m, A * x = b
 
+/-- Convenience corollary of `solve?_isSome`. -/
 theorem solve?_eq_none (A : Matrix F n m) (b : Vector F n) :
     solve? A b = none ↔ ¬ ∃ x : Vector F m, A * x = b
 
@@ -184,8 +188,12 @@ theorem solve_error (A : Matrix F n m) (b y : Vector F n) :
 
 theorem solve?_none_witness (A : Matrix F n m) (b : Vector F n) :
     solve? A b = none ↔
-      ∃ y : Vector F n, solve A b = .error y ∧
-        vecMul y A = 0 ∧ Vector.dotProduct y b ≠ 0
+      ∃ y : Vector F n, vecMul y A = 0 ∧ Vector.dotProduct y b ≠ 0
+
+/-- Uniqueness of the nullspace coefficients in a successful answer. -/
+theorem solve?_unique (A : Matrix F n m) (b : Vector F n) (s : SolveData A)
+    (c₁ c₂ : Vector F (m - rowReduce_rank A)) :
+    solve? A b = some s → s.2 * c₁ = s.2 * c₂ → c₁ = c₂
 ```
 
 `solve` is the witness-producing entry point; its `.error` means a proved
@@ -253,8 +261,11 @@ tactic selection and domain-certificate adapters belong to their consumers.
 
 ## Inverse and solve conformance
 
-Extend `conformance/HexRowReduce/{Conformance,EmitFixtures}.lean` and the
-existing oracle dispatch. Fixtures record dimensions explicitly (including
+Extend `conformance/HexRowReduce/{Conformance,EmitFixtures}.lean` and
+`scripts/oracle/matrix_flint.py`. Add carrier-tagged dispatch there, importing
+SymPy only for rational-function records. Preserve the existing rational and
+integer handlers used by the other matrix libraries. Add SymPy to the existing
+CI dependency step when implementing this extension. Fixtures record dimensions explicitly (including
 empty shapes), the carrier, `A`, `b`, and the returned inverse, particular
 solution and basis, or inconsistency witness. Exercise `Rat`, `ZMod64 p`
 with `[ZMod64.Bounds p] [ZMod64.PrimeModulus p]` and the field instance from
@@ -306,13 +317,29 @@ no cubic bit-complexity claim. Add modular dimension sweeps at a fixed prime
 and smaller rational-function dimensions `2, 4, 8` at fixed degree and
 coefficient height, recording those parameters separately.
 
+Represent each dimension sweep as a separate one-parameter registration per
+fixed carrier, height, and rank/consistency family, using a custom parameter
+schedule for the stated ladder. Represent each height sweep as a separate
+registration per fixed dimension and family. Use the harness's fixed,
+trial-major schedule for scientific measurements. The large dimensions and
+heights are scientific settings for manual shared-host runs, not CI inputs.
+For dimension registrations, configure the `verify` parameter to dimension
+`2` (`2n × n` or `n × 2n` for rectangular families), retaining the fixed
+coefficient height and rank/consistency family. For height registrations,
+use height `8` while retaining the fixed dimension and family. Use degree
+`1` and coefficient height `8` as the fixed rational-function family for both
+scientific runs and verification. Give verification minimal tuning budgets
+and repeat counts. Measure total `verify` time across registrations against
+the existing per-library warning and repository cap. Adjust only verification
+budgets if needed, retaining the scientific ladders and input families.
+
 Informational external comparisons use `fmpq_mat.inv()` and, for nonsingular
 square inputs with empty nullspace, `fmpq_mat.solve()`. Compare complete
 outputs on the same inputs, with construction outside timing. The general
 affine solution/witness surface has no matching python-flint callable;
 correctness still has the conformance checks above. Follow the shared-host
 schedule and retention rules in `SPEC/benchmarking.md`; extend the existing
-single CI job's smoke checks when implementing these targets.
+single CI job's `Bench verify` checks when implementing these targets.
 
 ## Complexity and benchmark contract
 

--- a/HexRowReduce/SPEC/hex-row-reduce.md
+++ b/HexRowReduce/SPEC/hex-row-reduce.md
@@ -1,6 +1,12 @@
 # hex-row-reduce (depends on hex-matrix)
 
-Executable row reduction (RREF over fields) plus span/nullspace machinery.
+Executable row reduction (RREF over fields), span/nullspace machinery, field
+inverse, and exact linear solve.
+
+In this computational SPEC, `Field` and `Ring` abbreviate `Lean.Grind.Field`
+and `Lean.Grind.Ring`; matrices and operations live in `Hex.Matrix`.
+The inverse and solve APIs below are required extensions, not existing
+implementation. They add no Mathlib or determinant dependency.
 
 **Row-echelon data and contracts:**
 
@@ -72,13 +78,13 @@ requires RREF (`[Field R]`).
 def IsRowReduced.nullspaceMatrix [Ring R] (E : IsRowReduced M D) : Matrix R m (m - D.rank)
 def IsRowReduced.nullspace [Ring R] (E : IsRowReduced M D) : Vector (Vector R m) (m - D.rank)
 def Matrix.nullspace [Field R] [DecidableEq R] (M : Matrix R n m) :
-    Vector (Vector R m) (m - rowReduce_rank)
+    Vector (Vector R m) (m - Matrix.rowReduce_rank M)
 ```
 
 **Key properties:**
-- `spanCoeffs_sound : E.spanCoeffs v = some c → rowCombination M c = v`
-- `spanCoeffs_complete : (∃ c, rowCombination M c = v) → (E.spanCoeffs v).isSome`
-- `spanContains_iff : E.spanContains v = true ↔ ∃ c, rowCombination M c = v`
+- `IsEchelonForm.spanCoeffs_sound : E.spanCoeffs v = some c → vecMul c M = v`
+- `IsRowReduced.spanCoeffs_complete : (∃ c, vecMul c M = v) → (E.toIsEchelonForm.spanCoeffs v).isSome`
+- `IsRowReduced.spanContains_iff : E.toIsEchelonForm.spanContains v = true ↔ ∃ c, vecMul c M = v`
 - `transform_mul_inv : ∃ Tinv, D.transform * Tinv = 1`
 - `freeCols_sorted`, `colPartition`, `colPartition_exclusive`
 - `pivotCols_injective`, `freeCols_injective` (from `_sorted`)
@@ -106,6 +112,208 @@ with `colPartition` (free columns telescope to `v[freeCols[l]]`; pivot columns
 follow from `pivot_one` / `above_pivot_zero` / `below_pivot_zero` / `zero_row`);
 package into `E.nullspaceMatrix * c = v`.
 
+## Field inverse and complete linear solve
+
+All new executable APIs and their computational contracts take
+`[Lean.Grind.Field F] [DecidableEq F]`, with `F : Type u` and dimensions
+`n m : Nat`. The following signatures specify new declarations in
+`Hex.Matrix`; theorem bodies are implementation obligations.
+
+### Inverse
+
+```lean
+def inverse? (A : Matrix F n n) : Option (Matrix F n n)
+
+theorem inverse?_spec (A B : Matrix F n n) :
+    inverse? A = some B →
+      A * B = Matrix.identity n ∧ B * A = Matrix.identity n
+
+theorem inverse?_isSome (A : Matrix F n n) :
+    (inverse? A).isSome ↔ rowReduce_rank A = n
+
+theorem inverse?_eq_none (A : Matrix F n n) :
+    inverse? A = none ↔ rowReduce_rank A ≠ n
+```
+
+Reduce the augmented system `[A | I]`, choosing pivots only in the `A`
+block. The existing `D := rowReduce A` already performs precisely these
+operations: `D.echelon = D.transform * A`, and `D.transform` is the
+transformed identity block. Return `some D.transform` exactly when
+`D.rank = n`; then `D.echelon = I`. The invertibility of the transform
+establishes both product identities. Do not test the rank of an unrestricted
+reduction of `[A | I]`: that augmented matrix has rank `n` even when `A`
+is singular.
+
+`rowReduce_rank A` is the definition `(rowReduce A).rank` in
+`HexRowReduce/Api.lean`, not a theorem identifying rank with a determinant.
+The determinant form of completeness, `inverse? A = none ↔ det A = 0`,
+belongs to the companion, using `rank_eq` on `rowReduce_isRowReduced A`.
+The computational code decides only the rank test and does not evaluate a
+determinant. There is no fuel, search limit, or resource-failure return.
+
+### Solve and inconsistency witness
+
+A solution stores a particular vector and a matrix whose columns are the
+existing canonical nullspace basis. Its type fixes the basis size from
+`A`, so a caller never supplies a rank witness.
+
+```lean
+abbrev SolveData (A : Matrix F n m) :=
+  Vector F m × Matrix F m (m - rowReduce_rank A)
+
+def solve (A : Matrix F n m) (b : Vector F n) :
+    Except (Vector F n) (SolveData A)
+
+def solve? (A : Matrix F n m) (b : Vector F n) : Option (SolveData A) :=
+  (solve A b).toOption
+
+theorem solve?_spec (A : Matrix F n m) (b : Vector F n) (s : SolveData A) :
+    solve? A b = some s →
+      A * s.1 = b ∧ s.2 = nullspaceBasisMatrix A ∧
+      ∀ x : Vector F m, A * x = b ↔
+        ∃ c : Vector F (m - rowReduce_rank A), x = s.1 + s.2 * c
+
+theorem solve?_isSome (A : Matrix F n m) (b : Vector F n) :
+    (solve? A b).isSome ↔ ∃ x : Vector F m, A * x = b
+
+theorem solve?_eq_none (A : Matrix F n m) (b : Vector F n) :
+    solve? A b = none ↔ ¬ ∃ x : Vector F m, A * x = b
+
+theorem solve_error (A : Matrix F n m) (b y : Vector F n) :
+    solve A b = .error y → vecMul y A = 0 ∧ Vector.dotProduct y b ≠ 0
+
+theorem solve?_none_witness (A : Matrix F n m) (b : Vector F n) :
+    solve? A b = none ↔
+      ∃ y : Vector F n, solve A b = .error y ∧
+        vecMul y A = 0 ∧ Vector.dotProduct y b ≠ 0
+```
+
+`solve` is the witness-producing entry point; its `.error` means a proved
+mathematical inconsistency. `solve?` only forgets that witness. Both are
+total over a field. A consumer needing a negative certificate calls `solve`
+once, rather than calling `solve?` and recomputing an elimination.
+
+Compute `D := rowReduce A`, `E := rowReduce_isRowReduced A`, and
+`c := D.transform * b`, sharing this reduction with basis construction.
+This is reduction of `[A | b]` with pivots restricted to the coefficient
+columns. If there is a row `i ≥ D.rank` with `c[i] ≠ 0`, return `.error y`
+where `i` is the first such row and `y` is row `i` of `D.transform`.
+`transform_mul` and `zero_row` give `yᵀ A = 0`; the same row of the
+transformed right-hand side gives `yᵀ b = c[i] ≠ 0`. Consequently no
+solution exists, since any `A * x = b` would imply `yᵀ b = 0`.
+
+Otherwise set every free coordinate of `x₀` to zero and set
+`x₀[D.pivotCols[j]] := c[j]` for each pivot row `j`. Return
+`.ok (x₀, E.nullspaceMatrix)`. Require that `x₀` has zero free coordinates
+and that the returned columns equal `Matrix.nullspace A` in its existing
+increasing free-column order. The zero-row test is necessary and sufficient:
+the RREF pivot equations give `D.echelon * x₀ = c`, and `transform_inv`
+transports this equality back to `A * x₀ = b`.
+
+For all solutions, apply the existing `nullspace_complete` to `x - x₀`;
+the converse uses `nullspace_sound` and linearity. The coefficient vector
+is unique: its coordinates are the free coordinates of `x - x₀`, since
+the free rows of the basis matrix form an identity. Thus the answer describes
+the entire affine solution set, including systems with nonzero nullity.
+The rank and basis always come from `A`, not from an augmented matrix with
+an extra pivot in the right-hand side.
+
+### Boundary cases
+
+These equations hold over every field, including characteristic two.
+
+| Input | Required answer and completeness check |
+| --- | --- |
+| `A : Matrix F 0 0` | `inverse? A = some (Matrix.identity 0)`. Rank is `0`; the empty determinant is `1`, so the `none` condition is false. Both inverse identities are equalities of empty matrices. |
+| `A : Matrix F 0 m`, empty `b` | Solve succeeds with `x₀ = 0` and basis `Iₘ`; there are no equations, and every vector is a solution. For `m = 0` this is the unique empty solution with an empty basis. |
+| `A : Matrix F n 0` | Solve succeeds with the empty vector and empty basis iff `b = 0`. Otherwise a coordinate vector at a nonzero entry of `b` is the inconsistency witness. |
+| `A = [[1, 0], [0, 0]]` | Inverse returns `none` (rank `1`, determinant `0`). For `b = [a, 0]`, solve returns `x₀ = [a, 0]` and basis column `[0, 1]`; singularity alone does not imply inconsistency. For `b = [a, 1]`, solve fails with witness `[0, 1]`. |
+| `A = [[1, 0, 0], [1, 0, 0]]`, `b = [0, 1]` | This inconsistent rectangular system reduces to a zero second coefficient row with transformed RHS `1`. Witness `y = [-1, 1]` satisfies `yᵀ A = 0`, `yᵀ b = 1`; `solve?` returns `none`. |
+| `A = [[0, 1, 1]]`, `b = [a]` | Solve returns `x₀ = [0, a, 0]` with basis columns `[1, 0, 0]`, `[0, -1, 1]`. Solutions are `[u, a - v, v]`; the leading free column is not mistaken for a pivot. |
+
+### Relationship to the domain rank certificate
+
+[hex-rank](../../SPEC/Libraries/hex-rank.md) specifies fraction-free
+elimination over domains with a checked numerator `adj` and nonzero
+`denom` for the inverse of a selected nonsingular minor. Division by
+`denom` takes place in a fraction field, or in the domain only when that
+denominator is a unit. A nonsingular integer matrix need not have an
+integer inverse.
+
+For a checked full-rank square certificate, write its selected submatrix
+as `B = P * A * Q`, where `P` and `Q` are the row and column permutation
+matrices determined by the selections. In the fraction field,
+`A⁻¹ = Q * (denom⁻¹ • adj) * P`. Dividing `adj` alone gives the inverse
+of `B`, so the selections must be undone; `adj` and `denom` need not be
+the literal adjugate and determinant for an arbitrary passing certificate.
+The field RREF route returns the inverse in the original indexing directly.
+The two routes agree by uniqueness of a two-sided inverse when interpreted
+over the same field. Neither library acquires a dependency on the other;
+tactic selection and domain-certificate adapters belong to their consumers.
+
+## Inverse and solve conformance
+
+Extend `conformance/HexRowReduce/{Conformance,EmitFixtures}.lean` and the
+existing oracle dispatch. Fixtures record dimensions explicitly (including
+empty shapes), the carrier, `A`, `b`, and the returned inverse, particular
+solution and basis, or inconsistency witness. Exercise `Rat`, `ZMod64 p`
+with `[ZMod64.Bounds p] [ZMod64.PrimeModulus p]` and the field instance from
+`HexPolyFp.PrimeField`, and `RationalFn Rat` (more generally the executable
+API accepts `RationalFn K` for any `Lean.Grind.Field K` with decidable
+equality). Carrier imports belong in conformance and bench drivers, not
+in the generic library.
+
+Include every boundary case above, invertible matrices requiring row swaps,
+tall and wide consistent systems, rank-deficient systems with non-leading
+pivots, inconsistent systems, and nonintegral rational coefficients. Modular
+fixtures include characteristic two and an odd prime. Rational-function
+fixtures include nonconstant denominators and pivots; check identities in
+`Rat(t)` exactly, without relying on evaluations at sample points.
+
+For `Rat`, compare inverse entries with python-flint `fmpq_mat.inv()` and
+unique square solutions with `fmpq_mat.solve()` (one-column RHS).
+[python-flint's solve contract](https://python-flint.readthedocs.io/en/latest/fmpq_mat.html#flint.fmpq_mat.solve)
+requires a square invertible coefficient matrix; its exception on a singular
+matrix does not certify that a particular RHS is inconsistent. For general
+systems use independent ranks of `A` and `[A | b]`, check `A * x₀ = b`,
+`A * N = 0`, and `rank N = m - rank A`, or check both witness identities.
+Use exact modular arithmetic for the analogous `ZMod64` checks. For rational
+functions use [SymPy DomainMatrix](https://docs.sympy.org/latest/modules/polys/domainmatrix.html)
+over `QQ.frac_field(t)` for inverse and RREF/rank checks of general systems.
+Do not compare arbitrary basis entries or particular solutions from different
+pivot conventions; compare the affine solution sets via these invariants.
+
+## Inverse and solve benchmarks
+
+Extend `bench/HexRowReduce/Bench.lean` with direct end-to-end coverage of
+`inverse?`, `solve`, and `solve?`, forcing all returned entries (including
+failure witnesses). Sweep square dimension `n = 4, 8, 16, 32, 64` at each
+fixed rational coefficient height `h = 8, 32, 128` bits, and sweep
+`h = 8, 16, 32, 64, 128, 256` at fixed dimensions `8` and `16`. Record
+actual numerator/denominator heights and use seeded dense inputs with
+nontrivial elimination. Separate full-rank, rank-`n - 1`, and rank-`n / 2`
+families, with both consistent and inconsistent RHSs for deficient inputs;
+add tall `2n × n` and wide `n × 2n` solve families. Construct and verify
+input ranks and consistency outside timing.
+
+The field-operation bound for inverse is `O(n³)`. For solve of rank `r`,
+reduction plus RHS multiplication and basis materialization costs
+`O(rn(n + m) + n² + m(m - r))` field operations/output work; do not rerun
+RREF to compute the dependent result size or the basis. The dimension model
+is cubic for dense fixed-aspect inputs with rank proportional to dimension.
+The height sweep measures bit cost, including coefficient growth; it makes
+no cubic bit-complexity claim. Add modular dimension sweeps at a fixed prime
+and smaller rational-function dimensions `2, 4, 8` at fixed degree and
+coefficient height, recording those parameters separately.
+
+Informational external comparisons use `fmpq_mat.inv()` and, for nonsingular
+square inputs with empty nullspace, `fmpq_mat.solve()`. Compare complete
+outputs on the same inputs, with construction outside timing. The general
+affine solution/witness surface has no matching python-flint callable;
+correctness still has the conformance checks above. Follow the shared-host
+schedule and retention rules in `SPEC/benchmarking.md`; extend the existing
+single CI job's smoke checks when implementing these targets.
+
 ## Complexity and benchmark contract
 
 For an `n × m` matrix of rank `r`, Gauss--Jordan reduction performs at most
@@ -119,7 +327,7 @@ free-column complement.  Prepared nullspace construction materializes the
 column-to-pivot-row lookup once and then writes `m(m - r)` output entries with
 constant-time lookup per entry; its fixed-aspect bound is quadratic.
 
-`bench/HexRowReduce/Bench.lean` gives all 12 advertised executable operations
+`bench/HexRowReduce/Bench.lean` gives the 12 existing executable operations
 direct mode-1 coverage:
 
 | Operations | Prepared state | Model |
@@ -142,7 +350,7 @@ python-flint's `fmpq_mat.rref()` through the shared persistent driver.  Both
 arms use the same dense `I + J` family; construction is cached during warmup,
 and each timed request returns only the integer rank.
 
-The remaining operations declare
+The remaining existing operations declare
 `no-comparable-surface-in-named-comparator`: Hex `rowReduce` returns the row
 transform that `fmpq_mat.rref()` omits; python-flint 0.9.0's `fmpq_mat` has no
 native nullspace callable; and span coefficients are transform-dependent

--- a/HexRowReduceMathlib/SPEC/hex-row-reduce-mathlib.md
+++ b/HexRowReduceMathlib/SPEC/hex-row-reduce-mathlib.md
@@ -52,3 +52,148 @@ theorem spanContains_iff_mem_span [Field R] [DecidableEq R]
 
 This makes our row-reduction computations computable witnesses for Mathlib's
 noncomputable rank/kernel/span definitions.
+
+**Span coefficients:** The soundness bridge accepts an `IsEchelonForm`;
+completeness of span testing above requires `IsRowReduced`.
+
+```lean
+theorem spanCoeffs_eq_linearCombination [Field R] [DecidableEq R]
+    {M : Hex.Matrix R n m} {D : Hex.Matrix.RowEchelonData R n m}
+    (E : Hex.Matrix.IsEchelonForm M D) (v : Vector R m) (c : Vector R n) :
+    E.spanCoeffs v = some c →
+      vectorEquiv v =
+        Fintype.linearCombination R (_root_.Matrix.row (matrixEquiv M)) (vectorEquiv c)
+```
+
+All four theorems above exist in
+`HexRowReduceMathlib/RankSpanNullspace.lean`, in namespace
+`HexMatrixMathlib`. In particular, `rank_eq` and `nullspace_span_eq_ker`
+require Mathlib `[Field R]` but no `DecidableEq R` when supplied a reduced
+witness; instantiating that witness with executable `rowReduce` additionally
+requires `[DecidableEq R]`.
+
+## Field inverse correspondence
+
+The inverse and solve theorems in this section and the next are required
+extensions, paired with the computational contracts in
+[hex-row-reduce](../../HexRowReduce/SPEC/hex-row-reduce.md#field-inverse-and-complete-linear-solve).
+They live in namespace `HexMatrixMathlib`. Their coefficient assumptions
+are Mathlib `[Field F] [DecidableEq F]`; the standard `Field.toGrindField`
+instance supplies the executable field laws on the same operations. Use
+`matrixEquiv` for matrices and `vectorEquiv` for vectors throughout.
+
+```lean
+theorem inverse?_eq_inv [Field F] [DecidableEq F]
+    (A B : Hex.Matrix F n n) :
+    Hex.Matrix.inverse? A = some B → matrixEquiv B = (matrixEquiv A)⁻¹
+
+theorem inverse?_eq_none [Field F] [DecidableEq F]
+    (A : Hex.Matrix F n n) :
+    Hex.Matrix.inverse? A = none ↔ (matrixEquiv A).det = 0
+```
+
+Together these require the full specification: under nonzero determinant,
+`Option.map matrixEquiv (Hex.Matrix.inverse? A) = some ((matrixEquiv A)⁻¹)`;
+under zero determinant the result is `none`. Transport the two product
+identities of computational `inverse?_spec` and use uniqueness of inverse.
+
+The pinned Mathlib names the noncomputable `Inv` instance `Matrix.inv`;
+`A⁻¹` is its nonsingular inverse, defined using `Ring.inverse A.det` and
+the adjugate in `Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean`.
+There is no separate `Matrix.nonsing_inv` definition in that file. The
+existing `Matrix.mul_nonsing_inv` and `Matrix.nonsing_inv_mul` require
+`IsUnit A.det`, over `[CommRing F]` and finite decidable square indices;
+a nonzero determinant over a field supplies this hypothesis. At singular
+input Mathlib's inverse is zero, whereas the executable returns `none`;
+no theorem should identify that `none` with an inverse witness.
+
+For determinant completeness, apply existing `rank_eq` to
+`Hex.Matrix.rowReduce_isRowReduced A`, identifying `rowReduce_rank A`
+with the Mathlib rank. Existing `Matrix.rank_of_det_ne_zero` in
+`Mathlib/LinearAlgebra/Matrix/Rank.lean` gives full rank over
+`[CommRing F] [IsDomain F]` with finite decidable square indices. The
+computational `inverse?_isSome` then gives success. Conversely, success
+and the transported product identity imply nonzero determinant by existing
+`Matrix.det_ne_zero_of_right_inverse` (commutative ring, nontrivial
+coefficients, finite decidable square indices). Thus `none` is equivalent
+to determinant zero without adding a determinant computation or dependency
+to `HexRowReduce`.
+
+## Linear solve correspondence and completeness
+
+```lean
+theorem solve?_spec [Field F] [DecidableEq F]
+    (A : Hex.Matrix F n m) (b : Vector F n) (s : Hex.Matrix.SolveData A) :
+    Hex.Matrix.solve? A b = some s →
+      (matrixEquiv A).mulVec (vectorEquiv s.1) = vectorEquiv b ∧
+      s.2 = Hex.Matrix.nullspaceBasisMatrix A ∧
+      ∀ x : Fin m → F,
+        (matrixEquiv A).mulVec x = vectorEquiv b ↔
+          x - vectorEquiv s.1 ∈
+            LinearMap.ker (_root_.Matrix.mulVecLin (matrixEquiv A))
+
+theorem solve?_eq_none [Field F] [DecidableEq F]
+    (A : Hex.Matrix F n m) (b : Vector F n) :
+    Hex.Matrix.solve? A b = none ↔
+      ¬ ∃ x : Fin m → F, (matrixEquiv A).mulVec x = vectorEquiv b
+```
+
+Also require the explicit parameter form of the solution-set theorem:
+for every successful result `s` and `x : Fin m → F`,
+
+```lean
+(matrixEquiv A).mulVec x = vectorEquiv b ↔
+  ∃ c : Fin (m - Hex.Matrix.rowReduce_rank A) → F,
+    x = vectorEquiv s.1 + (matrixEquiv s.2).mulVec c
+```
+
+The coefficients are unique because the returned columns are the computed
+basis with identity on the free coordinates. Use existing
+`nullspace_span_eq_ker (Hex.Matrix.rowReduce_isRowReduced A)` to identify
+the span of these columns with the kernel; the existing private
+`nullspace_linearIndependent` in `RankSpanNullspace.lean` takes `[Field F]`
+and an `IsRowReduced` witness. Reuse it within that module, or expose it
+if the new correspondence theorems live in a separate module. This gives
+an affine translate of the entire kernel, rather than only a residual
+check on one solution. The
+existing `vectorEquiv_mulVec` in `HexMatrixMathlib/Vector.lean` transports
+matrix-vector products over `[Semiring F]`.
+
+For every `Hex.Matrix.solve A b = .error y`, require
+`_root_.Matrix.vecMul (vectorEquiv y) (matrixEquiv A) = 0` and
+`dotProduct (vectorEquiv y) (vectorEquiv b) ≠ 0`. Moreover failure is
+equivalent to existence of such a left-kernel separator. Prove the
+constructive direction using the actual returned row of the RREF
+transform, and the converse by applying that row functional to a
+hypothetical solution. No resource bound or additional consistency
+hypothesis may appear in these completeness statements.
+
+## Verification and ownership
+
+Check the computational SPEC's boundary cases through these bridges:
+
+- For `0 × 0`, Mathlib's determinant is `1`, the inverse is the empty
+  identity, and solve returns the unique empty solution with no basis
+  columns. No theorem assumes a positive dimension.
+- For `0 × m`, the kernel is the full space and the returned basis is the
+  standard basis. For `n × 0`, consistency is exactly `b = 0`.
+- For singular `[[1, 0], [0, 0]]`, determinant zero forces inverse
+  failure, while RHS `[a, 0]` has the affine solution set `[a, t]`.
+- For `[[1, 0, 0], [1, 0, 0]]` with RHS `[0, 1]`, the returned separator
+  `[-1, 1]` has zero left product and dot product `1`, proving the
+  rectangular system inconsistent over any field.
+
+Instantiate the bridges on `Rat`, prime-modulus `ZMod64 p`, and
+`RationalFn Rat` with the corresponding Mathlib field structures on the
+same executable operations; carrier-specific bridge imports belong in
+conformance modules. Relating to `ZMod p` or `RatFunc Rat` further uses
+the respective carrier equivalences. The generic companion remains a
+correspondence layer and does not import those carrier libraries.
+
+`HexRowReduce` owns the exact FLINT/SymPy conformance and dimension/height
+benchmarks specified in its SPEC. This companion owns proof checks of the
+transported success, failure, and solution-set statements; it adds no
+benchmark executable. The domain certificate inverse described in hex-rank
+and the direct field inverse agree after transport to a common field and
+undoing the certificate's row/column selections, by uniqueness of inverse;
+that consumer-level comparison adds no dependency between the libraries.

--- a/HexRowReduceMathlib/SPEC/hex-row-reduce-mathlib.md
+++ b/HexRowReduceMathlib/SPEC/hex-row-reduce-mathlib.md
@@ -7,7 +7,7 @@ This library is a `correspondence-only-layer`.
 Computational conformance owner: `HexRowReduce`
 Computational performance owner: `HexRowReduce`
 
-Mathlib bridge for `hex-row-reduce`: connects our computable RREF / rank / span /
+Mathlib correspondence for `hex-row-reduce`: connects our computable RREF / rank / span /
 nullspace machinery to Mathlib's noncomputable linear-algebra definitions, via
 the base `matrixEquiv` from `hex-matrix-mathlib`.
 
@@ -23,7 +23,7 @@ theorem rank_eq [Field R]
 This is deliberately a theorem about a reduced row-echelon witness, not an
 arbitrary `IsEchelonForm`: the proof obtains the kernel dimension from the
 computed nullspace basis, whose completeness and independence require
-`IsRowReduced`. The bridge theorem uses Mathlib's `Field`; the executable
+`IsRowReduced`. The correspondence theorem uses Mathlib's `Field`; the executable
 row-reduction, span, and nullspace APIs in `HexRowReduce` use
 `Lean.Grind.Field` (and `DecidableEq` where computation requires it).
 
@@ -53,7 +53,7 @@ theorem spanContains_iff_mem_span [Field R] [DecidableEq R]
 This makes our row-reduction computations computable witnesses for Mathlib's
 noncomputable rank/kernel/span definitions.
 
-**Span coefficients:** The soundness bridge accepts an `IsEchelonForm`;
+**Span coefficients:** The soundness theorem accepts an `IsEchelonForm`;
 completeness of span testing above requires `IsRowReduced`.
 
 ```lean
@@ -78,9 +78,13 @@ The inverse and solve theorems in this section and the next are required
 extensions, paired with the computational contracts in
 [hex-row-reduce](../../HexRowReduce/SPEC/hex-row-reduce.md#field-inverse-and-complete-linear-solve).
 They live in namespace `HexMatrixMathlib`. Their coefficient assumptions
-are Mathlib `[Field F] [DecidableEq F]`; the standard `Field.toGrindField`
-instance supplies the executable field laws on the same operations. Use
-`matrixEquiv` for matrices and `vectorEquiv` for vectors throughout.
+are Mathlib `[Field F] [DecidableEq F]`, using the induced
+`Field.toGrindField` instance for the executable calls. Choose that instance
+before defining inputs and outputs, for example with
+`attribute [local instance 2000] Field.toGrindField` in examples. Do not assume
+it equals a separately installed `Lean.Grind.Field F` instance, or that
+results computed at another instance are directly accepted by these theorems.
+Use `matrixEquiv` for matrices and `vectorEquiv` for vectors throughout.
 
 ```lean
 theorem inverse?_eq_inv [Field F] [DecidableEq F]
@@ -143,7 +147,7 @@ for every successful result `s` and `x : Fin m → F`,
 
 ```lean
 (matrixEquiv A).mulVec x = vectorEquiv b ↔
-  ∃ c : Fin (m - Hex.Matrix.rowReduce_rank A) → F,
+  ∃! c : Fin (m - Hex.Matrix.rowReduce_rank A) → F,
     x = vectorEquiv s.1 + (matrixEquiv s.2).mulVec c
 ```
 
@@ -164,13 +168,14 @@ For every `Hex.Matrix.solve A b = .error y`, require
 `dotProduct (vectorEquiv y) (vectorEquiv b) ≠ 0`. Moreover failure is
 equivalent to existence of such a left-kernel separator. Prove the
 constructive direction using the actual returned row of the RREF
-transform, and the converse by applying that row functional to a
-hypothetical solution. No resource bound or additional consistency
-hypothesis may appear in these completeness statements.
+transform, and the converse by applying an arbitrary separating row
+functional to a hypothetical solution. No resource bound or additional
+consistency hypothesis may appear in these completeness statements.
 
 ## Verification and ownership
 
-Check the computational SPEC's boundary cases through these bridges:
+Check the computational SPEC's boundary cases through these
+correspondence theorems:
 
 - For `0 × 0`, Mathlib's determinant is `1`, the inverse is the empty
   identity, and solve returns the unique empty solution with no basis
@@ -183,12 +188,36 @@ Check the computational SPEC's boundary cases through these bridges:
   `[-1, 1]` has zero left product and dot product `1`, proving the
   rectangular system inconsistent over any field.
 
-Instantiate the bridges on `Rat`, prime-modulus `ZMod64 p`, and
-`RationalFn Rat` with the corresponding Mathlib field structures on the
-same executable operations; carrier-specific bridge imports belong in
-conformance modules. Relating to `ZMod p` or `RatFunc Rat` further uses
-the respective carrier equivalences. The generic companion remains a
-correspondence layer and does not import those carrier libraries.
+Exercise the carrier interpretations in a monorepo build-only module
+`Examples/RowReduce.lean`, registered in `HexReleaseExamples`, outside the
+generic companion's imports. These examples contain proof checks, not
+fixture emission or oracle tests.
+
+- `Rat`: computational conformance uses Lean's rational field instance.
+  Companion examples separately select the Mathlib-induced instance before
+  defining the matrices and calling inverse/solve. Equality of the two bundled
+  instances is not assumed. Transporting an already computed result between
+  them would require an additional explicit agreement proof.
+- `RationalFn Rat`: follow
+  [hex-rational-fn-mathlib's instance contract](../../HexRationalFnMathlib/SPEC/hex-rational-fn-mathlib.md#coefficient-instances-and-representation).
+  Choose the Mathlib-induced lightweight field on `Rat` before forming the
+  rational-function type, and the induced field on that type before forming
+  row-reduction calls. Use `HexRationalFnMathlib.field` and its equivalence
+  with `RatFunc Rat` for these examples. Computational fixtures separately
+  exercise the implementation with its executable instances. Changing
+  instance priorities does not convert previously defined values.
+- `ZMod64 p`: the tree provides an executable field under `Bounds p` and
+  `PrimeModulus p`, but no Mathlib `Field (ZMod64 p)`. For these examples,
+  transport the computational success and failure equations entrywise through
+  the existing `HexModArithMathlib.ZMod64.equiv` to `ZMod p`. Supply the prime
+  hypotheses for the executable and Mathlib fields. Multiplication, addition,
+  zero preservation and injectivity transport the inverse identities and
+  separating witness. Surjectivity also transports the quantified solution
+  and coefficient vectors, giving completeness and the affine solution set
+  over `ZMod p`. These example-level transport proofs are new obligations.
+  They use the ring equivalence without assuming a missing `toZMod_inv` lemma
+  or a Mathlib field structure on `ZMod64 p`, and do not require transporting
+  the elimination algorithm itself.
 
 `HexRowReduce` owns the exact FLINT/SymPy conformance and dimension/height
 benchmarks specified in its SPEC. This companion owns proof checks of the


### PR DESCRIPTION
Specify a direct field inverse and an exact linear solver with complete success and failure contracts. `solve?` returns a particular solution and the canonical nullspace basis; `solve` retains a constructive inconsistency witness. Inverse completeness uses computed rank in the computational library and determinant zero in the Mathlib companion.

The SPECs cover empty dimensions, singular but consistent systems, rectangular inconsistency, carrier conformance, dimension/height benchmarks, and the relationship to the domain rank certificate (including its row/column permutations). They distinguish existing theorem infrastructure from required new declarations and record the actual pinned Mathlib hypotheses. Carrier examples select field instances explicitly; prime-field certificates transport through the existing ring equivalence to `ZMod p`. The solve contracts include unique nullspace coefficients and failure equivalence with an arbitrary separating witness. Benchmark registrations separate scientific sweeps from reduced CI verification settings.

Validation: audited cited source signatures against pinned Mathlib; checked ten exact boundary/carrier examples with SymPy and python-flint, including empty inverse/solve; checked local Markdown links/fences; `git diff --check`; `python3 scripts/check_dag.py`. Documentation only; no Lean implementation or build in this issue.

Closes #10181.
