### PR TITLE
chore(ci): scope verification tails to changed libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           elif ! base="$(git merge-base "$BASE_SHA" HEAD 2>/dev/null)"; then
             reason="no merge base against \`$BASE_SHA\`"
           else
-            mapfile -t changed < <(git diff --name-only "$base" HEAD)
+            mapfile -t changed < <(git diff --no-renames --name-only "$base" HEAD)
             docs_only=true
             build_manual=false
             reason="all ${#changed[@]} changed files match the docs-only allowlist"
@@ -101,6 +101,8 @@ jobs:
           fi
           echo "::notice title=CI path::$path: $reason"
           printf '## CI path\n\n**%s**: %s; %s\n' "$path" "$reason" "$detail" >> "$GITHUB_STEP_SUMMARY"
+          python3 scripts/ci/classify_changed_libraries.py \
+            --event "$EVENT_NAME" --base "$BASE_SHA" --github-output "$GITHUB_OUTPUT"
       # --- Structural + source lints ---
       - run: python3 scripts/check_copyright_headers.py
       - name: Lint Lean file line counts (SPEC/CI.md §Source-file lints)
@@ -127,6 +129,8 @@ jobs:
       - name: Run bench source lints (SPEC/benchmarking.md)
         run: |
           python3 -m unittest scripts/ci/test_check_benches_mathlib_free.py
+          python3 -m unittest scripts/ci/test_check_bench_verify_budget.py
+          python3 -m unittest scripts/ci/test_classify_changed_libraries.py
           python3 -m unittest scripts/ci/test_check_persistent_flint_warmup.py
           python3 -m unittest scripts/bench/test_fresh_module_sweep.py
           python3 -m unittest scripts/bench/test_rationalfn_flint.py
@@ -395,35 +399,42 @@ jobs:
         env:
           # Hard cap per SPEC/benchmarking.md §CI integration "Time budget".
           BENCH_VERIFY_HARD_CAP_SECONDS: "360"
+          HEX_LIBRARY_FILTER: ${{ steps.classify.outputs.library_filter }}
         run: |
           bash scripts/ci/check_bench_verify_budget.sh \
-            hextruncatedseries_bench \
-            hexarith_bench hexpoly_bench hexpolyfast_bench hexrationalfn_bench hexpolysmith_bench \
-            hexmvpoly_bench hexmvgcd_bench \
-            hexpolyz_bench \
-            hexpolyzgcd_bench hexsparsepoly_bench hexpolyfp_bench \
-            hexmodarith_bench \
-            hexmodular_bench \
-            hexgf2_bench hexgfqring_bench hexgfqfield_bench hexgfq_bench \
-            hexhensel_bench hexprimality_bench hexintfactor_bench \
-            hexberlekamp_bench hexbz_bench \
-            hexconway_bench hexdeterminant_bench hexmatrix_bench hexrowreduce_bench \
-            hexhermite_bench hexsmith_bench \
-            hexcharpoly_bench hexminpoly_bench \
-            hexgramschmidt_bench hexlatticeenum_bench hexlll_gram_bench \
-            hexrealroots_bench hexrcf_bench hexroots_bench \
-            hexresultant_bench hexnumberfield_bench \
-            hexnumberfieldtower_bench hexinterval_decision_bench \
-            hexgraphiso_bench \
-            hexpermgroup_bench
+            HexTruncatedSeries=hextruncatedseries_bench \
+            HexArith=hexarith_bench HexPoly=hexpoly_bench \
+            HexPolyFast=hexpolyfast_bench HexRationalFn=hexrationalfn_bench \
+            HexPolySmith=hexpolysmith_bench HexMvPoly=hexmvpoly_bench \
+            HexMvGcd=hexmvgcd_bench HexPolyZ=hexpolyz_bench \
+            HexPolyZGcd=hexpolyzgcd_bench HexSparsePoly=hexsparsepoly_bench \
+            HexPolyFp=hexpolyfp_bench HexModArith=hexmodarith_bench \
+            HexModular=hexmodular_bench HexGF2=hexgf2_bench \
+            HexGFqRing=hexgfqring_bench HexGFqField=hexgfqfield_bench \
+            HexGFq=hexgfq_bench HexHensel=hexhensel_bench \
+            HexPrimality=hexprimality_bench HexIntFactor=hexintfactor_bench \
+            HexBerlekamp=hexberlekamp_bench HexBerlekampZassenhaus=hexbz_bench \
+            HexConway=hexconway_bench HexDeterminant=hexdeterminant_bench \
+            HexMatrix=hexmatrix_bench HexRowReduce=hexrowreduce_bench \
+            HexHermite=hexhermite_bench HexSmith=hexsmith_bench \
+            HexCharPoly=hexcharpoly_bench HexMinPoly=hexminpoly_bench \
+            HexGramSchmidt=hexgramschmidt_bench HexLatticeEnum=hexlatticeenum_bench \
+            HexLLL=hexlll_gram_bench HexRealRoots=hexrealroots_bench \
+            HexRCF=hexrcf_bench HexRoots=hexroots_bench \
+            HexResultant=hexresultant_bench HexNumberField=hexnumberfield_bench \
+            HexNumberFieldTower=hexnumberfieldtower_bench \
+            HexInterval=hexinterval_decision_bench HexGraphIso=hexgraphiso_bench \
+            HexPermGroup=hexpermgroup_bench
           # These two interval scheduler spikes are exact logical-count
           # canaries rather than lean-bench timing registrations. Build them
           # above and exercise their fixtures directly here.
