### PR TITLE
feat(reflect-mathlib): residue coefficients for positive characteristic

### DIFF
--- a/HexModArithMathlib.lean
+++ b/HexModArithMathlib.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexModArithMathlib.ZMod64Equiv
+public import HexModArithMathlib.Ring
 public import HexModArithMathlib.WordMod
 
 public section

--- a/HexModArithMathlib/Ring.lean
+++ b/HexModArithMathlib/Ring.lean
@@ -1,0 +1,43 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexModArithMathlib.ZMod64Equiv
+public import Mathlib.Algebra.Ring.InjSurj
+
+public section
+
+namespace HexModArithMathlib.ZMod64
+
+variable {p : Nat} [Hex.ZMod64.Bounds p]
+
+/-- Scalar multiplication by naturals transfers to `ZMod`. -/
+theorem toZMod_nsmul (n : Nat) (a : Hex.ZMod64 p) :
+    toZMod (n • a) = n • toZMod a := by
+  rw [Lean.Grind.Semiring.nsmul_eq_natCast_mul, toZMod_mul, toZMod_natCast,
+    nsmul_eq_mul]
+
+/-- Scalar multiplication by integers transfers to `ZMod`. -/
+theorem toZMod_zsmul (n : Int) (a : Hex.ZMod64 p) :
+    toZMod (n • a) = n • toZMod a := by
+  cases n with
+  | ofNat n => exact (toZMod_nsmul n a).trans (natCast_zsmul (toZMod a) n).symm
+  | negSucc n =>
+    change toZMod (-( (n + 1) • a)) = _
+    rw [toZMod_neg, toZMod_nsmul]
+    change -((n + 1) • toZMod a) = (-((n + 1 : Nat) : Int)) • toZMod a
+    rw [neg_zsmul, natCast_zsmul]
+
+/-- Mathlib's ring laws transported through `equiv`, retaining every executable
+operation, including scalar multiplication, casts, subtraction, and powers.
+Scoped to preserve existing exact Grind instance identities on import. -/
+scoped instance commRing : CommRing (Hex.ZMod64 p) :=
+  equiv.injective.commRing toZMod toZMod_zero toZMod_one toZMod_add toZMod_mul
+    toZMod_neg toZMod_sub toZMod_nsmul toZMod_zsmul toZMod_pow
+    toZMod_natCast toZMod_intCast
+
+end HexModArithMathlib.ZMod64

--- a/HexModArithMathlib/SPEC/hex-mod-arith-mathlib.md
+++ b/HexModArithMathlib/SPEC/hex-mod-arith-mathlib.md
@@ -11,3 +11,10 @@ Computational performance owner: `HexModArith`
 Proves `ZMod64 p ≃+* ZMod p`. This means any Mathlib theorem about
 `ZMod p` transfers to `ZMod64 p`, and any computation with `ZMod64 p`
 is known correct in the mathematical sense.
+
+`HexModArithMathlib.Ring` transports Mathlib's `CommRing` laws along this
+equivalence while retaining the executable operations, including powers,
+casts, and scalar multiplication. The instance is scoped to
+`HexModArithMathlib.ZMod64`: imports alone preserve the existing local
+structure-selection discipline of downstream bridges. It requires only
+`ZMod64.Bounds p`, so it also covers composite moduli and modulus one.

