### PR TITLE
refactor(matrix-mathlib): shared Mathlib matrix literal layer below the tactics

### DIFF
--- a/HexMatrixMathlib.lean
+++ b/HexMatrixMathlib.lean
@@ -12,6 +12,7 @@ public import HexMatrixMathlib.Algebra
 public import HexMatrixMathlib.Lemmas
 public import HexMatrixMathlib.Gram
 public import HexMatrixMathlib.Submatrix
+public import HexMatrixMathlib.Literal
 
 public section
 

--- a/HexMatrixMathlib/Literal.lean
+++ b/HexMatrixMathlib/Literal.lean
@@ -1,0 +1,290 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMatrixMathlib.Basic
+public import Mathlib.LinearAlgebra.Matrix.Notation
+public import Mathlib.Data.Fin.VecNotation
+public meta import Mathlib.Data.Fin.VecNotation
+public meta import Mathlib.Tactic.Echelon.Rat
+public meta import Lean
+
+public section
+
+/-!
+The Mathlib matrix literal layer shared by the matrix tactics (`rank`, `det`,
+`char_poly`): a row list as a Mathlib matrix, the two ways a closed literal
+is identified with its row list, and the recognition of the four literal
+syntaxes.
+
+`ofLists n m L` is the Mathlib matrix of a row list, built so that a literal
+`!![…]` or `Matrix.of ![…]` is definitionally `ofLists n m [[…], …]` after
+unfolding, one step per entry; a tactic discharges that identification by
+`rfl` and the kernel never evaluates an entry through `Matrix.of`/`vecCons`
+inside a certificate's arithmetic.  This costs about `6 ms` at `16 × 16`.
+
+A `fun i j => …` or `Matrix.ofArray xs h` literal is not a `vecCons` chain,
+so it is identified with its row list by one kernel `decide` on the
+entrywise comparison `entriesEq`, which evaluates `A i j` for every index
+pair; this costs about `200 ms` at `16 × 16`, and is the fallback route.
+
+The meta section recognizes a closed literal behind definitions, returns its
+shape, carrier and entry expressions with the identification route, and
+quotes row lists and the identification proof.
+-/
+
+open Matrix
+
+namespace HexMatrixMathlib
+
+/-! # `List.getD` -/
+
+theorem getD_eq_getElem' {α : Type*} (l : List α) (i : Nat) (d : α) (h : i < l.length) :
+    l.getD i d = l[i] := by
+  rw [List.getD_eq_getElem?_getD, List.getElem?_eq_getElem h, Option.getD_some]
+
+theorem getD_eq_default' {α : Type*} (l : List α) (i : Nat) (d : α) (h : l.length ≤ i) :
+    l.getD i d = d := by
+  rw [List.getD_eq_getElem?_getD, List.getElem?_eq_none h, Option.getD_none]
+
+/-! # Row lists as Mathlib matrices -/
+
+/-- A list as a vector, padded with zeros; `vecOfList (k + 1) (a :: l)` unfolds
+to `vecCons a (vecOfList k l)`, so a `![…]` literal is definitionally
+`vecOfList` of its entries. -/
+@[expose] def vecOfList {α : Type*} [Zero α] : (k : Nat) → List α → (Fin k → α)
+  | 0, _ => ![]
+  | k + 1, a :: l => Matrix.vecCons a (vecOfList k l)
+  | _ + 1, [] => fun _ => 0
+
+/-- The Mathlib matrix of a row list, padded with zeros. -/
+@[expose] def ofLists {α : Type*} [Zero α] (n m : Nat) (L : List (List α)) :
+    Matrix (Fin n) (Fin m) α :=
+  Matrix.of (vecOfList n (L.map (vecOfList m)))
+
+theorem vecOfList_apply {α : Type*} [Zero α] (k : Nat) (l : List α) (i : Fin k) :
+    vecOfList k l i = l.getD i 0 := by
+  induction k generalizing l with
+  | zero => exact i.elim0
+  | succ k ih =>
+    cases l with
+    | nil => simp [vecOfList]
+    | cons a l =>
+      refine Fin.cases ?_ (fun i => ?_) i
+      · simp [vecOfList]
+      · simp [vecOfList, ih]
+
+theorem ofLists_apply {α : Type*} [Zero α] (n m : Nat) (L : List (List α)) (i : Fin n)
+    (j : Fin m) : ofLists n m L i j = (L.getD i []).getD j 0 := by
+  rw [ofLists, Matrix.of_apply, vecOfList_apply]
+  by_cases hi : (i : Nat) < L.length
+  · rw [getD_eq_getElem' _ _ _ (by simpa using hi), List.getElem_map, vecOfList_apply,
+      getD_eq_getElem' _ _ _ hi]
+  · have h1 : (L.map (vecOfList m)).getD i 0 = 0 := getD_eq_default' _ _ _ (by simpa using hi)
+    have h2 : L.getD i [] = [] := getD_eq_default' _ _ _ (by omega)
+    rw [h1, h2]
+    rfl
+
+/-! # Entrywise identification -/
+
+/-- The entrywise comparison of a matrix with its row list, as a Boolean the
+kernel evaluates by enumerating every index pair. -/
+@[expose] def entriesEq {α : Type*} [Zero α] [DecidableEq α] (n m : Nat)
+    (A : Matrix (Fin n) (Fin m) α) (L : List (List α)) : Bool :=
+  (List.finRange n).all fun i => (List.finRange m).all fun j => decide (A i j = ofLists n m L i j)
+
+/-- A passing entrywise comparison identifies the matrix with its row list. -/
+theorem eq_ofLists_of_entriesEq {α : Type*} [Zero α] [DecidableEq α] (n m : Nat)
+    (A : Matrix (Fin n) (Fin m) α) (L : List (List α)) (h : entriesEq n m A L = true) :
+    A = ofLists n m L := by
+  ext i j
+  have h := List.all_eq_true.mp h i (List.mem_finRange i)
+  have h := List.all_eq_true.mp h j (List.mem_finRange j)
+  exact of_decide_eq_true h
+
+/-! # Certified values -/
+
+/-- The record returned by the result-producing term forms (`det% A`): the
+value of `f a` and the proof. -/
+structure Certified {α : Type*} {β : Type*} (f : α → β) (a : α) where
+  /-- The computed value. -/
+  value : β
+  /-- The certificate that it is `f a`. -/
+  proof : f a = value
+
+end HexMatrixMathlib
+
+end
+
+public meta section
+
+namespace HexMatrixMathlib.Literal
+
+open Lean Meta Elab
+
+/-- How a recognized literal is identified with its row list. -/
+inductive Route where
+  /-- A `Matrix.of` vector chain (`!![…]`, `Matrix.of ![…]`): `A = ofLists n m L` is `rfl`. -/
+  | chain
+  /-- A `fun i j => …` or `Matrix.ofArray xs h` literal: `A = ofLists n m L` by one kernel
+  `decide` on `entriesEq`. -/
+  | entrywise
+  deriving Repr, DecidableEq
+
+/-- A recognized closed matrix literal. -/
+structure Recognized where
+  /-- Rows. -/
+  n : Nat
+  /-- Columns. -/
+  m : Nat
+  /-- The entry carrier. -/
+  carrier : Expr
+  /-- The entry expressions, row-major, as they appear in the literal (or, for
+  the `fun` and `ofArray` forms, as instantiated at each index pair). -/
+  entries : Array (Array Expr)
+  /-- The identification route. -/
+  route : Route
+
+/-- How many definitions are unfolded when looking for a literal. -/
+def unfoldBudget : Nat := 8
+
+/-- The shape of the type `Matrix (Fin n) (Fin m) R` with closed dimensions:
+`(n, m, R)`, or of the function type `Fin n → Fin m → R` a bare lambda has.
+The dimensions may be any closed expressions that evaluate to numerals, as
+`Matrix.of ![…]` elaborates them as `Nat.succ` chains. -/
+def shape? (ty : Expr) : MetaM (Option (Nat × Nat × Expr)) := do
+  let (finN, finM, R) ← match ← whnfR ty with
+    | .app (.app (.app (.const ``Matrix _) finN) finM) R => pure (finN, finM, R)
+    | .forallE _ finN (.forallE _ finM R _) _ =>
+        if R.hasLooseBVars then return none else pure (finN, finM, R)
+    | _ => return none
+  let_expr Fin nE := ← whnfR finN | return none
+  let_expr Fin mE := ← whnfR finM | return none
+  let some n ← (Meta.evalNat nE).run | return none
+  let some m ← (Meta.evalNat mE).run | return none
+  return some (n, m, R)
+
+/-- Match a `Matrix.of ![…]` chain (the `!![…]` notation included) of the given
+shape.  Like Mathlib's `matchMatrixLit?`, but every `vecCons` chain must end in
+`vecEmpty`, so that the literal is definitionally the `ofLists` of its
+entries. -/
+def matchChain? (n m : Nat) (A : Expr) : MetaM (Option (Array (Array Expr))) := do
+  let_expr DFunLike.coe _ _ _ _ f v := A | return none
+  let_expr Matrix.of _ _ _ := f | return none
+  let (rows, _, tail) ← Matrix.matchVecConsPrefix (mkNatLit n) v
+  unless rows.length == n && tail.getAppFn.isConstOf ``Matrix.vecEmpty do return none
+  let entries ← rows.toArray.mapM fun row => do
+    let (es, _, tail) ← Matrix.matchVecConsPrefix (mkNatLit m) row
+    unless es.length == m && tail.getAppFn.isConstOf ``Matrix.vecEmpty do failure
+    return es.toArray
+  return some entries
+
+/-- `⟨k, _⟩ : Fin n`. -/
+def finLit (n k : Nat) : MetaM Expr := do
+  let lt ← mkAppM ``LT.lt #[mkNatLit k, mkNatLit n]
+  return mkApp3 (mkConst ``Fin.mk) (mkNatLit n) (mkNatLit k) (← mkDecideProof lt)
+
+/-- Match a `fun i j => …` literal: the body instantiated at every index pair. -/
+def matchFn? (n m : Nat) (A : Expr) : MetaM (Option (Array (Array Expr))) := do
+  let .lam _ _ (.lam ..) _ := A | return none
+  let rows ← (List.range n).toArray.mapM fun i => do
+    let iE ← finLit n i
+    (List.range m).toArray.mapM fun j => do
+      let jE ← finLit m j
+      return (mkApp2 A iE jE).headBeta
+  return some rows
+
+/-- Match a `Matrix.ofArray xs h` literal whose array is a `#[…]` literal of
+`n * m` entries. -/
+def matchOfArray? (n m : Nat) (A : Expr) : MetaM (Option (Array (Array Expr))) := do
+  let_expr Matrix.ofArray _ _ _ xs _ := A | return none
+  let some (_, es) := xs.listLit? <|> (do
+      let_expr List.toArray _ l := xs | none
+      l.listLit?) | return none
+  unless es.length == n * m do return none
+  let es := es.toArray
+  return some ((List.range n).toArray.map fun i => (List.range m).toArray.map fun j => es[i * m + j]!)
+
+/-- Find the literal behind `A : Matrix (Fin n) (Fin m) R`, unfolding definitions
+within `unfoldBudget`; an open term is not a literal. -/
+partial def matchLiteral? (n m : Nat) (R : Expr) (A : Expr) (budget : Nat := unfoldBudget) :
+    MetaM (Option Recognized) := do
+  if A.hasFVar || A.hasMVar then return none
+  if let some es ← matchChain? n m A then return some ⟨n, m, R, es, .chain⟩
+  if let some es ← matchFn? n m A then return some ⟨n, m, R, es, .entrywise⟩
+  if let some es ← matchOfArray? n m A then return some ⟨n, m, R, es, .entrywise⟩
+  if budget = 0 then return none
+  match ← unfoldDefinition? A with
+  | some A' => matchLiteral? n m R A' (budget - 1)
+  | none => return none
+
+/-- Recognize a closed matrix literal from its type and its expression. -/
+def literal? (A : Expr) : MetaM (Option Recognized) := do
+  let A ← instantiateMVars A
+  let some (n, m, R) ← shape? (← inferType A) | return none
+  matchLiteral? n m (← whnfR R) A
+
+/-- Evaluate an entry to a rational with `norm_num`; an entry `norm_num` alone
+does not evaluate (the `fun i j => …` form instantiates its body at `Fin`
+literals, leaving `Fin.val`, casts and `if i = j` tests) is first simplified
+with the default simp set.  An entry that is not a closed numeric expression
+is an error naming it. -/
+def evalEntry (e : Expr) : MetaM Rat := do
+  try Mathlib.Tactic.Echelon.evalRatEntry true e
+  catch _ =>
+    let ctx ← Simp.mkContext (config := { decide := true })
+      (simpTheorems := #[← getSimpTheorems]) (congrTheorems := ← getSimpCongrTheorems)
+    let r ← Mathlib.Meta.NormNum.deriveSimp ctx true e
+    Mathlib.Tactic.Echelon.evalRatEntry true r.expr
+
+/-- Evaluate every entry to a rational. -/
+def evalEntries (lit : Recognized) : MetaM (Array (Array Rat)) :=
+  lit.entries.mapM (·.mapM evalEntry)
+
+/-- The row list of quoted entries, as a `List (List type)`. -/
+def rowList (type : Expr) (rows : Array (Array Expr)) : MetaM Expr := do
+  let rows ← rows.toList.mapM fun row => mkListLit type row.toList
+  mkListLit (mkApp (mkConst ``List [Level.zero]) type) rows
+
+/-- `of_decide_eq_true` on a closed decidable proposition, for the kernel to
+evaluate; no elaborator-side evaluation happens. -/
+def decideProof (prop : Expr) : MetaM Expr := do
+  let d ← mkDecide prop
+  return mkApp3 (mkConst ``of_decide_eq_true) prop d.appArg! (← mkEqRefl (mkConst ``Bool.true))
+
+/-- The proof of `A = ofLists n m L` along the literal's route: `rfl` for a
+vector chain, one kernel `decide` on `entriesEq` otherwise. -/
+def identification (lit : Recognized) (A L : Expr) : MetaM Expr := do
+  let ofL ← mkAppM ``HexMatrixMathlib.ofLists #[mkNatLit lit.n, mkNatLit lit.m, L]
+  match lit.route with
+  | .chain => mkExpectedTypeHint (← mkEqRefl A) (← mkEq A ofL)
+  | .entrywise =>
+      let check ← mkEq (← mkAppM ``HexMatrixMathlib.entriesEq #[mkNatLit lit.n, mkNatLit lit.m, A, L])
+        (mkConst ``Bool.true)
+      mkAppM ``HexMatrixMathlib.eq_ofLists_of_entriesEq
+        #[mkNatLit lit.n, mkNatLit lit.m, A, L, ← decideProof check]
+
+/-- Elaborate a matrix argument of a term form.  The `!![…]` notations are
+given an integer entry expectation so their numerals do not default to
+`Nat`. -/
+def elabArgument (t : Syntax) : Term.TermElabM Expr := do
+  let e ←
+    if t.getKind == ``Matrix.matrixNotation ||
+        t.getKind == ``Matrix.matrixNotationRx0 ||
+        t.getKind == ``Matrix.matrixNotation0xC then
+      let n ← mkFreshExprMVar (mkConst ``Nat)
+      let m ← mkFreshExprMVar (mkConst ``Nat)
+      let fin (k : Expr) := mkApp (mkConst ``Fin) k
+      let expected := mkApp3 (mkConst ``Matrix [Level.zero, Level.zero, Level.zero])
+        (fin n) (fin m) (mkConst ``Int)
+      Term.elabTerm t (some expected)
+    else
+      Term.elabTerm t none
+  Term.synthesizeSyntheticMVarsNoPostponing
+  instantiateMVars e
+
+end HexMatrixMathlib.Literal

--- a/HexMatrixMathlib/SPEC/hex-matrix-mathlib.md
+++ b/HexMatrixMathlib/SPEC/hex-matrix-mathlib.md
@@ -73,3 +73,41 @@ theorem matrixEquiv_principalSubmatrix : matrixEquiv (principalSubmatrix M k hk)
 ```
 
 (plus `matrixEquiv_takeRows`).
+
+## Matrix literals
+
+`HexMatrixMathlib/Literal.lean` is the literal layer the matrix tactics
+share ([SPEC/matrix-tactics.md](../../SPEC/matrix-tactics.md) §Placement);
+no tactic lives here.
+
+```lean
+def vecOfList [Zero α] : (k : Nat) → List α → (Fin k → α)
+def ofLists [Zero α] (n m : Nat) (L : List (List α)) : Matrix (Fin n) (Fin m) α
+theorem ofLists_apply (L) (i : Fin n) (j : Fin m) : ofLists n m L i j = (L.getD i []).getD j 0
+def entriesEq [Zero α] [DecidableEq α] (n m) (A : Matrix (Fin n) (Fin m) α) (L) : Bool
+theorem eq_ofLists_of_entriesEq (h : entriesEq n m A L = true) : A = ofLists n m L
+structure Certified (f : α → β) (a : α) where value : β; proof : f a = value
+```
+
+A tactic accepts a closed matrix in four syntaxes, possibly behind
+definitions unfolded within a budget of eight, and identifies it with the
+row list `L` of its entries by one of two routes:
+
+| syntax | route | cost at `16 × 16` |
+|---|---|---|
+| `!![…]`, `Matrix.of ![…]` | definitional: `vecOfList (k + 1) (a :: l)` unfolds to `vecCons a (vecOfList k l)`, so `A = ofLists n m L` is `rfl`, one unfolding per entry | 6 ms |
+| `fun i j => …`, `Matrix.ofArray xs h` | one kernel `decide` on `entriesEq n m A L`, which evaluates `A i j` at every index pair | about 200 ms |
+
+The definitional route is the primary one: the kernel never evaluates an
+entry through `Matrix.of` and `vecCons` inside a certificate's arithmetic.
+The meta section (`HexMatrixMathlib.Literal`) recognizes the shape and
+carrier from the type (`shape?`), the literal behind definitions
+(`matchLiteral?`, returning the dimensions, carrier, row-major entry
+expressions and the route), evaluates entries with Mathlib's
+`evalRatEntry` (`evalEntries`), quotes row lists (`rowList`), builds the
+identification proof along the route (`identification`) and elaborates a
+term-form argument with an integer expectation for the `!![…]` notations
+(`elabArgument`). `Certified` is the record the `%` term forms return.
+The empty shapes `!![]`, `!![,,,]` and `!![;;;]` are literals of their
+dimensions. Tests: `HexMatrixMathlib/Tests.lean` identifies each syntax and
+the empty shapes with its row list.

--- a/HexMatrixMathlib/Tests.lean
+++ b/HexMatrixMathlib/Tests.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+module
+
+import HexMatrixMathlib
+
+/-! Build-only examples for the literal layer: the identification of each
+literal syntax with its row list, by `rfl` for the vector chains and by the
+kernel's `entriesEq` for the other shapes, and the empty shapes. -/
+
+open HexMatrixMathlib
+
+example : (!![1, 2; 3, 4] : Matrix (Fin 2) (Fin 2) ℤ) = ofLists 2 2 [[1, 2], [3, 4]] := rfl
+example : Matrix.of ![![(1 : ℤ), 2], ![3, 4]] = ofLists 2 2 [[1, 2], [3, 4]] := rfl
+example : (!![] : Matrix (Fin 0) (Fin 0) ℤ) = ofLists 0 0 [] := rfl
+example : (!![,,,] : Matrix (Fin 0) (Fin 3) ℤ) = ofLists 0 3 [] := rfl
+example : (!![;;;] : Matrix (Fin 3) (Fin 0) ℤ) = ofLists 3 0 [[], [], []] := rfl
+example : (!![1 / 2, 3; -1, 5 / 3] : Matrix (Fin 2) (Fin 2) ℚ) = ofLists 2 2 [[1 / 2, 3], [-1, 5 / 3]] :=
+  rfl
+
+/-- A `fun i j => …` literal. -/
+def fromFn : Matrix (Fin 2) (Fin 2) ℤ := fun i j => (i : ℤ) + 2 * j
+
+example : fromFn = ofLists 2 2 [[0, 2], [1, 3]] :=
+  eq_ofLists_of_entriesEq 2 2 fromFn _ (by decide +kernel)
+
+/-- A row-major array literal. -/
+def ofArr : Matrix (Fin 2) (Fin 2) ℤ := Matrix.ofArray #[1, 2, 3, 4] rfl
+
+example : ofArr = ofLists 2 2 [[1, 2], [3, 4]] :=
+  eq_ofLists_of_entriesEq 2 2 ofArr _ (by decide +kernel)
+
+example (i : Fin 2) (j : Fin 3) : ofLists 2 3 [[1, 2, 3], [4, 5, 6]] i j = ([[1, 2, 3], [4, 5, 6]].getD i []).getD j (0 : ℤ) :=
+  ofLists_apply 2 3 _ i j

--- a/HexRankMathlib/Kernel.lean
+++ b/HexRankMathlib/Kernel.lean
@@ -9,7 +9,7 @@ module
 public import HexRank.Kernel
 public import Mathlib.LinearAlgebra.Matrix.Rank
 public import Mathlib.LinearAlgebra.Matrix.Block
-public import Mathlib.LinearAlgebra.Matrix.Notation
+public import HexMatrixMathlib.Literal
 public import Mathlib.Data.ZMod.Basic
 
 public section
@@ -18,10 +18,9 @@ public section
 Soundness of the kernel certificate: a passing `checkRankList` on the rows of
 a Mathlib matrix determines `Matrix.rank`.
 
-`ofLists n m L` is the Mathlib matrix of a row list, built so that a literal
-`!![…]` is definitionally `ofLists n m [[…], …]` after unfolding, one step
-per entry; the tactic discharges that identification by `rfl` and the kernel
-never evaluates an entry through `Matrix.of`/`vecCons` inside the arithmetic.
+The row list is identified with the Mathlib matrix through `ofLists` of the
+shared literal layer (`HexMatrixMathlib.Literal`), so the kernel never
+evaluates an entry through `Matrix.of`/`vecCons` inside the arithmetic.
 -/
 
 open Matrix
@@ -29,53 +28,6 @@ open Matrix
 namespace HexMatrixMathlib
 
 open Hex.Matrix Hex.Matrix.RankWitness
-
-/-! # `List.getD` -/
-
-theorem getD_eq_getElem' {α : Type*} (l : List α) (i : Nat) (d : α) (h : i < l.length) :
-    l.getD i d = l[i] := by
-  rw [List.getD_eq_getElem?_getD, List.getElem?_eq_getElem h, Option.getD_some]
-
-theorem getD_eq_default' {α : Type*} (l : List α) (i : Nat) (d : α) (h : l.length ≤ i) :
-    l.getD i d = d := by
-  rw [List.getD_eq_getElem?_getD, List.getElem?_eq_none h, Option.getD_none]
-
-/-! # Row lists as Mathlib matrices -/
-
-/-- A list as a vector, padded with zeros; `vecOfList (k + 1) (a :: l)` unfolds
-to `vecCons a (vecOfList k l)`, so a `![…]` literal is definitionally
-`vecOfList` of its entries. -/
-@[expose] def vecOfList {α : Type*} [Zero α] : (k : Nat) → List α → (Fin k → α)
-  | 0, _ => ![]
-  | k + 1, a :: l => Matrix.vecCons a (vecOfList k l)
-  | _ + 1, [] => fun _ => 0
-
-/-- The Mathlib matrix of a row list, padded with zeros. -/
-@[expose] def ofLists {α : Type*} [Zero α] (n m : Nat) (L : List (List α)) : Matrix (Fin n) (Fin m) α :=
-  Matrix.of (vecOfList n (L.map (vecOfList m)))
-
-theorem vecOfList_apply {α : Type*} [Zero α] (k : Nat) (l : List α) (i : Fin k) :
-    vecOfList k l i = l.getD i 0 := by
-  induction k generalizing l with
-  | zero => exact i.elim0
-  | succ k ih =>
-    cases l with
-    | nil => simp [vecOfList]
-    | cons a l =>
-      refine Fin.cases ?_ (fun i => ?_) i
-      · simp [vecOfList]
-      · simp [vecOfList, ih]
-
-theorem ofLists_apply {α : Type*} [Zero α] (n m : Nat) (L : List (List α)) (i : Fin n)
-    (j : Fin m) : ofLists n m L i j = (L.getD i []).getD j 0 := by
-  rw [ofLists, Matrix.of_apply, vecOfList_apply]
-  by_cases hi : (i : Nat) < L.length
-  · rw [getD_eq_getElem' _ _ _ (by simpa using hi), List.getElem_map, vecOfList_apply,
-      getD_eq_getElem' _ _ _ hi]
-  · have h1 : (L.map (vecOfList m)).getD i 0 = 0 := getD_eq_default' _ _ _ (by simpa using hi)
-    have h2 : L.getD i [] = [] := getD_eq_default' _ _ _ (by omega)
-    rw [h1, h2]
-    rfl
 
 /-! # The checker's primitives -/
 

--- a/HexRankMathlib/SPEC/hex-rank-mathlib.md
+++ b/HexRankMathlib/SPEC/hex-rank-mathlib.md
@@ -376,12 +376,11 @@ pass and no elimination of `A`.
 
 `HexRankMathlib/Kernel.lean` proves the kernel certificate of
 [hex-rank §The kernel certificate](../../HexRank/SPEC/hex-rank.md#the-kernel-certificate) sound
-for `Matrix.rank` over `ℤ`, stated on the Mathlib matrix directly:
+for `Matrix.rank` over `ℤ`, stated on the Mathlib matrix of a row list
+(`ofLists`, from the literal layer of
+[hex-matrix-mathlib](../../HexMatrixMathlib/SPEC/hex-matrix-mathlib.md#matrix-literals)):
 
 ```lean
-def vecOfList [Zero α] : (k : Nat) → List α → (Fin k → α)
-def ofLists [Zero α] (n m : Nat) (L : List (List α)) : Matrix (Fin n) (Fin m) α
-theorem ofLists_apply (L) (i : Fin n) (j : Fin m) : ofLists n m L i j = (L.getD i []).getD j 0
 theorem rank_eq_of_checkList (n m) (L) (c : RankWitness)
     (h : checkRankList n m L c = true) : (ofLists n m L).rank = c.rank
 theorem rank_eq_of_checkList' (A : Matrix (Fin n) (Fin m) ℤ) (L) (c)
@@ -390,13 +389,13 @@ theorem rank_le_of_checkList' … (hr : c.rank ≤ r) : A.rank ≤ r
 theorem le_rank_of_checkList' … (hr : r ≤ c.rank) : r ≤ A.rank
 ```
 
-`vecOfList (k + 1) (a :: l)` unfolds to `vecCons a (vecOfList k l)`, so a
-literal `!![…]` is *definitionally* `ofLists n m [[…], …]` of its own
+A literal `!![…]` is *definitionally* `ofLists n m [[…], …]` of its own
 entry expressions, one unfolding per entry; `hA` is `rfl`, and the kernel
 never evaluates an entry through `Matrix.of` and `vecCons` inside the
 arithmetic. This matters: reading the entries of a `16 × 16` literal by
 kernel evaluation of `A i j` costs about `200 ms`, more than the whole
-certificate check, while the definitional identification costs `6 ms`.
+certificate check, while the definitional identification costs `6 ms`; the
+`fun i j => …` and `Matrix.ofArray` forms take the `200 ms` route.
 
 The proof follows `rank_eq_of_cert`. Lower bound: with `B` the pivot block
 `A.submatrix rows cols` and `V̄` the matrix of `vt` over `ZMod modulus`
@@ -426,8 +425,10 @@ A.rank ≤ r      r ≥ A.rank
 r ≤ A.rank      A.rank ≥ r
 ```
 
-for `A : Matrix (Fin n) (Fin m) ℤ` a closed `!![…]` or `Matrix.of ![…]`
-literal, possibly behind definitions (unfolded within a small budget), and
+for `A : Matrix (Fin n) (Fin m) ℤ` a closed literal in one of the four
+syntaxes of the literal layer of `hex-matrix-mathlib` (`!![…]`,
+`Matrix.of ![…]`, `fun i j => …`, `Matrix.ofArray xs h`), possibly behind
+definitions (unfolded within a small budget), and
 `r` a closed natural number compared in the ordinary order on `Nat`.
 Entries are closed integer expressions that `norm_num` evaluates and that
 the kernel reduces to their numerals: numerals and arithmetic on them
@@ -580,7 +581,8 @@ An implementer must re-run these searches when the Mathlib pin moves.
   `exists_rankCert_of_decomposition` on a `2 × 2` matrix of rank `1`, to
   check that the hypotheses are stated in the form a consumer has;
 - the `rank` tactic in every orientation on the `3 × 4` example, on
-  `!![…]` with a compound entry, on `Matrix.of ![…]`, on the empty shapes,
+  `!![…]` with a compound entry, on `Matrix.of ![…]`, `fun i j => …` and
+  `Matrix.ofArray` literals, on the empty shapes,
   on a `16 × 16` full-rank and a `32 × 32` rank-`2` literal, and its
   messages on a false target, a symbolic matrix, a rational matrix and a
   closed non-literal (`#guard_msgs`).

--- a/HexRankMathlib/Tactic.lean
+++ b/HexRankMathlib/Tactic.lean
@@ -8,8 +8,6 @@ module
 
 public meta import HexRankMathlib.Kernel
 public import HexRankMathlib.Kernel
-public meta import Mathlib.Data.Fin.VecNotation
-public meta import Mathlib.Tactic.Echelon.Rat
 public meta import Lean
 
 public meta section
@@ -17,12 +15,15 @@ public meta section
 /-!
 The `rank` tactic on Mathlib matrices: closes `A.rank = r`, `A.rank ≤ r`,
 `r ≤ A.rank` (and their mirror images) for a closed integer matrix literal
-`A` written as `!![…]` or `Matrix.of ![…]`, possibly behind definitions.
+`A` in one of the four syntaxes of `HexMatrixMathlib.Literal` (`!![…]`,
+`Matrix.of ![…]`, `fun i j => …`, `Matrix.ofArray xs h`), possibly behind
+definitions.
 
 Compiled code evaluates the entries with `norm_num`, runs the rank producer
 and builds a `RankWitness`; the proof is `rank_eq_of_checkList'` applied to
-`rfl` (the literal is definitionally `ofLists n m L` for the row list `L`
-of its entries' numerals) and to one kernel `decide` on `checkRankList`.
+the identification of the literal with the row list `L` of its entries'
+numerals (`rfl` for a vector chain, one kernel `decide` on `entriesEq`
+otherwise) and to one kernel `decide` on `checkRankList`.
 The whole proof is added as an auxiliary theorem, checked synchronously, so
 the kernel checks it exactly once and a rejection is reported by the tactic.
 Entries must be closed integer expressions that `norm_num` evaluates and
@@ -72,68 +73,29 @@ def rankTarget? (target : Expr) : Option (Expr × Expr × Rel × Bool) :=
       else none
   | _ => none
 
-/-- A recognized integer matrix literal: its shape, the entry expressions as
-written, and their values. -/
+/-- A recognized integer matrix literal with its evaluated entries. -/
 structure Literal where
-  /-- Rows. -/
-  n : Nat
-  /-- Columns. -/
-  m : Nat
-  /-- The entry expressions, row-major, as they appear in the literal. -/
-  entries : Array (Array Expr)
+  /-- The recognized literal. -/
+  lit : HexMatrixMathlib.Literal.Recognized
   /-- The evaluated entries. -/
   values : Array (Array Int)
 
-/-- How many definitions are unfolded when looking for a literal. -/
-def unfoldBudget : Nat := 8
-
-/-- Match a closed `Matrix.of ![…]` literal (the `!![…]` notation included):
-its dimensions, entry type, and rows of entries.  Like Mathlib's
-`matchMatrixLit?`, but the dimensions may be any closed expressions that
-evaluate to numerals, as `Matrix.of ![…]` elaborates them as `Nat.succ`
-chains, and every `vecCons` chain must end in `vecEmpty`, so that the
-literal is definitionally the `ofLists` of its entries. -/
-def matchLit? (A : Expr) : MetaM (Option (Nat × Nat × Expr × Array (Array Expr))) := do
-  if A.hasFVar || A.hasMVar then return none
-  let_expr Matrix finM finN R := ← inferType A | return none
-  let_expr Fin mE := ← whnfR finM | return none
-  let_expr Fin nE := ← whnfR finN | return none
-  let some m ← (Meta.evalNat mE).run | return none
-  let some n ← (Meta.evalNat nE).run | return none
-  let_expr DFunLike.coe _ _ _ _ f v := A | return none
-  let_expr Matrix.of _ _ _ := f | return none
-  let (rows, _, tail) ← Matrix.matchVecConsPrefix mE v
-  unless rows.length == m && tail.getAppFn.isConstOf ``Matrix.vecEmpty do return none
-  let entries ← rows.toArray.mapM fun row => do
-    let (es, _, tail) ← Matrix.matchVecConsPrefix nE row
-    unless es.length == n && tail.getAppFn.isConstOf ``Matrix.vecEmpty do failure
-    return es.toArray
-  return some (m, n, R, entries)
-
-/-- Find the literal behind `A`, unfolding definitions within `unfoldBudget`. -/
-partial def matchLiteral? (A : Expr) (budget : Nat := unfoldBudget) :
-    MetaM (Option (Nat × Nat × Expr × Array (Array Expr))) := do
-  if let some r ← matchLit? A then return some r
-  if budget = 0 then return none
-  match ← unfoldDefinition? A with
-  | some A' => matchLiteral? A' (budget - 1)
-  | none => return none
-
 /-- Recognize and evaluate a closed integer literal. -/
 def literal? (A : Expr) : MetaM (Option Literal) := do
-  let some (n, m, R, entries) ← matchLiteral? A | return none
-  unless (← whnfR R).isConstOf ``Int do
-    throwError "rank: declined: only integer matrices are supported; the entry type is{indentExpr R}"
-  let values ← entries.mapM (·.mapM fun e => do
-    let q ← Mathlib.Tactic.Echelon.evalRatEntry true e
+  let some lit ← HexMatrixMathlib.Literal.literal? A | return none
+  unless lit.carrier.isConstOf ``Int do
+    throwError "rank: declined: only integer matrices are supported; the entry type is{indentExpr lit.carrier}"
+  let values ← lit.entries.mapM (·.mapM fun e => do
+    let q ← HexMatrixMathlib.Literal.evalEntry e
     unless q.den = 1 do
       throwError "rank: declined: the entry is not an integer{indentExpr e}"
     return q.num)
-  return some ⟨n, m, entries, values⟩
+  return some ⟨lit, values⟩
 
 /-- The witness of a literal, by the compiled producer. -/
 def witness (lit : Literal) : MetaM RankWitness := do
-  let A : Hex.Matrix Int lit.n lit.m := Hex.Matrix.ofFn fun i j => (lit.values[i.val]!)[j.val]!
+  let A : Hex.Matrix Int lit.lit.n lit.lit.m :=
+    Hex.Matrix.ofFn fun i j => (lit.values[i.val]!)[j.val]!
   match Hex.Matrix.rankWitness A with
   | .ok w => return w
   | .error e => throwError "rank: declined: the producer found no witness: {e}"
@@ -142,16 +104,10 @@ def witness (lit : Literal) : MetaM RankWitness := do
 literal is syntactically the same expression, so the identification with
 the literal is by `rfl` at no cost; any other closed entry, such as
 `1 - 1`, is reduced to its numeral by the kernel once. -/
-def rowList (lit : Literal) : MetaM Expr := do
-  let int := mkConst ``Int
-  let rows ← lit.values.toList.mapM fun row => mkListLit int (row.toList.map toExpr)
-  mkListLit (mkApp (mkConst ``List [Level.zero]) int) rows
+def rowList (lit : Literal) : MetaM Expr :=
+  HexMatrixMathlib.Literal.rowList (mkConst ``Int) (lit.values.map (·.map toExpr))
 
-/-- `of_decide_eq_true` on a closed decidable proposition, for the kernel to
-evaluate; no elaborator-side evaluation happens. -/
-def decideProof (prop : Expr) : MetaM Expr := do
-  let d ← mkDecide prop
-  return mkApp3 (mkConst ``of_decide_eq_true) prop d.appArg! (← mkEqRefl (mkConst ``Bool.true))
+open HexMatrixMathlib.Literal (decideProof)
 
 /-- Diagnose a proof the kernel rejected: evaluate the bound comparison and
 the certificate check with the kernel, and test the identification of the
@@ -191,14 +147,14 @@ def proveGoal (target : Expr) : MetaM Expr := do
   if other.hasFVar || other.hasExprMVar then
     throwError "rank: declined: the bound{indentExpr other}\nmust be a closed term"
   let some lit ← literal? A |
-    throwError "rank: declined: the matrix is not a closed `!![…]` or `Matrix.of ![…]` literal{indentExpr A}"
+    throwError "rank: declined: the matrix is not a closed `!![…]`, `Matrix.of ![…]`, `fun i j => …` or `Matrix.ofArray` literal{indentExpr A}"
   let w ← witness lit
   let L ← rowList lit
   let c := toExpr w
-  let nE := mkNatLit lit.n
-  let mE := mkNatLit lit.m
+  let nE := mkNatLit lit.lit.n
+  let mE := mkNatLit lit.lit.m
   let ofL ← mkAppM ``HexMatrixMathlib.ofLists #[nE, mE, L]
-  let hA ← mkExpectedTypeHint (← mkEqRefl A) (← mkEq A ofL)
+  let hA ← HexMatrixMathlib.Literal.identification lit.lit A L
   let check ← mkEq (← mkAppM ``Hex.Matrix.checkRankList #[nE, mE, L, c]) (mkConst ``Bool.true)
   let hcheck ← decideProof check
   -- the certified rank as a literal; `c.rank` reduces to it

--- a/HexRankMathlib/Tests.lean
+++ b/HexRankMathlib/Tests.lean
@@ -67,6 +67,18 @@ example : Matrix.rank (R := ℤ) !![1, 2, 3; 2, 4, 6] = 1 := by rank
 example : Matrix.rank (R := ℤ) !![1; 2; 3] = 1 := by rank
 example : Matrix.rank (R := ℤ) !![0, 1; 0, 0] = 1 := by rank
 
+/-- The rank-`1` matrix as a `fun i j => …` literal. -/
+def rankFromFn : Matrix (Fin 3) (Fin 3) ℤ := fun i j => (i.val : ℤ) * j.val
+
+example : rankFromFn.rank = 1 := by rank
+example : Matrix.rank (fun i j : Fin 2 => if i = j then (2 : ℤ) else 0) = 2 := by rank
+
+/-- The rank-`2` matrix as a row-major array literal. -/
+def rankOfArray : Matrix (Fin 2) (Fin 3) ℤ := Matrix.ofArray #[1, 2, 3, 2, 4, 7] rfl
+
+example : rankOfArray.rank = 2 := by rank
+example : Matrix.rank (Matrix.ofArray (m := 2) (n := 2) #[(1 : ℤ), 2, 2, 4] rfl) = 1 := by rank
+
 /-- A `16 × 16` matrix of full rank. -/
 def dense16 : Matrix (Fin 16) (Fin 16) ℤ :=
   !![-9, 2, 8, -1, -6, -2, -1, -8, 2, 1, 9, -6, 9, 8, -5, 0;
@@ -146,7 +158,7 @@ error: rank: declined: only integer matrices are supported; the entry type is
 example : Matrix.rank (R := ℚ) !![1 / 2, 1; 1, 2] = 1 := by rank
 
 /--
-error: rank: declined: the matrix is not a closed `!![…]` or `Matrix.of ![…]` literal
+error: rank: declined: the matrix is not a closed `!![…]`, `Matrix.of ![…]`, `fun i j => …` or `Matrix.ofArray` literal
   1 * 1
 -/
 #guard_msgs in

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -967,7 +967,8 @@ lean_exe hex_interval_pnt_fks2_local where
 -- examples and regression tests are compiled through this separate target so
 -- removing them from an umbrella cannot silently remove them from CI.
 lean_lib HexReleaseTests where
-  globs := #[`HexBerlekamp.FactorTacticTests,
+  globs := #[`HexMatrixMathlib.Tests,
+    `HexBerlekamp.FactorTacticTests,
     `HexBerlekampMathlib.FactorPolyTests,
     `HexBerlekampZassenhaus.FactorTacticTests,
     `HexBerlekampZassenhausMathlib.FactorPolyTests,
@@ -999,6 +1000,9 @@ lean_lib HexReleaseTests where
     `HexRCF.DecisionTests,
     `HexRCF.ReifyTests,
     `HexRCF.LintTests]
+    -- a name array mapped through Glob.one: an array literal this long is
+    -- elaborated in chunks, on which the name-to-glob coercion fails
+    |>.map Glob.one
 
 -- Verification-only modules for the incubating multivariate factorization
 -- stack. Keep this separate from the released-test target, whose module list

--- a/scripts/release/released.yml
+++ b/scripts/release/released.yml
@@ -372,6 +372,7 @@ repos:
 
   - repo: leanprover/hex-matrix-mathlib
     lib: HexMatrixMathlib
+    test_modules: [HexMatrixMathlib.Tests]
     umbrella: true
     spec: hex-matrix-mathlib
     pins: [hex-basic, hex-matrix]


### PR DESCRIPTION
This PR moves the Mathlib matrix literal layer out of `HexRankMathlib` into `HexMatrixMathlib/Literal.lean`, where `SPEC/matrix-tactics.md` §Placement puts it, so that `det` and `char_poly` reuse it without importing the rank library. `vecOfList`, `ofLists` and `ofLists_apply` move unchanged; the meta recognizer (`shape?`, `matchLiteral?`, the unfolding budget, `evalEntries`, `rowList`, `identification`, `elabArgument`) now covers the four syntaxes `!![…]`, `Matrix.of ![…]`, `fun i j => …` and `Matrix.ofArray xs h`, with the definitional identification for the vector chains and one kernel `decide` on the new `entriesEq` for the other two shapes. `Certified` is the record the `%` term forms return. The `rank` tactic is switched to the shared layer and accepts the two new shapes; `HexMatrixMathlib/Tests.lean` identifies each syntax and the empty shapes with its row list and is built through `HexReleaseTests`, and `hex-matrix-mathlib`'s SPEC gains a §Matrix literals section.

Closes https://github.com/kim-em/hex-dev/issues/10213

🤖 Prepared with Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Acr25EBQLiGqJkxu3bv5Tr