### PR TITLE
docs(graph-iso): document verified sparse nauty

### DIFF
--- a/HexManual/Chapters/HexGraphIso.lean
+++ b/HexManual/Chapters/HexGraphIso.lean
@@ -29,26 +29,37 @@ tag := "hex-graph-iso-intro"
 %%%
 
 `HexGraphIso` computes canonical forms and isomorphisms of finite simple
-undirected graphs with ordered vertex colours. The canonical labelling
-algorithm used in `HexGraphIso` is an exact translation of the
-[nauty](https://users.cecs.anu.edu.au/~bdm/nauty/) 2.9.3 algorithm into Lean. (We
-use conformance testing, rather than a theorem, to ensure they are
-identical, and prove our theorems about the Lean translation.) The exact
-algorithm, including the output-relevant choices absent from the published
-literature, is specified in {ref "nauty-algorithm"}[The `nauty` canonical
-labelling algorithm]. The
-public names (`canonicalize`, `canon`, `label`, `isIso`) run that
-translation directly, and the theorems reach them because a proven
-certificate checker is shown to accept the translation's answer on
-every input. Two coloured graphs are isomorphic exactly when their
-canonical forms are equal
-({name Hex.GraphIso.iso_iff_canon_eq}`iso_iff_canon_eq`),
-and the
-`graph_iso` tactic closes both positive and negative isomorphism goals with the
-kernel performing the decisive replay: positive goals through the
-checked transporter, negative goals through the root refinement code
-when it separates the two graphs and through a checked canonical-key
-certificate otherwise.
+undirected graphs with ordered vertex colours. It implements both dense
+and sparse [nauty](https://users.cecs.anu.edu.au/~bdm/nauty/) 2.9.3 in Lean.
+Conformance tests compare each implementation with its corresponding C
+engine, including the search decisions and canonical labels. The Lean
+theorems prove totality and correctness of the implementations themselves.
+{ref "nauty-algorithm"}[The `nauty` canonical labelling algorithm]
+describes the dense algorithm and the rules that differ in sparse nauty.
+
+Import `HexGraphIso` for both native graph representations, their
+operations and `graph_iso`. The computational library does not depend
+on Mathlib. Import `HexGraphIsoMathlib` for the correspondence theorems
+and tactic support on Mathlib graphs.
+
+The graph type selects the implementation. {name Hex.Graph}`Graph` and
+{name Hex.GraphIso.Colored}`Colored` use dense nauty.
+{name Hex.SparseGraph}`SparseGraph` and
+{name Hex.GraphIso.Sparse.Colored}`Sparse.Colored` use sparse nauty.
+Both provide canonicalization, isomorphism search and automorphism
+groups. There is no automatic switch based on graph size or density.
+The {ref "hex-graph-iso-sparse"}[sparse examples] show the native edge
+constructor and explain when an explicit conversion is useful.
+
+Within either implementation, two coloured graphs are isomorphic
+exactly when their canonical forms are equal, by
+{name Hex.GraphIso.iso_iff_canon_eq}`iso_iff_canon_eq` or
+{name Hex.GraphIso.Sparse.iso_iff_canon_eq}`Sparse.iso_iff_canon_eq`.
+The public canonicalization functions execute the search directly,
+without producing or replaying a certificate. The `graph_iso` tactic
+produces kernel proofs: positive goals use a checked transporter,
+and negative goals use a separating root refinement code or checked
+canonical-key certificates. The same syntax supports both graph types.
 
 Colours are the general input, but a graph with no colours to speak of
 should not have to acquire one. The same operations and the same
@@ -196,7 +207,8 @@ open HexGraphIsoChapterExample
 
 #guard (Graph.autos petersen).order = 120
 #guard (Graph.autos petersen).numOrbits = 1
-#guard (Graph.autos petersen).orbits = #[0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+#guard (Graph.autos petersen).orbits =
+  #[0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 #guard ((Graph.autos petersen).gens.map
   fun p => (List.finRange 10).map fun i => (p.get i).val) =
     [[0, 1, 2, 7, 5, 4, 6, 3, 9, 8],
@@ -210,7 +222,8 @@ The list is data, but membership is a theorem: every permutation
 check the isomorphism surface runs.
 
 ```lean
-example (p : Perm 10) (h : p ∈ (Graph.autos petersen).gens) :
+example (p : Perm 10)
+    (h : p ∈ (Graph.autos petersen).gens) :
     Graph.IsIso petersen petersen p :=
   Graph.autos_isIso h
 
@@ -226,6 +239,216 @@ also proves that the reported orbit count and order are the cardinalities
 of the orbit quotient and the full automorphism group, respectively.
 Here `order = 120` is the group order. Conformance independently compares
 these values against nauty.
+
+# Sparse graphs
+%%%
+tag := "hex-graph-iso-sparse"
+%%%
+
+A graph given by a short edge list need not allocate an adjacency
+matrix. {name Hex.SparseGraph}`SparseGraph n` stores `n + 1` offsets
+and a flat array containing the neighbours of every vertex, using
+`O(n + |E|)` storage. Each row is sorted, duplicate-free and loopless,
+and each undirected edge occurs in both directions.
+
+{name Hex.SparseGraph.ofEdges}`SparseGraph.ofEdges` accepts pairs of
+vertices in `Fin n`, removes duplicate edges and drops loops.
+For external data with natural-number endpoints, use
+{name Hex.SparseGraph.ofEdges?}`SparseGraph.ofEdges?`: it rejects
+loops and out-of-range endpoints instead. Both constructors normalize
+edge orientation and row order. General input requires sorting, so the
+storage bound is not a claim that every construction takes linear time.
+
+## Canonicalization and isomorphism
+%%%
+tag := "hex-graph-iso-sparse-canon"
+%%%
+
+Here is the Petersen graph built directly from its fifteen edges.
+Relabelling swaps vertices `0` and `9`; the pentagonal prism replaces
+the inner star by a pentagon. All three values remain sparse throughout
+construction and search.
+
+```lean
+namespace HexGraphIsoSparseExample
+
+def petersen : SparseGraph 10 := SparseGraph.ofEdges
+  [(0, 1), (1, 2), (2, 3), (3, 4), (0, 4),
+   (5, 7), (7, 9), (6, 9), (6, 8), (5, 8),
+   (0, 5), (1, 6), (2, 7), (3, 8), (4, 9)]
+
+def swapEnds : Perm 10 :=
+  ⟨#v[9, 1, 2, 3, 4, 5, 6, 7, 8, 0], by decide, by decide⟩
+
+def renamed : SparseGraph 10 := petersen.relabel swapEnds
+
+def prism : SparseGraph 10 := SparseGraph.ofEdges
+  [(0, 1), (1, 2), (2, 3), (3, 4), (0, 4),
+   (5, 6), (6, 7), (7, 8), (8, 9), (5, 9),
+   (0, 5), (1, 6), (2, 7), (3, 8), (4, 9)]
+
+#guard SparseGraph.ofEdges? 3 [(0, 1), (1, 0)] =
+  some (SparseGraph.ofEdges [(0, 1)])
+#guard (SparseGraph.ofEdges? 3 [(0, 3)]).isNone
+#guard (SparseGraph.ofEdges? 3 [(1, 1)]).isNone
+
+#guard petersen ≠ renamed
+#guard SparseGraph.canon petersen =
+  SparseGraph.canon renamed
+#guard (SparseGraph.findIso petersen renamed).isSome
+#guard !(SparseGraph.isIso petersen prism)
+
+example : SparseGraph.Isomorphic petersen renamed := by
+  graph_iso
+
+example : ¬ SparseGraph.Isomorphic petersen prism := by
+  graph_iso
+```
+
+{name Hex.SparseGraph.canonicalize}`SparseGraph.canonicalize` returns
+the form and its label together. A label maps each new vertex to its
+old vertex. In contrast, the permutation returned by
+{name Hex.SparseGraph.findIso}`SparseGraph.findIso` maps vertices of
+the first input to vertices of the second. These operations are total,
+including on the empty graph. A result of `none` from isomorphism search
+means that the graphs are not isomorphic, by
+{name Hex.SparseGraph.findIso_eq_none_iff}`SparseGraph.findIso_eq_none_iff`.
+
+```lean
+example (G : SparseGraph 10) :
+    G.relabel (SparseGraph.label G).perm =
+      SparseGraph.canon G :=
+  SparseGraph.relabel_label G
+
+example (G H : SparseGraph 10) :
+    SparseGraph.Isomorphic G H ↔
+      SparseGraph.canon G = SparseGraph.canon H :=
+  SparseGraph.iso_iff_canon_eq G H
+
+example : SparseGraph.Isomorphic
+    (SparseGraph.empty 0) (SparseGraph.empty 0) := by
+  graph_iso
+```
+
+## Ordered colours and automorphisms
+%%%
+tag := "hex-graph-iso-sparse-autos"
+%%%
+
+Sparse coloured graphs use the same
+{name Hex.GraphIso.Coloring}`Coloring` as dense graphs. Marking a
+Petersen edge or a non-edge imposes exactly the constraints from the
+{ref "hex-graph-iso-colours"}[ordered-colour example].
+
+```lean
+def edgeMarkA : Sparse.Colored 10 2 :=
+  ⟨petersen, HexGraphIsoChapterExample.markPair 0 1⟩
+def edgeMarkB : Sparse.Colored 10 2 :=
+  ⟨petersen, HexGraphIsoChapterExample.markPair 2 3⟩
+def nonedgeMark : Sparse.Colored 10 2 :=
+  ⟨petersen, HexGraphIsoChapterExample.markPair 0 2⟩
+
+example : Sparse.Isomorphic edgeMarkA edgeMarkB := by
+  graph_iso
+
+example : ¬ Sparse.Isomorphic edgeMarkA nonedgeMark := by
+  graph_iso
+
+#guard (SparseGraph.autos petersen).order = 120
+#guard (SparseGraph.autos petersen).numOrbits = 1
+#guard (Sparse.autos edgeMarkA).order = 8
+
+example (p : Perm 10)
+    (h : p ∈ (SparseGraph.autos petersen).gens) :
+    SparseGraph.IsIso petersen petersen p :=
+  SparseGraph.autos_isIso h
+
+end HexGraphIsoSparseExample
+```
+
+{name Hex.GraphIso.Sparse.autos}`Sparse.autos` and
+{name Hex.SparseGraph.autos}`SparseGraph.autos` return generators,
+orbit representatives, the orbit count and an exact natural-number
+group order from one traversal. The generators generate every
+automorphism, by
+{name Hex.GraphIso.Sparse.autos_complete}`Sparse.autos_complete`.
+Equality of two orbit entries is equivalent to the existence of an
+automorphism carrying one vertex to the other, by
+{name Hex.GraphIso.Sparse.autos_sameOrbit}`Sparse.autos_sameOrbit`.
+The order is the product of the stabilizer indices accumulated during
+the search. Its cardinality theorem and the corresponding Mathlib
+operations appear in the
+{ref "hex-graph-iso-mathlib-sparse"}[sparse Mathlib section].
+
+## Choosing and converting representations
+%%%
+tag := "hex-graph-iso-representations"
+%%%
+
+Native sparse input avoids storing or scanning an adjacency matrix.
+For an existing dense graph,
+{name Hex.Graph.toSparse}`Graph.toSparse` scans its `n²` entries.
+{name Hex.SparseGraph.toDense}`SparseGraph.toDense` allocates a dense
+matrix. Both conversions preserve adjacency and isomorphism. To compare
+graphs stored differently, convert one so that both use the same engine.
+The {ref "hex-graph-iso-performance"}[performance comparison] shows
+how the choice affects different graph families.
+
+Canonicalization itself need not commute with conversion. For two
+disjoint edges, dense and sparse nauty choose different canonical
+adjacency matrices:
+
+```lean
+namespace HexGraphIsoRepresentationExample
+
+def matching : SparseGraph 4 :=
+  SparseGraph.ofEdges [(0, 3), (1, 2)]
+
+#guard (Graph.label matching.toDense).toArray =
+  #[0, 3, 1, 2]
+#guard (SparseGraph.label matching).toArray = #[0, 1, 2, 3]
+#guard (SparseGraph.canon matching).toDense ≠
+  Graph.canon matching.toDense
+
+end HexGraphIsoRepresentationExample
+```
+
+Each result is a canonical form for its own algorithm. When storing
+canonical forms as persistent keys, record which engine and options
+produced them. Traces defines another algorithm and is included in the
+performance comparison, but has no Lean implementation in this library.
+
+## Certificates and tactic limits
+%%%
+tag := "hex-graph-iso-certificates"
+%%%
+
+`graph_iso` operates on closed graph expressions and selects the dense
+or sparse checker from their types. A positive proof checks a literal
+vertex permutation. For a negative proof, a differing root refinement
+code suffices when available. Otherwise the tactic produces compact
+certificates for both sparse canonical keys and replays their literal
+checkers in the kernel. The sparse checker recomputes sparse refinement
+and comparisons. The direct canonicalization API does not perform this
+replay.
+
+The tactic accepts two optional limits. `maxSearchNodes` bounds search
+node visits, and `maxCertRecords` bounds certificate records. Both
+default to `100000`. Exceeding a limit makes the tactic fail; it does
+not establish non-isomorphism. They can be raised independently:
+
+```lean
+example : ¬ SparseGraph.Isomorphic
+    HexGraphIsoSparseExample.petersen
+    HexGraphIsoSparseExample.prism := by
+  graph_iso (maxSearchNodes := 200000)
+    (maxCertRecords := 200000)
+```
+
+These limits do not apply to the total canonicalization and isomorphism
+functions. Kernel replay has no estimated-cost cutoff or operation
+meter. Lean's ordinary heartbeat and recursion-depth options still
+apply to elaboration.
 
 # Latin-square isotopy as graph isomorphism
 %%%
@@ -447,19 +670,21 @@ columns, `6, 7, 8` the symbols, and `9 + 3 * i + j` the position
 namespace LatinAutomorphismExample
 
 def incidenceEdges : List (Nat × Nat) :=
-  (List.range 3).flatMap fun i => (List.range 3).flatMap fun j =>
+  (List.range 3).flatMap fun i =>
+    (List.range 3).flatMap fun j =>
     [(i, 9 + 3 * i + j), (3 + j, 9 + 3 * i + j),
      (6 + (i + j) % 3, 9 + 3 * i + j)]
 
 def incidence : Colored 18 4 where
-  graph := (Graph.ofEdges? 18 incidenceEdges).getD (Graph.empty 18)
+  graph := (Graph.ofEdges? 18 incidenceEdges).getD
+    (Graph.empty 18)
   coloring := (Coloring.ofVector? (Hex.Vector.ofFn' fun v =>
       if v.val < 3 then 0 else if v.val < 6 then 1
-      else if v.val < 9 then 2 else 3)).getD (Coloring.mod 18 4)
+      else if v.val < 9 then 2 else 3)).getD
+        (Coloring.mod 18 4)
 
--- the cyclic square of order three: eighteen isotopies, and four
--- orbits, one on each of the rows, the columns, the symbols and the
--- positions
+-- The cyclic square of order three has eighteen isotopies.
+-- The orbits are rows, columns, symbols and positions.
 #guard (autos incidence).order = 18
 #guard (autos incidence).numOrbits = 4
 #guard (autos incidence).orbits =
@@ -490,82 +715,86 @@ symbols.
 tag := "hex-graph-iso-performance"
 %%%
 
-The Lean implementation runs the same algorithm as nauty in the
-strictest sense: conformance testing pins the visited-node counters, so
-both programs traverse exactly the same search tree on every
-conformance case. Every timing difference is therefore a per-node
-constant factor of the implementation, never an algorithmic
-difference, and the one way that factor could grow with the vertex
-count would be a loop over vertices where nauty runs a word
-operation. The search keeps its vertex sets packed sixty-three to a
-word, so a least-squares fit of per-node cost against `n` on the
-benchmark corpus gives hex the same exponent as nauty on every family:
-`n^1.7` to `n^1.9` on grids, Paley graphs, circulants and random
-graphs, `n^1.3` on Kneser graphs and `n^1.0` on Johnson graphs, in
-each case within `0.2` of nauty's, and the hex/nauty ratio is `7.7`
-below 64 vertices and `7.1` above. CI refits every recorded sweep and
-fails when a family's hex exponent exceeds nauty's by more than `0.2`.
-The table shows the factor on four parametrised families: grids, where
-refinement discretizes quickly; Paley graphs, refinement's hard case
-among the sparse families; and the dense Latin-square and Kneser
-graphs. The `hex` column is `canonicalize`, which carries the theorems
-of this chapter as it stands: no certificate is produced or replayed
-on that path.
+The six-way comparison runs C dense nauty, C sparse nauty, C Traces,
+Hex dense, Hex sparse and Alex Meiburg's IsoGraph on the same 333
+labelled graphs from 20 families, through 3,072 vertices. It measures
+native canonicalization after input construction. For Hex sparse this
+includes parsing the returned label and producing normalized sparse
+canonical rows. It does not include certificate production or kernel
+replay.
+
+![Canonicalization time by graph family for all six implementations](https://kim-em.github.io/hex-dev/figures/hexgraphiso-comparison-families.svg)
+
+![Six-way cactus plot of canonicalization times](https://kim-em.github.io/hex-dev/figures/hexgraphiso-comparison-cactus.svg)
+
+Open the [family plot](https://kim-em.github.io/hex-dev/figures/hexgraphiso-comparison-families.svg)
+or [cactus plot](https://kim-em.github.io/hex-dev/figures/hexgraphiso-comparison-cactus.svg)
+at full size to inspect the individual curves.
+
+In the retained measurements, the implementations complete these numbers
+of instances within the five-second per-call cutoff:
 
 :::table +header
-* * graph
-  * vertices
-  * nauty (ms)
-  * hex (ms)
-* * `Families.grid 5 5`
-  * 25
-  * 0.014
-  * 0.084
-* * `Families.grid 15 15`
-  * 225
-  * 0.86
-  * 4.0
-* * `Families.paley 29`
-  * 29
-  * 0.019
-  * 0.14
-* * `Families.paley 229`
-  * 229
-  * 1.1
-  * 6.7
-* * `Families.latinSquare 5`
-  * 25
-  * 0.019
-  * 0.19
-* * `Families.latinSquare 13`
-  * 169
-  * 0.78
-  * 6.6
-* * `Families.kneser 7 2`
-  * 21
-  * 0.014
-  * 0.16
-* * `Families.kneser 22 2`
-  * 231
-  * 3.4
-  * 38
+* * implementation
+  * completed / 333
+* * C dense nauty
+  * 307
+* * C sparse nauty
+  * 318
+* * C Traces
+  * 308
+* * Hex dense
+  * 282
+* * Hex sparse
+  * 310
+* * IsoGraph
+  * 296
 :::
 
-Measured on chungus2, 2026-09-05, minimum over repeated runs;
-regenerate with `scripts/bench/graphiso_cactus_sweep.sh`. On
-ten-vertex pairs like the examples of this chapter, the kernel-checked
-`graph_iso` proof costs roughly 20 milliseconds on a positive goal and
-0.7 to 0.9 seconds on a negative one. That price is separate from the
-table and does not shrink with it: a kernel proof still replays a
-certificate inside the kernel, whereas `canonicalize` runs no replay
-at all. For breadth across the whole benchmark corpus, see the cactus
-plots in `reports/figures/` in the repository:
-`hexgraphiso-canon-cactus.svg` for canonical labelling over the
-deterministic families, and `hexgraphiso-pairs-cactus.svg` for the
-proof obligations. The latter plots the negative pairs only. For the
-reason just given the two polarities differ by well over an order of
-magnitude, so a single curve over both would describe neither; the
-figure's caption carries the positive median for comparison.
+On 282 cases completed by both Hex implementations, the median
+per-instance sparse/dense time ratio is `0.25`. On 296 cases completed
+by both Hex sparse and IsoGraph, the corresponding ratio is `0.73`.
+These ratios describe different solved subsets. The sparse measurements
+were refreshed while the other five series were retained from earlier
+sessions on the same shared host, so the ratios are observations about
+this corpus, not universal speed factors.
+
+The family plot shows where each algorithm does well. A cross marks
+where a series stops: a call exceeding five seconds stops that series
+on the family, and larger sizes are not attempted. Missing observations
+are not assigned the cutoff time. The cactus plot sorts each series'
+completed instances independently; farther right means more completed
+instances, while lower means less time. Neither plot claims a general
+complexity bound for graph isomorphism.
+
+The protocol uses two passes, a warmup and five timed calls per case
+(one when warmup exceeds one second), and reports the minimum completed
+call. The [comparison report](https://github.com/kim-em/hex-dev/blob/main/reports/graphiso-comparison.md)
+records the corpus, versions, input boundaries, stopping rules, raw
+outcomes and reproduction commands. Its
+[search and conversion figure](https://kim-em.github.io/hex-dev/figures/hexgraphiso-comparison-search-families.svg)
+and tables separate construction and relabelling costs. Constructing a
+sparse graph from edges avoids a dense intermediate; converting an
+existing matrix still requires reading that matrix.
+
+Conformance compares Hex dense with C dense, and Hex sparse with C
+sparse. The sparse comparison agrees on visited-node counts on every
+completed case. Its per-node scaling check passes the recorded `0.2`
+exponent tolerance on every family with enough matched sizes. This is
+evidence that the representation improvements preserve the intended
+search, rather than evidence that dense, sparse and Traces explore the
+same tree.
+
+Proof-producing use has separate costs. A call to `graph_iso` must
+construct a proof whose decisive checks run in the kernel. Positive
+transporter checks and negative certificate replays can have very
+different costs, and neither can be inferred from native
+canonicalization timings. The
+[validation report](https://github.com/kim-em/hex-dev/blob/main/reports/sparse-nauty-validation.md)
+links the separate automorphism, certificate-production, native-replay
+and imported kernel-proof measurements. The public totality and
+correctness theorems apply to the optimized sparse search used in the
+comparison.
 
 # The Mathlib correspondence
 %%%
@@ -676,3 +905,90 @@ of `Colored.Iso G G` itself.
 {docstring Hex.GraphIso.Mathlib.autNumOrbits_card}
 
 {docstring Hex.GraphIso.Mathlib.autOrder_card}
+
+## Choosing sparse search from Mathlib
+%%%
+tag := "hex-graph-iso-mathlib-sparse"
+%%%
+
+The direct `graph_iso` extension on Mathlib graphs uses the dense
+encoding. To select sparse nauty, apply
+{name Hex.GraphIso.Mathlib.Sparse.encode_iso_iff}`Sparse.encode_iso_iff`
+and then use `graph_iso` on the resulting native sparse goal. Both
+enumerations may be chosen independently. The theorem transports the
+answer back to the original coloured Mathlib graphs.
+
+Here two presentations of a five-cycle use steps of one and two in
+`Fin 5`. A path on the same five vertices supplies a negative example.
+The definitions and claims are on the Mathlib side; the sparse
+encoding appears only inside the proofs.
+
+```lean
+namespace HexGraphIsoSparseMathlibExample
+
+def cycle : SimpleGraph (Fin 5) :=
+  SimpleGraph.fromRel fun i j => j = i + 1
+def star : SimpleGraph (Fin 5) :=
+  SimpleGraph.fromRel fun i j => j = i + 2
+def path : SimpleGraph (Fin 5) :=
+  SimpleGraph.fromRel fun i j => j.val = i.val + 1
+
+instance : DecidableRel cycle.Adj := fun _ _ =>
+  decidable_of_iff _ (SimpleGraph.fromRel_adj ..).symm
+instance : DecidableRel star.Adj := fun _ _ =>
+  decidable_of_iff _ (SimpleGraph.fromRel_adj ..).symm
+instance : DecidableRel path.Adj := fun _ _ =>
+  decidable_of_iff _ (SimpleGraph.fromRel_adj ..).symm
+
+def uncoloured (G : SimpleGraph (Fin 5)) :
+    Hex.GraphIso.Mathlib.Colored (Fin 5) 1 :=
+  ⟨G, fun _ => 0, fun c => ⟨0, Subsingleton.elim _ c⟩⟩
+
+instance (G : SimpleGraph (Fin 5)) [DecidableRel G.Adj] :
+    DecidableRel (uncoloured G).graph.Adj :=
+  inferInstanceAs (DecidableRel G.Adj)
+
+example : (uncoloured cycle).Isomorphic
+    (uncoloured star) := by
+  apply (Sparse.encode_iso_iff
+    (Equiv.refl (Fin 5)) (Equiv.swap (0 : Fin 5) 4)).mpr
+  graph_iso
+
+example : ¬ (uncoloured cycle).Isomorphic
+    (uncoloured path) := by
+  rw [Sparse.encode_iso_iff
+    (Equiv.refl (Fin 5)) (Equiv.refl (Fin 5))]
+  graph_iso
+
+end HexGraphIsoSparseMathlibExample
+```
+
+{name Hex.GraphIso.Mathlib.Sparse.encode}`Sparse.encode` constructs
+sorted neighbour rows without allocating a dense matrix. Given only
+an arbitrary decidable adjacency relation, it still tests vertex pairs.
+For input already available as an edge list, the native
+{name Hex.SparseGraph.ofEdges}`SparseGraph.ofEdges` constructor avoids
+that quadratic enumeration.
+
+{name Hex.GraphIso.Mathlib.Sparse.iso_iff_canon_eq}`Sparse.iso_iff_canon_eq`
+characterizes Mathlib isomorphism by equality of the computed sparse
+forms, and
+{name Hex.GraphIso.Mathlib.Sparse.canon_encode_eq}`Sparse.canon_encode_eq`
+proves independence from the chosen enumeration. A successful
+isomorphism search can also be decoded directly with
+{name Hex.GraphIso.Mathlib.Sparse.isoOfFindIso}`Sparse.isoOfFindIso`.
+
+The automorphism operations have the same Mathlib interpretations as
+their dense counterparts.
+{name Hex.GraphIso.Mathlib.Sparse.autEquiv}`Sparse.autEquiv` identifies
+the colour-preserving Mathlib automorphism group with the executable
+sparse permutation subgroup.
+{name Hex.GraphIso.Mathlib.Sparse.autos_complete}`Sparse.autos_complete`
+states generation using {name Subgroup.closure}`Subgroup.closure`, and
+{name Hex.GraphIso.Mathlib.Sparse.autos_sameOrbit}`Sparse.autos_sameOrbit`
+identifies the computed representatives with the full group action.
+The numerical results are exact cardinalities:
+
+{docstring Hex.GraphIso.Mathlib.Sparse.autNumOrbits_card}
+
+{docstring Hex.GraphIso.Mathlib.Sparse.autOrder_card}

--- a/HexManual/Chapters/NautyAlgorithm.lean
+++ b/HexManual/Chapters/NautyAlgorithm.lean
@@ -24,11 +24,14 @@ tag := "nauty-algorithm"
 A canonical labelling algorithm takes a finite graph and renames its
 vertices in a standard way, so that two graphs receive the same result
 exactly when they are isomorphic. The most widely used program for this
-task is Brendan McKay's nauty. This chapter is a complete written
-specification of the exact function computed by one pinned version of
-that program: dense nauty 2.9.3, run with the fixed options listed at
-the end of part one. `HexGraphIso` reimplements this algorithm in
-Lean, with identical behaviour.
+task is Brendan McKay's nauty. Parts one and two specify the exact
+function computed by dense nauty 2.9.3 with the fixed options listed
+at the end of part one, and describe its Lean implementation.
+{ref "nauty-algorithm-sparse"}[Part three] describes the different
+refinement, target selection and canonical comparison rules of sparse
+nauty 2.9.3. `HexGraphIso` implements both algorithms and proves their
+correctness. Traces is a separate comparator, with no Lean implementation
+in this library.
 
 No published document specifies this function. Three descriptions come
 closest:
@@ -705,6 +708,226 @@ target cells, row order, and label tie-breaking included, is the
 conformance suite, which compares the two programs on every graph with
 up to six vertices and on the families described in the `HexGraphIso`
 conformance documentation.
+
+# Part three: sparse nauty
+%%%
+tag := "nauty-algorithm-sparse"
+%%%
+
+Sparse nauty shares the individualization and search machinery of
+dense nauty, but changes several choices that determine the answer.
+Replacing dense rows by adjacency lists while keeping dense refinement
+would not reproduce sparse nauty. This section describes the sparse
+rules implemented by {name Hex.GraphIso.Nauty.Sparse.runColored}`runColored`.
+The {ref "hex-graph-iso-sparse"}[sparse API tutorial] gives examples of
+the public operations and their theorems.
+
+## Input and options
+
+The target is `sparsenauty` from the same pinned nauty 2.9.3 release.
+It uses `DEFAULTOPTIONS_SPARSEGRAPH`, with `getcanon = 1`,
+`defaultptn = FALSE`, `digraph = FALSE`, `tc_level = 100`,
+`invarproc = NULL` and `schreier = FALSE`. Other options keep their
+defaults. There are no edge weights or user refinement procedures.
+Vertices initially occur in increasing colour order, then increasing
+original vertex order within each colour. Input neighbour lists are
+sorted, and every initial colour cell is active.
+
+The working graph retains the native compressed adjacency arrays from
+{name Hex.SparseGraph}`SparseGraph`. The partition arrays and
+representation-independent orbit and search operations are shared with
+dense nauty. Sparse dispatch supplies refinement, target selection,
+automorphism testing, canonical comparison and canonical update.
+
+## Sparse refinement
+
+Refinement still produces an equitable ordered partition. Its active
+cells are stored in an array, initially in increasing position order.
+At each pass, it chooses the first singleton among the first ten array
+entries. If there is none, it chooses the last entry. Removal fills the
+chosen slot with the last entry and shortens the array. Thus subsequent
+choices depend on the array order, not just on the set of active cells.
+
+Before this loop, a shallow distance refinement applies when the level
+is at most two, the active array contains exactly one singleton, and
+the partition has at most `n / 8` cells. Breadth-first search computes
+distances from that singleton, using `n` for unreachable vertices.
+Each nontrivial cell is split by increasing distance. The singleton is
+removed from the active array, and the fragments made active by these
+splits are processed by the ordinary loop.
+
+{docstring Hex.GraphIso.Nauty.Sparse.distvals}
+
+For an ordinary pass, neighbour scans record only the nontrivial cells
+touched by the splitter. Their starting positions are sorted, and
+those cells are processed in that order. Untouched cells have zero
+counts throughout and need no scan. The two splitter cases have
+different rules:
+
+* With a singleton splitter, non-neighbours retain their order at the
+  front of the cell. Neighbours follow in reverse of their former
+  cell order. If both fragments are nonempty, they become separate
+  cells. An already active cell keeps both fragments active. Otherwise
+  the smaller fragment becomes active, with the non-neighbour fragment
+  chosen on a tie.
+* With a non-singleton splitter, vertices are grouped by increasing
+  neighbour count. The first two count values are separated by nauty's
+  three-way insertion procedure. Remaining values use its indirect
+  sort. If the old cell was active, every fragment is active.
+  Otherwise all but a largest fragment become active. The two-fragment
+  case activates the first fragment on a size tie. With three or more
+  fragments, the first largest fragment stays inactive.
+
+The indirect sort is part of the algorithm, including its permutation
+of equal-count vertices. Segments shorter than eleven use insertion
+sort. Larger segments use Bentley-McIlroy partitioning, with median of
+three pivot sampling below length `320` and median of nine thereafter.
+The smaller partition is processed first. A stable sort with the same
+numeric keys is not an interchangeable replacement.
+
+{docstring Hex.GraphIso.Nauty.Sparse.Sort.indirect}
+
+The refinement code uses the same
+{name Hex.GraphIso.Nauty.mash}`mash` and
+{name Hex.GraphIso.Nauty.cleanup}`cleanup` arithmetic as dense nauty,
+but summarizes the sparse events. Each ordinary pass records its
+splitter position and the number of touched cells. Singleton processing
+records each touched cell's start, its hit count and any new boundary.
+Count and distance processing have distinct updates involving the
+fragment values, boundaries and activation choices. The dense update
+sequence from part one does not apply to these branches. The executed
+definitions expose their exact update order:
+
+{docstring Hex.GraphIso.Nauty.Sparse.splitSingleton}
+
+{docstring Hex.GraphIso.Nauty.Sparse.splitCounts}
+
+{docstring Hex.GraphIso.Nauty.Sparse.refineWith}
+
+The optimized implementation retains counting and generation-mark
+arrays between nodes. A count is cleared before the first neighbour
+contribution to its cell. Vertex-to-cell indices and cell endpoints
+are maintained through refinement and may be reused by target selection.
+Individualization and partition recovery invalidate these indices.
+Entering refinement with no active cells also leaves them invalid, so
+target selection then scans the partition independently.
+
+The proofs show agreement with fresh refinement on the labelling,
+partition, active set, cell count and refinement code. They establish
+equitable output under the active-splitter invariant, preservation of
+ancestor cells, and equivariance under isomorphism. The bounds on array
+loops do not truncate reachable runs. Reusing storage changes none of
+the choices described above.
+
+## Target selection
+
+For each nontrivial cell, inspect its first vertex. Count the
+nontrivial cells to which that vertex has some but not all possible
+neighbours, including its own cell when applicable. At levels through
+`tc_level`, choose the first cell attaining the greatest count. At
+greater levels, choose the first nontrivial cell. A valid supplied
+target-cell hint takes precedence.
+
+{docstring Hex.GraphIso.Nauty.Sparse.bestcell}
+
+{docstring Hex.GraphIso.Nauty.Sparse.targetcell}
+
+The cached implementation uses the indices maintained by refinement
+and computes the same target. The unpruned specification uses fresh
+refinement and hint-free target selection, branching over every vertex
+of the chosen cell. Proofs justify the cached and hinted choices in
+the production traversal.
+
+## Canonical comparison and the declarative form
+
+A leaf key consists of its path of sparse refinement codes, terminated
+by the same `32767` sentinel, followed by the relabelled sparse graph.
+Codes compare lexicographically first. When they tie, graphs compare
+row by row, from vertex zero onwards. At the first differing row:
+
+* A smaller degree is preferred.
+* With equal degrees, the row containing the smallest vertex in the
+  symmetric difference of the two neighbour sets is preferred.
+
+Thus the degree comparison precedes adjacency comparison. This differs
+from the dense graph order and can select a different canonical form,
+as the {ref "hex-graph-iso-representations"}[two-edge example] shows.
+
+{docstring Hex.GraphIso.Nauty.Sparse.rowCmp}
+
+{docstring Hex.GraphIso.Nauty.Sparse.Key +hideFields}
+
+{name Hex.GraphIso.Nauty.Sparse.testcanlab}`testcanlab` computes the
+comparison together with the number of equal leading rows. The raw
+canonical store need not have sorted rows. Marks identify the first
+differing neighbour without sorting each candidate.
+{name Hex.GraphIso.Nauty.Sparse.updatecan}`updatecan` preserves the
+equal prefix and rewrites the remaining rows using inverse labels.
+Its invariant distinguishes allocated storage from the prefix that
+already represents valid canonical rows. Public output normalization
+sorts rows after the search, without choosing another label.
+
+{docstring Hex.GraphIso.Nauty.Sparse.testcanlab}
+
+{docstring Hex.GraphIso.Nauty.Sparse.updatecan}
+
+The declarative canonical key is the greatest leaf key of the finite
+unpruned sparse tree. A leaf attains this maximum, and its relabelling
+defines the canonical form. Equal maximum keys may have different
+attaining labels. The form is invariant under isomorphism; the label
+records how the particular input is renamed.
+
+{docstring Hex.GraphIso.Nauty.Sparse.canonSpecKey}
+
+{docstring Hex.GraphIso.Nauty.Sparse.specCanon}
+
+## Production proofs and certificates
+
+The production search proves totality and equality with the declarative
+maximum while retaining nauty's pruning and representation choices.
+{name Hex.GraphIso.Sparse.canon_eq_specCanon}`canon_eq_specCanon`
+identifies the total public form with that specification on every
+input, including the empty graph. This proof does not depend on
+certificate replay. The public label is parsed from the production
+search's literal output array.
+
+{docstring Hex.GraphIso.Sparse.canon_eq_specCanon}
+
+The full generator trace generates every colour-preserving
+automorphism. It is distinct from the bounded workspace used to prune
+the search: overwriting a pruning entry does not discard a returned
+generator. The orbit array gives the exact orbits of the full group.
+The product of indices along the first search path is its exact order,
+with no additional searches on individualized graphs.
+
+{name Hex.GraphIso.Sparse.Aut.generated_iff}`Aut.generated_iff`
+states that a permutation is generated by the returned list if and
+only if it is a colour-preserving automorphism.
+{name Hex.GraphIso.Sparse.autos_sameOrbit}`autos_sameOrbit` states the
+equivalence between equal orbit entries and an automorphism carrying
+one vertex to the other.
+
+Certificates serve a separate purpose: producing kernel proofs about
+closed inputs without reducing the whole optimized search. The sparse
+certificate records discrete leaves, branches discarded by a strictly
+smaller code, complete child lists, and checked automorphism references
+to earlier records. The checker recomputes sparse refinement and
+comparison and proves that the claimed maximum is attained and bounds
+all leaves. Production is proved complete, and the literal kernel
+checker is proved to agree with the specification checker.
+
+The public `graph_iso` tactic uses these sparse checkers for sparse
+goals. Its {ref "hex-graph-iso-certificates"}[search and certificate
+limits] count actual nodes and records. An exhausted limit is a tactic
+failure, not a mathematical verdict. Direct canonicalization and
+isomorphism search are total APIs without these limits.
+
+All correctness statements concern the executed Lean implementation.
+Agreement with C sparse nauty is established separately by exact
+conformance tests for indirect sorting, refinement, target selection,
+canonical labels, search counters, generators, orbits and group order.
+The [validation report](https://github.com/kim-em/hex-dev/blob/main/reports/sparse-nauty-validation.md)
+records those checks and the kernel replay and performance evidence.
 
 # References
 %%%

--- a/HexManual/Theme.lean
+++ b/HexManual/Theme.lean
@@ -56,6 +56,12 @@ h1, h2, h3 {
   color: #2d6a4f;
 }
 
+/* Keep figures within the reading column on narrow screens. */
+main img {
+  max-width: 100%;
+  height: auto;
+}
+
 /* ===== Links ===== */
 a {
   color: #40916c;


### PR DESCRIPTION
The HexGraphIso manual still described only dense nauty after the verified sparse implementation shipped. Document the native sparse constructors and total APIs, kernel-proved isomorphism examples, complete automorphism output, representation-dependent canonical forms, and explicit sparse selection from Mathlib.

Extend the algorithm chapter with sparse refinement, sorting ties, target selection, canonical comparison, and the production/certificate proof guarantees. Replace the dense-only performance discussion with the six-way figures and their measurement boundaries. Keep figures within the reading column and provide full-size links.

Validation:
- `lake build HexManual hexmanual`
- Render the complete manual with `lake exe hexmanual`.
- Check the sparse, Mathlib, algorithm and performance pages in Chromium, including mobile layout and both bundled SVGs.
- Check local link destinations and `scripts/release/check_manual_split.py`.