-          .lake/build/bin/hex_interval_scheduler_spike canary
-          .lake/build/bin/hex_interval_policy_frontier_spike canary
-          # The decision target has fixed timing registrations above plus a
-          # separate canonical logical policy-comparison canary.
-          .lake/build/bin/hexinterval_decision_bench canary
+          if [ -z "$HEX_LIBRARY_FILTER" ] || [[ " $HEX_LIBRARY_FILTER " == *" HexInterval "* ]]; then
+            .lake/build/bin/hex_interval_scheduler_spike canary
+            .lake/build/bin/hex_interval_policy_frontier_spike canary
+            # The decision target has fixed timing registrations above plus a
+            # separate canonical logical policy-comparison canary.
+            .lake/build/bin/hexinterval_decision_bench canary
+          fi
           touch "$RUNNER_TEMP/bench.ok"
       - name: Conformance oracles + BZ gates
         if: steps.classify.outputs.docs_only != 'true'
@@ -437,24 +448,35 @@ jobs:
           HEX_EMIT_JOBS: "1"
           # Missing comparator packages are release failures, not green skips.
           HEX_REQUIRE_ORACLES: "1"
+          HEX_LIBRARY_FILTER: ${{ steps.classify.outputs.library_filter }}
         run: |
-          python3 -m unittest scripts/oracle/test_graphiso_trace.py scripts/bench/test_graphiso_compare.py
-          .lake/build/bin/hexgraphiso_emit_trace > /tmp/graphiso-trace.jsonl
-          python3 scripts/oracle/graphiso_trace.py /tmp/graphiso-trace.jsonl
-          .lake/build/bin/hexgraphiso_emit_campaign | python3 scripts/oracle/graphiso_nauty.py
-          .lake/build/bin/tower_factor_diff
-          # The compiled quadratic regression uses <100 MiB RSS locally.
-          # Keep generous catastrophic-regression limits, outside elaboration.
-          sudo systemd-run --wait --pipe --collect \
-            -p MemoryMax=1G -p MemorySwapMax=0 -p CPUQuota=100% -p RuntimeMaxSec=30 \
-            "$PWD/.lake/build/bin/hexnumberfield_quadratic" regression 20
+          selected() { [ -z "$HEX_LIBRARY_FILTER" ] || [[ " $HEX_LIBRARY_FILTER " == *" $1 "* ]]; }
+          echo "Conformance check library filter: ${HEX_LIBRARY_FILTER:-all libraries (no filter)}"
+          if selected HexGraphIso; then
+            python3 -m unittest scripts/oracle/test_graphiso_trace.py scripts/bench/test_graphiso_compare.py
+            .lake/build/bin/hexgraphiso_emit_trace > /tmp/graphiso-trace.jsonl
+            python3 scripts/oracle/graphiso_trace.py /tmp/graphiso-trace.jsonl
+            .lake/build/bin/hexgraphiso_emit_campaign | python3 scripts/oracle/graphiso_nauty.py
+          fi
+          if selected HexNumberFieldTower; then
+            .lake/build/bin/tower_factor_diff
+          fi
+          if selected HexNumberField; then
+            # The compiled quadratic regression uses <100 MiB RSS locally.
+            # Keep generous catastrophic-regression limits, outside elaboration.
+            sudo systemd-run --wait --pipe --collect \
+              -p MemoryMax=1G -p MemorySwapMax=0 -p CPUQuota=100% -p RuntimeMaxSec=30 \
+              "$PWD/.lake/build/bin/hexnumberfield_quadratic" regression 20
+          fi
           bash scripts/ci/run_oracles.sh
           # Deterministic anti-regression gate: a recombination blow-up,
           # unexpected method downgrade, or unexpected decline/fallback fails the
           # merge even though it would still factor correctly.
-          python3 scripts/oracle/bz_trace_gate.py
-          # Catastrophic (order-of-magnitude) slow-downs trip this generous cap.
-          timeout 180 lake exe hexbz_emit_fixtures > /dev/null
+          if selected HexBerlekampZassenhaus; then
+            python3 scripts/oracle/bz_trace_gate.py
+            # Catastrophic (order-of-magnitude) slow-downs trip this generous cap.
+            timeout 180 lake exe hexbz_emit_fixtures > /dev/null
+          fi
           touch "$RUNNER_TEMP/conformance.ok"
       - wait-all:
       - name: Gate on parallel verification results (fail-closed)

--- a/SPEC/CI.md
+++ b/SPEC/CI.md
@@ -97,6 +97,22 @@ Concretely:
   [SPEC/benchmarking.md §CI integration](benchmarking.md), `verify` is a
   smoke gate (does the bench module compile and run?), not a timing
   measurement; timing-relevant runs are collected manually on the shared host.
+
+  On pull requests, these two verification tails are scoped to the libraries
+  that own changed source, bench, conformance, fixture, or oracle paths. The
+  classifier uses `libraries.yml` ownership and the pull request's diff against
+  its merge base; changes to shared infrastructure and unclassified non-documentation
+  paths select every library. It reports both the selected library names and the
+  paths that caused the selection. This is deliberately an owner-only filter:
+  dependents are not added, so a change to `HexPoly` runs only `HexPoly`'s oracle
+  and bench verify. If an owning library has no oracle tuple or bench executable,
+  that verification tail has no per-library work for the change; downstream
+  coverage remains deferred to `main` by design.
+  The full conformance target set still builds before the tails, so this does
+  not weaken compile coverage. Pushes to `main` and manual runs leave the
+  filter empty and run every oracle, library-specific gate, and bench verify.
+  The oracle log records wall time for each tuple, and the bench log records
+  wall time for each executable.
 - Conformance used to be a second workflow (`conformance.yml`). It was
   folded into this job because a separate workflow re-elaborated the
   entire hex graph on a second runner — pure duplicated compute. Sharing

