### PR TITLE
spec: define structural matrix tactics in algorithm companions

### DIFF
--- a/HexHermiteMathlib/SPEC/hex-hermite-mathlib.md
+++ b/HexHermiteMathlib/SPEC/hex-hermite-mathlib.md
@@ -2,7 +2,8 @@
 
 ## Correspondence-only classification
 
-This library is a `correspondence-only-layer`.
+The existing API is a `correspondence-only-layer`; implementing the `hermite`
+frontend below adds companion conformance and fresh-module proof evidence.
 
 Computational conformance owner: `HexHermite`
 Computational performance owner: `HexHermite`
@@ -16,9 +17,8 @@ the core library.
 
 ## Scope
 
-This layer owns correspondence only. It has no executable reifier,
-certificate checker, tactic, conformance target, benchmark target, or proof
-performance probe of its own.
+The existing layer owns correspondence. The tactic below is a specified
+extension; its producer and list checker remain in HexHermite.
 
 Its public surface is:
 
@@ -79,7 +79,7 @@ proved in Lean. Its index type has the executable nullity
 
 ## Verification
 
-This is a correspondence-only layer, so Phase 3 is established by auditing
+For the existing correspondence, Phase 3 is established by auditing
 the executable coverage in `hex-hermite`, not by adding a ceremonial Mathlib
 conformance module:
 
@@ -95,7 +95,129 @@ build and by the pair's Mathlib lint regression.
 
 ## External comparators
 