--- a/HexReflect/Provider.lean
+++ b/HexReflect/Provider.lean
@@ -47,6 +47,24 @@ structure CoeffLaws {C : Type} {α : Type u} [Zero C] [Add C] [Lean.Grind.Ring �
   /-- The interpretation is additive. -/
   interp_add : ∀ a b : C, interp (a + b) = interp a + interp b
 
+/-- Reuse coefficient laws at a ring with the same interpretation operations.
+Other ring fields, such as the implementation of powers, need not coincide. -/
+theorem CoeffLaws.changeRing {C : Type} {α : Type u} [Zero C] [Add C]
+    (r s : Lean.Grind.Ring α) (ofInt : Int → C) (interp : C → α)
+    (h : @CoeffLaws C α _ _ r ofInt interp)
+    (cast_eq : (letI := r; (Int.cast : Int → α)) = (letI := s; (Int.cast : Int → α)))
+    (zero_eq : (letI := r; (0 : α)) = (letI := s; (0 : α)))
+    (add_eq : (letI := r; (fun a b : α => a + b)) =
+      (letI := s; (fun a b : α => a + b))) :
+    @CoeffLaws C α _ _ s ofInt interp := by
+  rcases h with ⟨hc, hz, ha⟩
+  constructor
+  · intro k
+    exact (hc k).trans (congrFun cast_eq k)
+  · exact hz.trans zero_eq
+  · intro a b
+    exact (ha a b).trans (congrFun (congrFun add_eq (interp a)) (interp b))
+
 /-- Integer coefficients interpreted by the integer cast satisfy the laws in
 every ring. -/
 theorem CoeffLaws.int {α : Type u} [Lean.Grind.Ring α] :
@@ -74,6 +92,10 @@ structure CoeffProvider where
   interp : Expr
   /-- A proof of `CoeffLaws ofInt interp` for the carrier's exact instances. -/
   laws : Expr
+  /-- Additional quoted instances for downstream coefficient algorithms, such
+  as modulus bounds and primality. Consumers can introduce these as local
+  instances; they are not installed globally by provider selection. -/
+  auxInstances : Array Expr := #[]
 
 /-- Evidence returned by a recognizing registration. -/
 inductive Evidence where

--- a/HexReflect/Result.lean
+++ b/HexReflect/Result.lean
@@ -68,6 +68,8 @@ inductive Decline where
   | ambiguousProvider (capability : Capability) (candidates : Array ProviderId)
   /-- The source type is outside the supported translations. -/
   | unsupportedSourceType (type : Expr)
+  /-- A recognizing provider cannot satisfy a required condition. -/
+  | providerCondition (provider : ProviderId) (reason : String)
   /-- A budget dimension would be exceeded. -/
   | budgetExhausted (info : BudgetExhausted)
   /-- A proof-producing batch mixes two carriers. -/
@@ -290,6 +292,7 @@ def Decline.toMessageData : Decline → MessageData
       {candidates.map (·.name)}"
   | .unsupportedSourceType type =>
     m!"unsupported source type{indentExpr type}"
+  | .providerCondition provider reason => m!"provider {provider.name}: {reason}"
   | .budgetExhausted info => info.toMessageData
   | .mixedCarriers first second =>
     m!"a batch must use one carrier, but found both{indentExpr first}\nand{indentExpr second}"

--- a/HexReflect/SPEC/hex-reflect.md
+++ b/HexReflect/SPEC/hex-reflect.md
@@ -237,8 +237,20 @@ rather than an independent Hex rewrite, justify that collapse.
 
 A coefficient provider supplies an executable coefficient type, a map from
 reflected integer coefficients, an interpretation into the source carrier,
-and the laws needed by `Hex.MvPoly.eval₂`. There is no universal rational
+and the laws needed by `Hex.MvPoly.eval₂`. Providers may also return
+type-checked auxiliary coefficient instances for downstream consumers to introduce locally. There is no universal rational
 coefficient type.
+
+| Provider | Owner | Coefficient carrier | Selection |
+| --- | --- | --- | --- |
+| `intCoeffProvider` | `hex-reflect` | `Int` | Universal, priority 0 |
+| `residueCoeffProvider p` | `hex-reflect-mathlib` | `ZMod64 p` | Known prime characteristic `0 < p < 2^31`, compatible Mathlib field and `CharP`; priority 5 |
+
+The residue provider uses `Bounds p` and `PrimeModulus p`, and interprets
+coefficients injectively through `ZMod p`. Recognized composite
+characteristic, out-of-bounds moduli, or missing carrier evidence decline
+with a provider condition diagnostic; unknown characteristic and zero keep
+the integer provider. See the companion SPEC for the scoped ring transport.
 
 The pinned ring reifier recognizes nested `BitVec.ofNat` inside its recursive
 worker, but its top-level match has no `BitVec.ofNat` arm. Consequently a

--- a/HexReflect/SPEC/hex-reflect.md
+++ b/HexReflect/SPEC/hex-reflect.md
@@ -248,9 +248,10 @@ coefficient type.
 
 The residue provider uses `Bounds p` and `PrimeModulus p`, and interprets
 coefficients injectively through `ZMod p`. Recognized composite
-characteristic, out-of-bounds moduli, or missing carrier evidence decline
-with a provider condition diagnostic; unknown characteristic and zero keep
-the integer provider. See the companion SPEC for the scoped ring transport.
+characteristic, out-of-bounds moduli, or missing characteristic evidence for
+a recognized field decline with a provider condition diagnostic. Unknown
+characteristic, zero, and prime-characteristic carriers without a Mathlib
+field instance keep the integer provider. See the companion SPEC for the scoped ring transport.
 
 The pinned ring reifier recognizes nested `BitVec.ofNat` inside its recursive
 worker, but its top-level match has no `BitVec.ofNat` arm. Consequently a

--- a/HexReflect/Session.lean
+++ b/HexReflect/Session.lean
@@ -360,6 +360,12 @@ def validateCoefficients (ring : Arith.CommRing) (p : CoeffProvider) : m Unit :=
     (mkForall `c .default p.coeffType ring.type)
   checkField p.id "laws" p.laws (mkAppN (mkConst ``CoeffLaws [ring.u])
     #[p.coeffType, ring.type, p.zeroInst, p.addInst, ring.ringInst, p.ofInt, p.interp])
+  for inst in p.auxInstances do
+    let some ty ← (observing? (inferType inst) : MetaM (Option Expr))
+      | failWith (.invalidProviderEvidence p.id "auxiliary instance is ill-typed")
+    unless (← (isClass? ty : MetaM (Option Name))).isSome do
+      failWith (.invalidProviderEvidence p.id "auxiliary evidence is not a typeclass instance")
+    checkField p.id "auxiliary instance" inst ty
 
 /-- Validate the evidence returned by a registration. -/
 private def validateEvidence (ring : Arith.CommRing) (reg : Registration) : Evidence → m Unit

--- a/HexReflectMathlib.lean
+++ b/HexReflectMathlib.lean
@@ -8,6 +8,7 @@ module
 
 public import HexReflectMathlib.Carrier
 public import HexReflectMathlib.Correspondence
+public import HexReflectMathlib.Residue
 
 public section
 

--- a/HexReflectMathlib/Carrier.lean
+++ b/HexReflectMathlib/Carrier.lean
@@ -59,9 +59,11 @@ theorem intCast_eq_intCastRingHom :
   rfl
 
 /-- Mathlib characteristic evidence gives the Grind form used by
-`Expr.toPolyC`. It is a theorem rather than a global instance, so importing
-this module does not change how `Lean.Meta.Sym.Arith` classifies a carrier;
-a frontend supplies it explicitly when it wants the characteristic arm. -/
+`Expr.toPolyC`. This helper is a theorem, not a global instance. Importing
+`Mathlib.Algebra.CharP.Basic` separately supplies a global bridge for
+cancellative semirings, so frontends may already obtain characteristic
+evidence through instance search. This theorem also permits supplying the
+Mathlib ring's exact characteristic instance explicitly. -/
 theorem isCharP_of_charP (p : Nat) [CharP R p] : Lean.Grind.IsCharP R p where
   ofNat_ext_iff {x y} := by
     rw [Lean.Grind.Semiring.ofNat_eq_natCast, Lean.Grind.Semiring.ofNat_eq_natCast]

--- a/HexReflectMathlib/Residue.lean
+++ b/HexReflectMathlib/Residue.lean
@@ -72,8 +72,7 @@ def residueCoeffProvider (p : Nat) (ring : CarrierRequest) :
     if ← isDefEq ring.type zmod then
       carrier := zmod
       fieldInst? ← Sym.synthInstance? (mkApp (mkConst ``Field [ring.u]) carrier)
-  let some fieldInst := fieldInst?
-    | return decline "residue coefficients require a Mathlib Field instance"
+  let some fieldInst := fieldInst? | return .notApplicable
   let commRingInst ← mkAppOptM ``Field.toCommRing #[carrier, fieldInst]
   let mathlibRingInst ← mkAppOptM ``CommRing.toRing #[carrier, commRingInst]
   let mathlibRing ← mkAppOptM ``Ring.toGrindRing #[carrier, mathlibRingInst]

--- a/HexReflectMathlib/Residue.lean
+++ b/HexReflectMathlib/Residue.lean
@@ -36,6 +36,13 @@ theorem residueCoeffLaws (p : Nat) [Hex.ZMod64.Bounds p]
     CoeffLaws (C := Hex.ZMod64 p) (α := F) Int.cast (residueHom p F) :=
   coeffLaws_ofRingHom (residueHom p F) Int.cast (fun k => map_intCast _ k)
 
+/-- A nonzero field characteristic supplies the prime-modulus evidence needed
+by executable coefficient algorithms, without replaying a primality search. -/
+theorem residuePrime (p : Nat) (F : Type u) [Field F] [CharP F p] (hp : 0 < p) :
+    Hex.ZMod64.PrimeModulus p := by
+  have prime := CharP.char_prime_of_ne_zero F (Nat.ne_of_gt hp)
+  exact ⟨⟨prime.two_le, fun _ h => (Nat.dvd_prime prime).mp h⟩⟩
+
 meta section
 
 open Lean Meta
@@ -46,10 +53,11 @@ def residueCoefficientsId : ProviderId := { name := `HexReflectMathlib.residueCo
 /-- Recognize a known positive characteristic and quote the residue coefficient
 provider against the classified carrier's exact ring instance. -/
 def residueCoeffProvider (p : Nat) (ring : CarrierRequest) :
-    Sym.SymM (ProviderOutcome CoeffProvider) := do
+    Sym.SymM (ProviderOutcome CoeffProvider) := withNewMCtxDepth do
   let decline (reason : String) : ProviderOutcome CoeffProvider :=
     .declined (.providerCondition residueCoefficientsId reason) Budget.zero
-  if p ≥ 2147483648 then
+  let bound := Nat.pow 2 31
+  if p ≥ bound then
     return decline "residue coefficients require characteristic p < 2^31"
   if !Hex.Nat.isPrimeTrial p then
     return decline "residue coefficients require prime characteristic"
@@ -74,19 +82,17 @@ def residueCoeffProvider (p : Nat) (ring : CarrierRequest) :
   let charType ← mkAppOptM ``CharP #[carrier, castInst, pE]
   let some charInst ← Sym.synthInstance? charType
     | return decline "residue coefficients require Mathlib CharP evidence"
-  let bounds ← mkAppM ``Hex.ZMod64.Bounds.mk #[
-    ← mkDecideProof (← mkAppM ``LT.lt #[mkNatLit 0, pE]),
-    ← mkDecideProof (← mkAppM ``LT.lt #[pE, mkNatLit 2147483648])]
-  let prime ← mkAppM ``Hex.ZMod64.primeModulusOfPrime #[
-    ← mkDecideProof (mkApp (mkConst ``Hex.Nat.Prime) pE)]
-  let coeffRing ← mkAppOptM ``HexModArithMathlib.ZMod64.commRing #[pE, bounds]
+  let pos ← mkDecideProof (← mkAppM ``LT.lt #[mkNatLit 0, pE])
+  let bounds ← mkAppM ``Hex.ZMod64.Bounds.mk #[pos,
+    ← mkDecideProof (← mkAppM ``LT.lt #[pE, mkNatLit bound])]
   let coeffType := mkApp2 (mkConst ``Hex.ZMod64) pE bounds
-  let zeroInst ← Sym.synthInstance (mkApp (mkConst ``Zero [.zero]) coeffType)
-  let addInst ← Sym.synthInstance (mkApp (mkConst ``Add [.zero]) coeffType)
-  let beqInst ← Sym.synthInstance (mkApp (mkConst ``BEq [.zero]) coeffType)
-  let lawfulBEqInst ← Sym.synthInstance
-    (mkApp2 (mkConst ``LawfulBEq [.zero]) coeffType beqInst)
-  let ofInt ← mkAppOptM ``Int.cast #[coeffType, none]
+  let zeroInst ← mkAppOptM ``Hex.ZMod64.instZero #[pE, bounds]
+  let addInst ← mkAppOptM ``Hex.ZMod64.instAdd #[pE, bounds]
+  let decEq ← mkAppOptM ``Hex.ZMod64.instDecidableEq #[pE, bounds]
+  let beqInst ← mkAppOptM ``instBEqOfDecidableEq #[coeffType, decEq]
+  let lawfulBEqInst ← mkAppOptM ``instLawfulBEq #[coeffType, decEq]
+  let intCast ← mkAppOptM ``Hex.ZMod64.instIntCast #[pE, bounds]
+  let ofInt ← mkAppOptM ``Int.cast #[coeffType, intCast]
   let hom ← mkAppOptM ``residueHom #[pE, bounds, carrier, commRingInst, charInst]
   let interp ← mkAppM ``DFunLike.coe #[hom]
   let laws ← mkAppOptM ``residueCoeffLaws #[pE, bounds, carrier, commRingInst, charInst]
@@ -101,6 +107,8 @@ def residueCoeffProvider (p : Nat) (ring : CarrierRequest) :
     return some (mkAppN bridge proofs)
   let some laws := laws?
     | return decline "the classified ring operations do not agree with the Mathlib field"
+  let prime ← mkAppOptM ``residuePrime #[pE, carrier, fieldInst, charInst, pos]
+  let coeffRing ← mkAppOptM ``HexModArithMathlib.ZMod64.commRing #[pE, bounds]
   return .success {
     id := residueCoefficientsId
     coeffType, zeroInst, addInst, beqInst, lawfulBEqInst, ofInt, interp, laws

--- a/HexReflectMathlib/Residue.lean
+++ b/HexReflectMathlib/Residue.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexReflectMathlib.Carrier
+public import HexModArithMathlib.Ring
+public import Mathlib.Algebra.Field.Defs
+public meta import HexReflect.Provider
+public meta import HexArith.Nat.Prime
+
+public section
+
+namespace HexReflectMathlib
+
+open Hex.Reflect
+open scoped HexModArithMathlib.ZMod64
+
+/-- Interpret machine residues in any ring of the same characteristic. -/
+def residueHom (p : Nat) [Hex.ZMod64.Bounds p] (F : Type u) [CommRing F] [CharP F p] :
+    Hex.ZMod64 p →+* F :=
+  (ZMod.castHom (dvd_refl p) F).comp HexModArithMathlib.ZMod64.equiv.toRingHom
+
+/-- The characteristic assumption makes the coefficient interpretation injective,
+including when the field is an extension of its prime field. -/
+theorem residueHom_injective (p : Nat) [Hex.ZMod64.Bounds p]
+    (F : Type u) [CommRing F] [CharP F p] : Function.Injective (residueHom p F) :=
+  (ZMod.castHom_injective F (n := p)).comp HexModArithMathlib.ZMod64.equiv.injective
+
+/-- Residue coefficients satisfy reflection's laws by the ring homomorphism laws. -/
+theorem residueCoeffLaws (p : Nat) [Hex.ZMod64.Bounds p]
+    (F : Type u) [CommRing F] [CharP F p] :
+    CoeffLaws (C := Hex.ZMod64 p) (α := F) Int.cast (residueHom p F) :=
+  coeffLaws_ofRingHom (residueHom p F) Int.cast (fun k => map_intCast _ k)
+
+meta section
+
+open Lean Meta
+
+/-- Stable identity of the positive-characteristic coefficient registration. -/
+def residueCoefficientsId : ProviderId := { name := `HexReflectMathlib.residueCoefficients }
+
+/-- Recognize a known positive characteristic and quote the residue coefficient
+provider against the classified carrier's exact ring instance. -/
+def residueCoeffProvider (p : Nat) (ring : CarrierRequest) :
+    Sym.SymM (ProviderOutcome CoeffProvider) := do
+  let decline (reason : String) : ProviderOutcome CoeffProvider :=
+    .declined (.providerCondition residueCoefficientsId reason) Budget.zero
+  if p ≥ 2147483648 then
+    return decline "residue coefficients require characteristic p < 2^31"
+  if !Hex.Nat.isPrimeTrial p then
+    return decline "residue coefficients require prime characteristic"
+  let pE := mkNatLit p
+  -- Canonicalization unfolds a concrete `ZMod p` to `Fin p`. Try the
+  -- corresponding Mathlib carrier as well, but require definitional equality
+  -- of the type and interpretation operations before accepting its evidence.
+  let mut carrier := ring.type
+  let mut fieldInst? ← Sym.synthInstance? (mkApp (mkConst ``Field [ring.u]) carrier)
+  if fieldInst?.isNone then
+    let zmod := mkApp (mkConst ``ZMod) pE
+    if ← isDefEq ring.type zmod then
+      carrier := zmod
+      fieldInst? ← Sym.synthInstance? (mkApp (mkConst ``Field [ring.u]) carrier)
+  let some fieldInst := fieldInst?
+    | return decline "residue coefficients require a Mathlib Field instance"
+  let commRingInst ← mkAppOptM ``Field.toCommRing #[carrier, fieldInst]
+  let mathlibRingInst ← mkAppOptM ``CommRing.toRing #[carrier, commRingInst]
+  let mathlibRing ← mkAppOptM ``Ring.toGrindRing #[carrier, mathlibRingInst]
+  let addGroup ← mkAppOptM ``Ring.toAddGroupWithOne #[carrier, mathlibRingInst]
+  let castInst ← mkAppOptM ``AddGroupWithOne.toAddMonoidWithOne #[carrier, addGroup]
+  let charType ← mkAppOptM ``CharP #[carrier, castInst, pE]
+  let some charInst ← Sym.synthInstance? charType
+    | return decline "residue coefficients require Mathlib CharP evidence"
+  let bounds ← mkAppM ``Hex.ZMod64.Bounds.mk #[
+    ← mkDecideProof (← mkAppM ``LT.lt #[mkNatLit 0, pE]),
+    ← mkDecideProof (← mkAppM ``LT.lt #[pE, mkNatLit 2147483648])]
+  let prime ← mkAppM ``Hex.ZMod64.primeModulusOfPrime #[
+    ← mkDecideProof (mkApp (mkConst ``Hex.Nat.Prime) pE)]
+  let coeffRing ← mkAppOptM ``HexModArithMathlib.ZMod64.commRing #[pE, bounds]
+  let coeffType := mkApp2 (mkConst ``Hex.ZMod64) pE bounds
+  let zeroInst ← Sym.synthInstance (mkApp (mkConst ``Zero [.zero]) coeffType)
+  let addInst ← Sym.synthInstance (mkApp (mkConst ``Add [.zero]) coeffType)
+  let beqInst ← Sym.synthInstance (mkApp (mkConst ``BEq [.zero]) coeffType)
+  let lawfulBEqInst ← Sym.synthInstance
+    (mkApp2 (mkConst ``LawfulBEq [.zero]) coeffType beqInst)
+  let ofInt ← mkAppOptM ``Int.cast #[coeffType, none]
+  let hom ← mkAppOptM ``residueHom #[pE, bounds, carrier, commRingInst, charInst]
+  let interp ← mkAppM ``DFunLike.coe #[hom]
+  let laws ← mkAppOptM ``residueCoeffLaws #[pE, bounds, carrier, commRingInst, charInst]
+  let bridge := mkAppN (mkConst ``CoeffLaws.changeRing [ring.u])
+    #[coeffType, ring.type, zeroInst, addInst, mathlibRing, ring.ringInst, ofInt, interp, laws]
+  let laws? ← forallTelescopeReducing (← inferType bridge) fun hs _ => do
+    let mut proofs := #[]
+    for h in hs do
+      let some (_, lhs, rhs) := (← inferType h).eq? | return none
+      unless ← isDefEq lhs rhs do return none
+      proofs := proofs.push (← mkEqRefl lhs)
+    return some (mkAppN bridge proofs)
+  let some laws := laws?
+    | return decline "the classified ring operations do not agree with the Mathlib field"
+  return .success {
+    id := residueCoefficientsId
+    coeffType, zeroInst, addInst, beqInst, lawfulBEqInst, ofInt, interp, laws
+    auxInstances := #[bounds, prime, coeffRing]
+  } Budget.zero
+
+/-- Prefer residue coefficients to universal integers for a classified positive
+characteristic. Unknown characteristic and characteristic zero keep integers. -/
+@[hex_reflect_provider]
+def residueCoefficients : Registration where
+  id := residueCoefficientsId
+  capability := .commRingNormalize
+  priority := 5
+  recognize ring := do
+    let some (_, p) := ring.charInst? | return .notApplicable
+    if p == 0 then return .notApplicable
+    return (← residueCoeffProvider p ring).map Evidence.coefficients
+
+end
+end HexReflectMathlib

--- a/HexReflectMathlib/SPEC/hex-reflect-mathlib.md
+++ b/HexReflectMathlib/SPEC/hex-reflect-mathlib.md
@@ -16,7 +16,8 @@ Computational performance owner: `HexReflect`.
 
 ## Dependencies
 
-The companion depends on `hex-reflect`, `hex-mv-poly-mathlib`, and Mathlib.
+The companion depends on `hex-reflect`, `hex-mv-poly-mathlib`,
+`hex-mod-arith-mathlib`, and Mathlib.
 It obtains `hex-mv-poly` and `hex-basic` transitively. No matrix,
 row-reduction, determinant, characteristic-polynomial, gcd, or factorization
 library is an implementation dependency.
@@ -24,9 +25,10 @@ library is an implementation dependency.
 ## Module layout
 
 The Lake library is `HexReflectMathlib`, its namespace is
-`HexReflectMathlib`, and `HexReflectMathlib.lean` is its umbrella. The initial
-modules are `Carrier.lean` for registrations and `Correspondence.lean` for
-theorems. It has no independent conformance, benchmark, or proof-probe target;
+`HexReflectMathlib`, and `HexReflectMathlib.lean` is its umbrella. The
+modules are `Carrier.lean` for carrier laws, `Residue.lean` for the residue
+provider, and `Correspondence.lean` for polynomial theorems. It has no
+independent conformance, benchmark, or proof-probe target;
 the computational owner tests each registration and conversion path.
 
 ## Carrier translations
@@ -47,6 +49,54 @@ A frontend re-synthesizes and canonicalizes its requested structures in its
 actual scope. Open- and closed-scope Grind instances are distinct exact
 instance identities; a registration may support both explicitly, but provider
 lookup and caches never identify them solely from the carrier type.
+
+## Positive-characteristic coefficients
+
+`residueCoeffProvider p` supplies `Hex.ZMod64 p` coefficients when the
+classified carrier reports positive characteristic `p`, `p` is prime,
+`p < 2^31`, and the target has compatible Mathlib `Field F` and `CharP F p`
+evidence. The registration has priority 5, above the universal integer
+provider. Unknown characteristic and characteristic zero retain integer
+coefficients. Frontends can supply `isCharP_of_charP` explicitly to enable
+characteristic recognition; this theorem remains outside global instance
+search.
+
+A recognized positive characteristic that is composite (or one) declines
+with a prime-characteristic diagnostic. Moduli `p ≥ 2^31` decline with the
+word-bound diagnostic before primality testing. Missing field or Mathlib
+characteristic evidence, and incompatible interpretation operations also
+decline with their reason. These declines stop fallback to the integer provider.
+
+The executable carrier uses `Hex.ZMod64.Bounds p` and
+`Hex.ZMod64.PrimeModulus p`; the latter supports downstream `LawfulGcdOps`
+without adding a gcd-library dependency here. The provider's `auxInstances`
+contains quoted bounds, primality, and the scoped Mathlib ring instance for
+consumers to introduce locally. Every auxiliary instance is type-checked by
+provider validation. Its interpretation is
+`residueHom p F`, the composite of `HexModArithMathlib.ZMod64.equiv` with
+`ZMod.castHom`. `residueHom_injective` proves injectivity into every ring
+of the same characteristic, in particular arbitrary field extensions of
+`ZMod p`. `residueCoeffLaws` follows from `coeffLaws_ofRingHom`.
+`CoeffLaws.changeRing` transfers those laws to the classified exact Grind
+ring after checking definitional equality of its integer cast, zero, and
+addition with the Mathlib operations. Other structure fields need not be
+definitionally identical. In particular, canonicalization can unfold
+`ZMod p` to `Fin p`; the provider also tries the Mathlib `ZMod p` field
+when its type is definitionally equal to the classified carrier. It never
+accepts evidence from the type name alone.
+
+The Mathlib `CommRing (Hex.ZMod64 p)` instance lives in
+`HexModArithMathlib.Ring`, in scope `HexModArithMathlib.ZMod64`, which the
+provider opens. It transports laws along the existing equivalence while
+retaining executable zero, one, addition, subtraction, negation,
+multiplication, powers, casts, and scalar multiplication. Division and
+decidable equality are unchanged. The instance is scoped because the Mathlib
+Grind reduct has different numeral instance expressions from the executable
+ring. The
+[determinant transport audit](../../HexDetMathlib/SPEC/hex-det-mathlib.md#outstanding-arm-and-carrier-obligations)
+requires compatibility with executable operations; a scoped instance keeps
+the existing explicit structure-selection discipline of those transports. Consumers open this scope when using the
+Mathlib coefficient homomorphism.
 
 ## `MvPolynomial` correspondence
 
@@ -95,6 +145,14 @@ the Mathlib-free `hex-reflect` library depend on Mathlib.
 
 ## Verification requirements
 
+`conformance/HexReflect/ResidueConformance.lean` checks the matrix
+`!![x ^ 3 - x]` over `ZMod 3`: the quoted residue polynomial is `X₀³ − X₀`,
+and its interpretation equals the matrix entry by a kernel-checked proof.
+It also checks an abstract characteristic-three field, downstream instance
+synthesis from the provider's auxiliary evidence at modulus five, and the
+decline and integer-fallback paths. Existing reflection conformance remains
+unchanged.
+
 - Every carrier registration includes the exact instance expressions in its
   lookup identity.
 - Open- and closed-`HexMvPolyMathlib`-scope instances cannot share a cache
@@ -103,5 +161,5 @@ the Mathlib-free `hex-reflect` library depend on Mathlib.
   Mathlib-free soundness theorem.
 - No source parser, computational algebra algorithm, or `native_decide` use is
   added.
-- The import graph contains only `hex-reflect`, `hex-mv-poly-mathlib`, their
-  transitive dependencies, and Mathlib.
+- The import graph contains only `hex-reflect`, `hex-mv-poly-mathlib`,
+  `hex-mod-arith-mathlib`, their transitive dependencies, and Mathlib.

--- a/HexReflectMathlib/SPEC/hex-reflect-mathlib.md
+++ b/HexReflectMathlib/SPEC/hex-reflect-mathlib.md
@@ -65,13 +65,18 @@ cancellative semirings. Recognition is therefore automatic when instance
 search finds that evidence. `isCharP_of_charP` remains a theorem for callers
 that need to supply an exact instance explicitly. A concrete `ZMod p` field
 requires Mathlib's usual `Fact (Nat.Prime p)` instance; the provider does not
-install target field instances.
+install target field instances. When the modulus passes the prime and word
+checks but no target `Field` instance is available, the provider is not
+applicable and the universal integer provider remains available. This
+includes prime-characteristic rings with zero divisors and concrete `ZMod p`
+carriers lacking a `Fact (Nat.Prime p)` instance.
 
 A recognized positive characteristic that is composite (or one) declines
 with a prime-characteristic diagnostic. Moduli `p ≥ 2^31` decline with the
-word-bound diagnostic before primality testing. Missing field or Mathlib
-characteristic evidence, and incompatible interpretation operations also
-decline with their reason. These declines stop fallback to the integer provider.
+word-bound diagnostic before primality testing. For a recognized field,
+missing Mathlib characteristic evidence and incompatible interpretation
+operations decline with their reason. These declines stop fallback to the
+integer provider.
 
 The executable carrier uses `Hex.ZMod64.Bounds p` and
 `Hex.ZMod64.PrimeModulus p`; the latter supports downstream `LawfulGcdOps`

--- a/HexReflectMathlib/SPEC/hex-reflect-mathlib.md
+++ b/HexReflectMathlib/SPEC/hex-reflect-mathlib.md
@@ -20,7 +20,9 @@ The companion depends on `hex-reflect`, `hex-mv-poly-mathlib`,
 `hex-mod-arith-mathlib`, and Mathlib.
 It obtains `hex-mv-poly` and `hex-basic` transitively. No matrix,
 row-reduction, determinant, characteristic-polynomial, gcd, or factorization
-library is an implementation dependency.
+library is an implementation dependency. The modular arithmetic dependency
+also brings its precompiled native library and GMP linkage into consumers of
+this companion.
 
 ## Module layout
 
@@ -57,9 +59,13 @@ classified carrier reports positive characteristic `p`, `p` is prime,
 `p < 2^31`, and the target has compatible Mathlib `Field F` and `CharP F p`
 evidence. The registration has priority 5, above the universal integer
 provider. Unknown characteristic and characteristic zero retain integer
-coefficients. Frontends can supply `isCharP_of_charP` explicitly to enable
-characteristic recognition; this theorem remains outside global instance
-search.
+coefficients. Mathlib's `Algebra.CharP.Basic`, imported transitively here,
+provides a global bridge from `CharP` to Grind characteristic evidence for
+cancellative semirings. Recognition is therefore automatic when instance
+search finds that evidence. `isCharP_of_charP` remains a theorem for callers
+that need to supply an exact instance explicitly. A concrete `ZMod p` field
+requires Mathlib's usual `Fact (Nat.Prime p)` instance; the provider does not
+install target field instances.
 
 A recognized positive characteristic that is composite (or one) declines
 with a prime-characteristic diagnostic. Moduli `p ≥ 2^31` decline with the
@@ -72,7 +78,9 @@ The executable carrier uses `Hex.ZMod64.Bounds p` and
 without adding a gcd-library dependency here. The provider's `auxInstances`
 contains quoted bounds, primality, and the scoped Mathlib ring instance for
 consumers to introduce locally. Every auxiliary instance is type-checked by
-provider validation. Its interpretation is
+provider validation. Consumers still synthesize or check their required
+capability at the actual coefficient type: generic auxiliary evidence does
+not itself certify a particular downstream capability. Its interpretation is
 `residueHom p F`, the composite of `HexModArithMathlib.ZMod64.equiv` with
 `ZMod.castHom`. `residueHom_injective` proves injectivity into every ring
 of the same characteristic, in particular arbitrary field extensions of
@@ -80,7 +88,12 @@ of the same characteristic, in particular arbitrary field extensions of
 `CoeffLaws.changeRing` transfers those laws to the classified exact Grind
 ring after checking definitional equality of its integer cast, zero, and
 addition with the Mathlib operations. Other structure fields need not be
-definitionally identical. In particular, canonicalization can unfold
+definitionally identical. The quoted coefficient operations are the named
+executable `ZMod64` instances, independent of the caller's instance scope.
+`residuePrime` deduces primality evidence from the field's nonzero
+characteristic after this compatibility check succeeds. The runtime
+recognizer uses the existing bounded trial-division test, but the kernel
+does not replay that search to validate the auxiliary prime certificate. In particular, canonicalization can unfold
 `ZMod p` to `Fin p`; the provider also tries the Mathlib `ZMod p` field
 when its type is definitionally equal to the classified carrier. It never
 accepts evidence from the type name alone.
@@ -148,6 +161,7 @@ the Mathlib-free `hex-reflect` library depend on Mathlib.
 `conformance/HexReflect/ResidueConformance.lean` checks the matrix
 `!![x ^ 3 - x]` over `ZMod 3`: the quoted residue polynomial is `X₀³ − X₀`,
 and its interpretation equals the matrix entry by a kernel-checked proof.
+The residue provider also works with the coefficient-ring scope closed.
 It also checks an abstract characteristic-three field, downstream instance
 synthesis from the provider's auxiliary evidence at modulus five, and the
 decline and integer-fallback paths. Existing reflection conformance remains

--- a/conformance/HexReflect/ResidueConformance.lean
+++ b/conformance/HexReflect/ResidueConformance.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexReflectMathlib
+import HexMvGcd.Instances
+import Mathlib.Algebra.Field.ZMod
+import Mathlib.LinearAlgebra.Matrix.Notation
+
+/-!
+# Residue coefficient conformance
+
+**Oracle:** none.
+**Mode:** `always`.
+**Covered operations:** coefficient selection, matrix-entry reification, and
+kernel checking of the interpretation proof over `ZMod 3`.
+**Covered properties:** residue polynomial equality, retained primality and ring
+instances for downstream gcd operations, injectivity for extension fields,
+and preservation of executable ring operations.
+**Covered edge cases:** composite and oversized characteristic, missing field
+and characteristic evidence, incompatible ring operations, characteristic
+zero, and unknown characteristic.
+-/
+
+namespace Hex.ReflectResidueConformance
+
+open Lean Meta Hex.Reflect HexReflectMathlib
+open scoped HexModArithMathlib.ZMod64
+
+local instance : ZMod64.Bounds 3 := ⟨by decide, by decide⟩
+local instance : ZMod64.PrimeModulus 3 := ⟨by decide⟩
+local instance : Lean.Grind.IsCharP (ZMod 3) 3 := isCharP_of_charP 3
+
+private def matrixInput (x : ZMod 3) : Matrix (Fin 1) (Fin 1) (ZMod 3) := !![x ^ 3 - x]
+
+private def expected : MvPoly 1 (ZMod64 3) Mono.grevlex :=
+  MvPoly.X 0 ^ 3 - MvPoly.X 0
+
+-- These operations must retain their executable implementations under the scope.
+example (a b : ZMod64 3) : a * b = ZMod64.mul a b := rfl
+example (a : ZMod64 3) (n : Nat) : a ^ n = ZMod64.pow a n := rfl
+example (a b : ZMod64 3) : a - b = ZMod64.sub a b := rfl
+example : Hex.LawfulGcdOps (ZMod64 3) := inferInstance
+
+example (F : Type u) [Field F] [CharP F 3] : Function.Injective (residueHom 3 F) :=
+  residueHom_injective 3 F
+
+private def kernelCheck (xs : Array Expr) (proof : Expr) : MetaM Unit := do
+  let name ← mkFreshUserName `Hex.ReflectResidueConformance.proof
+  let type ← mkForallFVars xs (← inferType proof)
+  let value ← mkLambdaFVars xs proof
+  addDecl (.thmDecl { name, levelParams := [], type, value })
+
+/-- info: ZMod 3 matrix: residue coefficients, X₀³ - X₀, kernel accepted -/
+#guard_msgs in
+run_meta do
+  let ty := mkApp (mkConst ``ZMod) (mkNatLit 3)
+  withLocalDeclD `x ty fun x => do
+    let matrix ← mkAppM ``matrixInput #[x]
+    let input ← mkAppM ``HSub.hSub #[← mkAppM ``HPow.hPow #[x, mkNatLit 3], x]
+    let matrixEntry := mkApp2 matrix (toExpr (0 : Fin 1)) (toExpr (0 : Fin 1))
+    unless ← isDefEq input matrixEntry do throwError "wrong matrix entry"
+    let outcome ← reflectRingBatch #[input] (cfg := { checkProofs := true })
+    let .success batch _ := outcome | throwError "{outcome.toMessageData (fun _ => "batch") }"
+    let some entry := batch.entries[0]? | throwError "empty batch"
+    unless entry.conversion.provider.id == residueCoefficientsId do
+      throwError "wrong coefficient provider"
+    unless batch.sealed.n == 1 do throwError "wrong atom count"
+    let expectedE := mkConst ``expected
+    -- The kernel checks the actual quoted residue polynomial against X³ - X,
+    -- independently of the source interpretation proof.
+    let eq ← mkEq entry.result.value expectedE
+    let proof ← mkDecideProof eq
+    kernelCheck #[] proof
+    let matrixEq ← mkEq entry.result.interpretation matrixEntry
+    kernelCheck #[x] (← mkExpectedTypeHint entry.result.proof matrixEq)
+    for inst in entry.conversion.provider.auxInstances do
+      Meta.check inst
+    unless entry.conversion.provider.auxInstances.size == 3 do
+      throwError "missing downstream coefficient instances"
+    logInfo "ZMod 3 matrix: residue coefficients, X₀³ - X₀, kernel accepted"
+
+private def checkAux (coeffType : Expr) : List Expr → MetaM Unit
+  | [] => do
+    let target ← mkAppOptM ``Hex.LawfulGcdOps
+      #[coeffType, none, none, none, none, none, none]
+    Meta.check (← synthInstance target)
+    Meta.check (← synthInstance (mkApp (mkConst ``CommRing [.zero]) coeffType))
+  | inst :: rest => do
+    withLetDecl `coefficientInstance (← inferType inst) inst fun _ =>
+      checkAux coeffType rest
+
+local instance : Fact (_root_.Nat.Prime 5) := ⟨by decide⟩
+
+/-- info: ZMod 5: auxiliary instances supply lawful gcd and Mathlib ring -/
+#guard_msgs in
+run_meta do
+  let ty := mkApp (mkConst ``ZMod) (mkNatLit 5)
+  withLocalDeclD `x ty fun x => do
+    let outcome ← reflectRing x
+    let .success entry _ := outcome | throwError "{outcome.toMessageData (fun _ => "entry")}"
+    unless entry.conversion.provider.id == residueCoefficientsId do throwError "wrong provider"
+    checkAux entry.conversion.provider.coeffType entry.conversion.provider.auxInstances.toList
+    kernelCheck #[x] entry.result.proof
+    logInfo "ZMod 5: auxiliary instances supply lawful gcd and Mathlib ring"
+
+private def declineProbe (p : Nat) (reason : String) : MetaM Unit := do
+  let ty := mkApp (mkConst ``ZMod) (mkNatLit p)
+  withLocalDeclD `x ty fun x => do
+    let .declined (.providerCondition id message) _ ← reflectRing x
+      | throwError "expected a provider condition decline"
+    unless id == residueCoefficientsId && message == reason do
+      throwError "wrong decline: {message}"
+
+/-- info: composite, modulus one, and oversized characteristic decline with reasons -/
+#guard_msgs in
+run_meta do
+  declineProbe 6 "residue coefficients require prime characteristic"
+  declineProbe 1 "residue coefficients require prime characteristic"
+  declineProbe 2147483648 "residue coefficients require characteristic p < 2^31"
+  declineProbe 4294967291 "residue coefficients require characteristic p < 2^31"
+  logInfo "composite, modulus one, and oversized characteristic decline with reasons"
+
+/-- info: missing field declines; zero and unknown characteristic retain integers -/
+#guard_msgs in
+run_meta do
+  let ty := mkConst ``Int
+  withLocalDeclD `x ty fun x => do
+    Hex.Reflect.run do
+      let .success r _ ← reifyCommRing x | throwError "reification declined"
+      let ring ← ringOf r
+      let .declined (.providerCondition _ message) _ ← residueCoeffProvider 3 ring
+        | throwError "expected missing field decline"
+      unless message == "residue coefficients require a Mathlib Field instance" do
+        throwError "wrong decline"
+      -- Exercise dispatch's two non-applicable paths independently of the
+      -- characteristic instances a particular toolchain provides for Int.
+      for charInst? in [none, some (mkConst ``True.intro, 0)] do
+        let .notApplicable ← residueCoefficients.recognize { ring with charInst? }
+          | throwError "residue provider should not apply"
+      let .success entry _ ← ringBatch #[x] | throwError "integer batch declined"
+      let some result := entry.entries[0]? | throwError "empty batch"
+      unless result.conversion.provider.id == intCoefficientsId do
+        throwError "integer fallback changed"
+    logInfo "missing field declines; zero and unknown characteristic retain integers"
+
+/-- info: arbitrary characteristic-three field: missing CharP declines, supplied CharP reifies -/
+#guard_msgs in
+run_meta do
+  withLocalDeclD `F (mkSort (.succ .zero)) fun f => do
+  withLocalDecl `field .instImplicit (mkApp (mkConst ``Field [.zero]) f) fun field => do
+  withLocalDeclD `x f fun x => do
+    Hex.Reflect.run do
+      let .success r _ ← reifyCommRing x | throwError "reification declined"
+      let .declined (.providerCondition _ message) _ ← residueCoeffProvider 3 (← ringOf r)
+        | throwError "expected missing CharP decline"
+      unless message == "residue coefficients require Mathlib CharP evidence" do
+        throwError "wrong decline"
+    let charTy ← mkAppOptM ``CharP #[f, none, mkNatLit 3]
+    withLocalDecl `char .instImplicit charTy fun char => do
+      let charProof ← mkAppOptM ``isCharP_of_charP #[f, none, mkNatLit 3, char]
+      withLetDecl `grindChar (← inferType charProof) charProof fun grindChar => do
+        let input ← mkAppM ``HSub.hSub #[← mkAppM ``HPow.hPow #[x, mkNatLit 3], x]
+        let outcome ← reflectRing input (cfg := { checkProofs := true })
+        let .success entry _ := outcome
+          | throwError "{outcome.toMessageData (fun _ => "entry")}"
+        unless entry.conversion.provider.id == residueCoefficientsId do
+          throwError "wrong provider"
+        kernelCheck #[f, field, x, char, grindChar] entry.result.proof
+        let eq ← mkEq entry.result.value (mkConst ``expected)
+        kernelCheck #[] (← mkDecideProof eq)
+        withLocalDecl `otherRing .instImplicit
+            (mkApp (mkConst ``Lean.Grind.CommRing [.zero]) f) fun _ => do
+          Hex.Reflect.run do
+            let .success r _ ← reifyCommRing x | throwError "reification declined"
+            let .declined (.providerCondition _ message) _ ← residueCoeffProvider 3 (← ringOf r)
+              | throwError "expected incompatible-operation decline"
+            unless message ==
+                "the classified ring operations do not agree with the Mathlib field" do
+              throwError "wrong decline"
+    logInfo "arbitrary characteristic-three field: missing CharP declines, supplied CharP reifies"
+
+end Hex.ReflectResidueConformance

--- a/conformance/HexReflect/ResidueConformance.lean
+++ b/conformance/HexReflect/ResidueConformance.lean
@@ -123,7 +123,7 @@ run_meta do
   declineProbe 4294967291 "residue coefficients require characteristic p < 2^31"
   logInfo "composite, modulus one, and oversized characteristic decline with reasons"
 
-/-- info: missing field declines; zero and unknown characteristic retain integers -/
+/-- info: non-fields, zero and unknown characteristic retain integers -/
 #guard_msgs in
 run_meta do
   let ty := mkConst ``Int
@@ -131,10 +131,8 @@ run_meta do
     Hex.Reflect.run do
       let .success r _ ← reifyCommRing x | throwError "reification declined"
       let ring ← ringOf r
-      let .declined (.providerCondition _ message) _ ← residueCoeffProvider 3 ring
-        | throwError "expected missing field decline"
-      unless message == "residue coefficients require a Mathlib Field instance" do
-        throwError "wrong decline"
+      let .notApplicable ← residueCoeffProvider 3 ring
+        | throwError "non-field should retain integer fallback"
       -- Exercise dispatch's two non-applicable paths independently of the
       -- characteristic instances a particular toolchain provides for Int.
       for charInst? in [none, some (mkConst ``True.intro, 0)] do
@@ -144,7 +142,7 @@ run_meta do
       let some result := entry.entries[0]? | throwError "empty batch"
       unless result.conversion.provider.id == intCoefficientsId do
         throwError "integer fallback changed"
-    logInfo "missing field declines; zero and unknown characteristic retain integers"
+    logInfo "non-fields, zero and unknown characteristic retain integers"
 
 /-- info: arbitrary characteristic-three field: missing CharP declines, supplied CharP reifies -/
 #guard_msgs in
@@ -218,3 +216,37 @@ example (F : Type u) [Field F] [CharP F 2147483647] :
   residuePrime 2147483647 F (by decide)
 
 end Hex.ReflectResidueClosedConformance
+
+namespace Hex.ReflectResidueFallbackConformance
+
+open Lean Meta Hex.Reflect
+
+private def probe (ty : Expr) (xs : Array Expr) (p : Nat) : MetaM Unit :=
+  withLocalDeclD `x ty fun x => do
+    let input ← mkAppM ``HAdd.hAdd #[x, x]
+    let outcome ← reflectRing input (cfg := { checkProofs := true })
+    let .success entry _ := outcome
+      | throwError "{outcome.toMessageData (fun _ => "entry")}"
+    unless entry.reflected.charInst?.map (·.2) == some p do
+      throwError "expected characteristic {p}"
+    unless entry.conversion.provider.id == intCoefficientsId do
+      throwError "non-field lost integer fallback"
+    let name ← mkFreshUserName `Hex.ReflectResidueFallbackConformance.proof
+    let type ← mkForallFVars (xs.push x) (← inferType entry.result.proof)
+    let value ← mkLambdaFVars (xs.push x) entry.result.proof
+    addDecl (.thmDecl { name, levelParams := [], type, value })
+
+/-- info: prime-characteristic rings without field instances: integer fallback, kernel accepted -/
+#guard_msgs in
+run_meta do
+  -- A concrete prime modulus without Mathlib's `Fact (Nat.Prime 7)`.
+  probe (mkApp (mkConst ``ZMod) (mkNatLit 7)) #[] 7
+  -- An arbitrary characteristic-three commutative ring, with no Field assumption.
+  withLocalDeclD `R (mkSort (.succ .zero)) fun r => do
+  withLocalDecl `ring .instImplicit (mkApp (mkConst ``CommRing [.zero]) r) fun ring => do
+    let charTy ← mkAppOptM ``CharP #[r, none, mkNatLit 3]
+    withLocalDecl `char .instImplicit charTy fun char => do
+      probe r #[r, ring, char] 3
+  logInfo "prime-characteristic rings without field instances: integer fallback, kernel accepted"
+
+end Hex.ReflectResidueFallbackConformance

--- a/conformance/HexReflect/ResidueConformance.lean
+++ b/conformance/HexReflect/ResidueConformance.lean
@@ -183,3 +183,38 @@ run_meta do
     logInfo "arbitrary characteristic-three field: missing CharP declines, supplied CharP reifies"
 
 end Hex.ReflectResidueConformance
+
+namespace Hex.ReflectResidueClosedConformance
+
+open Lean Meta Hex.Reflect HexReflectMathlib
+
+-- No coefficient-ring scope, local bounds, or local Grind characteristic
+-- instance is active here. Mathlib discovers the target characteristic.
+/-- info: closed scope: executable coefficient instances, kernel accepted -/
+#guard_msgs in
+run_meta do
+  let ty := mkApp (mkConst ``ZMod) (mkNatLit 3)
+  withLocalDeclD `x ty fun x => do
+    let input ← mkAppM ``HSub.hSub #[← mkAppM ``HPow.hPow #[x, mkNatLit 3], x]
+    let outcome ← reflectRing input (cfg := { checkProofs := true })
+    let .success entry _ := outcome
+      | throwError "{outcome.toMessageData (fun _ => "entry")}"
+    let provider := entry.conversion.provider
+    unless provider.id == residueCoefficientsId && entry.conversion.terms.length == 2 do
+      throwError "wrong residue conversion"
+    unless provider.zeroInst.getAppFn.isConstOf ``Hex.ZMod64.instZero &&
+        provider.addInst.getAppFn.isConstOf ``Hex.ZMod64.instAdd do
+      throwError "coefficient operations depend on caller scope"
+    let name ← mkFreshUserName `Hex.ReflectResidueClosedConformance.proof
+    let type ← mkForallFVars #[x] (← inferType entry.result.proof)
+    let value ← mkLambdaFVars #[x] entry.result.proof
+    addDecl (.thmDecl { name, levelParams := [], type, value })
+    logInfo "closed scope: executable coefficient instances, kernel accepted"
+
+-- Even at the largest supported prime, the certificate follows from the
+-- field characteristic; the kernel does not run trial division.
+example (F : Type u) [Field F] [CharP F 2147483647] :
+    ZMod64.PrimeModulus 2147483647 :=
+  residuePrime 2147483647 F (by decide)
+
+end Hex.ReflectResidueClosedConformance

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -877,7 +877,7 @@ lean_lib HexConformance where
 
     ++ #[`HexRealAlgebraic.Conformance, `HexRealAlgebraic.Checks, `HexNumberField.ComplexChecks, `HexRealAlgebraic.ReprChecks].map Glob.one
 
-    ++ #[`HexReflect.TestProviders, `HexReflect.Conformance, `HexReflect.ScopeConformance].map Glob.one
+    ++ #[`HexReflect.TestProviders, `HexReflect.Conformance, `HexReflect.ScopeConformance, `HexReflect.ResidueConformance].map Glob.one
 
     ++ #[`HexSmith.Conformance].map Glob.one
 

--- a/libraries.yml
+++ b/libraries.yml
@@ -1045,7 +1045,7 @@ libraries:
     done_through: 1
     status: active
   HexReflectMathlib:
-    deps: [HexReflect, HexMvPolyMathlib]
+    deps: [HexReflect, HexMvPolyMathlib, HexModArithMathlib]
     mathlib: true
     correspondence_only: true
     done_through: 1


### PR DESCRIPTION
Adds residue coefficients for reflection over fields of known prime characteristic below `2^31`. The provider quotes `ZMod64 p` polynomials, interprets them through the injective composite `ZMod64 p ≃+* ZMod p →+* F`, and returns bounds, primality, and Mathlib ring evidence for downstream consumers. Composite and oversized characteristics decline with a reason. Characteristic zero, unknown characteristic, and prime-characteristic carriers without a Mathlib field instance retain integer coefficients.

The Mathlib ring transport is scoped and preserves executable operations. Provider recognition handles canonicalization of `ZMod p` to `Fin p`, checking the interpretation operations against the exact classified Grind ring. Coefficient laws come from the ring homomorphism and a proved change-of-ring lemma. Executable coefficient instances are quoted independently of the caller’s scope; primality evidence follows from the target field’s characteristic without kernel trial division.

Validation: `lake build`; `python3 scripts/check_dag.py`; existing `HexReflect.Conformance` and `HexReflect.ScopeConformance` unchanged; new residue conformance kernel-checks `!![x ^ 3 - x]` over `ZMod 3`, an abstract characteristic-three field, a closed-scope frontend, downstream lawful-gcd instance synthesis at modulus five, the algebraic prime certificate at `2^31 - 1`, and refusal/fallback cases including arbitrary commutative rings and `ZMod 7` without a field instance. Conformance-target, copyright, file-size, and whitespace checks pass. No `sorry`, `axiom`, or `native_decide` added.

Closes #10231.
