### PR TITLE
test: docs-only fast path probe (do not merge)

### DIFF
--- a/SPEC/CI.md
+++ b/SPEC/CI.md
@@ -397,3 +397,4 @@ class of CI work that genuinely cannot share a runner with existing
 work — e.g. a release workflow that runs on tag push only. Even
 then, the trigger, concurrency, single-job, and cache rules above
 all still apply.
+


### PR DESCRIPTION
Throwaway probe for https://github.com/kim-em/hex-dev/pull/10194: exercises the docs-only fast path on real CI. Will be closed, not merged.