### PR TITLE
chore(bench): audit OfFn runtime exemptions

### DIFF
--- a/scripts/bench/proof_only_runtime_exemptions/hexbasic-offn-vector-map-7fa5f278-72a79162.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexbasic-offn-vector-map-7fa5f278-72a79162.json
@@ -2,5 +2,5 @@
   "path": "HexBasic/OfFn.lean",
   "baseline_blob": "7fa5f2789534fe0333160fa3005a7d003840cc4d",
   "current_blob": "72a79162cc362c9c3a4701652436694d6784bfaf",
-  "reason": "Updates only docstrings and module documentation to record the Lean v4.35.0-rc1 removal points, then adds Hex.Vector.map' with its simp lemmas and a csimp rule for the determinant enumeration. No existing declaration changes; every new simp and csimp rule has the new Vector.map' constant at its head, so it cannot rewrite any pre-existing term. The only non-test caller is HexDeterminant/Enumeration.lean, outside the factorization service call graph, so every measured factorization operation and branch is unchanged."
+  "reason": "Updates only the Array.map' and Array.zipWith' docstrings in #10161 and the Array.ofFn'/Vector.ofFn' module documentation in #10169, then adds Hex.Vector.map' with its simp lemmas and a csimp rule for determinant enumeration in #10165. No existing declaration changes; every new simp and csimp rule's left-hand side contains the new Vector.map' constant, so none can match a pre-existing term. Its only non-test caller is Hex.Matrix.permutationVectors. HexDeterminant is linked into the service through HexGramSchmidt.Int.Core, but no factorization operation calls the Leibniz enumeration, so every measured operation and branch is unchanged."
 }

--- a/scripts/bench/proof_only_runtime_exemptions/hexbasic-offn-vector-map-7fa5f278-72a79162.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexbasic-offn-vector-map-7fa5f278-72a79162.json
@@ -2,5 +2,5 @@
   "path": "HexBasic/OfFn.lean",
   "baseline_blob": "7fa5f2789534fe0333160fa3005a7d003840cc4d",
   "current_blob": "72a79162cc362c9c3a4701652436694d6784bfaf",
-  "reason": "Combines the already exempted new Hex.Vector.map' shim (9775512d) with the removal-date docstrings (2c512ed4). Existing declarations and compiler rules are unchanged. The new csimp rule rewrites only the new Vector.map' constant, whose computational caller is HexDeterminant/Enumeration.lean; neither it nor HexDeterminant is in the integer-factorization service call graph. This exact combined transition is runtime-neutral for the retained factorization sweep."
+  "reason": "Updates only docstrings and module documentation to record the Lean v4.35.0-rc1 removal points, then adds Hex.Vector.map' with its simp lemmas and a csimp rule for the determinant enumeration. No existing declaration changes; every new simp and csimp rule has the new Vector.map' constant at its head, so it cannot rewrite any pre-existing term. The only non-test caller is HexDeterminant/Enumeration.lean, outside the factorization service call graph, so every measured factorization operation and branch is unchanged."
 }

--- a/scripts/bench/proof_only_runtime_exemptions/hexbasic-offn-vector-map-7fa5f278-9775512d.json
+++ b/scripts/bench/proof_only_runtime_exemptions/hexbasic-offn-vector-map-7fa5f278-9775512d.json
@@ -1,6 +1,0 @@
-{
-  "path": "HexBasic/OfFn.lean",
-  "baseline_blob": "7fa5f2789534fe0333160fa3005a7d003840cc4d",
-  "current_blob": "9775512d2e787cc1ce8be69f5806ab52982c99c5",
-  "reason": "Adds Hex.Vector.map' with its simp lemmas and a csimp rule, alongside the existing Array.ofFn'/map'/zipWith' shims, and records the v4.35.0-rc1 removal points on the Array.map'/zipWith' docstrings (the latter merged from #10161, which exempted the same docstring edit). Every new declaration is new; no existing definition, lemma or csimp rule is modified. The new csimp rewrites only the newly introduced Vector.map' constant, so no preexisting compiled path changes. Vector.map' has exactly one caller in the tree, HexDeterminant/Enumeration.lean, and HexDeterminant is not in the factorization service call graph. This exemption covers the integer-factorization sweep only."
-}


### PR DESCRIPTION
## Summary

- correct the composite `HexBasic/OfFn.lean` exemption added by #10167 to distinguish import/link reachability from the runtime paths exercised by factorization
- record the exact provenance and explain why the additive simp/csimp rules cannot match pre-existing terms
- remove the obsolete exemption whose current blob never existed on `main`

Closes #10201.

## Verification

- `python3 scripts/bench/check_factor_sweep_freshness.py`
- `python3 -m scripts.bench.test_sweep_freshness` (62 tests)
- `git diff --check`
