### PR TITLE
fix(ci): classify changes against the merge parent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           # The release-manifest admission check reads release-sync-baseline.
           fetch-depth: 0
       # --- Docs-only fast path (SPEC/CI.md § Docs-only fast path) ---
-      # A pull request whose diff against its merge base touches only
+      # A pull request whose diff against its merge parent touches only
       # documentation and planning text skips everything from dependency
       # installation onward; the structural lints and Python unit tests
       # below still run. Pushes to main and manual dispatches always build
@@ -50,23 +50,34 @@ jobs:
         id: classify
         env:
           EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
+          # On pull_request the checkout is the synthetic merge commit, so
+          # HEAD^1 is the base tip this tree was actually built on -- the
+          # exact delta under test, even when the payload's base SHA has
+          # since moved. Reading the diff from a file (NUL-separated, after
+          # checking git's exit status) keeps a failed diff from looking
+          # like a short allowlisted list.
+          base=
           docs_only=false
           build_manual=true
+          changed_paths="$RUNNER_TEMP/changed-paths"
           if [ "$EVENT_NAME" != pull_request ]; then
             reason="\`$EVENT_NAME\` event; only pull requests take the fast path"
-          elif ! base="$(git merge-base "$BASE_SHA" HEAD 2>/dev/null)"; then
-            reason="no merge base against \`$BASE_SHA\`"
+          elif ! git rev-parse -q --verify HEAD^2 >/dev/null; then
+            reason="HEAD is not a merge commit"
+          elif ! base="$(git rev-parse --verify HEAD^1)" \
+            || ! git diff --no-renames --name-only -z "$base" HEAD > "$changed_paths"; then
+            base=
+            reason="could not compute the changed paths"
           else
-            mapfile -t changed < <(git diff --no-renames --name-only "$base" HEAD)
+            mapfile -d '' -t changed < "$changed_paths"
             docs_only=true
             build_manual=false
             reason="all ${#changed[@]} changed files match the docs-only allowlist"
             [ "${#changed[@]}" -gt 0 ] || {
               docs_only=false
               build_manual=true
-              reason="no changed files against the merge base"
+              reason="no changed files against the merge parent"
             }
             for f in "${changed[@]}"; do
               if [ "$docs_only" = true ]; then
@@ -102,7 +113,7 @@ jobs:
           echo "::notice title=CI path::$path: $reason"
           printf '## CI path\n\n**%s**: %s; %s\n' "$path" "$reason" "$detail" >> "$GITHUB_STEP_SUMMARY"
           python3 scripts/ci/classify_changed_libraries.py \
-            --event "$EVENT_NAME" --base "$BASE_SHA" --github-output "$GITHUB_OUTPUT"
+            --event "$EVENT_NAME" --base "$base" --github-output "$GITHUB_OUTPUT"
       # --- Structural + source lints ---
       - run: python3 scripts/check_copyright_headers.py
       - name: Lint Lean file line counts (SPEC/CI.md §Source-file lints)

--- a/SPEC/CI.md
+++ b/SPEC/CI.md
@@ -124,11 +124,14 @@ Concretely:
 
 ### Docs-only fast path
 
-A pull request whose diff against its merge base touches only
-documentation and planning text takes a fast path through the same
+A pull request whose diff touches only documentation, planning text,
+reports and repository metadata takes a fast path through the same
 `build` job. An early step classifies the change from
-`git diff --name-only` against the merge base with the base branch and
-records both the fast-path and manual-build decisions in the job summary.
+`git diff --no-renames --name-only` between the tested merge commit and
+its base parent (`HEAD^1`) -- the exact delta under test, and the
+spelling that counts a source file renamed under an allowlisted path as
+a source change -- and records both the fast-path and manual-build
+decisions in the job summary.
 Every step from dependency installation through the verification tails,
 apart from the separately guarded manual build, carries
 `if: steps.classify.outputs.docs_only != 'true'`, and the fail-closed gate
@@ -161,14 +164,16 @@ Within the full-build path, `HexManual` runs for changes to `HexManual.lean`,
 `HexManual/**`, `lakefile.lean`, `lake-manifest.json`, `lean-toolchain`, and
 ordinary library `.lean` sources. It is skipped when the only non-documentation
 changes are under `bench/**`, `conformance/**`, or `Examples/**`, or affect CI
-automation and scripts without changing those inputs. A missing merge base or
-an empty diff fails closed and builds the manual. Every non-pull-request run
-also builds it unconditionally.
+automation and scripts without changing those inputs. A non-merge `HEAD`, an
+unreadable diff, or an empty diff fails closed and builds the manual. Every
+non-pull-request run also builds it unconditionally.
 
 ### Polynomial-factorization performance artifacts
 
-Every pull request runs two deterministic checks for the published integer
-polynomial factorization comparison:
+Every full-path pull request and every push to `main` runs two
+deterministic checks for the published integer polynomial factorization
+comparison (a docs-only PR skips them, even when it edits `reports/`;
+see § Docs-only fast path):
 
 - `scripts/bench/check_factor_sweep_freshness.py` requires a complete,
   cross-checked current-corpus measurement for Hex, FLINT, NTL, PARI, Isabelle


### PR DESCRIPTION
This PR diffs the tested merge commit against `HEAD^1`, the base tip the tree was actually built on, rather than a merge base recomputed from the event payload's base SHA, which can name an older tip than the merge GitHub built. The changed paths are read NUL-separated from a file after checking `git diff`'s exit status, so a failed diff falls back to the full build instead of being misread as a short allowlisted list; a non-merge `HEAD` falls back the same way, for both the docs-only decision and the manual build. `scripts/ci/classify_changed_libraries.py` takes the same resolved base, so the fast-path decision and the library scope are computed from one range.

SPEC/CI.md now says the performance-freshness checks run on every full-path pull request and every `main` push, since a docs-only PR may edit `reports/` and skips them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)