-`correspondence-only-layer`: this library has zero benchmark targets because
-it owns no computational or proof-search surface. Its computational
-performance owner is `hex-hermite`; that library's benchmark target carries
-the evidence for HNF, rank, lattice membership, and kernel extraction.
+The computational performance owner is `hex-hermite`; its benchmark target
+carries the evidence for HNF, rank, lattice membership and kernel extraction.
+The tactic below adds a proof-performance track when implemented, without a
+Mathlib-importing benchmark executable.
+
+## The `hermite` tactic
+
+This required extension follows [the matrix tactic protocol](../../SPEC/matrix-tactics.md)
+and [the `rank` template](../../HexRankMathlib/SPEC/hex-rank-mathlib.md#the-rank-tactic).
+The list certificate and producer belong to HexHermite, with Mathlib transport
+and the frontend here. The existing `HexHermiteMathlib/Kernel.lean` proves
+kernel-basis correspondence; extend it or use a separate certificate module
+without displacing that API.
+
+### Goals, result and carriers
+
+Declare non-reserved `hermite` and term form `hermite% A`. Accept closed
+integer `A : Matrix (Fin n) (Fin m) ℤ`. Write
+`L(A) := Submodule.span ℤ (Set.range A)` in this section. Supported goals are
+`v ∈ L(A)`, `v ∉ L(A)` for a closed integer vector, and a basis goal
+`Basis (Fin r) ℤ L(A)` with a stated closed rank `r` (also its `Nonempty`
+wrapper). A basis goal constructs the canonical nonzero HNF rows; it is
+not an equality to an arbitrarily chosen noncomputable basis.
+
+The new term record `HermiteResult A` exposes `rank`, `rank_le : rank ≤ min n m`,
+`form : Matrix (Fin n) (Fin m) ℤ`, an HNF proof, `span : L(form) = L(A)`,
+`basis : Basis (Fin rank) ℤ L(A)`, and a theorem that the underlying vector
+of `basis i` is row `i` of `form` (using `rank_le` for its row index).
+The HNF proof is the existing `Hex.Matrix.IsHNF` on decoded data, transported
+through `matrixEquiv`; the record retains the checked pivots and transforms
+needed to state it. Values are literals, with no dependent dimension computed
+by reducing `hnfRank A`. This is the row-lattice basis from `hnfBasis`,
+not `HexHermiteMathlib.kernelBasis`, whose vectors live in `Fin n → ℤ`
+and describe the left kernel instead.
+
+Use [the shared literal layer](../../HexMatrixMathlib/SPEC/hex-matrix-mathlib.md#matrix-literals).
+Request against its SPEC the closed integer vector adapter for `v` and its
+`vecOfList` identification. Matrix recognition and supported unfolding stay
+with that layer. Noninteger and symbolic coefficients are outside this arm.
+
+### Kernel certificate and soundness
+
+Existing `Hex.Matrix.hnfCert A H U W r piv` in `HexHermite/Cert.lean`
+checks `U * A = H`, `U * W = I`, and `isHNFForm H r piv`.
+`hnfCert_sound` concludes `IsHNF A ⟨r, H, U, piv⟩` for arbitrary accepted
+data. It derives the reverse inverse over square integer matrices; that is
+not an extra producer hypothesis. Its packed matrix checker is a reference
+form, not a suitable reduction path for the tactic.
+
+Require `HermiteWitness`/`checkHermiteList` in HexHermite with row lists for
+`H`, `U`, `W`, a natural rank and a list of natural pivot columns. Check
+exact dimensions, rank bounds, pivot count/range/strict order, positive
+leading pivots, leading and below-pivot zeros, zero trailing rows, and the
+bounds `0 ≤ entry < pivot` above each pivot, as well as both displayed
+products. All arithmetic is exposed structural recursion on lists of
+`Int`/`Nat`, with no `Hex.Matrix`, `Array`, `Vector`, `Fin`, `Finset` or
+well-founded recursion on the reduction path. Do not run HNF elimination.
+
+For membership, augment the certificate with an integer coefficient list
+`q` of length `r` and residual `t` of length `m`, verifying
+`v = q * H.take r + t` and `0 ≤ t[piv i] < H[i,piv i]` for every pivot.
+The producer obtains these by the ordinary left-to-right HNF remainder
+calculation; the kernel only checks the identity and bounds. A zero residual
+certifies membership. A nonzero residual certifies nonmembership: if it were
+in the row lattice, its first nonzero pivot coefficient would make a pivot
+coordinate a nonzero multiple of the positive pivot, contradicting the
+bounds; successively zero coefficients force the whole residual to zero.
+This also covers a residual supported only in nonpivot columns and rank zero.
+
+Require new `hermite_of_checkList` to establish the record's HNF, span and
+basis properties from the Boolean check and `hA : A = ofLists n m rows`.
+The proof decodes to `hnfCert_sound`, then transports the arbitrary witness.
+Existing `span_hnf`, `hnfRank_eq_rank` and `latticeContains_iff_mem` in this
+companion are about the canonical producer output; they cannot be applied
+by evaluating `hnf A` or `latticeContains A v` in the kernel. Extend their
+proofs to checked `IsHNF` data, using the same membership equivalence as
+`latticeContains_iff_mem`, and add a list-remainder soundness theorem with
+both membership outcomes. For the basis, lattice preservation and zero
+trailing rows prove spanning, while strictly increasing positive pivots
+prove independence. Membership alone is insufficient to construct a basis.
+These arbitrary-witness and list-remainder bridges are new obligations,
+not claims that the existing canonical correspondence already accepts lists.
+
+### Producer and proof assembly
+
+Use compiled `Hex.Matrix.hnfWithInv`, which retains both transforms
+in `HermiteData`, reshape its `hnfCert` data, and compute membership remainder
+data only when needed. Re-check the complete list certificate before quoting.
+Following `HexRankMathlib/Kernel.lean` and `Tactic.lean`, keep decoding and
+transport in proved lemmas, use the shared literal identification, and check
+all certificate propositions in one synchronous auxiliary theorem. Construct
+the basis/term record from that theorem; do not pass a `Basis` type itself
+to `mkAuxTheorem`. There is no preliminary kernel evaluation of the check.
+
+Use the shared four outcomes: other operations/carriers are `notApplicable`,
+in-fragment capability/budget limits are `declined`, accepted proofs are
+`success`, and bad certificates/kernel rejections are `failure`. A false
+membership target reports the certified nonzero residual; a false
+nonmembership target reports the coefficients, and a wrong basis dimension
+reports the rank. Preserve the user's proposition and diagnose rejection
+without replaying `hnf` or `latticeContains`.
+
+### Conformance and proof probes
+
+Test both membership outcomes, basis construction and its row equations,
+term mode, every literal route, zero and empty shapes, tall/wide matrices,
+non-leading pivots and negative inputs. Refute incorrect transform products,
+inverses, dimensions, duplicate/out-of-range pivots, negative pivots,
+nonzero trailing rows, out-of-range above-pivot entries, corrupted remainder
+identities and residual bounds. Include nonmembership supported in a nonpivot
+column and a valid noncanonical transform. Audit all accepted proof axioms
+against `propext`, `Classical.choice`, `Quot.sound` only.
+
+On implementation reserve `bench/HexHermiteMathlib/ProofProbe`. Named seeded
+families: `unimodular-conjugate`, `tall-hermite` (`2n × n`),
+`rank-deficient-hermite` (rank `n / 2`), and `membership-residual` (members
+and nonmembers of the same lattice), at `n = 2, 4, 8, 16` and input heights
+`8, 32, 128` bits. Measure basis construction and membership separately.
+There is no Mathlib tactic comparator. Record absolute fresh-module times
+and medians, baseline deltas and a kernel-only profile per family, using
+six adjacent baseline/probe pairs with alternating orientation per
+[SPEC/benchmarking.md](../../SPEC/benchmarking.md#fresh-module-proof-evidence).
+Record certificate entry counts/serialized bytes, maximum integer height,
+emitted artifact sizes, axiom sets and source/toolchain/host provenance;
+retain all completed samples and timeouts. Preregister operational caps.
+Compiled producer/checker complexity evidence remains in HexHermite.

--- a/HexHermiteMathlib/SPEC/hex-hermite-mathlib.md
+++ b/HexHermiteMathlib/SPEC/hex-hermite-mathlib.md
@@ -80,8 +80,9 @@ proved in Lean. Its index type has the executable nullity
 ## Verification
 
 For the existing correspondence, Phase 3 is established by auditing
-the executable coverage in `hex-hermite`, not by adding a ceremonial Mathlib
-conformance module:
+the executable coverage in `hex-hermite`, without a separate runtime Mathlib
+conformance module. The frontend additionally requires the build-only proof
+tests below:
 
 - HNF form and transform checks cover `span_hnf` and `isUnit_transform`;
 - rank-deficient cases cover `hnfRank_eq_rank`;
@@ -99,6 +100,39 @@ The computational performance owner is `hex-hermite`; its benchmark target
 carries the evidence for HNF, rank, lattice membership and kernel extraction.
 The tactic below adds a proof-performance track when implemented, without a
 Mathlib-importing benchmark executable.
+
+## Frontend implementation and validation
+
+The tactic contracts below are design requirements. Their kernel-certificate
+subsections specify additions owned by the Mathlib-free algorithm library;
+they do not move that code into this companion. When implementing those
+additions, cross-link the algorithm's kernel-certificate SPEC to this contract.
+Keep existing phase evidence as evidence for the existing correspondence only.
+Before activating the frontend, remove `correspondence_only: true` if present,
+add `proof_probes: [bench/HexHermiteMathlib/ProofProbe]`, and reopen the
+library's conformance/performance obligations: cap `done_through` at `2` until
+the new build-only proof tests pass, then at `3` until complete proof evidence
+passes. Do not add an empty reservation while retaining a completed Phase 4.
+This SPEC-only change does not alter the manifest or attest implementation.
+
+Proof tests live in `HexHermiteMathlib/Tests.lean`, built with the ordinary
+library; malformed list certificates also belong in the algorithm library's
+Mathlib-free conformance driver. Proof probes are fresh modules, not runtime
+oracle drivers or Mathlib-importing benchmark executables. Each frontend uses
+`HexHermiteMathlib/Tactic.lean`; result records and list soundness belong
+in `HexHermiteMathlib/Kernel.lean` (Hermite's existing kernel-basis module
+may instead re-export a new certificate module). No library name changes.
+
+For the named families below, shipping requires complete clean-tree evidence
+under the `absolute_only` mode of
+[SPEC/benchmarking.md](../../SPEC/benchmarking.md#fresh-module-proof-evidence).
+Preregister six rounds and a per-candidate absolute build budget of 60 seconds
+on the measurement host for every stated rung. Every candidate sample must
+meet it; report the median and kernel-only time as well. A timeout, incomplete
+pair, budget failure or provenance mismatch blocks the frontend's performance
+sign-off. This is an operational shipping gate, not an asymptotic or portable
+wall-time claim. Retain slow completed samples; do not trim the ladder to get
+a passing verdict. Any budget revision requires an explicit SPEC amendment.
 
 ## The `hermite` tactic
 
@@ -177,6 +211,48 @@ trailing rows prove spanning, while strictly increasing positive pivots
 prove independence. Membership alone is insufficient to construct a basis.
 These arbitrary-witness and list-remainder bridges are new obligations,
 not claims that the existing canonical correspondence already accepts lists.
+
+Required API schemata (all new; proof fields supplement the prose contract):
+
+```lean
+-- HexHermite/Kernel.lean, namespace Hex.Matrix
+structure HermiteWitness where
+  rank : Nat
+  pivots : List Nat
+  form transform inverse : List (List Int)
+
+def checkHermiteList (n m : Nat) (rows : List (List Int))
+    (c : HermiteWitness) : Bool
+
+-- HexHermiteMathlib/Kernel.lean, namespace HexHermiteMathlib
+structure HermiteResult {n m : Nat} (A : Matrix (Fin n) (Fin m) ℤ) where
+  rank : Nat
+  rank_le : rank ≤ min n m
+  form : Matrix (Fin n) (Fin m) ℤ
+  inputRows : List (List Int)
+  input_eq : A = HexMatrixMathlib.ofLists n m inputRows
+  witness : Hex.Matrix.HermiteWitness
+  rank_eq : rank = witness.rank
+  form_eq : form = HexMatrixMathlib.ofLists n m witness.form
+  checked : Hex.Matrix.checkHermiteList n m inputRows witness = true
+  span : Submodule.span ℤ (Set.range form) = Submodule.span ℤ (Set.range A)
+  basis : Module.Basis (Fin rank) ℤ (Submodule.span ℤ (Set.range A))
+  basis_row : ∀ i : Fin rank,
+    (basis i : Fin m → ℤ) = form ⟨i.val, lt_of_lt_of_le i.isLt
+      (le_trans rank_le (Nat.min_le_left n m))⟩
+
+noncomputable def hermite_of_checkList {n m : Nat}
+    (A : Matrix (Fin n) (Fin m) ℤ) (rows : List (List Int))
+    (c : Hex.Matrix.HermiteWitness)
+    (hA : A = HexMatrixMathlib.ofLists n m rows)
+    (hc : Hex.Matrix.checkHermiteList n m rows c = true) : HermiteResult A
+```
+
+The record stores checked HNF data rather than requiring an equality to the
+output of `hnf`; `hnfCert_sound` supplies its `IsHNF` property without
+producer replay. Constructor projection theorems fix `rank` and `form` to
+the witness. Membership soundness takes this checked witness plus the
+coefficient/residual list checks and concludes `v ∈ L(A) ↔ residual = 0`.
 
 ### Producer and proof assembly
 

--- a/HexMatrixMathlib/SPEC/hex-matrix-mathlib.md
+++ b/HexMatrixMathlib/SPEC/hex-matrix-mathlib.md
@@ -111,3 +111,28 @@ term-form argument with an integer expectation for the `!![…]` notations
 The empty shapes `!![]`, `!![,,,]` and `!![;;;]` are literals of their
 dimensions. Tests: `HexMatrixMathlib/Tests.lean` identifies each syntax and
 the empty shapes with its row list.
+
+
+### Requests from structural tactic frontends
+
+The [structural tactic contracts](../../SPEC/matrix-tactics.md#placement)
+request the following extensions to this shared layer before the relevant
+numeric handler ships. They are requirements, not descriptions of current
+`Literal.lean` capabilities:
+
+- Field-aware `%` argument elaboration, preserving the expected carrier
+  rather than defaulting every unannotated literal to integers.
+- Rational and prime-residue entry codecs with proved decoding/arithmetic
+  agreement and coherent field instances. Rational codecs preserve a `Rat`
+  input row list for definitional literal identification and certify its
+  agreement with integer rows and a positive common scale, following
+  `checkDetRat`'s boundary. Algorithm-specific products and polynomial checks
+  remain in their owning libraries.
+- Closed vector/factor-function literal recognition with a `vecOfList`
+  identification theorem, for RHSs, stated solutions, lattice members and
+  invariant-factor targets. Match the matrix layer's supported unfolding and
+  diagnostic discipline.
+
+These adapters serve `min_poly`, `smith`, `hermite`, `inverse` and `solve`;
+they introduce no shared tactic dispatcher or new library. Polynomial-target
+recognition is requested separately against hex-poly-mathlib.

--- a/HexMinPolyMathlib/SPEC/hex-min-poly-mathlib.md
+++ b/HexMinPolyMathlib/SPEC/hex-min-poly-mathlib.md
@@ -28,12 +28,137 @@ The bridge proves that the executable minimal polynomial:
 - is invariant under conjugation by a unit, hence under similarity.
 
 The characteristic-polynomial consequences depend on
-`hex-char-poly-mathlib`. All executable work, certificates, conformance, and
-performance evidence belong to `hex-min-poly`.
+`hex-char-poly-mathlib`. The executable algorithm and reference certificates belong to `hex-min-poly`.
+The tactic specified below adds a proof-performance surface to this companion.
 
 ## Performance classification
 
-This is a correspondence-only Mathlib layer. It owns no compiled operation,
-elaborator, tactic, or proof-search procedure, so it has no benchmark track
-and no external comparator. The computational performance owner is
-`hex-min-poly`.
+The existing correspondence is a proof-only Mathlib layer; its computational
+performance owner is `hex-min-poly`. Implementing the tactic below requires
+companion conformance and a `proof_probes` reservation, with fresh-module
+evidence rather than a Mathlib-importing benchmark executable.
+
+## The `min_poly` tactic
+
+This section specifies an extension, not an implemented frontend. Follow
+[the matrix tactic protocol](../../SPEC/matrix-tactics.md) and
+[hex-rank-mathlib §The `rank` tactic](../../HexRankMathlib/SPEC/hex-rank-mathlib.md#the-rank-tactic).
+New witness/checker/producer declarations belong to `HexMinPoly`; their
+Mathlib soundness and frontend belong here. No additional library is needed.
+
+### Goals, result and carriers
+
+Declare `min_poly` once as a non-reserved tactic atom; `min_poly% A` is the
+term form. For closed square `A : Matrix (Fin n) (Fin n) F`, accept
+`minpoly F A = p` and `p = minpoly F A`, with a closed polynomial `p`.
+The term form returns the existing shared
+`Certified (fun A => minpoly F A) A`, whose `value : Polynomial F` and
+`proof : minpoly F A = value` expose the computed result. The empty matrix
+has minimal polynomial `1`, including the zero-dimensional algebra case.
+
+Soundness takes Mathlib `[Field F] [DecidableEq F]`, with the induced
+`Field.toGrindField` selected before executable inputs and certificates
+are formed. The initial numeric frontend must support `ℚ`, including
+nonintegral coefficients. A field instance alone does not supply a literal
+codec: arbitrary abstract fields, symbolic entries and unsupported closed
+field expressions are outside this handler. Prime `ZMod p` is an extension
+once a proved residue codec is available; composite moduli are not fields.
+
+Use the [shared literal layer](../../HexMatrixMathlib/SPEC/hex-matrix-mathlib.md#matrix-literals)
+for matrix recognition and identification. Request against that SPEC:
+field-aware argument elaboration and rational/residue entry codecs with
+proved decoding and arithmetic agreement. Against
+[hex-poly-mathlib](../../HexPolyMathlib/SPEC/hex-poly-mathlib.md), request a
+closed Mathlib polynomial literal adapter to ascending coefficient lists,
+with a proof identifying the target polynomial. These are adapter requests,
+not local competing reifiers. The polynomial checker belongs to HexMinPoly.
+
+### Kernel certificate and soundness
+
+Existing `Hex.Matrix.MinPolyCert` in `HexMinPoly/Cert.lean` carries `poly`,
+one `OrderCert` per standard basis vector, and one `LcmStep` per LCM fold.
+`MinPolyCert.check_sound`, under `[Lean.Grind.Field F] [DecidableEq F]`,
+proves monicity, annihilation on every vector, and divisibility into every
+annihilator. It does **not** directly state equality with Mathlib `minpoly`.
+`HexMinPolyMathlib.equiv_minPoly` in `Basic.lean` identifies the executable
+`minPoly` under Mathlib field assumptions, but reducing that producer is
+not the tactic proof path.
+
+Require a new `MinPolyWitness` and `checkMinPolyList` that reshape precisely
+this certificate: ascending coefficient lists for all polynomials, a list
+of `n` orders `(poly, deg, inv)`, and a list of `n` LCM steps. Matrices,
+including each `n × deg` right inverse, are row lists. Validate exact lengths,
+`deg ≤ n`, polynomial normalization (no trailing zero except the empty zero
+polynomial), monicity and every dimension before arithmetic. In basis-index
+order check:
+
+- the order polynomial has degree `deg`, is monic and annihilates its
+  standard basis vector;
+- the `deg × n` Krylov row matrix times `inv` is the identity, certifying
+  independence of all lower powers, not just annihilation;
+- starting at `running = 1`, each step satisfies the existing four identities
+  `running = common * left`, `incoming = common * right`,
+  `bezoutLeft * running + bezoutRight * incoming = common`, and
+  `result = left * incoming`; the final result equals `poly` and is monic.
+
+Krylov powers and Horner evaluation are structural list recursions, with
+no row reduction, GCD/LCM search or field division. For rationals use
+numerator/positive-denominator data and division-free cross multiplication
+for equality; check every denominator is nonzero. The reduction path uses
+only list data and exposed structural recursion on `Nat`/`Int`, as in
+`HexRank/Kernel.lean`; neither `DensePoly` nor `Hex.Matrix`, `Array`,
+`Vector`, `Fin`, `Finset` or well-founded recursion is reduced there.
+
+Required new companion theorem `minpoly_eq_of_checkList` takes dimensions,
+input lists, a witness and `checkMinPolyList ... = true`, and concludes
+`minpoly F (ofLists n n decodedRows) = decodedPolynomial`. Prove list checks
+imply the reference check (decoding stays in the proof, outside reduction),
+then use `MinPolyCert.check_sound`, `vectorEquiv_evalVec` and
+`minpoly.unique`, just as `equiv_minPoly` uses monicity, annihilation and
+minimal degree. Add a wrapper with `hA : A = ofLists ...` and the checked
+identification of `p`; both goal orientations reuse this soundness theorem.
+No hypothesis asserts that the witness came from the producer.
+
+### Producer and proof assembly
+
+Run compiled `Hex.Matrix.minPolyCert` from `Producer.lean`, convert its
+output to the list witness, and re-check it with the compiled list checker
+before quotation. This preserves the roles of `rankWitness`, the literal
+identification, and `rank_eq_of_checkList'` in the rank implementation.
+Build the Boolean proof by kernel reduction and emit the complete goal proof
+as one synchronous `mkAuxTheorem`, with no elaborator kernel pre-check.
+`!![…]` uses definitional identification; other supported literal routes
+use the shared adapter's single identification proof.
+
+Follow `notApplicable`/`declined`/`success`/`failure` from the shared protocol.
+A different operation or unsupported field fragment is `notApplicable`;
+a missing codec or exceeded budget within the advertised fragment is
+`declined`, naming the capability or entry. A false target reports the
+computed polynomial; a malformed producer certificate or kernel rejection
+is `failure`. Diagnose only after rejection, without replaying `minPoly`.
+
+### Conformance and proof probes
+
+Add companion proof tests for both orientations and the term record, each
+literal route, bounded unfolding, false polynomials and unsupported carriers.
+Refute malformed witnesses: omitted/reordered basis orders, wrong list
+lengths, excessive degree, corrupted right inverse, an annihilator of larger
+than minimal degree, a broken Bézout identity, wrong final polynomial,
+nonmonic output and zero denominators. Use mutations known to violate the
+identity (not changes to unused data). Audit accepted theorem axioms: only
+`propext`, `Classical.choice`, `Quot.sound`, never `sorryAx` or native trust.
+
+Reserve `bench/HexMinPolyMathlib/ProofProbe` in `libraries.yml` when the
+frontend is implemented. Named seeded families are `cyclic` (companion
+matrices), `repeated-block` (identical blocks, minimal degree below dimension),
+`nilpotent` (Jordan blocks), and `rational-dense`; dimensions `2, 4, 8, 16`
+and input heights `8, 32` bits, plus `0 × 0` as a correctness probe.
+Mathlib has no corresponding tactic, so no comparator ratio or superiority
+claim is required. Per [fresh-module evidence](../../SPEC/benchmarking.md#fresh-module-proof-evidence),
+record six complete samples paired with import-only baselines, adjacent and
+alternating orientation, raw absolute build times and their median, baseline
+deltas, one kernel-only profile per family, certificate entry counts and
+serialized bytes, largest numerator/denominator bit lengths, emitted artifact
+sizes and axiom sets. Retain provenance, all completed samples and timeouts;
+preregister operational caps without treating them as portable performance
+claims. Executable producer/checker benchmarks remain in HexMinPoly.

--- a/HexMinPolyMathlib/SPEC/hex-min-poly-mathlib.md
+++ b/HexMinPolyMathlib/SPEC/hex-min-poly-mathlib.md
@@ -38,6 +38,38 @@ performance owner is `hex-min-poly`. Implementing the tactic below requires
 companion conformance and a `proof_probes` reservation, with fresh-module
 evidence rather than a Mathlib-importing benchmark executable.
 
+## Frontend implementation and validation
+
+The tactic contracts below are design requirements. Their kernel-certificate
+subsections specify additions owned by the Mathlib-free algorithm library;
+they do not move that code into this companion. When implementing those
+additions, cross-link the algorithm's kernel-certificate SPEC to this contract.
+Keep existing phase evidence as evidence for the existing correspondence only.
+Before activating the frontend, remove `correspondence_only: true` if present,
+add `proof_probes: [bench/HexMinPolyMathlib/ProofProbe]`, and reopen the
+library's conformance/performance obligations: cap `done_through` at `2` until
+the new build-only proof tests pass, then at `3` until complete proof evidence
+passes. Do not add an empty reservation while retaining a completed Phase 4.
+This SPEC-only change does not alter the manifest or attest implementation.
+
+Proof tests live in `HexMinPolyMathlib/Tests.lean`, built with the ordinary
+library; malformed list certificates also belong in the algorithm library's
+Mathlib-free conformance driver. Proof probes are fresh modules, not runtime
+oracle drivers or Mathlib-importing benchmark executables. Each frontend uses
+`HexMinPolyMathlib/Tactic.lean`; result records and list soundness belong
+in `HexMinPolyMathlib/Kernel.lean`. No library name changes.
+
+For the named families below, shipping requires complete clean-tree evidence
+under the `absolute_only` mode of
+[SPEC/benchmarking.md](../../SPEC/benchmarking.md#fresh-module-proof-evidence).
+Preregister six rounds and a per-candidate absolute build budget of 60 seconds
+on the measurement host for every stated rung. Every candidate sample must
+meet it; report the median and kernel-only time as well. A timeout, incomplete
+pair, budget failure or provenance mismatch blocks the frontend's performance
+sign-off. This is an operational shipping gate, not an asymptotic or portable
+wall-time claim. Retain slow completed samples; do not trim the ladder to get
+a passing verdict. Any budget revision requires an explicit SPEC amendment.
+
 ## The `min_poly` tactic
 
 This section specifies an extension, not an implemented frontend. Follow
@@ -102,22 +134,82 @@ order check:
   `result = left * incoming`; the final result equals `poly` and is monic.
 
 Krylov powers and Horner evaluation are structural list recursions, with
-no row reduction, GCD/LCM search or field division. For rationals use
-numerator/positive-denominator data and division-free cross multiplication
-for equality; check every denominator is nonzero. The reduction path uses
+no row reduction, GCD/LCM search or field division. For rationals follow the
+scaled-integer boundary of `checkDetRat` in
+`HexBareiss/Kernel.lean`: retain the input row list at `Rat` for cheap literal
+identification, and check its agreement with integer rows `Z` and a single
+positive scale `D`, so `A = Z / D`, by numerator/denominator cross products.
+This scaling is for certificate arithmetic; it does not claim that scaling
+preserves the minimal polynomial. Give each polynomial and inverse block its
+own positive common denominator, check those scale factors, and multiply out
+all denominator powers in the identities. The shared codec supplies the
+literal/encoding agreement proof; `A = ofLists ... rationalRows` remains
+`rfl` for numeral literals, never `A = ofLists ... (decode encodedRows)`.
+
+Recompute Krylov powers as integer vectors `Z^k eᵢ` with known scale `D^k`.
+The annihilation check for a degree-`d` polynomial with common denominator `s`
+checks the numerator of `s * D^d * p(A)eᵢ` using those powers. Do not multiply
+unreduced per-entry denominators at each dot-product addition. If `b` bounds
+bit heights in `Z` and `D`, power entries and scales have
+`O(k * (b + log(n + 1)))` bits; record this scaled input height separately
+from the original entry heights. Supplied polynomial/inverse numerators add
+their own recorded bit heights. LCM identities use integer coefficient
+convolutions with common denominators cleared once per identity.
+The reduction path uses
 only list data and exposed structural recursion on `Nat`/`Int`, as in
 `HexRank/Kernel.lean`; neither `DensePoly` nor `Hex.Matrix`, `Array`,
 `Vector`, `Fin`, `Finset` or well-founded recursion is reduced there.
 
 Required new companion theorem `minpoly_eq_of_checkList` takes dimensions,
 input lists, a witness and `checkMinPolyList ... = true`, and concludes
-`minpoly F (ofLists n n decodedRows) = decodedPolynomial`. Prove list checks
+`minpoly ℚ (ofLists n n rationalRows) = decodedPolynomial` on the initial
+rational arm (with the corresponding transport for any later field codec).
+Prove list checks
 imply the reference check (decoding stays in the proof, outside reduction),
 then use `MinPolyCert.check_sound`, `vectorEquiv_evalVec` and
 `minpoly.unique`, just as `equiv_minPoly` uses monicity, annihilation and
 minimal degree. Add a wrapper with `hA : A = ofLists ...` and the checked
 identification of `p`; both goal orientations reuse this soundness theorem.
 No hypothesis asserts that the witness came from the producer.
+
+The basis-wide certificate stores `O(n³)` inverse scalars in the worst case
+(`deg ≤ n` for each of `n` orders), plus the LCM/Bézout polynomial coefficients,
+whose supplied lengths and heights must also be recorded. Krylov reconstruction
+and inverse checks cost `O(n⁴)` scalar operations overall; polynomial identity
+checks additionally cost the pairwise products of their coefficient lengths.
+These are arithmetic counts, not a bit-complexity claim. The advertised first
+release is bounded to dimension `16`; larger inputs are `declined` with the
+configured dimension budget. The bound is a frontend capability limit, never
+a hypothesis of `minpoly_eq_of_checkList`. Retain the existing basis-wide
+certificate to reuse its proved minimality contract; any smaller certificate
+requires a separate soundness argument and new measured evidence.
+
+Required initial rational API schemata, with the integer-encoded witness
+fields specified above and a proved coefficient decoder `decodePoly`:
+
+```lean
+-- HexMinPoly/Kernel.lean, namespace Hex.Matrix
+def checkMinPolyList (n : Nat) (rows : List (List Rat))
+    (c : MinPolyWitness) : Bool
+
+-- HexMinPolyMathlib/Kernel.lean, namespace HexMinPolyMathlib
+theorem minpoly_eq_of_checkList {n : Nat}
+    (A : Matrix (Fin n) (Fin n) ℚ) (rows : List (List Rat))
+    (c : Hex.Matrix.MinPolyWitness)
+    (hA : A = HexMatrixMathlib.ofLists n n rows)
+    (hc : Hex.Matrix.checkMinPolyList n rows c = true) :
+    minpoly ℚ A = decodePoly c
+
+-- Type returned by min_poly% A:
+abbrev MinPolyResult {n : Nat} (A : Matrix (Fin n) (Fin n) ℚ) :=
+  HexMatrixMathlib.Certified (fun M => minpoly ℚ M) A
+```
+
+The exposed kernel checks read rational input numerators/denominators once
+for scale agreement, as `checkDetRat` does; Krylov and polynomial arithmetic
+then use only the encoded integer lists. `decodePoly` is used in the theorem
+statement and transport proof, not as a polynomial computation in the check.
+General field transport is parametric in a proved codec, as required above.
 
 ### Producer and proof assembly
 

--- a/HexPolyMathlib/SPEC/hex-poly-mathlib.md
+++ b/HexPolyMathlib/SPEC/hex-poly-mathlib.md
@@ -24,3 +24,17 @@ matched inputs and verify hash agreement; that is the relevant
 shape of comparison for a correspondence library. External tools (FLINT
 etc.) would compare against the underlying polynomial arithmetic,
 which is HexPoly's surface and is covered there.
+
+
+## Polynomial literal adapter request
+
+[The `min_poly` frontend](../../HexMinPolyMathlib/SPEC/hex-min-poly-mathlib.md#the-min_poly-tactic)
+requires a closed Mathlib polynomial literal adapter: recognize a polynomial
+in the supported field codec, expose ascending coefficients, and prove the
+identification with their decoded polynomial. Reuse this layer's polynomial
+equivalence and the field codecs requested against
+[hex-matrix-mathlib](../../HexMatrixMathlib/SPEC/hex-matrix-mathlib.md#requests-from-structural-tactic-frontends).
+The initial carrier is `ℚ`; prime residues are a later codec extension.
+This is a requested shared adapter, not an existing API or an alternative
+minimal-polynomial checker. Its elaboration cost belongs in the consuming
+tactic's complete fresh-module probes.

--- a/HexRowReduce/SPEC/hex-row-reduce.md
+++ b/HexRowReduce/SPEC/hex-row-reduce.md
@@ -152,7 +152,14 @@ belongs to the companion, using `rank_eq` on `rowReduce_isRowReduced A`.
 The computational code decides only the rank test and does not evaluate a
 determinant. There is no fuel, search limit, or resource-failure return.
 This API exposes singularity through its completeness theorem. A separate
-witness-producing inverse operation is outside this extension's scope.
+witness-producing inverse operation is outside this algorithm extension's
+scope. The [inverse tactic contract](../../HexRowReduceMathlib/SPEC/hex-row-reduce-mathlib.md#the-inverse-tactic)
+additionally requests a certificate-producer wrapper here: retain this RREF
+and extract a nonzero nullspace column on singular input, without changing
+`inverse?`. The [solve tactic contract](../../HexRowReduceMathlib/SPEC/hex-row-reduce-mathlib.md#the-solve-tactic)
+requests retained inverse-transform data for its complete list certificate.
+Those wrappers and list checkers are required before the frontends ship;
+their reduction paths never execute inverse, solve or RREF producers.
 
 ### Solve and inconsistency witness
 
@@ -241,7 +248,7 @@ These equations hold over every field, including characteristic two.
 
 ### Relationship to the domain rank certificate
 
-[hex-rank](../../SPEC/Libraries/hex-rank.md) specifies fraction-free
+[hex-rank](../../HexRank/SPEC/hex-rank.md) specifies fraction-free
 elimination over domains with a checked numerator `adj` and nonzero
 `denom` for the inverse of a selected nonsingular minor. Division by
 `denom` takes place in a fraction field, or in the domain only when that

--- a/HexRowReduceMathlib/SPEC/hex-row-reduce-mathlib.md
+++ b/HexRowReduceMathlib/SPEC/hex-row-reduce-mathlib.md
@@ -2,7 +2,9 @@
 
 ## Correspondence-only classification
 
-This library is a `correspondence-only-layer`.
+The existing API is a `correspondence-only-layer`. The inverse and solve
+frontends specified below add companion conformance and fresh-module proof
+evidence when implemented; compiled algorithms remain in HexRowReduce.
 
 Computational conformance owner: `HexRowReduce`
 Computational performance owner: `HexRowReduce`
@@ -226,3 +228,242 @@ benchmark executable. The domain certificate inverse described in hex-rank
 and the direct field inverse agree after transport to a common field and
 undoing the certificate's row/column selections, by uniqueness of inverse;
 that consumer-level comparison adds no dependency between the libraries.
+
+## The `inverse` tactic
+
+This is a required frontend extension to the field inverse correspondence
+above, conditional on implementing its algorithm contracts from
+[issue #10181](https://github.com/kim-em/hex-dev/issues/10181). Follow
+[the matrix tactic protocol](../../SPEC/matrix-tactics.md) and
+[the `rank` template](../../HexRankMathlib/SPEC/hex-rank-mathlib.md#the-rank-tactic).
+List witness/checker/producer additions belong to HexRowReduce and their
+Mathlib transport and frontend belong here, without a new library.
+
+### Goals, result and carriers
+
+Declare non-reserved `inverse` and term form `inverse% A`. For closed square
+`A B : Matrix (Fin n) (Fin n) F`, close `A * B = 1` and `A⁻¹ = B`,
+including reversed equality orientations. The new `InverseResult A` is a
+tagged dependent result with two alternatives:
+
+- `invertible`: literal `value : Matrix (Fin n) (Fin n) F`,
+  `A * value = 1`, `value * A = 1`, and `A⁻¹ = value`;
+- `singular`: literal `kernel : Fin n → F`, `kernel ≠ 0`,
+  `A.mulVec kernel = 0`, `A.det = 0`, and `A⁻¹ = 0`.
+
+The singular alternative is mathematical success in term mode, not a
+producer error. It closes `A⁻¹ = 0` but cannot close `A * B = 1`. For
+`n = 0`, return the empty identity in the invertible alternative; no
+nonzero kernel vector exists. On invertible inputs check the stated `B`
+against the unique computed inverse.
+
+Soundness assumes Mathlib `[Field F] [DecidableEq F]` and coherent induced
+`Field.toGrindField`, as in the inverse correspondence above. The initial
+frontend supports closed `ℚ` entries including fractions; an arbitrary
+field instance does not imply a codec. Prime `ZMod p` is an extension once
+its codec and field transport are proved; composite moduli and symbolic
+entries are outside this handler. Rational functions are covered by the
+algorithm SPEC, but are not promised by this numeric frontend.
+
+Use [the shared literal layer](../../HexMatrixMathlib/SPEC/hex-matrix-mathlib.md#matrix-literals)
+for both `A` and `B`. Request against its SPEC field-aware term elaboration,
+rational/residue codecs with proved arithmetic agreement, and vector
+literal identification for the kernel witness. These requests are shared
+with `min_poly` and `solve`, not separate local reifiers.
+
+### Kernel certificate and soundness
+
+The planned `inverse?` returns a matrix, not an independent certificate or
+a singularity witness. Its `inverse?_spec` requires the producer equation
+`inverse? A = some B`; the tactic must not discharge that by replaying RREF.
+Require a new list `InverseWitness` and `checkInverseList`. In the invertible
+case the quoted inverse is the witness: check its exact square shape and
+`A * B = I` and `B * A = I`. In the singular case check a vector of length
+`n`, a nonzero coordinate (with its index in range), and `A * v = 0`.
+The list products use only exposed structural recursion on `Nat`/`Int` data.
+For `ℚ`, encode numerator/positive denominator pairs, reject zero denominators,
+and use division-free rational arithmetic and cross multiplication. No
+`Array`, `Vector`, `Fin`, `Finset`, `Hex.Matrix`, well-founded recursion,
+field inversion or producer execution occurs on the reduction path.
+
+Require new `inverse_of_checkList` to transport the successful product checks
+and `hA : A = ofLists ...` (and the analogous identification of `B`) to both
+Mathlib product identities and `A⁻¹ = B`. It uses inverse uniqueness and
+the same Mathlib inverse theory as the correspondence above, independently
+of `inverse?_spec`. Require a separate singular soundness lemma: a nonzero
+right-kernel vector implies determinant zero over a field and hence zero
+Mathlib inverse. These are new arbitrary-witness transport lemmas. They
+must not assume a positive dimension, nonzero determinant in the singular
+case, or that quoted data is definitionally the producer's output.
+
+### Producer and proof assembly
+
+Run the compiled field RREF inverse path once, retaining its reduced data.
+On failure of the full-rank test, extract a nonzero column of its existing
+nullspace basis; do not claim `inverse?` itself returns this vector. This
+witness-producing wrapper is a new HexRowReduce obligation and leaves the
+specified `inverse?` API intact. Re-check either list witness before quoting.
+
+Follow `HexRankMathlib/Kernel.lean` and `Tactic.lean`: shared literal
+identification, list soundness wrapper, and one synchronous auxiliary theorem
+covering all proof fields or the requested orientation. Do not kernel
+pre-check. Other operations/carriers are `notApplicable`; an in-fragment
+missing capability or exceeded budget is `declined`; a false target reports
+the inverse or certified singularity; malformed output or kernel rejection
+is `failure`. No singular branch fabricates an inverse product witness.
+
+### Conformance and proof probes
+
+Test both equalities and orientations, both term-result alternatives, all
+literal routes, fractions, required pivot swaps, singular nonzero matrices,
+the zero matrix, and `0 × 0`. Refute wrong inverse entries, wrong shapes,
+zero denominators, zero kernel vectors, out-of-range nonzero-coordinate
+indices and nonzero residuals. Test that singular `A⁻¹ = 0` succeeds while
+`A * 0 = 1` is rejected for positive dimensions. Audit axioms: only
+`propext`, `Classical.choice`, `Quot.sound`.
+
+On implementation reserve `bench/HexRowReduceMathlib/ProofProbe` for both
+frontends, with inverse modules below `Inverse/`. Named seeded families:
+`dense-invertible`, `pivot-swaps`, `singular-kernel` (rank `n - 1` and
+`n / 2`), and `rational-height`; dimensions `2, 4, 8, 16`, input heights
+`8, 32` bits, and `64, 256` for the height family. Profile product and inverse
+goals separately, including singular inverse goals. No Mathlib tactic
+comparator exists. Record six complete fresh-module samples paired with
+import-only baselines, adjacent and alternating orientation, absolute
+wall times/medians, baseline deltas and one kernel-only profile per family
+per [SPEC/benchmarking.md](../../SPEC/benchmarking.md#fresh-module-proof-evidence).
+Include certificate entry counts/serialized bytes, largest numerator and
+denominator heights, emitted artifact sizes, axiom sets and full
+source/toolchain/host provenance. Retain completed samples and timeouts;
+preregister operational caps. Compiled benchmarks stay in HexRowReduce.
+
+## The `solve` tactic
+
+This is a required extension conditional on the complete solve algorithm and
+correspondence above, not an assertion that `solve?` and its theorems already
+exist. Follow [the matrix tactic protocol](../../SPEC/matrix-tactics.md) and
+[the `rank` template](../../HexRankMathlib/SPEC/hex-rank-mathlib.md#the-rank-tactic).
+It shares HexRowReduce's field certificate primitives with `inverse`.
+
+### Goals, result and carriers
+
+Declare non-reserved `solve` and term form `solve% A b`. For closed
+`A : Matrix (Fin n) (Fin m) F`, `b : Fin n → F`, `x : Fin m → F`, accept
+`A.mulVec x = b` and its reverse. The stated `x` need not be the producer's
+canonical particular solution: check its residual directly. Also accept
+`∃ x, A.mulVec x = b` and `¬ ∃ x, A.mulVec x = b` using the corresponding
+certified outcome.
+
+The new dependent `SolveResult A b` has two alternatives:
+
+- `consistent`: a literal particular solution `value : Fin m → F`, a
+  literal `nullity : Nat`, a literal matrix
+  `basis : Matrix (Fin m) (Fin nullity) F`, `A.mulVec value = b`, and
+  `∀ x, A.mulVec x = b ↔ ∃! c, x = value + basis.mulVec c`;
+- `inconsistent`: a literal `separator : Fin n → F`,
+  `Matrix.vecMul separator A = 0`, `dotProduct separator b ≠ 0`,
+  and `¬ ∃ x, A.mulVec x = b`.
+
+The particular solution has zero free coordinates and the basis uses the
+algorithm SPEC's increasing free-column order. The term result certifies the
+entire affine space, not just one residual or linearly independent kernel
+vectors. Its dimensions are quoted naturals, not a reduction of
+`rowReduce_rank A`. A certified inconsistent system is a successful negative
+term result; on a positive goal it reports the checked separator and nonzero
+dot product, then leaves the goal unproved.
+
+Use the same Mathlib field assumptions, initial `ℚ` fragment, optional prime
+`ZMod p` arm and instance discipline as `inverse`. Import matrix recognition
+from [the shared literal layer](../../HexMatrixMathlib/SPEC/hex-matrix-mathlib.md#matrix-literals).
+Request against that SPEC the field codecs and closed vector adapters for
+`b` and `x`, with their proved identifications; share the requests with
+`inverse`. Unsupported symbolic fields/rational-function expressions do not
+inherit a frontend merely from their executable field instance.
+
+### Kernel certificate and soundness
+
+The planned `solve` returns either `SolveData A` or a separating row;
+`solve?` forgets the separator. The planned success/failure theorems have
+producer-equation hypotheses, so their invocation is not a kernel checker.
+Require list `SolveWitness`/`checkSolveList` in HexRowReduce with separate
+checks for a particular residual, complete affine data, and inconsistency.
+
+- For a supplied solution goal, check exact shapes and `A * x = b` directly.
+- For term mode or an existential success, retain RREF data `R`, transforms
+  `U`, `W`, rank `r` and pivot/free-column lists from the compiled solve.
+  Check `U * A = R`, `U * W = I`, both rank bounds, the full RREF clauses
+  (sorted in-range pivots, pivot ones, zeros before and above/below pivots,
+  zero trailing rows), and that pivots/free columns partition all `m`
+  columns in increasing order. Check `nullity = m - r`, `A * value = b`,
+  zero free coordinates of `value`, and that every basis column has the
+  prescribed identity free coordinates and negative RREF pivot entries.
+  These last checks certify completeness and unique coefficients; checking
+  only `A * basis = 0` would not.
+- For inconsistency, check separator length `n`, `y * A = 0` and
+  `y · b ≠ 0`. This does not require an RREF certificate.
+
+All matrices/vectors are exact-length lists, indices are checked naturals,
+and field scalars use the division-free numerator/positive-denominator data
+of `inverse`. All reduction-path definitions are exposed structural list
+recursions, with no `Array`, `Vector`, `Fin`, `Finset`, `Hex.Matrix`,
+well-founded recursion or replay of row reduction/solve/nullspace search.
+
+Required new `solve_of_checkList` proves the residual equality for decoded
+lists; the complete branch additionally reconstructs an `IsRowReduced`
+witness from the checked identities and shape. The existing
+`HexMatrixMathlib.nullspace_span_eq_ker` takes Mathlib `[Field F]` and
+`IsRowReduced M D`, and identifies the computed nullspace span with the
+kernel. Reuse it, plus the free-coordinate identity for uniqueness, to
+prove the term record's affine-space statement. Expose or reuse the private
+independence proof as specified in the correspondence above. A separate
+separator lemma transports the zero left product and nonzero dot product
+and rules out every solution by associativity. None of these new lemmas
+requires `solve A b = ...`. Wrappers take matrix/vector literal
+identifications for the actual Mathlib goal, just like rank's `hA` wrapper.
+
+### Producer and proof assembly
+
+For complete/negative output call compiled `solve` once, retaining RREF data
+and its inverse transform for the complete witness. Retaining the inverse
+transform in this wrapper is a new certificate-producer obligation; no
+elimination is rerun merely to recover a dependent output size. For a stated
+solution, the direct residual check accepts any valid `x`; if it fails, use
+the complete producer to distinguish a wrong candidate from inconsistency.
+Re-check all emitted list data in compiled code before quoting.
+
+Follow `HexRankMathlib/Kernel.lean` and `Tactic.lean`: identify literals once,
+quote the witness, and build all proof fields/the goal through one synchronous
+auxiliary theorem. No preliminary kernel check or native proof trust. Other
+operations/carriers are `notApplicable`; missing in-fragment codecs or
+budgets are `declined`. A wrong candidate reports its residual and, when
+consistent, a certified particular solution; inconsistency reports the
+checked separator. Only a producer bug, malformed certificate or kernel
+rejection is `failure`, never an ordinary inconsistent system.
+
+### Conformance and proof probes
+
+Test rectangular systems, a noncanonical valid stated solution, both
+existential outcomes, both equation orientations, both term records and
+unique coefficient reconstruction. Include `0 × 0`, `0 × m` (full kernel),
+`n × 0` (consistent exactly for zero RHS), rank zero, non-leading pivots,
+fractions and all literal routes. Refute corrupted residuals, missing or
+duplicate basis columns, a zero or incomplete kernel basis, bad free-column
+partitions, invalid RREF shapes/transforms, wrong nullity, zero denominators,
+and separators with either nonzero left product or zero dot product.
+Audit the accepted theorem axioms against `propext`, `Classical.choice`,
+`Quot.sound` only, including negative results.
+
+Use modules below `bench/HexRowReduceMathlib/ProofProbe/Solve` in the shared
+reservation. Named seeded families: `square-unique`, `tall-consistent`
+(`2n × n`), `wide-affine` (`n × 2n`), `deficient-affine` (rank `n / 2`),
+and `inconsistent-separator` (the same deficient matrices with inconsistent
+RHS), at `n = 2, 4, 8, 16` and rational input heights `8, 32, 128` bits.
+Measure the supplied-solution and complete-record surfaces separately.
+There is no Mathlib tactic comparator; record absolute numbers and no ratio.
+Per [SPEC/benchmarking.md](../../SPEC/benchmarking.md#fresh-module-proof-evidence),
+use six adjacent import-baseline/probe pairs, alternating orientation, retain
+all raw build times/medians and deltas, and record one kernel-only profile
+per family. Record certificate entry counts/serialized bytes, scalar heights,
+emitted artifact sizes, axiom sets and exact source/toolchain/host provenance.
+Retain every completed sample and timeout, with preregistered operational
+caps. Compiled solver/certificate benchmarks remain in HexRowReduce.

--- a/HexRowReduceMathlib/SPEC/hex-row-reduce-mathlib.md
+++ b/HexRowReduceMathlib/SPEC/hex-row-reduce-mathlib.md
@@ -229,6 +229,38 @@ and the direct field inverse agree after transport to a common field and
 undoing the certificate's row/column selections, by uniqueness of inverse;
 that consumer-level comparison adds no dependency between the libraries.
 
+## Frontend implementation and validation
+
+The tactic contracts below are design requirements. Their kernel-certificate
+subsections specify additions owned by the Mathlib-free algorithm library;
+they do not move that code into this companion. When implementing those
+additions, cross-link the algorithm's kernel-certificate SPEC to this contract.
+Keep existing phase evidence as evidence for the existing correspondence only.
+Before activating the frontend, remove `correspondence_only: true` if present,
+add `proof_probes: [bench/HexRowReduceMathlib/ProofProbe]`, and reopen the
+library's conformance/performance obligations: cap `done_through` at `2` until
+the new build-only proof tests pass, then at `3` until complete proof evidence
+passes. Do not add an empty reservation while retaining a completed Phase 4.
+This SPEC-only change does not alter the manifest or attest implementation.
+
+Proof tests live in `HexRowReduceMathlib/Tests.lean`, built with the ordinary
+library; malformed list certificates also belong in the algorithm library's
+Mathlib-free conformance driver. Proof probes are fresh modules, not runtime
+oracle drivers or Mathlib-importing benchmark executables. Each frontend uses
+`HexRowReduceMathlib/Tactic.lean`; result records and list soundness belong
+in `HexRowReduceMathlib/Kernel.lean`. No library name changes.
+
+For the named families below, shipping requires complete clean-tree evidence
+under the `absolute_only` mode of
+[SPEC/benchmarking.md](../../SPEC/benchmarking.md#fresh-module-proof-evidence).
+Preregister six rounds and a per-candidate absolute build budget of 60 seconds
+on the measurement host for every stated rung. Every candidate sample must
+meet it; report the median and kernel-only time as well. A timeout, incomplete
+pair, budget failure or provenance mismatch blocks the frontend's performance
+sign-off. This is an operational shipping gate, not an asymptotic or portable
+wall-time claim. Retain slow completed samples; do not trim the ladder to get
+a passing verdict. Any budget revision requires an explicit SPEC amendment.
+
 ## The `inverse` tactic
 
 This is a required frontend extension to the field inverse correspondence
@@ -281,9 +313,18 @@ case the quoted inverse is the witness: check its exact square shape and
 `A * B = I` and `B * A = I`. In the singular case check a vector of length
 `n`, a nonzero coordinate (with its index in range), and `A * v = 0`.
 The list products use only exposed structural recursion on `Nat`/`Int` data.
-For `ℚ`, encode numerator/positive denominator pairs, reject zero denominators,
-and use division-free rational arithmetic and cross multiplication. No
-`Array`, `Vector`, `Fin`, `Finset`, `Hex.Matrix`, well-founded recursion,
+For `ℚ`, follow the scaled-integer boundary of `checkDetRat` in
+`HexBareiss/Kernel.lean`. Keep each literal's row list at `Rat` for its
+`rfl` identification and check agreement with integer rows and a positive
+common denominator using entrywise numerator/denominator cross products.
+Encode each witness matrix/vector with its own common denominator. For
+`A = Z / d` and `B = V / e`, check `Z * V = (d * e) I`; for
+`v = w / s`, check `Z * w = 0`. Thus products and sums are integer list
+arithmetic, not repeated addition of unreduced fractions. Reject zero scales;
+the codec supplies the proved literal/encoding agreement. Product bit heights
+are bounded by the summed operand heights plus `O(log(n + 1))`; scale and
+witness numerator heights are recorded separately from original input heights.
+No `Array`, `Vector`, `Fin`, `Finset`, `Hex.Matrix`, well-founded recursion,
 field inversion or producer execution occurs on the reduction path.
 
 Require new `inverse_of_checkList` to transport the successful product checks
@@ -296,13 +337,47 @@ Mathlib inverse. These are new arbitrary-witness transport lemmas. They
 must not assume a positive dimension, nonzero determinant in the singular
 case, or that quoted data is definitionally the producer's output.
 
+Required result signature in `HexRowReduceMathlib/Kernel.lean` (namespace
+`HexMatrixMathlib`), using the same coherent field instance as above:
+
+```lean
+inductive InverseResult {F : Type u} [Field F] {n : Nat}
+    (A : Matrix (Fin n) (Fin n) F) where
+  | invertible (value : Matrix (Fin n) (Fin n) F)
+      (right_inv : A * value = 1) (left_inv : value * A = 1)
+      (inv_eq : A⁻¹ = value)
+  | singular (kernel : Fin n → F) (nonzero : kernel ≠ 0)
+      (annihilates : A.mulVec kernel = 0) (det_eq : A.det = 0)
+      (inv_eq : A⁻¹ = 0)
+
+-- Initial rational checker in HexRowReduce/Kernel.lean, namespace Hex.Matrix:
+def checkInverseList (n : Nat) (rows : List (List Rat))
+    (c : InverseWitness) : Bool
+
+-- Companion constructor; its proof fields come from the product/kernel lemmas.
+noncomputable def inverse_of_checkList {n : Nat}
+    (A : Matrix (Fin n) (Fin n) ℚ) (rows : List (List Rat))
+    (c : Hex.Matrix.InverseWitness)
+    (hA : A = HexMatrixMathlib.ofLists n n rows)
+    (hc : Hex.Matrix.checkInverseList n rows c = true) : InverseResult A
+```
+
+`InverseWitness` is a tagged list record: an invertible branch stores the
+scaled input and inverse blocks; a singular branch stores the scaled input
+block, scaled kernel vector and nonzero-coordinate index. Every scale is a
+`Nat` and every numerator is an `Int`. The constructor's projection theorems
+identify its returned value/vector with that branch's decoded literals.
+
 ### Producer and proof assembly
 
 Run the compiled field RREF inverse path once, retaining its reduced data.
 On failure of the full-rank test, extract a nonzero column of its existing
 nullspace basis; do not claim `inverse?` itself returns this vector. This
-witness-producing wrapper is a new HexRowReduce obligation and leaves the
-specified `inverse?` API intact. Re-check either list witness before quoting.
+witness-producing wrapper is a new HexRowReduce obligation for this tactic,
+requested against its SPEC's §Field inverse and complete linear solve. That
+section excludes such a wrapper only from the earlier algorithm extension;
+it must be extended before this frontend ships. The `inverse?` API stays intact.
+Re-check either list witness before quoting.
 
 Follow `HexRankMathlib/Kernel.lean` and `Tactic.lean`: shared literal
 identification, list soundness wrapper, and one synchronous auxiliary theorem
@@ -327,8 +402,11 @@ frontends, with inverse modules below `Inverse/`. Named seeded families:
 `dense-invertible`, `pivot-swaps`, `singular-kernel` (rank `n - 1` and
 `n / 2`), and `rational-height`; dimensions `2, 4, 8, 16`, input heights
 `8, 32` bits, and `64, 256` for the height family. Profile product and inverse
-goals separately, including singular inverse goals. No Mathlib tactic
-comparator exists. Record six complete fresh-module samples paired with
+goals separately, including singular inverse goals. Mathlib has no dedicated
+inverse tactic. Include an informational matched proof using entrywise
+`simp [Matrix.mul_apply]`/`norm_num` for small closed product goals; report
+whether it closes each rung rather than presuming a complete competitor.
+Record six complete fresh-module samples paired with
 import-only baselines, adjacent and alternating orientation, absolute
 wall times/medians, baseline deltas and one kernel-only profile per family
 per [SPEC/benchmarking.md](../../SPEC/benchmarking.md#fresh-module-proof-evidence).
@@ -347,7 +425,9 @@ It shares HexRowReduce's field certificate primitives with `inverse`.
 
 ### Goals, result and carriers
 
-Declare non-reserved `solve` and term form `solve% A b`. For closed
+Declare non-reserved `solve` and term form `solve% A b`. Add parser
+regression tests for the bare matrix tactic, term form and ordinary
+identifiers/function applications named `solve`. For closed
 `A : Matrix (Fin n) (Fin m) F`, `b : Fin n → F`, `x : Fin m → F`, accept
 `A.mulVec x = b` and its reverse. The stated `x` need not be the producer's
 canonical particular solution: check its residual directly. Also accept
@@ -403,8 +483,9 @@ checks for a particular residual, complete affine data, and inconsistency.
   `y · b ≠ 0`. This does not require an RREF certificate.
 
 All matrices/vectors are exact-length lists, indices are checked naturals,
-and field scalars use the division-free numerator/positive-denominator data
-of `inverse`. All reduction-path definitions are exposed structural list
+and field scalars use the positive-common-denominator integer blocks
+of `inverse`, clearing denominators once per identity. All reduction-path
+definitions are exposed structural list
 recursions, with no `Array`, `Vector`, `Fin`, `Finset`, `Hex.Matrix`,
 well-founded recursion or replay of row reduction/solve/nullspace search.
 
@@ -420,6 +501,46 @@ separator lemma transports the zero left product and nonzero dot product
 and rules out every solution by associativity. None of these new lemmas
 requires `solve A b = ...`. Wrappers take matrix/vector literal
 identifications for the actual Mathlib goal, just like rank's `hA` wrapper.
+
+Required result signature in `HexRowReduceMathlib/Kernel.lean`, namespace
+`HexMatrixMathlib`; `c` is explicitly indexed by the quoted nullity:
+
+```lean
+inductive SolveResult {F : Type u} [Field F] {n m : Nat}
+    (A : Matrix (Fin n) (Fin m) F) (b : Fin n → F) where
+  | consistent (value : Fin m → F) (nullity : Nat)
+      (basis : Matrix (Fin m) (Fin nullity) F)
+      (solution : A.mulVec value = b)
+      (complete : ∀ x : Fin m → F, A.mulVec x = b ↔
+        ∃! c : Fin nullity → F, x = value + basis.mulVec c)
+  | inconsistent (separator : Fin n → F)
+      (annihilates : Matrix.vecMul separator A = 0)
+      (separates : dotProduct separator b ≠ 0)
+      (impossible : ¬ ∃ x : Fin m → F, A.mulVec x = b)
+
+-- Initial rational residual checker, namespace Hex.Matrix:
+def checkSolutionList (n m : Nat) (rows : List (List Rat))
+    (rhs candidate : List Rat) : Bool
+
+-- Direct residual soundness, namespace HexMatrixMathlib:
+theorem solve_of_checkList {n m : Nat}
+    (A : Matrix (Fin n) (Fin m) ℚ) (b : Fin n → ℚ) (x : Fin m → ℚ)
+    (rows : List (List Rat)) (rhs candidate : List Rat)
+    (hA : A = ofLists n m rows) (hb : b = vecOfList n rhs)
+    (hx : x = vecOfList m candidate)
+    (hc : Hex.Matrix.checkSolutionList n m rows rhs candidate = true) :
+    A.mulVec x = b
+```
+
+The direct residual checker obtains common denominators by a structural
+list fold before integer products. The complete `checkSolveList` additionally
+takes a tagged `SolveWitness`: the consistent branch contains the scaled
+RREF/transform/inverse, pivot and free-column lists, rank, particular solution
+and basis; the inconsistent branch contains the scaled separator. Its new
+companion constructor `solveResult_of_checkList` takes the analogous `hA`,
+`hb` and accepted check and returns `SolveResult A b`, with projection
+lemmas fixing its literal data to the witness. These types avoid the existing
+`SolveData A`'s producer-dependent dimension on the reduction path.
 
 ### Producer and proof assembly
 
@@ -459,7 +580,11 @@ reservation. Named seeded families: `square-unique`, `tall-consistent`
 and `inconsistent-separator` (the same deficient matrices with inconsistent
 RHS), at `n = 2, 4, 8, 16` and rational input heights `8, 32, 128` bits.
 Measure the supplied-solution and complete-record surfaces separately.
-There is no Mathlib tactic comparator; record absolute numbers and no ratio.
+There is no dedicated Mathlib solve tactic. For supplied-solution goals,
+include an informational matched entrywise `simp [Matrix.mulVec]`/`norm_num`
+proof on small rungs where it closes the same goal. This normalization
+baseline does not compute a solution or certify the complete affine space;
+record absolute numbers for all surfaces.
 Per [SPEC/benchmarking.md](../../SPEC/benchmarking.md#fresh-module-proof-evidence),
 use six adjacent import-baseline/probe pairs, alternating orientation, retain
 all raw build times/medians and deltas, and record one kernel-only profile

--- a/HexSmithMathlib/SPEC/hex-smith-mathlib.md
+++ b/HexSmithMathlib/SPEC/hex-smith-mathlib.md
@@ -2,7 +2,9 @@
 
 ## Correspondence-only classification
 
-This library is a `correspondence-only-layer`.
+The existing API is a `correspondence-only-layer`; the specified `smith`
+frontend adds conformance and a fresh-module proof-performance track when
+implemented.
 
 Computational conformance owner: `HexSmith`
 Computational performance owner: `HexSmith`
@@ -61,13 +63,142 @@ benchmark requirements shared with this layer are in
 
 ## Runtime boundary
 
-`hex-smith-mathlib` owns no independent executable algorithm, reifier,
-certificate checker, or tactic. Its computable projections, such as
+The existing `hex-smith-mathlib` correspondence owns no independent
+executable algorithm. Its computable projections, such as
 `relationVector`, only expose data computed by `HexSmith`; the remaining
 declarations are correspondence proofs checked by the kernel in the ordinary
 `HexSmithMathlib` build.
 
-For Phase 4 this is a `correspondence-only-layer`: `HexSmith` is the
-performance owner for every transported operation. This companion therefore
-has no independent benchmark executable, comparator, raw timing evidence, or
-performance report.
+For the correspondence API, `HexSmith` is the computational performance
+owner. The tactic below requires its own proof probes and report when
+implemented, while introducing no Mathlib-importing benchmark executable.
+
+## The `smith` tactic
+
+This is a required extension following
+[the matrix tactic protocol](../../SPEC/matrix-tactics.md) and
+[the `rank` template](../../HexRankMathlib/SPEC/hex-rank-mathlib.md#the-rank-tactic).
+The certificate producer/checker belong to HexSmith; Mathlib transport and
+the frontend belong here. `invariant_factors` remains reserved for the future
+hex-invariant-factors library.
+
+### Goals, result and carriers
+
+Declare the non-reserved atom `smith` and term form `smith% A`. Initially
+accept closed `A : Matrix (Fin n) (Fin m) ℤ`. For this section abbreviate
+`L(A) := Submodule.span ℤ (Set.range A)`. Rows are relations, so the
+presented cokernel is `(Fin m → ℤ) ⧸ L(A)`, equivalently the cokernel of
+`Matrix.vecMulLinear A`, not the cokernel of `A.mulVecLin`.
+
+Choose the `quotientEquiv`-shaped goal, with stated closed rank `r` and
+closed factors `d : Fin r → ℤ`:
+
+```text
+((Fin m → ℤ) ⧸ L(A)) ≃ₗ[ℤ]
+  (Fin (m - r) → ℤ) × ⨁ i : Fin r, ℤ ⧸ Ideal.span ({d i} : Set ℤ)
+```
+
+`by smith` constructs that equivalence; also accept its `Nonempty` wrapper.
+Require `r ≤ min n m`, positive factors in divisibility order, including
+unit factors; zeros describe the free complement and are not listed in `d`.
+Compare the certified factors exactly with the target. Isomorphic quotients
+with noncanonical alternative presentations are outside this tactic's goal
+normalization. This choice exposes both torsion and free coordinates and
+avoids asking users to specify nonunique ambient/relation bases.
+
+The new dependent term record `SmithResult A` contains `rank : Nat`,
+`rank_le : rank ≤ min n m`, `factors : Fin rank → ℤ`, positivity and
+adjacent divisibility proofs, and `equiv` of the displayed type using these
+fields. Its values are quoted lists read as functions, never reductions of
+`snfRank A` or `invariantFactors A`. The empty and rectangular cases retain
+the full free complement; a unit factor contributes the zero quotient.
+
+Use [hex-matrix-mathlib's literal layer](../../HexMatrixMathlib/SPEC/hex-matrix-mathlib.md#matrix-literals).
+Request against its SPEC a closed vector literal adapter for the stated
+factor function, with identification by `vecOfList`; do not duplicate it.
+An explicitly optional `F[x]` arm belongs to HexPolySmithMathlib, attaches a
+handler to this same syntax kind, and uses HexPolySmith's polynomial SNF
+certificate over `[Lean.Grind.Field F] [DecidableEq F]`. It must transport to
+Mathlib `Polynomial F` under coherent Mathlib field instances, use monic
+nonzero factors and exact coefficient-list identities, and supply its own
+arbitrary-certificate quotient bridge and proof evidence. The integer arm
+acquires no HexPolySmith dependency. This optional arm is not an assertion
+that the current polynomial companion already provides that bridge.
+
+### Kernel certificate and soundness
+
+Existing `Hex.Matrix.snfCert A S T` in `HexSmith/Cert.lean` checks
+`T = S.left * A`, `T * S.right = diagMatrix S.diag n m`, both recorded
+right-inverse identities, and SNF shape. `snfCert_sound` concludes
+`IsSNF A S` for any accepted `SmithData n m`, with no producer hypothesis.
+Its current packed `mulEqCert` route still reads `Hex.Matrix`; do not reduce
+that reference checker in a tactic proof.
+
+Require new `SmithWitness`/`checkSmithList` in HexSmith: rank, positive
+diagonal list, row lists for `left`, `leftInv`, `right`, `rightInv`, and
+`T`. Check all exact shapes and rank bounds, the four product identities,
+positivity and adjacent divisibility. Structural list products over `Int`
+are the initial checker; the second product may transpose lists as the
+reference checker does. The kernel never runs Smith reduction, pivot search,
+GCD, or a packed matrix access. All reduction-path definitions are exposed
+structural recursions over list/`Nat`/`Int`, without `Array`, `Vector`, `Fin`,
+`Finset`, `Hex.Matrix` or well-founded recursion.
+
+The required new `smith_of_checkList` transports acceptance at input rows
+`L` to a `SmithResult (ofLists n m L)`, with rank/factors fixed to the
+witness, and a wrapper accepts `hA : A = ofLists n m L`. Establish the
+reference check and apply `snfCert_sound` in the proof of this bridge.
+Then generalize the constructions in `HexSmithMathlib/Basis.lean` and
+`Quotient.lean` to arbitrary `S` with `IsSNF A S`. Their existing
+`smithNormalForm`, `smithNormalForm_chain` and `quotientEquiv` take `A` and
+use `snfData A`; they are not already arbitrary-certificate transports.
+The new bridge uses the supplied inverse right transform for ambient
+coordinates and the supplied left transform for relations. The inverse
+identities prove unimodularity, and the diagonal identity proves the kernel
+and surjectivity facts needed for the quotient equivalence. No reduction or
+equality proof of the producer's transforms is permitted; transforms need
+not be canonical even when factors are. The divisibility proof comes from
+the checked shape, rather than replaying `smithNormalForm_chain A`.
+
+### Producer and proof assembly
+
+Run compiled `snfData` once (the data-producing counterpart of `snf`), form
+`T`, convert the reference certificate to `SmithWitness`, and re-check with
+`checkSmithList` before quotation. As in `HexRankMathlib/Kernel.lean` and
+`Tactic.lean`, separate list-to-Mathlib soundness, literal identification,
+and frontend assembly. All proof fields use one synchronous auxiliary
+theorem certifying the witness; build the equivalence as data from those
+fields, since `mkAuxTheorem` certifies propositions, not a linear equivalence
+itself. Do not kernel pre-check and then check again.
+
+Different operations/carriers are `notApplicable`; an in-fragment missing
+adapter or exceeded budget is `declined`. A mismatching target reports the
+computed rank and factors; a rejected producer witness or kernel proof is
+`failure`. Unimodular transforms cannot be silently replaced to force a
+target match. Follow the shared diagnostic and axiom protocol.
+
+### Conformance and proof probes
+
+Test the equivalence and `Nonempty` forms and every term-record proof, all
+literal routes, zero matrices, `0 × m`, `n × 0`, full rank, rectangular and
+rank-deficient presentations, units, negative input entries and false target
+factors. Refute malformed certificates by corrupting each transform/inverse
+product, `T`, dimensions, rank, diagonal positivity or divisibility. Include
+a noncanonical but valid transform certificate to ensure soundness does not
+assume producer equality. Audit axioms against `propext`, `Classical.choice`,
+`Quot.sound` only.
+
+On implementation reserve `bench/HexSmithMathlib/ProofProbe`. Named families:
+`chain-conjugate` (unimodular transforms of positive divisibility chains),
+`rectangular-presentation` (`n × 2n` and `2n × n`), `rank-deficient`
+(rank `n / 2`), and `large-coefficients`; dimensions `2, 4, 8, 16`, input
+heights `8, 32`, and `64, 256` bits for the last family. Include factors
+`1` and nontrivial free summands. With no Mathlib tactic comparator, record
+absolute fresh-module times/medians, baseline deltas and one kernel-only
+profile per family, not a speedup ratio. Use six samples paired adjacently
+with import-only baselines, alternating orientation, per
+[SPEC/benchmarking.md](../../SPEC/benchmarking.md#fresh-module-proof-evidence).
+Record certificate entry counts, serialized bytes, maximum integer height,
+emitted artifact sizes, axiom sets and complete source/toolchain/host
+provenance; retain every completed sample and report timeouts. Preregister
+operational caps. Ordinary compiled performance remains HexSmith's concern.

--- a/HexSmithMathlib/SPEC/hex-smith-mathlib.md
+++ b/HexSmithMathlib/SPEC/hex-smith-mathlib.md
@@ -73,6 +73,38 @@ For the correspondence API, `HexSmith` is the computational performance
 owner. The tactic below requires its own proof probes and report when
 implemented, while introducing no Mathlib-importing benchmark executable.
 
+## Frontend implementation and validation
+
+The tactic contracts below are design requirements. Their kernel-certificate
+subsections specify additions owned by the Mathlib-free algorithm library;
+they do not move that code into this companion. When implementing those
+additions, cross-link the algorithm's kernel-certificate SPEC to this contract.
+Keep existing phase evidence as evidence for the existing correspondence only.
+Before activating the frontend, remove `correspondence_only: true` if present,
+add `proof_probes: [bench/HexSmithMathlib/ProofProbe]`, and reopen the
+library's conformance/performance obligations: cap `done_through` at `2` until
+the new build-only proof tests pass, then at `3` until complete proof evidence
+passes. Do not add an empty reservation while retaining a completed Phase 4.
+This SPEC-only change does not alter the manifest or attest implementation.
+
+Proof tests live in `HexSmithMathlib/Tests.lean`, built with the ordinary
+library; malformed list certificates also belong in the algorithm library's
+Mathlib-free conformance driver. Proof probes are fresh modules, not runtime
+oracle drivers or Mathlib-importing benchmark executables. Each frontend uses
+`HexSmithMathlib/Tactic.lean`; result records and list soundness belong
+in `HexSmithMathlib/Kernel.lean`. No library name changes.
+
+For the named families below, shipping requires complete clean-tree evidence
+under the `absolute_only` mode of
+[SPEC/benchmarking.md](../../SPEC/benchmarking.md#fresh-module-proof-evidence).
+Preregister six rounds and a per-candidate absolute build budget of 60 seconds
+on the measurement host for every stated rung. Every candidate sample must
+meet it; report the median and kernel-only time as well. A timeout, incomplete
+pair, budget failure or provenance mismatch blocks the frontend's performance
+sign-off. This is an operational shipping gate, not an asymptotic or portable
+wall-time claim. Retain slow completed samples; do not trim the ladder to get
+a passing verdict. Any budget revision requires an explicit SPEC amendment.
+
 ## The `smith` tactic
 
 This is a required extension following
@@ -121,8 +153,12 @@ handler to this same syntax kind, and uses HexPolySmith's polynomial SNF
 certificate over `[Lean.Grind.Field F] [DecidableEq F]`. It must transport to
 Mathlib `Polynomial F` under coherent Mathlib field instances, use monic
 nonzero factors and exact coefficient-list identities, and supply its own
-arbitrary-certificate quotient bridge and proof evidence. The integer arm
-acquires no HexPolySmith dependency. This optional arm is not an assertion
+arbitrary-certificate quotient bridge and proof evidence. Activating this optional arm requires a future HexPolySmithMathlib change:
+add a dependency on HexSmithMathlib to import the syntax kind, remove its
+`correspondence_only` flag, reserve its own proof probes and reopen its
+conformance/performance phases as above. No such manifest edge or activation
+is part of the integer frontend. The integer arm acquires no HexPolySmith
+dependency. This optional arm is not an assertion
 that the current polynomial companion already provides that bridge.
 
 ### Kernel certificate and soundness
@@ -159,6 +195,41 @@ and surjectivity facts needed for the quotient equivalence. No reduction or
 equality proof of the producer's transforms is permitted; transforms need
 not be canonical even when factors are. The divisibility proof comes from
 the checked shape, rather than replaying `smithNormalForm_chain A`.
+
+Required API schemata (new declarations, not existing theorem citations):
+
+```lean
+-- HexSmith/Kernel.lean, namespace Hex.Matrix
+structure SmithWitness where
+  rank : Nat
+  diag : List Int
+  left leftInv right rightInv intermediate : List (List Int)
+
+def checkSmithList (n m : Nat) (rows : List (List Int))
+    (c : SmithWitness) : Bool
+
+-- HexSmithMathlib/Kernel.lean, namespace HexSmithMathlib
+structure SmithResult {n m : Nat} (A : Matrix (Fin n) (Fin m) ℤ) where
+  rank : Nat
+  rank_le : rank ≤ min n m
+  factors : Fin rank → ℤ
+  positive : ∀ i, 0 < factors i
+  chain : ∀ i j : Fin rank, i.val + 1 = j.val → factors i ∣ factors j
+  equiv : ((Fin m → ℤ) ⧸ Submodule.span ℤ (Set.range A)) ≃ₗ[ℤ]
+    (Fin (m - rank) → ℤ) ×
+      ⨁ i : Fin rank, ℤ ⧸ Ideal.span ({factors i} : Set ℤ)
+
+noncomputable def smith_of_checkList {n m : Nat}
+    (A : Matrix (Fin n) (Fin m) ℤ) (rows : List (List Int))
+    (c : Hex.Matrix.SmithWitness)
+    (hA : A = HexMatrixMathlib.ofLists n m rows)
+    (hc : Hex.Matrix.checkSmithList n m rows c = true) : SmithResult A
+```
+
+The constructor additionally exposes projection theorems equating its `rank`
+to `c.rank` and its factor function to `vecOfList c.rank c.diag` after that
+rank identification. It is a definition returning data; the identities it
+uses and the projection equalities are theorems, not computational SNF calls.
 
 ### Producer and proof assembly
 

--- a/SPEC/matrix-tactics.md
+++ b/SPEC/matrix-tactics.md
@@ -1,7 +1,7 @@
 # Matrix tactics
 
 Proof-producing tactics on closed matrices (`rank`, `det`, `char_poly`, and
-later `min_poly`, `inverse`, `solve`) are not a library of their own. Each
+later `min_poly`, `smith`, `hermite`, `inverse`, `solve`) are not a library of their own. Each
 tactic lives with the algorithm library whose certificate it checks, its
 Mathlib-input form lives in that library's Mathlib companion, and the only
 shared code is the literal layer of `hex-matrix-mathlib`. This note fixes
@@ -25,7 +25,18 @@ their library structure and their kernel-replay proof strategy do not.
 | `rank`, symbolic entries | `A.rank = r` (conditional), `A.rank ≤ r`, generic rank of the reified matrix | `hex-generic-rank`: hex-rank's certificate at `MvPoly` | `hex-generic-rank-mathlib`: a second handler on the `rank` syntax kind; `checkRank_sound_at` | specified: [hex-generic-rank-mathlib](Libraries/hex-generic-rank-mathlib.md) |
 | `det`, symbolic entries | `A.det = e`, `e = A.det`, `det% A` (unconditional) | `hex-bareiss`: generic `detWitness`, `checkDetPolyList`, instantiated at polynomials by the companion | `hex-bareiss-mathlib`: `checkDetPolyList_sound`, second handler on the `det` syntax kind | specified: [Symbolic determinant](../HexBareissMathlib/SPEC/hex-bareiss-mathlib.md#symbolic-determinant) |
 | `rank_locus` | `A.rank < r ↔ ⋀ gᵢ = 0` as a hypothesis; `A.rank < r`, `A.rank ≤ r`, `r ≤ A.rank`, `A.rank = r` | `hex-determinantal-ideal`: `detIdealGens`, and its list form `detIdealGensList` | `hex-determinantal-ideal-mathlib`: `gens_vanish_iff_rank_lt`, `HexDeterminantalIdealMathlib/Tactic.lean`; default `r` from a hex-generic-rank-mathlib handler | specified: [hex-determinantal-ideal-mathlib §The `rank_locus` tactic](../HexDeterminantalIdealMathlib/SPEC/hex-determinantal-ideal-mathlib.md#the-rank_locus-tactic) |
+| `min_poly` | `minpoly F A = p` | hex-min-poly: list form of `MinPolyCert` | hex-min-poly-mathlib | specified: [companion contract](../HexMinPolyMathlib/SPEC/hex-min-poly-mathlib.md#the-min_poly-tactic) |
+| `smith` | integer row-presentation quotient equivalence | hex-smith: list form of `snfCert` | hex-smith-mathlib; optional polynomial handler in hex-poly-smith-mathlib | specified: [companion contract](../HexSmithMathlib/SPEC/hex-smith-mathlib.md#the-smith-tactic) |
+| `hermite` | integer lattice membership and row-lattice basis | hex-hermite: list form of `hnfCert` and checked remainder | hex-hermite-mathlib | specified: [companion contract](../HexHermiteMathlib/SPEC/hex-hermite-mathlib.md#the-hermite-tactic) |
+| `inverse` | `A * B = 1`, `A⁻¹ = B` | hex-row-reduce: list products or nonzero kernel vector | hex-row-reduce-mathlib | specified: [companion contract](../HexRowReduceMathlib/SPEC/hex-row-reduce-mathlib.md#the-inverse-tactic) |
+| `solve` | `A.mulVec x = b`, existence or inconsistency | hex-row-reduce: list residual, complete RREF data or separator | hex-row-reduce-mathlib | specified: [companion contract](../HexRowReduceMathlib/SPEC/hex-row-reduce-mathlib.md#the-solve-tactic) |
 | literal layer | reading `!![…]`, `Matrix.of ![…]`, `fun i j => …`, `Matrix.ofArray xs h` | none | `hex-matrix-mathlib`: `ofLists`, `vecOfList`, `entriesEq`, literal recognition, definitional identification (`HexMatrixMathlib/Literal.lean`) | shipped (https://github.com/kim-em/hex-dev/pull/10218) |
+
+`invariant_factors` is reserved for hex-invariant-factors; it is not an alias
+for `smith`. The five structural frontends marked specified use the
+absolute-budget proof track in their companion contracts because Mathlib has
+no dedicated tactic for those results. Ordinary entrywise normalization is
+an informational baseline for inverse-product and supplied-solution goals.
 
 Rules that follow from the table:
 


### PR DESCRIPTION
Specify `min_poly`, `smith`, `hermite`, `inverse`, and `solve` in their existing Mathlib companions, following the rank tactic's list-certificate and synchronous kernel-checking model. Define accepted goals, typed term-result/checker interfaces, carrier limits, arbitrary-certificate transport obligations, malformed-certificate tests, and named fresh-module proof probes.

Smith exposes the quotient by the row lattice; Hermite constructs its HNF row basis; solve returns a complete affine solution or a certified inconsistency witness. Inverse covers both genuine inverses and Mathlib's zero inverse at singular matrices. Rational certificates retain cheap literal identification and perform their arithmetic on scaled integer lists, with explicit growth accounting for minimal-polynomial checks.

The contracts distinguish existing APIs from new obligations, including the inverse/solve algorithms specified by #10181. Supporting SPEC edits register the five frontends, record shared adapter requests, and reconcile the row-reduce witness-wrapper scope. Frontend activation explicitly requires manifest/phase transitions, build-only proof tests and absolute-budget proof evidence. This PR changes specifications only; it introduces no library or implementation.

Validation: audited cited theorem/certificate signatures against source; all local Markdown links and anchors in changed files resolve; `git diff --check`, `scripts/check_dag.py`, `scripts/check_phase4.py`, `scripts/check_phase7.py`, and `scripts/check_file_line_counts.py` pass. No Lean sources or build configuration changed. Rebased onto current `main` without conflicts.

Closes #10183.
