### PR TITLE
chore(ci): cache dependencies and skip unrelated manual builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,9 @@ jobs:
       # below still run. Pushes to main and manual dispatches always build
       # in full. The allowlist is deliberately simple and permissive: a
       # missed edge case costs one slow-to-detect breakage on the next code
-      # PR, not a release.
+      # PR, not a release. The same pass also decides whether a full-build
+      # PR needs the manual: library/manual Lean and build-configuration
+      # changes do; bench, conformance, example, and automation changes do not.
       - name: Classify the change (docs-only fast path)
         id: classify
         env:
@@ -51,6 +53,7 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           docs_only=false
+          build_manual=true
           if [ "$EVENT_NAME" != pull_request ]; then
             reason="\`$EVENT_NAME\` event; only pull requests take the fast path"
           elif ! base="$(git merge-base "$BASE_SHA" HEAD 2>/dev/null)"; then
@@ -58,23 +61,43 @@ jobs:
           else
             mapfile -t changed < <(git diff --name-only "$base" HEAD)
             docs_only=true
+            build_manual=false
             reason="all ${#changed[@]} changed files match the docs-only allowlist"
-            [ "${#changed[@]}" -gt 0 ] || { docs_only=false; reason="no changed files against the merge base"; }
+            [ "${#changed[@]}" -gt 0 ] || {
+              docs_only=false
+              build_manual=true
+              reason="no changed files against the merge base"
+            }
             for f in "${changed[@]}"; do