--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -957,8 +957,10 @@ different settings layers — see [§Harness](#harness-lean-bench).
 
 The cap is enforced by
 `scripts/ci/check_bench_verify_budget.sh`, invoked at the tail of
-the `Bench verify` step. It wraps the per-library `lake exe X_bench
-verify` invocations (capturing wallclock per invocation), prints a
+the `Bench verify` step. CI passes explicit `Library=X_bench` ownership
+pairs so pull-request filtering cannot depend on executable-name inference.
+The script wraps the per-library `lake exe X_bench verify` invocations,
+captures wallclock per invocation, prints a
 sorted breakdown, logs the soft warnings, and exits non-zero if the
 total exceeds the hard cap.
 

--- a/SPEC/testing.md
+++ b/SPEC/testing.md
@@ -180,6 +180,19 @@ on the repository style guide's banned-vocabulary list.
 
 ## Oracle discipline
 
+On pull requests, external-oracle execution is filtered to the libraries that
+own paths changed against the merge base. Ownership includes library source,
+`bench/<Lib>/`, `conformance/<Lib>/`, `conformance-fixtures/<Lib>/`, and the
+oracle scripts consumed by a library's tuple. Shared CI, Lake, GitHub workflow,
+`Hex/`, common-oracle infrastructure, and unclassified non-documentation paths
+select all libraries. The filter does not include downstream dependents: a
+`HexPoly` change runs the `HexPoly` oracle tuple, not every consumer of `HexPoly`.
+A library with no oracle tuple contributes no oracle execution on its own PR.
+This scoping applies only to oracle and bench execution; CI continues to build
+all conformance and emit-fixture targets.
+Pushes to `main` and manual runs execute the complete suite, catching any
+downstream fixture breakage omitted from a pull request run.
+
 Every operation in a library's SPEC API surface that is exercised by fixtures
 via `conformance/HexFoo/EmitFixtures.lean` MUST have an external-oracle
 cross-check that satisfies all three rules below. A SPEC declaration

--- a/scripts/ci/check_bench_verify_budget.sh
+++ b/scripts/ci/check_bench_verify_budget.sh
@@ -3,7 +3,7 @@
 # "Time budget" subsection.
 #
 # Runs `lake exe X_bench list && lake exe X_bench verify` for each
-# bench-exe name passed on stdin or as args, captures wallclock per
+# bench specification passed as `Library=X_bench`, captures wallclock per
 # invocation, prints a sorted breakdown, emits `::warning::`
 # annotations for libraries over the per-library soft threshold, and
 # exits non-zero if the total wallclock exceeds the hard cap.
@@ -18,6 +18,8 @@
 #                                  for the initial rollout per HO-35
 #                                  so we collect telemetry before
 #                                  flipping the switch.
+#   HEX_LIBRARY_FILTER            optional whitespace-separated library
+#                                  names; empty or unset means all libraries.
 #
 # Run from the repository root, after `lake build`. Intended for
 # `.github/workflows/ci.yml`'s `build` job; also safe to run locally.
@@ -29,9 +31,42 @@ hard_cap="${BENCH_VERIFY_HARD_CAP_SECONDS:-600}"
 warn_only="${BENCH_VERIFY_WARN_ONLY:-0}"
 
 if [ "$#" -eq 0 ]; then
-  echo "usage: $0 <bench_exe_name> [<bench_exe_name> ...]" >&2
+  echo "usage: $0 <Library=bench_exe_name> [<Library=bench_exe_name> ...]" >&2
   exit 2
 fi
+
+library_selected() {
+  local wanted="$1"
+  [ -z "${HEX_LIBRARY_FILTER:-}" ] || [[ " $HEX_LIBRARY_FILTER " == *" $wanted "* ]]
+}
+
+if [ -z "${HEX_LIBRARY_FILTER:-}" ]; then
+  echo "Bench verify library filter: all libraries (no filter)"
+else
+  echo "Bench verify library filter: $HEX_LIBRARY_FILTER"
+fi
+
+filtered_benches=()
+for specification in "$@"; do
+  if [[ "$specification" == *=* ]]; then
+    library="${specification%%=*}"
+    bench="${specification#*=}"
+    if [ -z "$library" ] || [ -z "$bench" ]; then
+      echo "invalid bench specification: $specification" >&2
+      exit 2
+    fi
+  else
+    if [ -n "${HEX_LIBRARY_FILTER:-}" ]; then
+      echo "filtered runs require Library=bench_executable: $specification" >&2
+      exit 2
+    fi
+    bench="$specification"
+    library=""
+  fi
+  if library_selected "$library"; then
+    filtered_benches+=("$bench")
+  fi
+done
 
 # `gha_warn`: emit a workflow-command warning when running under GitHub
 # Actions (where `$GITHUB_ACTIONS == true`); otherwise just print to
@@ -49,7 +84,7 @@ results_file="$(mktemp)"
 trap 'rm -f "$results_file"' EXIT
 
 total=0
-for bench in "$@"; do
+for bench in "${filtered_benches[@]}"; do
   echo "::group::$bench"
   start=$(date +%s)
   # Run list + verify as a pair. GitHub Actions builds these executables

--- a/scripts/ci/classify_changed_libraries.py
+++ b/scripts/ci/classify_changed_libraries.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Classify a CI change by the libraries that own its changed paths."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from libgraph import library_owner_for_path, load_libraries, topological_order
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHARED_PREFIXES = ("Hex/", "scripts/ci/", ".github/")
+SHARED_PATHS = {
+    "scripts/oracle/common.py",
+    "lakefile.lean",
+    "lake-manifest.json",
+    "lean-toolchain",
+}
+OWNED_TEST_ROOTS = {"bench", "conformance", "conformance-fixtures"}
+IGNORED_PATHS = {"libraries.yml", "AGENTS.md", "LICENSE", ".gitignore"}
+IGNORED_PREFIXES = ("SPEC/", "PLAN/", "docs/", "reports/", ".claude/")
+ORACLE_ALIASES = {
+    "bz": "HexBerlekampZassenhaus",
+    "graphiso": "HexGraphIso",
+    "matrixcarriers": "HexDeterminant",
+}
+
+
+@dataclass(frozen=True)
+class Classification:
+    libraries: tuple[str, ...]
+    all_libraries: bool
+    reason: str
+
+    @property
+    def library_filter(self) -> str:
+        # The verification scripts define an empty filter as the full suite.
+        return "" if self.all_libraries else " ".join(self.libraries)
+
+
+def _normalise(name: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", name.lower())
+
+
+def _closest_library(name: str, library_names: set[str]) -> str | None:
+    """Return the longest library name that prefixes an auxiliary path name."""
+    normalised = _normalise(name)
+    matches = [
+        library
+        for library in library_names
+        if normalised.startswith(_normalise(library))
+    ]
+    return max(matches, key=len, default=None)
+
+
+def _is_documentation(path: str) -> bool:
+    return (
+        path.endswith(".md")
+        or path in IGNORED_PATHS
+        or path.startswith(IGNORED_PREFIXES)
+    )
+
+
+def load_oracle_owners(repo_root: Path = REPO_ROOT) -> dict[str, set[str]]:
+    """Read the oracle runner's public tuple listing, keyed by script path."""
+    result = subprocess.run(
+        ["bash", "scripts/ci/run_oracles.sh", "--list"],
+        cwd=repo_root,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    owners: dict[str, set[str]] = {}
+    for line in result.stdout.splitlines():
+        owner, _emit, oracle, _fixture = line.split("|", 3)
+        owners.setdefault(oracle, set()).add(owner)
+    return owners
+
+
+def classify_paths(
+    paths: list[str],
+    *,
+    oracle_owners: dict[str, set[str]],
+) -> Classification:
+    libraries = load_libraries()
+    library_names = set(libraries)
+    selected: set[str] = set()
+    reasons: list[str] = []
+
+    for raw_path in paths:
+        path = raw_path.removeprefix("./")
+        if path in SHARED_PATHS or path.startswith(SHARED_PREFIXES):
+            return Classification((), True, f"shared infrastructure changed: {path}")
+
+        owner = library_owner_for_path(Path(path), libraries)
+        if owner == "Hex":
+            return Classification((), True, f"shared library infrastructure changed: {path}")
+        if owner == "HexGraph":
+            selected.add("HexGraphIso")
+            reasons.append(f"{path} -> HexGraphIso")
+            continue
+        if owner in library_names:
+            selected.add(owner)
+            reasons.append(f"{path} -> {owner}")
+            continue
+
+        parts = Path(path).parts
+        if len(parts) >= 2 and parts[0] in OWNED_TEST_ROOTS:
+            owner = _closest_library(parts[1], library_names)
+            if owner is None:
+                return Classification((), True, f"unowned test path changed: {path}")
+            selected.add(owner)
+            reasons.append(f"{path} -> {owner}")
+            continue
+
+        if len(parts) == 3 and parts[:2] == ("scripts", "oracle"):
+            if path in oracle_owners:
+                owners = oracle_owners[path]
+            else:
+                stem = Path(path).stem.removeprefix("test_")
+                normalised_stem = _normalise(stem)
+                alias = next(
+                    (
+                        library
+                        for prefix, library in ORACLE_ALIASES.items()
+                        if normalised_stem.startswith(prefix)
+                    ),
+                    None,
+                )
+                inferred = alias or _closest_library(f"Hex{stem}", library_names)
+                if inferred is None:
+                    return Classification((), True, f"shared or unowned oracle changed: {path}")
+                owners = {inferred}
+            selected.update(owners)
+            reasons.append(f"{path} -> {','.join(sorted(owners))}")
+            continue
+
+        if _is_documentation(path):
+            continue
+
+        return Classification((), True, f"unclassified path changed: {path}")
+
+    if not selected:
+        return Classification((), True, "no changed path mapped to a library")
+
+    ordered = tuple(name for name in topological_order(libraries) if name in selected)
+    detail = "; ".join(reasons)
+    return Classification(ordered, False, detail)
+
+
+def changed_paths(base_sha: str, head: str = "HEAD") -> list[str]:
+    merge_base = subprocess.run(
+        ["git", "merge-base", base_sha, head],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    ).stdout.strip()
+    output = subprocess.run(
+        ["git", "diff", "--no-renames", "--name-only", "-z", merge_base, head],
+        cwd=REPO_ROOT,
+        check=True,
+        stdout=subprocess.PIPE,
+    ).stdout
+    return [part.decode("utf-8", "surrogateescape") for part in output.split(b"\0") if part]
+
+
+def write_github_output(path: Path, classification: Classification) -> None:
+    with path.open("a", encoding="utf-8") as output:
+        output.write(f"library_filter={classification.library_filter}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event", required=True)
+    parser.add_argument("--base")
+    parser.add_argument("--github-output", type=Path, required=True)
+    args = parser.parse_args()
+
+    if args.event != "pull_request":
+        classification = Classification((), True, f"{args.event} event runs the full suite")
+    elif not args.base:
+        classification = Classification((), True, "pull request base SHA is unavailable")
+    else:
+        try:
+            paths = changed_paths(args.base)
+            classification = classify_paths(paths, oracle_owners=load_oracle_owners())
+        except (OSError, subprocess.CalledProcessError, ValueError) as error:
+            classification = Classification((), True, f"classification failed: {error}")
+
+    write_github_output(args.github_output, classification)
+    scope = "all libraries" if classification.all_libraries else " ".join(classification.libraries)
+    print(f"CI verification library scope: {scope}")
+    print(f"Reason: {classification.reason}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/run_oracles.sh
+++ b/scripts/ci/run_oracles.sh
@@ -19,33 +19,15 @@
 # tuple order. Exits non-zero if any library failed, with a clear
 # marker per failing library. Same-runner process parallelism is the
 # form SPEC/CI.md permits: it raises no runner count.
+#
+# HEX_LIBRARY_FILTER is an optional whitespace-separated list of libraries.
+# Empty or unset means all libraries. `--list` prints the tuple registry without
+# building or checking oracle dependencies for use by the CI classifier.
 
 set -uo pipefail
 
-# Local development may intentionally run only the installed comparators, but
-# release CI must never turn a missing oracle dependency into a green `SKIP`.
-# Preflight the required oracle dependency families before emitting any fixtures so a
-# broken installation fails early and unambiguously.
-if [ "${HEX_REQUIRE_ORACLES:-0}" = "1" ]; then
-  if ! command -v gap >/dev/null 2>&1; then
-    echo "FAIL: required GAP oracle is unavailable" >&2
-    exit 1
-  fi
-  if ! python3 - <<'PY'
-import flint
-import cypari2
-import conway_polynomials
-import sympy
-PY
-  then
-    echo "FAIL: required oracle dependencies are unavailable" >&2
-    exit 1
-  fi
-  if ! python3 scripts/oracle/real_algebraic_flint.py --preflight --require-oracles; then
-    echo "FAIL: required real-algebraic oracle capabilities are unavailable" >&2
-    exit 1
-  fi
-fi
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/hex-oracles.XXXXXX")"
+trap 'rm -rf -- "$work_dir"' EXIT
 
 # Tuples are encoded as `lib|emit_exe|oracle_script|fixture_path`.
 ORACLES=(
@@ -73,7 +55,7 @@ ORACLES=(
   "HexRoots|hexroots_emit_fixtures|scripts/oracle/roots_flint.py|conformance-fixtures/HexRoots/roots.jsonl"
   "HexRealAlgebraic|hexrealalgebraic_emit_fixtures|scripts/oracle/real_algebraic_flint.py|conformance-fixtures/HexRealAlgebraic/real_algebraic.jsonl"
   # SymPy backed
-  "HexDeterminantCarriers|hexdeterminant_emit_carrier_fixtures|scripts/oracle/matrix_carriers.py|conformance-fixtures/HexDeterminant/carriers.jsonl"
+  "HexDeterminant|hexdeterminant_emit_carrier_fixtures|scripts/oracle/matrix_carriers.py|conformance-fixtures/HexDeterminant/carriers.jsonl"
   "HexRationalFn|hexrationalfn_emit_fixtures|scripts/oracle/rationalfn_sympy.py|conformance-fixtures/HexRationalFn/rationalfn.jsonl"
   "HexMvPoly|hexmvpoly_emit_fixtures|scripts/oracle/mvpoly_sympy.py|conformance-fixtures/HexMvPoly/mvpoly.jsonl"
   "HexTruncatedSeries|hextruncatedseries_emit_fixtures|scripts/oracle/series_sympy.py|conformance-fixtures/HexTruncatedSeries/series.jsonl"
@@ -102,96 +84,159 @@ ORACLES=(
   "HexPermGroup|hexpermgroup_emit_fixtures|scripts/oracle/perm_group_gap.py|conformance-fixtures/HexPermGroup/permgroup.jsonl"
 )
 
+if [ "${1:-}" = "--list" ]; then
+  printf '%s\n' "${ORACLES[@]}"
+  exit 0
+fi
+
+library_selected() {
+  local wanted="$1"
+  [ -z "${HEX_LIBRARY_FILTER:-}" ] || [[ " $HEX_LIBRARY_FILTER " == *" $wanted "* ]]
+}
+
+if [ -z "${HEX_LIBRARY_FILTER:-}" ]; then
+  echo "Oracle library filter: all libraries (no filter)"
+else
+  echo "Oracle library filter: $HEX_LIBRARY_FILTER"
+fi
+
+# Local development may intentionally run only the installed comparators, but
+# release CI must never turn a missing oracle dependency into a green `SKIP`.
+# Preflight the required oracle dependency families before emitting any fixtures so a
+# broken installation fails early and unambiguously.
+if [ "${HEX_REQUIRE_ORACLES:-0}" = "1" ]; then
+  if ! command -v gap >/dev/null 2>&1; then
+    echo "FAIL: required GAP oracle is unavailable" >&2
+    exit 1
+  fi
+  if ! python3 - <<'PY'
+import flint
+import cypari2
+import conway_polynomials
+import sympy
+PY
+  then
+    echo "FAIL: required oracle dependencies are unavailable" >&2
+    exit 1
+  fi
+  if ! python3 scripts/oracle/real_algebraic_flint.py --preflight --require-oracles; then
+    echo "FAIL: required real-algebraic oracle capabilities are unavailable" >&2
+    exit 1
+  fi
+fi
+
+FILTERED_ORACLES=()
+for entry in "${ORACLES[@]}"; do
+  IFS='|' read -r lib _ _ _ <<<"$entry"
+  if library_selected "$lib"; then
+    FILTERED_ORACLES+=("$entry")
+  fi
+done
+
 failed=0
 
 # One combined build of every emit executable: parallel `lake exe`
 # invocations would contend on the Lake build lock, and one build
 # parallelizes internally anyway.
 emits=()
-for entry in "${ORACLES[@]}"; do
+for entry in "${FILTERED_ORACLES[@]}"; do
   IFS='|' read -r _ emit _ _ <<<"$entry"
   emits+=("$emit")
 done
-if ! lake build "${emits[@]}"; then
+if [ "${#emits[@]}" -gt 0 ] && ! lake build "${emits[@]}"; then
   echo "FAIL: building emit executables" >&2
   exit 1
 fi
 
-run_one() {
+run_tuple() {
   local entry="$1"
+  local index="$2"
   local lib emit oracle fixture
   IFS='|' read -r lib emit oracle fixture <<<"$entry"
-  local fresh="/tmp/${lib}-fresh.jsonl"
-  local log="/tmp/oracle-${lib}.log"
-  {
-    echo
-    echo "=========================================================="
-    echo ">>> $lib :: emit=$emit oracle=$oracle"
-    echo "=========================================================="
+  local fresh="$work_dir/${lib}-${index}-fresh.jsonl"
 
-    if ! ".lake/build/bin/$emit" >"$fresh"; then
-      echo "FAIL: $lib :: $emit exited non-zero"
+  echo
+  echo "=========================================================="
+  echo ">>> $lib :: emit=$emit oracle=$oracle"
+  echo "=========================================================="
+
+  if ! ".lake/build/bin/$emit" >"$fresh"; then
+    echo "FAIL: $lib :: $emit exited non-zero"
+    return 1
+  fi
+
+  if ! diff -u "$fixture" "$fresh"; then
+    echo "FAIL: $lib :: fresh emission diverges from committed fixture"
+    return 1
+  fi
+
+  if [ "$lib" = "HexRealAlgebraic" ]; then
+    local repr_fresh="$work_dir/HexRealAlgebraic-ReprChecks.lean"
+    if ! ".lake/build/bin/$emit" --repr >"$repr_fresh" ||
+        ! diff -u conformance/HexRealAlgebraic/ReprChecks.lean "$repr_fresh"; then
+      echo "FAIL: $lib :: generated Lean Repr checks differ from the compiled fixture"
       return 1
     fi
-
-    if ! diff -u "$fixture" "$fresh"; then
-      echo "FAIL: $lib :: fresh emission diverges from committed fixture"
+    if ! python3 -m unittest scripts.oracle.test_real_algebraic_flint; then
+      echo "FAIL: $lib :: oracle rejection tests failed"
       return 1
     fi
+  fi
 
-    if [ "$lib" = "HexRealAlgebraic" ]; then
-      local repr_fresh="/tmp/HexRealAlgebraic-ReprChecks.lean"
-      if ! ".lake/build/bin/$emit" --repr >"$repr_fresh" ||
-          ! diff -u conformance/HexRealAlgebraic/ReprChecks.lean "$repr_fresh"; then
-        echo "FAIL: $lib :: generated Lean Repr checks differ from the compiled fixture"
-        return 1
+  local oracle_args=()
+  case "$oracle" in
+    *primality_pari.py)
+      if [ "${HEX_REQUIRE_ORACLES:-0}" = "1" ]; then
+        oracle_args=(--require-oracles)
       fi
-      if ! python3 -m unittest scripts.oracle.test_real_algebraic_flint; then
-        echo "FAIL: $lib :: oracle rejection tests failed"
-        return 1
+      ;;
+    *conway_luebeck.py)
+      if [ "${HEX_REQUIRE_ORACLES:-0}" = "1" ]; then
+        oracle_args=(--require-conway-polynomials)
+      else
+        # The committed Lübeck cache is always checked. Locally, add the
+        # package-backed leg when available and report a clean SKIP otherwise.
+        oracle_args=(--check-conway-polynomials)
       fi
-    fi
+      ;;
+  esac
 
-    local oracle_args=()
-    case "$oracle" in
-      *primality_pari.py)
-        if [ "${HEX_REQUIRE_ORACLES:-0}" = "1" ]; then
-          oracle_args=(--require-oracles)
-        fi
-        ;;
-      *conway_luebeck.py)
-        if [ "${HEX_REQUIRE_ORACLES:-0}" = "1" ]; then
-          oracle_args=(--require-conway-polynomials)
-        else
-          # The committed Lübeck cache is always checked. Locally, add the
-          # package-backed leg when available and report a clean SKIP otherwise.
-          oracle_args=(--check-conway-polynomials)
-        fi
-        ;;
-    esac
+  if ! python3 "$oracle" "${oracle_args[@]}" <"$fresh"; then
+    echo "FAIL: $lib :: oracle $oracle reported a divergence"
+    return 1
+  fi
 
-    if ! python3 "$oracle" "${oracle_args[@]}" <"$fresh"; then
-      echo "FAIL: $lib :: oracle $oracle reported a divergence"
-      return 1
-    fi
+  echo "OK: $lib"
+}
 
-    echo "OK: $lib"
-  } >"$log" 2>&1
+run_one() {
+  local entry="$1"
+  local index="$2"
+  local lib emit _oracle _fixture
+  IFS='|' read -r lib emit _oracle _fixture <<<"$entry"
+  local log="$work_dir/oracle-${index}.log"
+  local start end elapsed rc
+  start=$(date +%s)
+  if run_tuple "$entry" "$index" >"$log" 2>&1; then rc=0; else rc=$?; fi
+  end=$(date +%s)
+  elapsed=$((end - start))
+  printf 'TIMING: %s (%s) %ss\n' "$lib" "$emit" "$elapsed" >>"$log"
+  return "$rc"
 }
 
 jobs="${HEX_ORACLE_JOBS:-$(nproc)}"
 running=0
-declare -A lib_of_pid status_of
+declare -A index_of_pid status_of
 reap() {
   local done_pid st
   if wait -n -p done_pid; then st=0; else st=$?; fi
-  status_of["${lib_of_pid[$done_pid]}"]=$st
+  status_of["${index_of_pid[$done_pid]}"]=$st
   running=$((running - 1))
 }
-for entry in "${ORACLES[@]}"; do
-  IFS='|' read -r lib _ _ _ <<<"$entry"
-  run_one "$entry" &
-  lib_of_pid[$!]="$lib"
+for index in "${!FILTERED_ORACLES[@]}"; do
+  entry="${FILTERED_ORACLES[$index]}"
+  run_one "$entry" "$index" &
+  index_of_pid[$!]="$index"
   running=$((running + 1))
   if [ "$running" -ge "$jobs" ]; then
     reap
@@ -200,12 +245,11 @@ done
 while [ "$running" -gt 0 ]; do
   reap
 done
-for entry in "${ORACLES[@]}"; do
-  IFS='|' read -r lib _ _ _ <<<"$entry"
-  if [ "${status_of[$lib]:-1}" -ne 0 ]; then
+for index in "${!FILTERED_ORACLES[@]}"; do
+  if [ "${status_of[$index]:-1}" -ne 0 ]; then
     failed=1
   fi
-  cat "/tmp/oracle-${lib}.log"
+  cat "$work_dir/oracle-${index}.log"
 done
 
 if [ "$failed" -ne 0 ]; then
@@ -217,7 +261,7 @@ fi
 # Exercise the independent Lean/native binding in process against the same
 # committed corpus. The executable is built by the shared build phase above;
 # this adds only the FFI calls (about 0.1 s locally), not another elaboration.
-if ! .lake/packages/NautyFFI/.lake/build/bin/nautyffi_tests; then
+if library_selected HexGraphIso && ! .lake/packages/NautyFFI/.lake/build/bin/nautyffi_tests; then
   echo "Conformance: in-process nauty-ffi fixture check failed." >&2
   exit 1
 fi

--- a/scripts/ci/test_check_bench_verify_budget.py
+++ b/scripts/ci/test_check_bench_verify_budget.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts/ci/check_bench_verify_budget.sh"
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from libgraph import load_libraries
+
+
+class CheckBenchVerifyBudgetTests(unittest.TestCase):
+    def run_script(
+        self, *arguments: str, library_filter: str
+    ) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            fake_lake = Path(directory) / "lake"
+            fake_lake.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            fake_lake.chmod(0o755)
+            env = os.environ.copy()
+            env.update(
+                {
+                    "PATH": f"{directory}:{env['PATH']}",
+                    "HEX_LIBRARY_FILTER": library_filter,
+                    "BENCH_VERIFY_HARD_CAP_SECONDS": "0",
+                    "GITHUB_ACTIONS": "false",
+                }
+            )
+            return subprocess.run(
+                ["bash", str(SCRIPT), *arguments],
+                cwd=REPO_ROOT,
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                check=False,
+            )
+
+    def test_filter_uses_explicit_library_owner(self) -> None:
+        result = self.run_script(
+            "HexPoly=hexpoly_bench",
+            "HexRoots=hexroots_bench",
+            "HexGF2=hexgf2_bench",
+            library_filter="HexRoots",
+        )
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("::group::hexroots_bench", result.stdout)
+        self.assertNotIn("::group::hexpoly_bench", result.stdout)
+        self.assertNotIn("::group::hexgf2_bench", result.stdout)
+
+    def test_filtered_legacy_argument_fails_closed(self) -> None:
+        result = self.run_script("hexroots_bench", library_filter="HexRoots")
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("filtered runs require Library=bench_executable", result.stdout)
+
+    def test_workflow_pairs_match_lake_roots(self) -> None:
+        workflow = (REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+        block = workflow.split(
+            "bash scripts/ci/check_bench_verify_budget.sh \\\n", 1
+        )[1].split("          # These two interval", 1)[0]
+        pairs = re.findall(r"\b(Hex[A-Za-z0-9]+)=([a-z0-9_]+_bench)\b", block)
+        self.assertEqual(len(pairs), 43)
+
+        lakefile = (REPO_ROOT / "lakefile.lean").read_text(encoding="utf-8")
+        roots = dict(
+            re.findall(
+                r"lean_exe\s+([a-zA-Z0-9_]+)\s+where\s*\n"
+                r"(?:\s+.*\n)*?\s+root\s*:=\s*`([A-Za-z0-9_.]+)",
+                lakefile,
+            )
+        )
+        library_names = set(load_libraries())
+        for owner, executable in pairs:
+            with self.subTest(executable=executable):
+                root = roots[executable].replace(".", "").lower()
+                candidates = [
+                    library
+                    for library in library_names
+                    if root.startswith(library.lower())
+                ]
+                self.assertEqual(max(candidates, key=len), owner)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test_classify_changed_libraries.py
+++ b/scripts/ci/test_classify_changed_libraries.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from classify_changed_libraries import classify_paths, load_oracle_owners
+
+
+ORACLE_OWNERS = {
+    "scripts/oracle/roots_flint.py": {"HexRoots"},
+    "scripts/oracle/matrix_flint.py": {"HexBareiss", "HexDeterminant"},
+}
+
+
+class ClassifyChangedLibrariesTests(unittest.TestCase):
+    def classify(self, *paths: str):
+        return classify_paths(list(paths), oracle_owners=ORACLE_OWNERS)
+
+    def test_library_source_selects_only_owner(self) -> None:
+        result = self.classify("HexRoots/Basic.lean")
+        self.assertFalse(result.all_libraries)
+        self.assertEqual(result.libraries, ("HexRoots",))
+
+    def test_auxiliary_roots_select_owner(self) -> None:
+        for path in (
+            "bench/HexRoots/Bench.lean",
+            "conformance/HexRoots/Conformance.lean",
+            "conformance-fixtures/HexRoots/roots.jsonl",
+        ):
+            with self.subTest(path=path):
+                result = self.classify(path)
+                self.assertFalse(result.all_libraries)
+                self.assertEqual(result.libraries, ("HexRoots",))
+
+    def test_oracle_script_selects_every_tuple_owner(self) -> None:
+        result = self.classify("scripts/oracle/matrix_flint.py")
+        self.assertFalse(result.all_libraries)
+        self.assertEqual(set(result.libraries), {"HexBareiss", "HexDeterminant"})
+
+    def test_common_oracle_selects_all(self) -> None:
+        result = self.classify("scripts/oracle/common.py")
+        self.assertTrue(result.all_libraries)
+        self.assertEqual(result.library_filter, "")
+
+    def test_shared_paths_select_all(self) -> None:
+        for path in (
+            "Hex/Json.lean",
+            "scripts/ci/run_oracles.sh",
+            "lakefile.lean",
+            ".github/workflows/ci.yml",
+        ):
+            with self.subTest(path=path):
+                self.assertTrue(self.classify(path).all_libraries)
+
+    def test_no_dependents_are_added(self) -> None:
+        result = self.classify("HexPoly/Basic.lean")
+        self.assertEqual(result.libraries, ("HexPoly",))
+
+    def test_documentation_does_not_widen_mixed_change(self) -> None:
+        result = self.classify("HexRoots/Basic.lean", "SPEC/testing.md")
+        self.assertEqual(result.libraries, ("HexRoots",))
+
+    def test_unclassified_path_widens_mixed_change(self) -> None:
+        result = self.classify("HexRoots/Basic.lean", "scripts/libgraph.py")
+        self.assertTrue(result.all_libraries)
+
+    def test_hex_graph_is_owned_by_graph_iso(self) -> None:
+        result = self.classify("HexGraph/Basic.lean")
+        self.assertEqual(result.libraries, ("HexGraphIso",))
+
+    def test_oracle_alias_selects_owner(self) -> None:
+        result = self.classify("scripts/oracle/bz_trace_gate.py")
+        self.assertEqual(result.libraries, ("HexBerlekampZassenhaus",))
+
+    def test_auxiliary_suffix_uses_longest_owner(self) -> None:
+        result = self.classify("conformance/HexPrimalityMathlibConformance/Test.lean")
+        self.assertEqual(result.libraries, ("HexPrimalityMathlib",))
+
+    def test_live_oracle_registry_uses_library_owners(self) -> None:
+        owners = load_oracle_owners()
+        self.assertEqual(owners["scripts/oracle/roots_flint.py"], {"HexRoots"})
+        self.assertEqual(owners["scripts/oracle/matrix_carriers.py"], {"HexDeterminant"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #10192.

Scopes pull-request conformance/oracle execution and bench verify to the libraries owning changed paths, without expanding to dependents. Shared infrastructure and non-PR events retain the full suite. The full conformance build remains unchanged.

Also adds per-oracle-tuple wall times; bench verify already reports per-executable timings.

Local verification:
- `python3 -m unittest scripts/ci/test_classify_changed_libraries.py`
- shell syntax checks for both CI runners
- workflow YAML parse and repository structural checks
- real `HexRoots` focused run: only the `HexRoots` tuple and `hexroots_bench` ran successfully
- simulated mixed bench list confirmed filtering to `hexroots_bench` only