### PR TITLE
spec: rank tactic symbolic arm with side conditions

### DIFF
--- a/SPEC/Libraries/hex-matrix-tactic.md
+++ b/SPEC/Libraries/hex-matrix-tactic.md
@@ -217,12 +217,13 @@ Routing is by the converted polynomials, not by syntax:
   conditions), and the arm never assumes an atom is zero either: with
   `hx : x = 0` in context the polynomial matrix still contains the
   indeterminate for `x`, and the user substitutes first. Unknown
-  nonzeroness of an atom is therefore not a decline reason and is never
-  asked about. The generic rank of `[x / y]` is `1` exactly as for `[x]`,
-  its condition reads `x / y ≠ 0`, and whether that is discharged depends
-  only on the local context. The condition returned below is the only
-  nonvanishing fact any output depends on, so this is the whole treatment
-  of atoms of unknown nonzeroness.
+  nonzeroness of an atom is therefore not a decline reason, and neither
+  classification nor the generic rank ever asks about it; it can surface
+  only inside the one condition of output 2. The generic rank of `[x / y]`
+  is `1` exactly as for `[x]`, its condition reads `x / y ≠ 0`, and whether
+  that is discharged depends only on the local context. The condition
+  returned below is the only nonvanishing fact any output depends on, so
+  this is the whole treatment of atoms of unknown nonzeroness.
 
 The batch debits the hex-reflect budget (source nodes, atoms, reflected
 nodes, exponent, terms, coefficient bits, proof nodes) and two dimensions
@@ -244,8 +245,10 @@ one-line instantiation that
 `HexReflect` and `HexRank`; nothing carrier-specific is added to `HexRank`.
 
 The certificate `c : RankCert (MvPoly k C cmp) n m` is closed data:
-`c.rank = r`, `c.denom` a nonzero polynomial `d` (an `r × r` minor of `P`),
-`c.adj` a polynomial matrix. `checkRank P c = true` is a closed Boolean over
+`c.rank = r`, `c.denom` a nonzero polynomial `d` (a signed `r × r` minor of
+`P`: `sign π · det B` for the producer's row order `π`, per
+[hex-rank §Entry points](hex-rank.md#entry-points)), `c.adj` a polynomial
+matrix. `checkRank P c = true` is a closed Boolean over
 polynomial arithmetic, proved by kernel `decide` per the certificate strategy
 of [§Algorithms and proof strategy](#algorithms-and-proof-strategy); its
 cost is the checker's `n · r · m` polynomial products at the certificate's
@@ -290,18 +293,26 @@ of [hex-rank §MvPoly](hex-rank.md#mvpoly).
 
 The companion closes a goal `M.rank = r` (or either inequality) with the
 generic rank only when the goal's matrix is the symbolic matrix itself:
-the carrier of `M` is `MvPolynomial σ C` for a domain `C`, every atom of the
-batch is `MvPolynomial.X i` for a literal `i : σ`, the atoms are pairwise
-distinct, and the coefficient interpretation `ι` is injective (it is for
-`Int` into a characteristic-zero domain and for the residue carrier into a
-characteristic-`p` domain, the registered cases). Then the interpretation
-map is `MvPolynomial.map ι` composed with `MvPolynomial.rename` along the
-atom-to-index map, injective by `MvPolynomial.map_injective` and
-`MvPolynomial.rename_injective`, and `checkRank_sound_map` at that map
-closes the goal. A goal over `MvPolynomial σ C` whose atoms include anything
+the carrier of `M` is `MvPolynomial σ D` for a domain `D`; every atom of
+the batch is `MvPolynomial.X i` for a literal `i : σ`, so the atom valuation
+is `X ∘ f` for a map `f : Fin k → σ`, and `f` is injective (the literals are
+pairwise distinct); and the coefficient interpretation factors as
+`ι = MvPolynomial.C.comp ι₀` for an injective `ι₀ : C →+* D`. The
+registered providers satisfy the last condition: in characteristic zero
+`ι` is `Int.cast` into `MvPolynomial σ D`, which is `C ∘ Int.cast` with
+`Int.cast : ℤ → D` injective, and in characteristic `p` it is `C` composed
+with the residue carrier's injective map into `D`. An arbitrary injective
+`ι : C →+* MvPolynomial σ D` would not do, since its image could meet the
+atom variables. Under these conditions the interpretation map is
+`MvPolynomial.rename f ∘ MvPolynomial.map ι₀ ∘ HexMvPolyMathlib.equiv`,
+injective by `MvPolynomial.rename_injective`, `MvPolynomial.map_injective`
+and `RingEquiv.injective`, and `checkRank_sound_map` at that map closes the
+goal. A goal over `MvPolynomial σ C` whose atoms include anything
 else (`MvPolynomial.C a` for a local `a`, a `rename`, an opaque term) is a
 specialised matrix like any other and goes to output 2: two distinct atoms
 may be equal in the carrier, and the interpretation need not be injective.
+So is a goal whose carrier is `MvPolynomial σ D` but whose coefficient
+provider does not factor through `C` as above.
 The fraction-field form
 `(M.map (algebraMap (MvPolynomial σ C) K)).rank = r` is accepted under the
 same atom condition through `rank_map_eq`.
@@ -328,7 +339,8 @@ Condition.proposition := φ c.denom ≠ 0
 displayed as the interpreted polynomial in the source atoms (`x ^ 2 - 1 ≠ 0`
 below), with provenance `provider` the extension's rank provider, `source`
 the matrix expression, `operation` `"rank"`, and `reason` naming the
-certificate denominator as a nonzero `r × r` minor of the polynomial matrix.
+certificate denominator as a nonzero signed `r × r` minor of the polynomial
+matrix.
 There is exactly one condition per invocation, so deduplication and ordering
 are trivial. The theorem is
 
@@ -346,8 +358,9 @@ companion proves it from hex-rank-mathlib's transport lemmas. It is the
 statement "rank exactly `r` wherever `denom` does not vanish" of
 hex-rank §Generic rank is not a specialised rank.
 
-The condition is sufficient, not necessary. `V(I_r(P)) ⊆ V(d)` and the
-inclusion is strict in general: `!![x, y]` has generic rank `1` with pivot
+The condition is sufficient, not necessary. `d` is a unit multiple of the
+minor `det B ∈ I_r(P)`, so `V(I_r(P)) ⊆ V(d)`, and the inclusion is strict
+in general: `!![x, y]` has generic rank `1` with pivot
 minor `x`, so the condition is `x ≠ 0`, while the rank is `1` wherever
 `(x, y) ≠ (0, 0)`. The arm does not search for a minor whose nonvanishing
 is easier to discharge; that search, and the exact set, belong to output 3
@@ -381,9 +394,13 @@ substituted, and `A.rank = 0` for `[x]` under `hx : x = 0` is reached by
 substituting `hx` and using the numeric arm, not by this arm. The term form
 `rank% A` has no `r'`: it returns `value := r` with proof `A.rank = r` when
 the condition is discharged at steps 1 and 2 below, and otherwise declines
-with the condition displayed. The programmatic interface returns a
-`ConditionalResult` whose `conditions` array holds the one condition and
-whose `proof` depends on it; it never creates goals.
+with the condition displayed, which is the rule of
+[§Frontends and results](#frontends-and-results) that an unconditional
+term form declines unresolved conditions. The programmatic interface
+returns a `ConditionalResult` whose `conditions` array holds the one
+condition and whose `proof` depends on it. Neither creates goals, as
+[hex-reflect §Shared results and conditions](hex-reflect.md#shared-results-and-conditions)
+requires of term and programmatic interfaces.
 
 Conditions are processed in the hex-reflect order and nowhere else:
 
@@ -439,8 +456,8 @@ fixed by its own SPEC.
 
 ### Three examples
 
-**`[x]`**, `x : F` a field element. `k = 1`, `P = [X_0]`, `r = 1`,
-`d = X_0`.
+**`[x]`**, `x : F` an element of a characteristic-zero field, so the
+coefficient provider is `Int`. `k = 1`, `P = [X_0]`, `r = 1`, `d = X_0`.
 
 1. Generic: `S = !![X 0]` over `MvPolynomial (Fin 1) ℤ` has rank `1`;
    `generic_rank% !![x]` returns `1` with that proof.
@@ -467,7 +484,17 @@ the sign of the second pass.
 **`[x ^ q − x]`** over `𝔽_q`, the finite-field example of hex-rank; take
 `x : ZMod 3` and the entry `x ^ 3 - x`. Characteristic-aware conversion
 (`toPolyC 3`) reduces coefficients, not exponents, so `P = [X_0³ − X_0]`,
-`r = 1`, `d = X_0³ − X_0`.
+`r = 1`, `d = X_0³ − X_0`. The coefficient carrier `C` is the
+positive-characteristic provider's residue carrier: it must supply
+`LawfulGcdOps C` for the producer, which `ZMod64 p` does
+(`HexMvGcd/Instances.lean`, under `ZMod64.Bounds p`), and for the companion
+a Mathlib `CommRing C` with an injective `C →+* ZMod 3`, which `ZMod64 p`
+does not have today (`HexModArithMathlib.ZMod64.equiv` is the ring
+equivalence, but the global `CommRing` instance is absent, as
+[hex-det-mathlib](hex-det-mathlib.md) records). Supplying that
+coefficientwise transport is the hex-reflect-mathlib carrier translation's
+obligation; this SPEC depends on it and does not restate it. The three
+outputs below are the mathematics that transport yields.
 
 1. Generic: `S = !![X 0 ^ 3 - X 0]` over `MvPolynomial (Fin 1) (ZMod 3)`
    has rank `1`. This is true and unconditional.

--- a/SPEC/Libraries/hex-matrix-tactic.md
+++ b/SPEC/Libraries/hex-matrix-tactic.md
@@ -77,7 +77,8 @@ remains nonzero under interpretation. A symbolic polynomial nonzero before
 specialization may become zero afterwards. Generic rank must name the
 polynomial domain or its fraction field; conditional specialized rank retains
 all nonvanishing conditions. Unconditional rank of arbitrary specializations
-is not promised. Piecewise rank and case splitting are later work.
+is not promised. Piecewise rank and case splitting are later work. The
+symbolic rank arm is specified in [§Symbolic rank](#symbolic-rank).
 
 ## Frontends and results
 
@@ -169,6 +170,359 @@ alone is never a cutoff. Model-specific thresholds, proof-size and search
 budgets are fixed from the benchmark tables before claiming Phase 4 and
 reported with the chosen strategy. Provide a diagnostic strategy override for
 matched measurements and reproducibility.
+
+## Symbolic rank
+
+This section is the rank arm of the future `HexMatrixReflect` extension and
+its companion `HexMatrixReflectMathlib`: what `rank` returns when entries are
+ring expressions rather than literals, and how each output is certified. It
+is not a numeric-activation obligation. The outputs are the three fixed by
+[hex-rank §Generic rank is not a specialised rank](hex-rank.md#generic-rank-is-not-a-specialised-rank):
+generic rank, conditional rank and rank locus. The arm never presents a
+generic rank as the rank of a specialised matrix, and no path below closes an
+equality or lower-bound goal about the user's matrix without the certificate's
+condition being either proved or left as a visible goal.
+
+### Input classification
+
+The numeric arm runs first. When its literal recogniser answers
+`notApplicable` for some entry and the extension is imported, the whole
+matrix is reified as one [hex-reflect](hex-reflect.md#batch-reification-and-sealing)
+batch: every entry is canonicalised and reified with `reifyRing?` (top-level
+variables enabled), the environment is sealed at `k` atoms, and each entry is
+converted to `Hex.MvPoly k C cmp` with `Expr.toPolyC` when `Sym.Arith`
+supplies the characteristic and `Expr.toPoly` otherwise. `C` is the
+coefficient provider's carrier and `cmp` is fixed by the extension. The batch
+yields the *polynomial matrix* `P : Hex.Matrix (MvPoly k C cmp) n m`, the
+atom valuation `v : Fin k → F` (the sealed atom array, `F` the carrier of the
+user's matrix `A`), the coefficient interpretation `ι : C → F`, and one
+interpretation proof per entry, `eval₂ ι v P[i, j] = A i j`, from the
+hex-reflect soundness theorem. Building `P` reads no hypotheses; hypotheses
+enter only when a condition is discharged.
+
+Routing is by the converted polynomials, not by syntax:
+
+- A matrix in which some entry converts to a non-constant polynomial is
+  handled here. One such entry is enough.
+- A matrix in which every entry converts to a constant polynomial is a
+  numeric matrix over `C` that the numeric arm did not recognise (a closed
+  expression such as `(2 : ℝ) + 3`, or an atom that cancelled). It is handled
+  here without a special case: `k` may be positive, the certificate's
+  `denom` is a constant, and the single condition is a closed proposition
+  discharged at step 2 of the order below.
+- A subexpression outside the fixed ring language (`x / y`, `Real.exp t`, a
+  symbolic power, an opaque constant) becomes one atom, and an atom is an
+  independent indeterminate for the rest of the arm. Reification never
+  implies that an atom is nonzero (hex-reflect §Shared results and
+  conditions), and the arm never assumes an atom is zero either: with
+  `hx : x = 0` in context the polynomial matrix still contains the
+  indeterminate for `x`, and the user substitutes first. Unknown
+  nonzeroness of an atom is therefore not a decline reason and is never
+  asked about. The generic rank of `[x / y]` is `1` exactly as for `[x]`,
+  its condition reads `x / y ≠ 0`, and whether that is discharged depends
+  only on the local context. The condition returned below is the only
+  nonvanishing fact any output depends on, so this is the whole treatment
+  of atoms of unknown nonzeroness.
+
+The batch debits the hex-reflect budget (source nodes, atoms, reflected
+nodes, exponent, terms, coefficient bits, proof nodes) and two dimensions
+the extension adds: matrix size, and `caseSplits`, reserved for
+[piecewise rank](#piecewise-rank-later-extension) and fixed at `0` until that
+extension exists. Exhaustion is a `declined` outcome naming the dimension.
+
+### The certificate at `MvPoly`
+
+The producer is hex-rank's `rankCertWith Hex.exactDiv` at
+`R = MvPoly k C cmp`, with the exact quotient `Hex.MvPoly.instDiv` and its
+law `Hex.MvPoly.instExactDivLaws` from `HexMvGcd/Divide.lean`
+(`[LawfulGcdOps C]`, supplied for `Int`, `Rat` and `ZMod64 p`), and the
+checker is hex-rank's `checkRank P c`. `DomainLaws (MvPoly k C cmp)` is
+`DomainLaws.of_exactDivLaws` with `LawfulGcdOps.one_ne_zero`. This is the
+one-line instantiation that
+[hex-rank §Placement](hex-rank.md#placement) assigns to this consumer, so
+`HexMatrixReflect` depends on `HexMvGcd` as well as on `HexMatrixTactic`,
+`HexReflect` and `HexRank`; nothing carrier-specific is added to `HexRank`.
+
+The certificate `c : RankCert (MvPoly k C cmp) n m` is closed data:
+`c.rank = r`, `c.denom` a nonzero polynomial `d` (an `r × r` minor of `P`),
+`c.adj` a polynomial matrix. `checkRank P c = true` is a closed Boolean over
+polynomial arithmetic, proved by kernel `decide` per the certificate strategy
+of [§Algorithms and proof strategy](#algorithms-and-proof-strategy); its
+cost is the checker's `n · r · m` polynomial products at the certificate's
+realised support, and it is the only place where polynomial arithmetic is
+replayed. The producer's pivot search and exact divisions are never replayed.
+Kernel `decide` is applied to `P`, `c` and `checkRank P c` only, never to a
+statement containing the atoms
+([hex-reflect §Soundness theorem](hex-reflect.md#soundness-theorem)). All
+three outputs are read off the same `c`; in particular `d` *is* the
+condition of output 2.
+
+### Output 1: generic rank
+
+The generic rank is a statement about `P`, or about its Mathlib image
+
+```lean
+S := (e P).map HexMvPolyMathlib.equiv : Matrix (Fin n) (Fin m) (MvPolynomial (Fin k) C)
+```
+
+(`e` is `HexMatrixMathlib.matrixEquiv`), never about `A`.
+
+**Mathlib-free.** With `checkRank P c = true`, hex-rank's
+`RankCert.det_ne_zero` and `RankCert.det_succ_eq_zero` at `P` say that `r`
+is the largest size of a nonzero minor of `P`; that is the Mathlib-free
+content of "generic rank". The Mathlib-free goal form is the domain-rank
+form of [§Frontends and results](#frontends-and-results) at the `MvPoly`
+carrier, `Hex.Matrix.rankWith Hex.exactDiv P = r` (and either inequality)
+for a closed literal `P`, proved by kernel replay of the producer, since
+producer correctness (`rankWith P = c.rank`) is a companion theorem. Replay
+evaluates multivariate exact division in the kernel and is for small
+inputs; the certificate route is the one the companion uses.
+
+**Companion.** `HexMatrixReflectMathlib` proves `S.rank = r` from
+hex-rank-mathlib's `checkRank_sound_map` at
+`φ := HexMvPolyMathlib.equiv.toRingHom`, injective as a ring equivalence,
+using the Mathlib instance `HexMvPolyMathlib.instCommRingMvPoly` on the
+source and `MvPolynomial`'s domain instance on the target (`C` a domain
+with `DecidableEq`). For any `[IsFractionRing (MvPolynomial (Fin k) C) K]`,
+`rank_map_eq` gives `(S.map (algebraMap _ K)).rank = r`;
+`FractionRing (MvPolynomial (Fin k) C)` is the field `Frac(C)(x_1, …, x_k)`
+of [hex-rank §MvPoly](hex-rank.md#mvpoly).
+
+The companion closes a goal `M.rank = r` (or either inequality) with the
+generic rank only when the goal's matrix is the symbolic matrix itself:
+the carrier of `M` is `MvPolynomial σ C` for a domain `C`, every atom of the
+batch is `MvPolynomial.X i` for a literal `i : σ`, the atoms are pairwise
+distinct, and the coefficient interpretation `ι` is injective (it is for
+`Int` into a characteristic-zero domain and for the residue carrier into a
+characteristic-`p` domain, the registered cases). Then the interpretation
+map is `MvPolynomial.map ι` composed with `MvPolynomial.rename` along the
+atom-to-index map, injective by `MvPolynomial.map_injective` and
+`MvPolynomial.rename_injective`, and `checkRank_sound_map` at that map
+closes the goal. A goal over `MvPolynomial σ C` whose atoms include anything
+else (`MvPolynomial.C a` for a local `a`, a `rename`, an opaque term) is a
+specialised matrix like any other and goes to output 2: two distinct atoms
+may be equal in the carrier, and the interpretation need not be injective.
+The fraction-field form
+`(M.map (algebraMap (MvPolynomial σ C) K)).rank = r` is accepted under the
+same atom condition through `rank_map_eq`.
+
+The term form is `generic_rank% A` (proposed). It returns `value := r`, the
+sealed atom array, the quoted `P`, the checked `c`, and in the companion the
+proofs `S.rank = value` and `A = S.map (MvPolynomial.eval₂Hom ι v)`, the
+latter assembled from the batch interpretation proofs through
+`HexMvPolyMathlib.eval₂MathlibHom_apply`. Its `proof` field is about `S`,
+and its type says so; `rank% A` never returns a generic rank.
+
+### Output 2: conditional rank
+
+For `A : Matrix (Fin n) (Fin m) F` over a domain `F`, write
+`ψ := MvPolynomial.eval₂Hom ι v : MvPolynomial (Fin k) C →+* F` and
+`φ := HexMvPolyMathlib.eval₂MathlibHom ι v = ψ.comp equiv.toRingHom`, so
+that the batch gives `A = (e P).map φ = S.map ψ`. The certificate specialised
+at `v` has one condition,
+
+```text
+Condition.proposition := φ c.denom ≠ 0
+```
+
+displayed as the interpreted polynomial in the source atoms (`x ^ 2 - 1 ≠ 0`
+below), with provenance `provider` the extension's rank provider, `source`
+the matrix expression, `operation` `"rank"`, and `reason` naming the
+certificate denominator as a nonzero `r × r` minor of the polynomial matrix.
+There is exactly one condition per invocation, so deduplication and ordering
+are trivial. The theorem is
+
+```lean
+theorem checkRank_sound_at [CommRing R] [CommRing S] [IsDomain S] [DecidableEq R]
+    (φ : R →+* S) (h : Hex.Matrix.checkRank A c = true) (hd : φ c.denom ≠ 0) :
+    ((e A).map φ).rank = c.rank
+```
+
+proposed in `HexMatrixReflectMathlib`. Its proof is that of
+`checkRank_sound_map`, whose injectivity hypothesis is used only to obtain
+`φ c.denom ≠ 0`; hex-rank-mathlib may adopt it as the general form, with
+`checkRank_sound_map` as the corollary, and until then the extension
+companion proves it from hex-rank-mathlib's transport lemmas. It is the
+statement "rank exactly `r` wherever `denom` does not vanish" of
+hex-rank §Generic rank is not a specialised rank.
+
+The condition is sufficient, not necessary. `V(I_r(P)) ⊆ V(d)` and the
+inclusion is strict in general: `!![x, y]` has generic rank `1` with pivot
+minor `x`, so the condition is `x ≠ 0`, while the rank is `1` wherever
+`(x, y) ≠ (0, 0)`. The arm does not search for a minor whose nonvanishing
+is easier to discharge; that search, and the exact set, belong to output 3
+and to the later extension. Consequently the arm can fail to close a true
+goal (`!![x, y].rank = 1` from `hy : y ≠ 0`), and the diagnostic then names
+the condition, the generic rank and `rank_locus`.
+
+The upper bound needs no condition. Over a field `F`,
+hex-determinantal-ideal-mathlib's `rank_map_le_rank_fractionRing` at `ψ`
+(applied to `e.symm S`) and `rank_map_eq_rank_fractionRing` give
+`A.rank ≤ S.rank = r`. That theorem is stated over a field; over a domain
+that is not a field the upper bound passes through `rank_map_eq` at the
+domain's fraction field first, which is also how integer rank is defined in
+[§Frontends and results](#frontends-and-results). `checkRank_sound_at`
+needs only a domain.
+
+Tactic-mode goal forms, with `r` the generic rank and `r'` the user's
+number:
+
+| Goal | Condition | Behaviour of `rank` |
+|---|---|---|
+| `A.rank = r'`, `r' = r` | `φ d ≠ 0` | closes; an undischarged condition becomes the first remaining goal |
+| `r' ≤ A.rank`, `r' ≤ r` | `φ d ≠ 0` | as above, weakened from `r ≤ A.rank` |
+| `A.rank ≤ r'`, `r' ≥ r` | none | closes unconditionally |
+| `A.rank = r'`, `r' ≠ r` | | fails: the arm proves nothing about it, and the diagnostic reports `r` |
+| `r' ≤ A.rank`, `r' > r` | | fails, and the diagnostic states that `A.rank ≤ r` is provable |
+| `A.rank ≤ r'`, `r' < r` | | fails; the target may be true (`[x]` at `x = 0`) |
+
+A failing row is a decline, not a `failure`: no weaker statement is
+substituted, and `A.rank = 0` for `[x]` under `hx : x = 0` is reached by
+substituting `hx` and using the numeric arm, not by this arm. The term form
+`rank% A` has no `r'`: it returns `value := r` with proof `A.rank = r` when
+the condition is discharged at steps 1 and 2 below, and otherwise declines
+with the condition displayed. The programmatic interface returns a
+`ConditionalResult` whose `conditions` array holds the one condition and
+whose `proof` depends on it; it never creates goals.
+
+Conditions are processed in the hex-reflect order and nowhere else:
+
+1. definitional equality and matching local hypotheses (a hypothesis whose
+   type is definitionally the displayed proposition);
+2. explicitly configured cheap normalisers; the Mathlib-free extension's
+   default list is empty, the companion's default list contains only
+   `norm_num` on closed propositions, so a constant denominator is
+   discharged and everything else is opt-in configuration;
+3. facts known to the current Grind goal, when a Grind adapter runs the
+   arm; not applicable to the standalone tactic;
+4. a side goal, in tactic mode only: the main goal is closed with a proof
+   depending on the side goal, which is left first among the remaining
+   goals with the displayed proposition as its type;
+5. otherwise decline without changing the goal. The decline diagnostic
+   shows the condition, the generic rank, and the interpreted `P`.
+
+The arm does not test whether a condition is refutable; a false side goal
+is the user's signal, as in the finite-field example below. What the arm
+must never do is close `A.rank = r` or `r ≤ A.rank` with only
+`checkRank_sound_map` at an injective map that does not exist: `ψ` is not
+injective, and `S.rank = r` is never rewritten into a statement about `A`.
+
+### Output 3: rank locus
+
+The exact set of points where the rank drops below `r` is the zero set of
+the determinantal ideal `I_r(P)`, and the tactic that produces it is
+`rank_locus` (later SPEC; see
+[hex-determinantal-ideal §Consumers](hex-determinantal-ideal.md#consumers)).
+The `rank` tactic never states a locus. The handoff is programmatic:
+`rank_locus` invoked without an explicit `r` calls the extension's
+generic-rank provider, receives the `ProviderOutcome` carrying `P`, `c` and
+the sealed environment, takes `r := c.rank`, and runs `detIdealGens r P` on
+that same `P`, so its generators are over the same atoms as the `rank`
+diagnostics. The default `r` is therefore the generic rank, and the default
+locus is "rank drops below the generic rank", `InLocus c.rank P p` in
+hex-determinantal-ideal's terms. Choosing `r` is the whole of this arm's
+part; the locus goal forms, `mem_zeroLocus_iff_rank_lt`, and the display of
+generators belong to `rank_locus`.
+
+### Piecewise rank (later extension)
+
+Piecewise rank splits on the vanishing of `d`: rank `r` where `d ≠ 0`, and
+on `V(d)` a recursive certificate over the quotient by the vanishing
+condition or over the remaining minors, producing a finite case list whose
+conditions partition the parameter space. It is a later extension, not
+promised here, and it is where a search among minors for a dischargeable
+condition would also live. Its hook is the `caseSplits` budget dimension
+above: the first implementation fixes the limit at `0` and returns
+`declined` naming that dimension whenever a split would be needed, so the
+later extension raises a limit rather than adding a protocol. Its syntax is
+fixed by its own SPEC.
+
+### Three examples
+
+**`[x]`**, `x : F` a field element. `k = 1`, `P = [X_0]`, `r = 1`,
+`d = X_0`.
+
+1. Generic: `S = !![X 0]` over `MvPolynomial (Fin 1) ℤ` has rank `1`;
+   `generic_rank% !![x]` returns `1` with that proof.
+2. Conditional: `!![x].rank = 1` closes with side goal `x ≠ 0`, or
+   outright from `hx : x ≠ 0`; `!![x].rank ≤ 1` closes with no condition;
+   `!![x].rank = 0` is not this arm's.
+3. Locus: `rank_locus !![x]` takes `r = 1` and `I_1 = (X_0)`; the rank drops
+   below `1` exactly where `x = 0`.
+
+**`!![x, 1; 1, x]`**, generic rank `2` with a rank-`1` specialisation.
+`P = !![X_0, 1; 1, X_0]`; the producer pivots on `X_0`, eliminates to
+`(0, X_0² − 1)`, and the certificate has `r = 2` and `d = X_0² − 1` up to
+the sign of the second pass.
+
+1. Generic: `S.rank = 2` over `MvPolynomial (Fin 1) ℤ`, and
+   `(S.map (algebraMap _ K)).rank = 2` over its fraction field.
+2. Conditional: `!![x, 1; 1, x].rank = 2` closes with side goal
+   `x ^ 2 - 1 ≠ 0`, which is false at `x = 1`, where the matrix is
+   `!![1, 1; 1, 1]` of rank `1`; `!![x, 1; 1, x].rank ≤ 2` closes
+   unconditionally.
+3. Locus: `I_2 = (X_0² − 1)`, so the rank drops below `2` exactly at
+   `x = ±1`; `I_1 = (X_0, 1) = (1)`, so it never drops below `1`.
+
+**`[x ^ q − x]`** over `𝔽_q`, the finite-field example of hex-rank; take
+`x : ZMod 3` and the entry `x ^ 3 - x`. Characteristic-aware conversion
+(`toPolyC 3`) reduces coefficients, not exponents, so `P = [X_0³ − X_0]`,
+`r = 1`, `d = X_0³ − X_0`.
+
+1. Generic: `S = !![X 0 ^ 3 - X 0]` over `MvPolynomial (Fin 1) (ZMod 3)`
+   has rank `1`. This is true and unconditional.
+2. Conditional: `!![x ^ 3 - x].rank = 1` closes only with the side goal
+   `x ^ 3 - x ≠ 0`, which is false for every `x : ZMod 3`; the true
+   statement `!![x ^ 3 - x].rank = 0` needs the Frobenius identity, which
+   is not in the ring language, and is not produced here.
+   `!![x ^ 3 - x].rank ≤ 1` closes unconditionally.
+3. Locus: `I_1 = (X_0³ − X_0)`, and `rank_locus` states that the rank drops
+   below `1` exactly where `x ^ 3 - x = 0`, which is everywhere; the
+   equivalence is correct at each point and asserts nothing about the
+   complement.
+
+### Symbolic benchmark
+
+The `symbolic` fixture family of [§Phase-4 evidence](#phase-4-evidence),
+in `conformance-fixtures/HexMatrixReflect/matrices.jsonl`, is the rank
+arm's family: dimensions `2, 4, 8`, variables `1, 2, 4, 8`, degree
+`1, 2, 4`, support `1, 4, 16`, with generic full rank, known low rank
+(products of `n × r` and `r × m` polynomial factors, so `r` and a nonzero
+`r`-minor are known at generation), and repeated subexpressions for batch
+sharing. The three examples above are fixtures. Each record stores the
+realised support of the entries, the expected generic rank, and the
+expected `denom` up to sign. Mathlib translations of the fixtures belong to
+`HexMatrixReflectMathlib`.
+
+There is no comparator for this arm: `norm_rank`, the companion's declared
+rank comparator, requires kernel-decidable equality of entries and declines
+symbolic atoms, and neither `rank_locus` nor any other Lean tactic states a
+conditional rank. The absence is declared as
+**no-comparable-surface-in-named-comparator**, scoped to the symbolic rank
+targets, per [benchmarking](../benchmarking.md). The report
+`reports/hex-matrix-reflect-performance.md` therefore records absolute
+measurements and no ratio, and Phase 4 for this arm is a measurement
+report, not a speedup claim. The tables record, per rung: batch reification
+and conversion time; producer time (`rankCertWith Hex.exactDiv`); `checkRank`
+time in compiled code and in the kernel; the certificate size as the term
+count and maximum degree of `denom`, the total term count of `adj`, and the
+serialised bytes of `c`; realised intermediate support of the producer; and
+proof-expression node count, `.olean` size and total elaboration, all as
+fresh-module proof evidence with the matched baselines of
+§Phase-4 evidence. Compiled registrations in
+`bench/HexMatrixReflect/Bench.lean` (Mathlib-free) register conversion,
+producer and checker separately, with checker preparation holding a
+precomputed certificate; support and degree ladders are not one cubic
+model, so each registration states its mode under
+[benchmarking §Choosing the complexity claim](../benchmarking.md#choosing-the-complexity-claim)
+and the fixed-workload registrations use mode 3 with preregistered
+absolute ceilings from the first measurement. Proof probes in
+`bench/HexMatrixReflectMathlib/ProofProbe` cover, on the smallest rung of
+every family, the three outputs: generic rank on a `MvPolynomial` goal,
+conditional rank with the condition discharged from a hypothesis, and
+conditional rank leaving a side goal; each has the 120 s cleanup timeout,
+and a preregistered 30 s full-proof-build ceiling per case recorded in the
+external proof-runner manifest beside the numeric checks.
 
 ## Trust and migration
 


### PR DESCRIPTION
This PR specifies the symbolic arm of the `rank` tactic in `SPEC/Libraries/hex-matrix-tactic.md`: what the tactic returns when matrix entries are ring expressions rather than literals, and how each output is certified. It adds a `## Symbolic rank` section (owned by the future `HexMatrixReflect` extension and its companion) covering input classification through one hex-reflect batch, the hex-rank certificate instantiated at `MvPoly` with `HexMvGcd`'s exact quotient, and the three outputs fixed by hex-rank: generic rank as a statement about the symbolic matrix over `MvPolynomial (Fin k) C` (via `HexMvPolyMathlib.equiv`, `checkRank_sound_map` and `rank_map_eq`, with the injective-atom rule for when a `MvPolynomial`-carrier goal may be closed), conditional rank under the single condition `φ denom ≠ 0` with the hex-reflect discharge order and a goal-form table saying which forms take a side goal, which decline, and that the upper bound `A.rank ≤ r` closes unconditionally through `rank_map_le_rank_fractionRing`, and the programmatic handoff to `rank_locus` choosing the default `r`. It reserves the `caseSplits` budget dimension for the later piecewise-rank extension, works the three outputs on `[x]`, `!![x, 1; 1, x]` and `[x ^ 3 - x]` over `ZMod 3`, and states the symbolic benchmark contract with its comparator absence declared.

Closes https://github.com/kim-em/hex-dev/issues/10182

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sj8bR1FStpZsp5iCygkHa