+              if [ "$docs_only" = true ]; then
+                case "$f" in
+                  HexConway/SPEC/*) docs_only=false; reason="\`$f\` requires the Conway rebuild observation" ;;
+                  *.md|SPEC/*|PLAN/*|docs/*|reports/*|libraries.yml|AGENTS.md|.claude/*|LICENSE|.gitignore) ;;
+                  *) docs_only=false; reason="\`$f\` is outside the docs-only allowlist" ;;
+                esac
+              fi
               case "$f" in
-                HexConway/SPEC/*) docs_only=false; reason="\`$f\` requires the Conway rebuild observation"; break ;;
-                *.md|SPEC/*|PLAN/*|docs/*|reports/*|libraries.yml|AGENTS.md|.claude/*|LICENSE|.gitignore) ;;
-                *) docs_only=false; reason="\`$f\` is outside the docs-only allowlist"; break ;;
+                HexManual.lean|HexManual/*|lakefile.lean|lake-manifest.json|lean-toolchain)
+                  build_manual=true ;;
+                *.lean)
+                  case "$f" in
+                    bench/*|conformance/*|Examples/*) ;;
+                    *) build_manual=true ;;
+                  esac ;;
               esac
             done
           fi
           echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
+          echo "build_manual=$build_manual" >> "$GITHUB_OUTPUT"
           if [ "$docs_only" = true ]; then
             path="Docs-only fast path"
             detail="dependency installation, the Lean build and the verification tails are skipped."
-          else
+          elif [ "$build_manual" = true ]; then
             path="Full build"
-            detail="every step runs."
+            detail="the full graph, including HexManual, is built and verified."
+          else
+            path="Full build; HexManual skipped"
+            detail="the non-manual graph and verification tails run."
           fi
           echo "::notice title=CI path::$path: $reason"
           printf '## CI path\n\n**%s**: %s; %s\n' "$path" "$reason" "$detail" >> "$GITHUB_STEP_SUMMARY"
@@ -138,9 +161,11 @@ jobs:
       # --- System + Python deps (union of the bench comparator and the oracles) ---
       - name: Install system dependencies
         if: steps.classify.outputs.docs_only != 'true'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gap libgmp-dev libntl-dev pkg-config libpari-dev pari-gp singular
+        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
+        with:
+          packages: gap libgmp-dev libntl-dev pkg-config libpari-dev pari-gp singular
+          version: "1.0"
+          execute_install_scripts: true
       - name: Install Python dependencies (bench comparator + oracles)
         if: steps.classify.outputs.docs_only != 'true'
         run: |
@@ -182,14 +207,14 @@ jobs:
           test -d "$lean_prefix/lib/lean"
           echo "LD_LIBRARY_PATH=$lean_prefix/lib/lean:${LD_LIBRARY_PATH:-}" \
             >> "$GITHUB_ENV"
-      - name: Restore .lake/build (Hex modules only)
+      - name: Restore .lake/build (project modules)
         if: steps.classify.outputs.docs_only != 'true'
         id: hex-build-cache
         uses: actions/cache/restore@v4
         with:
           path: |
-            .lake/build/lib/lean/Hex*
-            .lake/build/ir/Hex*
+            .lake/build/lib/lean
+            .lake/build/ir
           key: lake-build-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}-${{ github.sha }}
           restore-keys: |
             lake-build-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}-
@@ -352,7 +377,7 @@ jobs:
             hexnumberfield_quadratic \
             hexnumberfieldtower_emit_fixtures hexgraphiso_emit_trace hexgraphiso_emit_campaign
       - name: Build HexManual
-        if: steps.classify.outputs.docs_only != 'true'
+        if: steps.classify.outputs.build_manual == 'true'
         run: lake build HexManual
       # --- Parallel verification tails (single job, in-job parallel steps) ---
       # Both tails only read the already-built .lake/build; they write to
@@ -446,13 +471,13 @@ jobs:
       # Save only a fully verified main snapshot. Pull-request caches are scoped
       # to their merge ref and cannot help another PR, so saving one per PR would
       # churn the repository's cache quota without providing shared reuse.
-      - name: Save .lake/build (Hex modules only; main only)
+      - name: Save .lake/build (project modules; main only)
         if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' && steps.hex-build-cache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |
-            .lake/build/lib/lean/Hex*
-            .lake/build/ir/Hex*
+            .lake/build/lib/lean
+            .lake/build/ir
           key: lake-build-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}-${{ github.sha }}
       # Publish only after every verification gate passes. R2 remains a
       # cross-runner fallback for a GitHub cache miss and for external consumers.

--- a/SPEC/CI.md
+++ b/SPEC/CI.md
@@ -75,7 +75,8 @@ Concretely:
   libraries, the bench exes, the conformance `#guard` drivers, and the
   emit-fixture exes — including the `HexBerlekampZassenhausMathlib`
   bridge required by integer-factorization correctness — followed by a
-  separate memory-bounded `lake build HexManual`). On pushes to `main` and on
+  separate memory-bounded `lake build HexManual` when manual or library Lean
+  inputs changed, and on every non-pull-request run). On pushes to `main` and on
   pull requests touching `HexConway/`, `HexConway.lean`, `HexGFq/`,
   `HexGFq.lean`, `HexGFqMathlib/`, `HexGFqMathlib.lean`, `scripts/conway/`, or
   `HexConway/SPEC/`, Conway and its companion first warm external imports, then
@@ -111,10 +112,11 @@ A pull request whose diff against its merge base touches only
 documentation and planning text takes a fast path through the same
 `build` job. An early step classifies the change from
 `git diff --name-only` against the merge base with the base branch and
-records the decision in the job summary; every step from dependency
-installation through the verification tails carries
-`if: steps.classify.outputs.docs_only != 'true'`, and the fail-closed
-gate passes trivially on that path. The structural lints and the Python
+records both the fast-path and manual-build decisions in the job summary.
+Every step from dependency installation through the verification tails,
+apart from the separately guarded manual build, carries
+`if: steps.classify.outputs.docs_only != 'true'`, and the fail-closed gate
+passes trivially on that path. The structural lints and the Python
 unit tests before that point (copyright headers, line counts, DAG,
 released manifest, manual split, `test_sync_released.py`, trust surface,
 Phase-4 and Phase-7 checks, conformance-matrix invariant) run on both
@@ -138,6 +140,14 @@ regardless of the changed files, so the cache snapshot and the Lake
 cache publish only ever come from a fully verified tree. The fast path is
 neither a second job nor a workflow-level `paths` filter: the required
 check stays the single `build` job and is reported green either way.
+
+Within the full-build path, `HexManual` runs for changes to `HexManual.lean`,
+`HexManual/**`, `lakefile.lean`, `lake-manifest.json`, `lean-toolchain`, and
+ordinary library `.lean` sources. It is skipped when the only non-documentation
+changes are under `bench/**`, `conformance/**`, or `Examples/**`, or affect CI
+automation and scripts without changing those inputs. A missing merge base or
+an empty diff fails closed and builds the manual. Every non-pull-request run
+also builds it unconditionally.
 
 ### Polynomial-factorization performance artifacts
 
@@ -296,6 +306,11 @@ repository's 10 GB cache quota without providing shared reuse. PRs and
 the Pages workflow restore the latest compatible `main` snapshot and
 let Lake rebuild their source delta.
 
+The cached Lean and IR directories cover every root-package module namespace,
+not only `Hex*`; in particular, the `Examples.*` release modules must survive a
+restore. Dependency packages keep their own build directories and are not part
+of this cache.
+
 Every build workflow installs the exact `lean-toolchain` pin through
 `scripts/ci/setup_lean_toolchain.sh`, which downloads the canonical GitHub
 release asset and verifies the reported version before placing its binaries on
@@ -309,8 +324,8 @@ verification gates pass.
 
 Coverage:
 
-- `.lake/build/lib/lean/Hex*` and `.lake/build/ir/Hex*` — the
-  project's own elaboration and IR outputs.
+- `.lake/build/lib/lean` and `.lake/build/ir` — the project's own elaboration
+  and IR outputs, including non-`Hex` namespaces such as `Examples`.
 - NOT Mathlib's build outputs — those come from `lake exe cache get`
   and are handled separately (see § Mathlib cache is mandatory).
 
@@ -381,7 +396,9 @@ To add a new conformance check, oracle, benchmark, or build target:
 1. **Default**: extend the script of the single `build` job in
    `ci.yml`. Conformance/oracle work goes in the conformance tail,
    build/check/benchmark work in the build phase or the bench tail.
-2. Add any new system dependency to the existing apt/brew step.
+2. Add any new system dependency to the cached apt package list. The list is
+   part of the cache key; bump its quoted `version` input only when manual
+   invalidation is required.
 3. Add any new Python or Lean dependency to the existing install
    step.
 4. Add a new sequential block to the helper script (e.g.


### PR DESCRIPTION
Closes #10193

## Summary
- cache the existing apt dependency set with a SHA-pinned package-cache action
- classify the manual build from the existing merge-base diff: library/manual/config changes include `HexManual`, while bench/conformance/example/automation-only PRs skip it; pushes and dispatches always include it
- restore and save both complete root-package Lean/IR directories so `Examples.*` outputs are reused
- update the CI doctrine to match

## Local verification
- `git diff --check` and PyYAML parsing
- CI structural/source checks and focused Python unit tests
- executed the workflow classifier against this rebased PR: `docs_only=false`, `build_manual=false`
- actionlint reports only the repository runner's pre-existing `background`/`wait-all` extensions

The cache path-set change intentionally creates a new actions/cache version. The first post-merge main run will be cold and seed the expanded cache; reuse of `Examples.*` is observable on subsequent PR runs.

A no-build Lake plan was attempted in the fresh worktree; without Mathlib/project artifacts Lake correctly reported the targets as out of date.