### PR TITLE
feat(mv-poly): add canonical kernel list form

### DIFF
--- a/HexMvPoly.lean
+++ b/HexMvPoly.lean
@@ -14,6 +14,7 @@ public import HexMvPoly.Eval
 public import HexMvPoly.Structural
 public import HexMvPoly.Recursive
 public import HexMvPoly.Ring
+public import HexMvPoly.Kernel
 
 public section
 

--- a/HexMvPoly/Kernel.lean
+++ b/HexMvPoly/Kernel.lean
@@ -1,0 +1,1230 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+import HexBasic.Fold
+public import HexMvPoly.Ring
+public import HexMvPoly.Structural
+
+@[expose] public section
+set_option backward.proofsInPublic true
+
+/-!
+Canonical list arithmetic for kernel certificate replay.
+
+Unlike the reference `MvPoly` representation, this module never traverses an
+`Array`, `Vector`, or `Fin` while computing. Exponents are ordinary lists and
+terms are kept in descending lexicographic order. The coefficient operations
+are deliberately the ordinary operations on the representation type: at
+`Int` they reduce to `Int.add`, `Int.mul`, and `Int.neg`; `Rat` is already a
+reduced numerator--denominator representation; a residue provider may use its
+canonical `Nat` representative.
+-/
+
+namespace Hex.MvPoly.Kernel
+
+open Hex
+open scoped Hex
+
+universe u
+
+/-- A list-form term: an exponent list and a coefficient. -/
+abbrev Term (κ : Type u) := List Nat × κ
+
+/-- A sparse polynomial represented by a canonical list of terms. -/
+abbrev PolyList (κ : Type u) := List (Term κ)
+
+/-! # Kernel primitives -/
+
+/-- Equality of exponent lists, using only `Nat.beq` and structural recursion. -/
+def expBeq : List Nat → List Nat → Bool
+  | [], [] => true
+  | a :: as, b :: bs => Nat.beq a b && expBeq as bs
+  | _, _ => false
+
+/-- Lexicographic comparison of exponent lists, using only `Nat.blt`. -/
+def expCmp : List Nat → List Nat → Ordering
+  | [], [] => .eq
+  | [], _ :: _ => .lt
+  | _ :: _, [] => .gt
+  | a :: as, b :: bs =>
+      if Nat.blt a b then .lt
+      else if Nat.blt b a then .gt
+      else expCmp as bs
+
+/-- Pointwise addition of exponent lists. Canonical inputs have equal length;
+the trailing clauses make the operation total on untrusted data. -/
+def addExp : List Nat → List Nat → List Nat
+  | [], bs => bs
+  | as, [] => as
+  | a :: as, b :: bs => Nat.add a b :: addExp as bs
+
+/-- Insert one term into descending lexicographic order, adding coefficients
+on a collision and dropping a zero coefficient. -/
+def insert [Zero κ] [Add κ] [DecidableEq κ] (t : Term κ) :
+    PolyList κ → PolyList κ
+  | [] => if t.2 = 0 then [] else [t]
+  | u :: us =>
+      match expCmp t.1 u.1 with
+      | .gt => if t.2 = 0 then u :: us else t :: u :: us
+      | .eq =>
+          let c := t.2 + u.2
+          if c = 0 then us else (u.1, c) :: us
+      | .lt => u :: insert t us
+
+/-- Canonicalize an arbitrary term stream by insertion. -/
+def normalize [Zero κ] [Add κ] [DecidableEq κ] :
+    PolyList κ → PolyList κ
+  | [] => []
+  | t :: ts => insert t (normalize ts)
+
+/-- Add canonical term lists. -/
+def add [Zero κ] [Add κ] [DecidableEq κ] :
+    PolyList κ → PolyList κ → PolyList κ
+  | [], q => q
+  | t :: ts, q => insert t (add ts q)
+
+/-- Map coefficients, filtering zero results without changing exponents. -/
+def mapCoeffs [Zero κ] [DecidableEq κ] (f : κ → κ) :
+    PolyList κ → PolyList κ
+  | [] => []
+  | t :: ts =>
+      let c := f t.2
+      if c = 0 then mapCoeffs f ts else (t.1, c) :: mapCoeffs f ts
+
+/-- Negate a canonical term list, defensively filtering zero results. -/
+def neg [Zero κ] [Neg κ] [DecidableEq κ]
+    (p : PolyList κ) : PolyList κ :=
+  mapCoeffs Neg.neg p
+
+/-- Multiply every coefficient by a scalar, filtering zero products. -/
+def smul [Zero κ] [Mul κ] [DecidableEq κ] (a : κ)
+    (p : PolyList κ) : PolyList κ :=
+  mapCoeffs (fun c => a * c) p
+
+/-- Multiply one term by every term of a polynomial, canonicalizing the row. -/
+def mulTerm [Zero κ] [Add κ] [Mul κ] [DecidableEq κ]
+    (t : Term κ) : PolyList κ → PolyList κ
+  | [] => []
+  | u :: us =>
+      insert (addExp t.1 u.1, t.2 * u.2) (mulTerm t us)
+
+/-- Multiply canonical term lists. Every product is accumulated through
+`insert`, so collisions and cancellations are normalized as they arise. -/
+def mul [Zero κ] [Add κ] [Mul κ] [DecidableEq κ] :
+    PolyList κ → PolyList κ → PolyList κ
+  | [], _ => []
+  | t :: ts, q => add (mulTerm t q) (mul ts q)
+
+/-- The zero test for a canonical list. -/
+def isZero : PolyList κ → Bool
+  | [] => true
+  | _ :: _ => false
+
+/-- Structural equality of term lists, with explicit exponent comparison. -/
+def beq [DecidableEq κ] : PolyList κ → PolyList κ → Bool
+  | [], [] => true
+  | t :: ts, u :: us =>
+      expBeq t.1 u.1 && decide (t.2 = u.2) && beq ts us
+  | _, _ => false
+
+/-- Linear-time exponentiation used by `evalAt`; unlike the reference
+repeated-squaring helper this is visibly structural recursion on `Nat`. -/
+def pow [One κ] [Mul κ] (a : κ) : Nat → κ
+  | 0 => 1
+  | n + 1 => pow a n * a
+
+/-- Evaluate a monomial at a list point, stopping at the shorter list. -/
+def evalMono [One κ] [Mul κ] : List κ → List Nat → κ
+  | x :: xs, e :: es => (pow x e) * evalMono xs es
+  | _, _ => 1
+
+/-- Evaluate a term list at a point. -/
+def evalAt [Zero κ] [One κ] [Add κ] [Mul κ]
+    (x : List κ) : PolyList κ → κ
+  | [] => 0
+  | t :: ts => t.2 * evalMono x t.1 + evalAt x ts
+
+/-- The zero exponent list of length `n`. -/
+def zeroExp : Nat → List Nat
+  | 0 => []
+  | n + 1 => 0 :: zeroExp n
+
+/-- The list-form multiplicative identity in `n` variables. -/
+def one [Zero κ] [One κ] [DecidableEq κ] (n : Nat) : PolyList κ :=
+  if (1 : κ) = 0 then [] else [(zeroExp n, 1)]
+
+/-! # Canonical form -/
+
+/-- Canonical lists have the declared arity, strictly descending
+lexicographic exponents, and no zero coefficient. The arity conjunct is
+essential: without it distinct exponent lists can denote the same fixed-arity
+monomial. -/
+def Canonical [Zero κ] (n : Nat) (p : PolyList κ) : Prop :=
+  (∀ t ∈ p, t.1.length = n) ∧
+  p.Pairwise (fun a b => b.1 < a.1) ∧
+  ∀ t ∈ p, t.2 ≠ 0
+
+/-- The structurally generated zero exponent has its declared length. -/
+theorem length_zeroExp (n : Nat) : (zeroExp n).length = n := by
+  induction n with
+  | zero => rfl
+  | succ n ih => simp [zeroExp, ih]
+
+/-- The list-form multiplicative identity is canonical. -/
+theorem one_canonical [Zero κ] [One κ] [DecidableEq κ] (n : Nat) :
+    Canonical n (one (κ := κ) n) := by
+  unfold one
+  split
+  · exact ⟨fun _ h => by contradiction, List.Pairwise.nil,
+      fun _ h => by contradiction⟩
+  · exact ⟨by simp [length_zeroExp], by simp, by simp_all⟩
+
+/-- The explicit equality test agrees with equality of exponent lists. -/
+theorem expBeq_iff {a b : List Nat} : expBeq a b = true ↔ a = b := by
+  induction a generalizing b with
+  | nil => cases b <;> simp [expBeq]
+  | cons x xs ih =>
+      cases b with
+      | nil => simp [expBeq]
+      | cons y ys => simp [expBeq, ih]
+
+/-- The explicit kernel comparator is the standard lexicographic list
+comparison. -/
+theorem expCmp_eq_compare (a b : List Nat) : expCmp a b = compare a b := by
+  induction a generalizing b with
+  | nil => cases b <;> rfl
+  | cons x xs ih =>
+      cases b with
+      | nil => rfl
+      | cons y ys =>
+          by_cases hxy : x < y
+          · simp [expCmp, Nat.blt_eq.mpr hxy, Nat.compare_eq_lt.mpr hxy]
+          · by_cases hyx : y < x
+            · simp [expCmp, Nat.blt_eq, hxy, hyx, Nat.compare_eq_gt.mpr hyx]
+            · have h : x = y := Nat.le_antisymm (Nat.le_of_not_gt hyx)
+                (Nat.le_of_not_gt hxy)
+              subst y
+              simp [expCmp, ih]
+
+/-- The result `.lt` of the explicit comparator is lexicographic `<`. -/
+theorem expCmp_eq_lt_iff {a b : List Nat} : expCmp a b = .lt ↔ a < b := by
+  induction a generalizing b with
+  | nil => cases b <;> simp [expCmp]
+  | cons x xs ih =>
+      cases b with
+      | nil => simp [expCmp]
+      | cons y ys =>
+          by_cases hxy : x < y
+          · simp [expCmp, Nat.blt_eq.mpr hxy, List.cons_lt_cons_iff, hxy]
+          · by_cases hyx : y < x
+            · have hne : x ≠ y := Nat.ne_of_gt hyx
+              simp [expCmp, Nat.blt_eq, hxy, hyx, hne, List.cons_lt_cons_iff]
+            · have heq : x = y := Nat.le_antisymm (Nat.le_of_not_gt hyx)
+                (Nat.le_of_not_gt hxy)
+              subst y
+              simp [expCmp, ih]
+
+/-- Pointwise exponent addition preserves a common arity. -/
+theorem length_addExp {a b : List Nat} {n : Nat}
+    (ha : a.length = n) (hb : b.length = n) :
+    (addExp a b).length = n := by
+  induction a generalizing b n with
+  | nil => simpa [addExp] using hb
+  | cons x xs ih =>
+      cases b with
+      | nil => simp_all [addExp]
+      | cons y ys =>
+          simp only [List.length_cons] at ha hb
+          have hxs : xs.length = ys.length := by omega
+          have hi := ih (b := ys) (n := xs.length) rfl hxs.symm
+          simp only [addExp, List.length_cons]
+          rw [hi]
+          omega
+
+/-- Every exponent emitted by insertion is either the inserted exponent or
+an exponent already present. -/
+theorem exp_mem_insert [Zero κ] [Add κ] [DecidableEq κ]
+    {t u : Term κ} {us : PolyList κ}
+    (h : u ∈ insert t us) : u.1 = t.1 ∨ ∃ v ∈ us, u.1 = v.1 := by
+  induction us with
+  | nil =>
+      by_cases hz : t.2 = 0
+      · simp [insert, hz] at h
+      · simp [insert, hz] at h
+        exact Or.inl (congrArg Prod.fst h)
+  | cons v vs ih =>
+      cases hc : expCmp t.1 v.1 with
+      | gt =>
+          by_cases hz : t.2 = 0
+          · simp [insert, hc, hz] at h
+            exact Or.inr ⟨u, List.mem_cons.mpr h, rfl⟩
+          · simp only [insert, hc, hz, ite_false, List.mem_cons] at h
+            rcases h with rfl | h
+            · exact Or.inl rfl
+            · exact Or.inr ⟨u, List.mem_cons.mpr h, rfl⟩
+      | eq =>
+          have heq : t.1 = v.1 := by
+            rw [expCmp_eq_compare] at hc
+            exact Std.LawfulEqCmp.eq_of_compare hc
+          by_cases hz : t.2 + v.2 = 0
+          · simp [insert, hc, hz] at h
+            exact Or.inr ⟨u, List.mem_cons_of_mem _ h, rfl⟩
+          · simp only [insert, hc, hz, ite_false, List.mem_cons] at h
+            rcases h with h | h
+            · left
+              simpa [heq] using congrArg Prod.fst h
+            · exact Or.inr ⟨u, List.mem_cons_of_mem _ h, rfl⟩
+      | lt =>
+          simp only [insert, hc, List.mem_cons] at h
+          rcases h with rfl | h
+          · exact Or.inr ⟨u, List.mem_cons_self .., rfl⟩
+          · rcases ih h with h | ⟨w, hw, he⟩
+            · exact Or.inl h
+            · exact Or.inr ⟨w, List.mem_cons_of_mem _ hw, he⟩
+
+/-- Insertion preserves canonical form. The inserted coefficient may be
+zero; in that case no term is added. -/
+theorem insert_canonical [Zero κ] [Add κ] [DecidableEq κ]
+    {n : Nat} {t : Term κ} {p : PolyList κ}
+    (ht : t.1.length = n) (hp : Canonical n p) :
+    Canonical n (insert t p) := by
+  induction p with
+  | nil =>
+      simp only [insert]
+      split
+      · exact ⟨by simp, by simp, by simp⟩
+      · exact ⟨by simpa, by simp, by simp_all⟩
+  | cons u us ih =>
+      rcases hp with ⟨hlen, hpair, hnz⟩
+      have huLen := hlen u (List.mem_cons_self ..)
+      have husLen : ∀ v ∈ us, v.1.length = n :=
+        fun v hv => hlen v (List.mem_cons_of_mem _ hv)
+      have husPair := (List.pairwise_cons.mp hpair).2
+      have husNz : ∀ v ∈ us, v.2 ≠ 0 :=
+        fun v hv => hnz v (List.mem_cons_of_mem _ hv)
+      have hi := ih ⟨husLen, husPair, husNz⟩
+      simp only [insert]
+      split
+      next hcmp =>
+        have htu : u.1 < t.1 := by
+          have hcomp : compare t.1 u.1 = .gt := by
+            simpa [expCmp_eq_compare] using hcmp
+          have hrev : compare u.1 t.1 = .lt :=
+            Std.OrientedCmp.gt_iff_lt.mp hcomp
+          have hcmp' : expCmp u.1 t.1 = .lt := by
+            rw [expCmp_eq_compare]
+            exact hrev
+          exact expCmp_eq_lt_iff.mp hcmp'
+        split
+        · exact ⟨hlen, hpair, hnz⟩
+        · refine ⟨?_, ?_, ?_⟩
+          · intro v hv
+            rcases List.mem_cons.mp hv with rfl | hv
+            · exact ht
+            · exact hlen v hv
+          · rw [List.pairwise_cons]
+            refine ⟨?_, hpair⟩
+            intro v hv
+            rcases List.mem_cons.mp hv with rfl | hv
+            · exact htu
+            · exact List.lt_trans ((List.pairwise_cons.mp hpair).1 v hv) htu
+          · intro v hv
+            rcases List.mem_cons.mp hv with rfl | hv
+            · assumption
+            · exact hnz v hv
+      next hcmp =>
+        have htu : t.1 = u.1 := by
+          rw [expCmp_eq_compare] at hcmp
+          exact Std.LawfulEqCmp.eq_of_compare hcmp
+        split
+        · exact ⟨husLen, husPair, husNz⟩
+        · refine ⟨?_, ?_, ?_⟩
+          · intro v hv
+            rcases List.mem_cons.mp hv with rfl | hv
+            · exact huLen
+            · exact husLen v hv
+          · simpa using hpair
+          · intro v hv
+            rcases List.mem_cons.mp hv with rfl | hv
+            · assumption
+            · exact husNz v hv
+      next hcmp =>
+        have htu : t.1 < u.1 := by
+          exact expCmp_eq_lt_iff.mp hcmp
+        refine ⟨?_, ?_, ?_⟩
+        · intro v hv
+          rcases List.mem_cons.mp hv with rfl | hv
+          · exact huLen
+          · exact hi.1 v hv
+        · rw [List.pairwise_cons]
+          refine ⟨?_, hi.2.1⟩
+          intro v hv
+          rcases exp_mem_insert hv with h | ⟨w, hw, he⟩
+          · simpa [h] using htu
+          · have huw := (List.pairwise_cons.mp hpair).1 w hw
+            simpa [he] using huw
+        · intro v hv
+          rcases List.mem_cons.mp hv with rfl | hv
+          · exact hnz v (List.mem_cons_self ..)
+          · exact hi.2.2 v hv
+
+/-- Normalization emits a canonical list when every input exponent has the
+declared arity. -/
+theorem normalize_canonical [Zero κ] [Add κ] [DecidableEq κ]
+    {n : Nat} {p : PolyList κ} (h : ∀ t ∈ p, t.1.length = n) :
+    Canonical n (normalize p) := by
+  induction p with
+  | nil =>
+      exact ⟨fun t ht => by contradiction, List.Pairwise.nil,
+        fun t ht => by contradiction⟩
+  | cons t ts ih =>
+      rw [normalize]
+      apply insert_canonical (h t (List.mem_cons_self ..))
+      exact ih fun u hu => h u (List.mem_cons_of_mem _ hu)
+
+/-- Addition preserves canonical form. -/
+theorem add_canonical [Zero κ] [Add κ] [DecidableEq κ]
+    {n : Nat} {p q : PolyList κ}
+    (hp : Canonical n p) (hq : Canonical n q) : Canonical n (add p q) := by
+  induction p with
+  | nil => exact hq
+  | cons t ts ih =>
+      rw [add]
+      apply insert_canonical (hp.1 t (List.mem_cons_self ..))
+      exact ih ⟨fun u hu => hp.1 u (List.mem_cons_of_mem _ hu),
+        (List.pairwise_cons.mp hp.2.1).2,
+        fun u hu => hp.2.2 u (List.mem_cons_of_mem _ hu)⟩
+
+/-- A coefficient map preserves the exponent of every surviving term. -/
+theorem exp_mem_mapCoeffs [Zero κ] [DecidableEq κ] (f : κ → κ)
+    {u : Term κ} {p : PolyList κ} (hu : u ∈ mapCoeffs f p) :
+    ∃ v ∈ p, u.1 = v.1 := by
+  induction p with
+  | nil => contradiction
+  | cons v vs ih =>
+      rw [mapCoeffs] at hu
+      split at hu
+      · rcases ih hu with ⟨w, hw, he⟩
+        exact ⟨w, List.mem_cons_of_mem _ hw, he⟩
+      · rcases List.mem_cons.mp hu with h | hu
+        · have he := congrArg (fun z : Term κ => z.1) h
+          exact ⟨v, List.mem_cons_self .., by simpa using he⟩
+        · rcases ih hu with ⟨w, hw, he⟩
+          exact ⟨w, List.mem_cons_of_mem _ hw, he⟩
+
+/-- Mapping and filtering coefficients preserves canonical form. -/
+theorem mapCoeffs_canonical [Zero κ] [DecidableEq κ] (f : κ → κ)
+    {n : Nat} {p : PolyList κ} (hp : Canonical n p) :
+    Canonical n (mapCoeffs f p) := by
+  induction p with
+  | nil => exact ⟨fun _ h => by contradiction, List.Pairwise.nil,
+      fun _ h => by contradiction⟩
+  | cons t ts ih =>
+      have htail : Canonical n ts :=
+        ⟨fun u hu => hp.1 u (List.mem_cons_of_mem _ hu),
+          (List.pairwise_cons.mp hp.2.1).2,
+          fun u hu => hp.2.2 u (List.mem_cons_of_mem _ hu)⟩
+      have hi := ih htail
+      rw [mapCoeffs]
+      split
+      · exact hi
+      · refine ⟨?_, ?_, ?_⟩
+        · intro u hu
+          rcases List.mem_cons.mp hu with rfl | hu
+          · exact hp.1 t (List.mem_cons_self ..)
+          · exact hi.1 u hu
+        · rw [List.pairwise_cons]
+          refine ⟨?_, hi.2.1⟩
+          intro u hu
+          have hu' := exp_mem_mapCoeffs f hu
+          rcases hu' with ⟨v, hv, he⟩
+          simpa [he] using (List.pairwise_cons.mp hp.2.1).1 v hv
+        · intro u hu
+          rcases List.mem_cons.mp hu with rfl | hu
+          · assumption
+          · exact hi.2.2 u hu
+
+/-- Negation preserves canonical form. -/
+theorem neg_canonical [Zero κ] [Neg κ] [DecidableEq κ]
+    {n : Nat} {p : PolyList κ} (hp : Canonical n p) :
+    Canonical n (neg p) := by
+  exact mapCoeffs_canonical Neg.neg hp
+
+/-- Scalar multiplication preserves canonical form. -/
+theorem smul_canonical [Zero κ] [Mul κ] [DecidableEq κ]
+    (a : κ) {n : Nat} {p : PolyList κ} (hp : Canonical n p) :
+    Canonical n (smul a p) := by
+  exact mapCoeffs_canonical (fun c => a * c) hp
+
+/-- A translated product row is canonical. -/
+theorem mulTerm_canonical [Zero κ] [Add κ] [Mul κ] [DecidableEq κ]
+    {n : Nat} {t : Term κ} {p : PolyList κ}
+    (ht : t.1.length = n) (hp : Canonical n p) :
+    Canonical n (mulTerm t p) := by
+  induction p with
+  | nil => exact ⟨fun _ h => by contradiction, List.Pairwise.nil,
+      fun _ h => by contradiction⟩
+  | cons u us ih =>
+      rw [mulTerm]
+      apply insert_canonical
+      · exact length_addExp ht (hp.1 u (List.mem_cons_self ..))
+      · exact ih ⟨fun v hv => hp.1 v (List.mem_cons_of_mem _ hv),
+          (List.pairwise_cons.mp hp.2.1).2,
+          fun v hv => hp.2.2 v (List.mem_cons_of_mem _ hv)⟩
+
+/-- Multiplication preserves canonical form. -/
+theorem mul_canonical [Zero κ] [Add κ] [Mul κ] [DecidableEq κ]
+    {n : Nat} {p q : PolyList κ}
+    (hp : Canonical n p) (hq : Canonical n q) : Canonical n (mul p q) := by
+  induction p with
+  | nil => exact ⟨fun _ h => by contradiction, List.Pairwise.nil,
+      fun _ h => by contradiction⟩
+  | cons t ts ih =>
+      rw [mul]
+      apply add_canonical
+      · exact mulTerm_canonical (hp.1 t (List.mem_cons_self ..)) hq
+      · exact ih ⟨fun u hu => hp.1 u (List.mem_cons_of_mem _ hu),
+          (List.pairwise_cons.mp hp.2.1).2,
+          fun u hu => hp.2.2 u (List.mem_cons_of_mem _ hu)⟩
+
+/-- Boolean check for the canonical invariant. -/
+def isCanonical [Zero κ] [DecidableEq κ] (n : Nat) :
+    PolyList κ → Bool
+  | [] => true
+  | [t] => Nat.beq t.1.length n && decide (t.2 ≠ 0)
+  | t :: u :: ts =>
+      Nat.beq t.1.length n && decide (t.2 ≠ 0) &&
+        (expCmp t.1 u.1 == .gt) && isCanonical n (u :: ts)
+
+/-- The Boolean canonicality check decides the proposition. -/
+theorem isCanonical_iff [Zero κ] [DecidableEq κ]
+    {n : Nat} {p : PolyList κ} :
+    isCanonical n p = true ↔ Canonical n p := by
+  induction p with
+  | nil => simp [isCanonical, Canonical]
+  | cons t ts ih =>
+      cases ts with
+      | nil => simp [isCanonical, Canonical]
+      | cons u us =>
+          simp only [isCanonical, Bool.and_eq_true, decide_eq_true_eq,
+            beq_iff_eq, Nat.beq_eq, ih]
+          rw [expCmp_eq_compare]
+          constructor
+          · rintro ⟨⟨⟨htlen, htnz⟩, hcmp⟩, htail⟩
+            have hut : u.1 < t.1 := by
+              have hrev : compare u.1 t.1 = .lt :=
+                Std.OrientedCmp.gt_iff_lt.mp hcmp
+              rw [← expCmp_eq_compare] at hrev
+              exact expCmp_eq_lt_iff.mp hrev
+            refine ⟨?_, ?_, ?_⟩
+            · intro v hv
+              rcases List.mem_cons.mp hv with rfl | hv
+              · exact htlen
+              · exact htail.1 v hv
+            · rw [List.pairwise_cons]
+              refine ⟨?_, htail.2.1⟩
+              intro v hv
+              rcases List.mem_cons.mp hv with rfl | hv
+              · exact hut
+              · exact List.lt_trans ((List.pairwise_cons.mp htail.2.1).1 v hv) hut
+            · intro v hv
+              rcases List.mem_cons.mp hv with rfl | hv
+              · exact htnz
+              · exact htail.2.2 v hv
+          · rintro ⟨hlen, hpair, hnz⟩
+            have hut := (List.pairwise_cons.mp hpair).1 u (List.mem_cons_self ..)
+            have hcmp : compare t.1 u.1 = .gt := by
+              apply Std.OrientedCmp.gt_iff_lt.mpr
+              rw [← expCmp_eq_compare]
+              exact expCmp_eq_lt_iff.mpr hut
+            refine ⟨⟨⟨hlen t (List.mem_cons_self ..),
+              hnz t (List.mem_cons_self ..)⟩, hcmp⟩, ?_⟩
+            exact ⟨fun v hv => hlen v (List.mem_cons_of_mem _ hv),
+              (List.pairwise_cons.mp hpair).2,
+              fun v hv => hnz v (List.mem_cons_of_mem _ hv)⟩
+
+/-! # Denotation and conversion -/
+
+/-- Read an exponent list as an `n`-variable monomial. Canonical inputs have
+exactly length `n`; `getD` merely makes denotation total on malformed input. -/
+def mono (n : Nat) (e : List Nat) : Mono n :=
+  Hex.Vector.ofFn' fun i => e.getD i 0
+
+/-- Denote a term list in the reference polynomial type. -/
+def denote {n : Nat} {κ : Type u} [Lean.Grind.Semiring κ] [BEq κ]
+    [LawfulBEq κ] {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] :
+    PolyList κ → MvPoly n κ cmp
+  | [] => 0
+  | t :: ts => MvPoly.monomial (mono n t.1) t.2 + denote ts
+
+/-- Convert a reference polynomial to the fixed canonical list order. This is
+a producer-side conversion; certificate replay sees only its quoted result. -/
+def toList {n : Nat} {κ : Type u} [Lean.Grind.Semiring κ] [BEq κ]
+    [LawfulBEq κ] [DecidableEq κ]
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    (p : MvPoly n κ cmp) : PolyList κ :=
+  normalize (p.termsList.map fun t => (t.1.toList, t.2))
+
+/-! # Denotation laws -/
+
+/-- A zero coefficient denotes the zero reference polynomial. -/
+private theorem monomial_zero {n : Nat} {κ : Type u} [Lean.Grind.Semiring κ]
+    [BEq κ] [LawfulBEq κ] [DecidableEq κ]
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] (m : Mono n) :
+    (MvPoly.monomial m 0 : MvPoly n κ cmp) = 0 := by
+  apply MvPoly.ext
+  intro k
+  by_cases h : k = m <;>
+    simp [MvPoly.coeff_monomial, MvPoly.coeff_zero, h]
+
+/-- Adding coefficients of one monomial agrees with reference addition. -/
+private theorem monomial_add {n : Nat} {κ : Type u} [Lean.Grind.Semiring κ]
+    [BEq κ] [LawfulBEq κ] [DecidableEq κ]
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] (m : Mono n) (a b : κ) :
+    (MvPoly.monomial m (a + b) : MvPoly n κ cmp) =
+      MvPoly.monomial m a + MvPoly.monomial m b := by
+  apply MvPoly.ext
+  intro k
+  by_cases h : k = m <;>
+    simp [MvPoly.coeff_monomial, MvPoly.coeff_add, h,
+      Lean.Grind.AddCommMonoid.zero_add]
+
+/-- Inserting a term has the denotation of adding its monomial. -/
+theorem denote_insert {n : Nat} {κ : Type u} [Lean.Grind.Semiring κ]
+    [BEq κ] [LawfulBEq κ] [DecidableEq κ]
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    (t : Term κ) (p : PolyList κ) :
+    denote (cmp := cmp) (insert t p) =
+      MvPoly.monomial (mono n t.1) t.2 + denote (cmp := cmp) p := by
+  induction p with
+  | nil =>
+      by_cases hz : t.2 = 0
+      · simp [insert, hz, denote, monomial_zero, MvPoly.zero_add]
+      · simp [insert, hz, denote, MvPoly.add_zero]
+  | cons u us ih =>
+      cases hc : expCmp t.1 u.1 with
+      | gt =>
+          by_cases hz : t.2 = 0
+          · simp [insert, hc, hz, denote, monomial_zero, MvPoly.zero_add]
+          · simp [insert, hc, hz, denote]
+      | eq =>
+          have he : t.1 = u.1 := by
+            rw [expCmp_eq_compare] at hc
+            exact Std.LawfulEqCmp.eq_of_compare hc
+          have hm : mono n t.1 = mono n u.1 := congrArg (mono n) he
+          by_cases hz : t.2 + u.2 = 0
+          · simp only [insert, hc]
+            rw [ite_eq_left hz]
+            simp only [denote]
+            rw [← MvPoly.add_assoc,
+              hm, ← monomial_add, hz, monomial_zero, MvPoly.zero_add]
+          · simp only [insert, hc]
+            rw [ite_eq_right hz]
+            simp only [denote]
+            rw [← MvPoly.add_assoc,
+              hm, ← monomial_add]
+      | lt =>
+          rw [insert, hc, denote, ih, denote, ← MvPoly.add_assoc,
+            MvPoly.add_comm (MvPoly.monomial (mono n u.1) u.2)
+              (MvPoly.monomial (mono n t.1) t.2),
+            MvPoly.add_assoc]
+
+/-- Normalization does not change denotation. -/
+theorem denote_normalize {n : Nat} {κ : Type u} [Lean.Grind.Semiring κ]
+    [BEq κ] [LawfulBEq κ] [DecidableEq κ]
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] (p : PolyList κ) :
+    denote (cmp := cmp) (normalize p) = denote (cmp := cmp) p := by
+  induction p with
+  | nil => rfl
+  | cons t ts ih =>
+      rw [normalize, denote_insert, ih]
+      rfl
+
+/-- List addition denotes reference addition. -/
+theorem denote_add {n : Nat} {κ : Type u} [Lean.Grind.Semiring κ]
+    [BEq κ] [LawfulBEq κ] [DecidableEq κ]
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] (p q : PolyList κ) :
+    denote (cmp := cmp) (add p q) =
+      denote (cmp := cmp) p + denote (cmp := cmp) q := by
+  induction p with
+  | nil => exact (MvPoly.zero_add (denote q)).symm
+  | cons t ts ih =>
+      rw [add, denote_insert, ih, denote]
+      exact (MvPoly.add_assoc _ _ _).symm
+
+/-- List negation denotes reference negation. -/
+theorem denote_neg {n : Nat} {κ : Type u} [Lean.Grind.CommRing κ]
+    [BEq κ] [LawfulBEq κ] [DecidableEq κ]
+    {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] (p : PolyList κ) :
+    denote (cmp := cmp) (neg p) = -denote (cmp := cmp) p := by
+  unfold neg
+  induction p with
+  | nil =>
+      simp only [mapCoeffs, denote]
+      exact MvPoly.neg_zero
+  | cons t ts ih =>
+      rw [mapCoeffs]
+      split <;> apply MvPoly.ext <;> intro m
+      all_goals have ihc := congrArg (MvPoly.coeff m) ih
+      all_goals simp only [denote, MvPoly.coeff_add, MvPoly.coeff_monomial,
+        MvPoly.coeff_neg] at ihc ⊢
+      all_goals by_cases hm : m = mono n t.1 <;>
+        simp [hm, Lean.Grind.AddCommMonoid.zero_add] at * <;>
+        grind
+
+/-- List scalar multiplication denotes multiplication by a constant. -/
+theorem denote_smul {n : Nat} {κ : Type u} [Lean.Grind.Semiring κ]
+    [BEq κ] [LawfulBEq κ] [DecidableEq κ]
+    {cmp : Mono n → Mono n → Ordering} [Std.TransCmp cmp]
+    [Std.LawfulEqCmp cmp] (a : κ) (p : PolyList κ) :
+    denote (cmp := cmp) (smul a p) =
+      MvPoly.C a * denote (cmp := cmp) p := by
+  unfold smul
+  induction p with
+  | nil =>
+      simp only [mapCoeffs, denote]
+      exact (MvPoly.mul_zero (MvPoly.C a)).symm
+  | cons t ts ih =>
+      rw [mapCoeffs]
+      split
+      next hz =>
+        apply MvPoly.ext
+        intro m
+        have ihc := congrArg (MvPoly.coeff m) ih
+        simp only [denote, MvPoly.coeff_add, MvPoly.coeff_monomial,
+          MvPoly.coeff_C_mul] at ihc ⊢
+        by_cases hm : m = mono n t.1
+        · simp [hm, Lean.Grind.Semiring.left_distrib, hz,
+            Lean.Grind.AddCommMonoid.zero_add]
+          simpa [hm] using ihc
+        · simp [hm, Lean.Grind.AddCommMonoid.zero_add, ihc]
+      next hnz =>
+        apply MvPoly.ext
+        intro m
+        have ihc := congrArg (MvPoly.coeff m) ih
+        simp only [denote, MvPoly.coeff_add, MvPoly.coeff_monomial,
+          MvPoly.coeff_C_mul] at ihc ⊢
+        by_cases hm : m = mono n t.1
+        · simp [hm, Lean.Grind.Semiring.left_distrib]
+          congr 1
+          simpa [hm] using ihc
+        · simp [hm, Lean.Grind.AddCommMonoid.zero_add, ihc]
+
+/-- Reading a list exponent through its denotation uses `getD`. -/
+theorem get_mono (n : Nat) (e : List Nat) (i : Fin n) :
+    (mono n e)[i] = e.getD i.val 0 := by
+  change (Hex.Vector.ofFn' fun j : Fin n => e.getD j.val 0)[i.val] = _
+  rw [Hex.Vector.getElem_ofFn' _ i.val i.isLt]
+
+/-- A pointwise sum has the pointwise sum of `getD` values when both lists
+have the declared arity. -/
+theorem getD_addExp {a b : List Nat} {n i : Nat}
+    (ha : a.length = n) (hb : b.length = n) (hi : i < n) :
+    (addExp a b).getD i 0 = a.getD i 0 + b.getD i 0 := by
+  induction a generalizing b n i with
+  | nil => simp_all; omega
+  | cons x xs ih =>
+      cases b with
+      | nil => simp_all; omega
+      | cons y ys =>
+          cases i with
+          | zero => simp [addExp]
+          | succ i =>
+              simp only [List.length_cons] at ha hb
+              simp only [addExp, List.getD_cons_succ]
+              exact ih (n := xs.length) (i := i) rfl (by omega) (by omega)
+
+/-- List exponent addition denotes monomial multiplication. -/
+theorem mono_addExp {a b : List Nat} {n : Nat}
+    (ha : a.length = n) (hb : b.length = n) :
+    mono n (addExp a b) = Mono.mul (mono n a) (mono n b) := by
+  apply Vector.ext
+  intro i hi
+  let j : Fin n := ⟨i, hi⟩
+  change (mono n (addExp a b))[j] = (Mono.mul (mono n a) (mono n b))[j]
+  rw [get_mono, Mono.getElem_mul, get_mono, get_mono,
+    getD_addExp ha hb j.isLt]
+
+/-- Multiplying one term through a list denotes multiplication by its
+reference monomial. -/
+theorem denote_mulTerm {n : Nat} {κ : Type u} [Lean.Grind.Semiring κ]
+    [BEq κ] [LawfulBEq κ] [DecidableEq κ]
+    {cmp : Mono n → Mono n → Ordering} [Std.TransCmp cmp]
+    [Std.LawfulEqCmp cmp] (t : Term κ) (p : PolyList κ)
+    (ht : t.1.length = n) (hp : ∀ u ∈ p, u.1.length = n) :
+    denote (cmp := cmp) (mulTerm t p) =
+      MvPoly.monomial (mono n t.1) t.2 * denote (cmp := cmp) p := by
+  induction p with
+  | nil =>
+      simp only [mulTerm, denote]
+      exact (MvPoly.mul_zero _).symm
+  | cons u us ih =>
+      rw [mulTerm, denote_insert, ih
+        (fun v hv => hp v (List.mem_cons_of_mem _ hv)), denote,
+        MvPoly.mul_add, MvPoly.monomial_mul_monomial,
+        mono_addExp ht (hp u (List.mem_cons_self ..))]
+
+/-- List multiplication denotes reference multiplication. -/
+theorem denote_mul {n : Nat} {κ : Type u} [Lean.Grind.Semiring κ]
+    [BEq κ] [LawfulBEq κ] [DecidableEq κ]
+    {cmp : Mono n → Mono n → Ordering} [Std.TransCmp cmp]
+    [Std.LawfulEqCmp cmp] (p q : PolyList κ)
+    (hp : ∀ t ∈ p, t.1.length = n) (hq : ∀ t ∈ q, t.1.length = n) :
+    denote (cmp := cmp) (mul p q) =
+      denote (cmp := cmp) p * denote (cmp := cmp) q := by
+  induction p with
+  | nil =>
+      simp only [mul, denote]
+      exact (MvPoly.zero_mul _).symm
+  | cons t ts ih =>
+      rw [mul, denote_add, denote_mulTerm t q
+        (hp t (List.mem_cons_self ..)) hq,
+        ih (fun u hu => hp u (List.mem_cons_of_mem _ hu)), denote,
+        MvPoly.add_mul]
+
+/-- The recursive sum denotation agrees with the reference bulk
+constructor. -/
+theorem denote_eq_ofTerms {n : Nat} {κ : Type u} [Lean.Grind.Semiring κ]
+    [BEq κ] [LawfulBEq κ] [DecidableEq κ]
+    {cmp : Mono n → Mono n → Ordering} [Std.TransCmp cmp]
+    [Std.LawfulEqCmp cmp] (p : PolyList κ) :
+    denote (cmp := cmp) p =
+      MvPoly.ofTerms (p.map fun t => (mono n t.1, t.2)) := by
+  induction p with
+  | nil => rfl
+  | cons t ts ih =>
+      rw [denote, ih]
+      apply MvPoly.ext
+      intro m
+      rw [MvPoly.coeff_add, MvPoly.coeff_monomial,
+        MvPoly.coeff_ofTerms, MvPoly.coeff_ofTerms]
+      by_cases ht : mono n t.1 = m
+      · have hmt : m = mono n t.1 := ht.symm
+        simp only [List.map_cons, List.filter_cons, ht, decide_true]
+        simp only [hmt, ite_eq_left]
+        rw [List.foldl_cons]
+        rw [Lean.Grind.AddCommMonoid.zero_add]
+        exact (List.foldl_add_eq_add_foldl (R := κ) _
+          (fun x : Mono n × κ => x.2) t.2).symm
+      · have hmt : m ≠ mono n t.1 := fun h => ht h.symm
+        simp [ht, hmt, Lean.Grind.AddCommMonoid.zero_add]
+
+/-- Converting a vector monomial to a list and reading it back is exact. -/
+theorem mono_toList {n : Nat} (m : Mono n) : mono n m.toList = m := by
+  apply Vector.ext
+  intro i hi
+  let j : Fin n := ⟨i, hi⟩
+  change (mono n m.toList)[j] = m[j]
+  rw [get_mono, List.getD_eq_getElem?_getD,
+    List.getElem?_eq_getElem (by simp), Option.getD_some]
+  exact Vector.getElem_toList (xs := m) (i := i) (by simpa using hi)
+
+/-- Producer conversion always emits a canonical list. -/
+theorem toList_canonical {n : Nat} {κ : Type u} [Lean.Grind.Semiring κ]
+    [BEq κ] [LawfulBEq κ] [DecidableEq κ]
+    {cmp : Mono n → Mono n → Ordering} [Std.TransCmp cmp]
+    [Std.LawfulEqCmp cmp] (p : MvPoly n κ cmp) : Canonical n (toList p) := by
+  apply normalize_canonical
+  intro t ht
+  rcases List.mem_map.mp ht with ⟨u, hu, rfl⟩
+  simp
+
+/-- Producer conversion round-trips through denotation. -/
+theorem denote_toList {n : Nat} {κ : Type u} [Lean.Grind.Semiring κ]
+    [BEq κ] [LawfulBEq κ] [DecidableEq κ]
+    {cmp : Mono n → Mono n → Ordering} [Std.TransCmp cmp]
+    [Std.LawfulEqCmp cmp] (p : MvPoly n κ cmp) :
+    denote (cmp := cmp) (toList p) = p := by
+  rw [toList, denote_normalize, denote_eq_ofTerms]
+  have hmap :
+      (p.termsList.map fun t => (mono n t.1.toList, t.2)) = p.termsList := by
+    simp [mono_toList]
+  rw [List.map_map]
+  change MvPoly.ofTerms
+    (p.termsList.map fun t => (mono n t.1.toList, t.2)) = p
+  rw [hmap]
+  apply MvPoly.ext
+  intro m
+  rw [MvPoly.coeff_ofTerms, MvPoly.coeff_terms]
+
+/-! # Evaluation -/
+
+/-- The linear structural power used by certificate replay has the standard
+semiring value. -/
+theorem pow_eq_pow [Lean.Grind.Semiring κ] (a : κ) (k : Nat) :
+    pow a k = a ^ k := by
+  induction k with
+  | zero => rw [pow, Lean.Grind.Semiring.pow_zero]
+  | succ k ih => rw [pow, ih, Lean.Grind.Semiring.pow_succ]
+
+/-- List monomial evaluation agrees with reference monomial evaluation when
+the point and exponent list have the declared arity. -/
+theorem evalMono_eq_prod [Lean.Grind.Semiring κ] {n : Nat}
+    {x : List κ} {e : List Nat} (hx : x.length = n) (he : e.length = n) :
+    evalMono x e = Mono.prod (fun i => x.getD i.val 0) (mono n e) := by
+  letI : Std.Associative (· * · : κ → κ → κ) :=
+    ⟨Lean.Grind.Semiring.mul_assoc⟩
+  letI : Std.LawfulIdentity (· * · : κ → κ → κ) 1 :=
+    { left_id := Lean.Grind.Semiring.one_mul
+      right_id := Lean.Grind.Semiring.mul_one }
+  induction n generalizing x e with
+  | zero =>
+      have hxnil : x = [] := List.eq_nil_of_length_eq_zero hx
+      have henil : e = [] := List.eq_nil_of_length_eq_zero he
+      subst x
+      subst e
+      rfl
+  | succ n ih =>
+      cases x with
+      | nil => simp at hx
+      | cons a xs =>
+          cases e with
+          | nil => simp at he
+          | cons k es =>
+              have hx' : xs.length = n := by
+                simp only [List.length_cons] at hx
+                omega
+              have he' : es.length = n := by
+                simp only [List.length_cons] at he
+                omega
+              rw [evalMono, Mono.prod, List.finRange_succ, List.foldl_cons,
+                List.foldl_map]
+              rw [List.foldl_mul_eq_mul_foldl]
+              simp only [get_mono,
+                Mono.powBySq_eq_pow, pow_eq_pow, Lean.Grind.Semiring.one_mul]
+              rw [ih hx' he']
+              unfold Mono.prod
+              apply congrArg (fun z => a ^ k * z)
+              apply List.foldl_mul_congr
+              intro i _
+              rw [Mono.powBySq_eq_pow, get_mono]
+              change xs.getD i.val 0 ^ es.getD i.val 0 =
+                (a :: xs).getD (i.val + 1) 0 ^ (k :: es).getD (i.val + 1) 0
+              rw [List.getD_cons_succ, List.getD_cons_succ]
+
+/-- List evaluation commutes with evaluation of the reference denotation. -/
+theorem evalAt_denote {n : Nat} {κ : Type u} [Lean.Grind.Semiring κ]
+    [BEq κ] [LawfulBEq κ] [DecidableEq κ]
+    {cmp : Mono n → Mono n → Ordering} [Std.TransCmp cmp]
+    [Std.LawfulEqCmp cmp] (x : List κ) (p : PolyList κ)
+    (hx : x.length = n) (hp : ∀ t ∈ p, t.1.length = n) :
+    evalAt x p = MvPoly.eval (fun i => x.getD i.val 0) (denote (cmp := cmp) p) := by
+  rw [denote_eq_ofTerms]
+  unfold MvPoly.eval
+  rw [MvPoly.eval₂_ofTerms (f := id) (x := fun i => x.getD i.val 0)
+    (by rfl) (by intros; rfl)]
+  induction p with
+  | nil => rfl
+  | cons t ts ih =>
+      simp only [evalAt, List.map_cons, List.foldl_cons, id_eq]
+      rw [Lean.Grind.AddCommMonoid.zero_add, List.foldl_add_eq_add_foldl,
+        evalMono_eq_prod hx (hp t (List.mem_cons_self ..)),
+        ih (fun u hu => hp u (List.mem_cons_of_mem _ hu))]
+      simp only [id_eq]
+
+/-! # Canonical uniqueness -/
+
+/-- An exact-length exponent list is recovered from its monomial. -/
+theorem toList_mono {e : List Nat} {n : Nat} (h : e.length = n) :
+    (mono n e).toList = e := by
+  apply List.ext_getElem
+  · simp [h]
+  · intro i hi hj
+    change (mono n e)[i] = e[i]
+    let k : Fin n := ⟨i, by simpa [h] using hi⟩
+    change (mono n e)[k] = e[i]
+    rw [get_mono, List.getD_eq_getElem?_getD,
+      List.getElem?_eq_getElem hj, Option.getD_some]
+
+/-- Denotation of exponent lists is injective at a fixed arity. -/
+theorem mono_inj {a b : List Nat} {n : Nat}
+    (ha : a.length = n) (hb : b.length = n) :
+    mono n a = mono n b ↔ a = b := by
+  constructor
+  · intro h
+    rw [← toList_mono ha, ← toList_mono hb, h]
+  · exact fun h => congrArg (mono n) h
+
+/-- Coefficient lookup on a canonical list. -/
+def coeffAt [Zero κ] (e : List Nat) : PolyList κ → κ
+  | [] => 0
+  | t :: ts => if e = t.1 then t.2 else coeffAt e ts
+
+/-- A monomial absent from a well-formed list has zero coefficient in its
+denotation. -/
+theorem coeff_denote_eq_zero {n : Nat} {κ : Type u} [Lean.Grind.Semiring κ]
+    [BEq κ] [LawfulBEq κ] [DecidableEq κ]
+    {cmp : Mono n → Mono n → Ordering} [Std.TransCmp cmp]
+    [Std.LawfulEqCmp cmp] (e : List Nat) (p : PolyList κ)
+    (he : e.length = n) (hp : ∀ t ∈ p, t.1.length = n)
+    (hnot : ∀ t ∈ p, e ≠ t.1) :
+    MvPoly.coeff (mono n e) (denote (cmp := cmp) p) = 0 := by
+  induction p with
+  | nil => exact MvPoly.coeff_zero _
+  | cons t ts ih =>
+      rw [denote, MvPoly.coeff_add, MvPoly.coeff_monomial,
+        ih (fun u hu => hp u (List.mem_cons_of_mem _ hu))
+          (fun u hu => hnot u (List.mem_cons_of_mem _ hu))]
+      have hne : mono n e ≠ mono n t.1 := by
+        intro h
+        exact hnot t (List.mem_cons_self ..)
+          ((mono_inj he (hp t (List.mem_cons_self ..))).mp h)
+      rw [ite_eq_right hne, Lean.Grind.AddCommMonoid.zero_add]
+
+/-- Reference coefficients read back the stored coefficient of a canonical
+list. -/
+theorem coeff_denote {n : Nat} {κ : Type u} [Lean.Grind.Semiring κ]
+    [BEq κ] [LawfulBEq κ] [DecidableEq κ]
+    {cmp : Mono n → Mono n → Ordering} [Std.TransCmp cmp]
+    [Std.LawfulEqCmp cmp] (e : List Nat) (p : PolyList κ)
+    (he : e.length = n) (hp : Canonical n p) :
+    MvPoly.coeff (mono n e) (denote (cmp := cmp) p) = coeffAt e p := by
+  induction p with
+  | nil => rw [denote, coeffAt, MvPoly.coeff_zero]
+  | cons t ts ih =>
+      have htlen := hp.1 t (List.mem_cons_self ..)
+      have htail : Canonical n ts :=
+        ⟨fun u hu => hp.1 u (List.mem_cons_of_mem _ hu),
+          (List.pairwise_cons.mp hp.2.1).2,
+          fun u hu => hp.2.2 u (List.mem_cons_of_mem _ hu)⟩
+      by_cases het : e = t.1
+      · have hzero : MvPoly.coeff (mono n e) (denote (cmp := cmp) ts) = 0 := by
+          apply coeff_denote_eq_zero e ts he htail.1
+          intro u hu heu
+          have hut := (List.pairwise_cons.mp hp.2.1).1 u hu
+          rw [← het, ← heu] at hut
+          exact List.lt_irrefl e hut
+        rw [denote, MvPoly.coeff_add, MvPoly.coeff_monomial,
+          ite_eq_left ((mono_inj he htlen).mpr het), hzero, coeffAt,
+          ite_eq_left het, Lean.Grind.Semiring.add_zero]
+      · have hm : mono n e ≠ mono n t.1 := fun h =>
+          het ((mono_inj he htlen).mp h)
+        rw [denote, MvPoly.coeff_add, MvPoly.coeff_monomial, ite_eq_right hm,
+          Lean.Grind.AddCommMonoid.zero_add, coeffAt, ite_eq_right het, ih htail]
+
+/-- Lookup is zero above the head of a descending canonical list. -/
+theorem coeffAt_eq_zero_of_gt_head [Zero κ] {e : List Nat}
+    {t : Term κ} {ts : PolyList κ}
+    (hp : (t :: ts).Pairwise (fun a b => b.1 < a.1)) (he : t.1 < e) :
+    coeffAt e (t :: ts) = 0 := by
+  have het : e ≠ t.1 := by
+    intro h
+    rw [h] at he
+    exact List.lt_irrefl t.1 he
+  rw [coeffAt, ite_eq_right het]
+  induction ts with
+  | nil => rfl
+  | cons u us ih =>
+      rw [coeffAt]
+      have hut := (List.pairwise_cons.mp hp).1 u (List.mem_cons_self ..)
+      have heu : e ≠ u.1 := by
+        intro h
+        have hue : u.1 < e := List.lt_trans hut he
+        rw [h] at hue
+        exact List.lt_irrefl u.1 hue
+      rw [ite_eq_right heu]
+      exact ih (List.pairwise_cons.mpr ⟨fun v hv =>
+        (List.pairwise_cons.mp hp).1 v (List.mem_cons_of_mem _ hv),
+        (List.pairwise_cons.mp (List.pairwise_cons.mp hp).2).2⟩)
+
+/-- The tail has zero coefficient at the head exponent. -/
+theorem coeffAt_tail_eq_zero [Zero κ] {t : Term κ} {ts : PolyList κ}
+    (hp : (t :: ts).Pairwise (fun a b => b.1 < a.1)) :
+    coeffAt t.1 ts = 0 := by
+  induction ts with
+  | nil => rfl
+  | cons u us ih =>
+      rw [coeffAt]
+      have hut := (List.pairwise_cons.mp hp).1 u (List.mem_cons_self ..)
+      have htu : t.1 ≠ u.1 := by
+        intro h
+        rw [← h] at hut
+        exact List.lt_irrefl t.1 hut
+      rw [ite_eq_right htu]
+      exact ih (List.pairwise_cons.mpr ⟨fun v hv =>
+        (List.pairwise_cons.mp hp).1 v (List.mem_cons_of_mem _ hv),
+        (List.pairwise_cons.mp (List.pairwise_cons.mp hp).2).2⟩)
+
+/-- Canonical lists with the same coefficient function are equal. -/
+theorem coeffAt_ext [Zero κ] {p q : PolyList κ}
+    (hp : p.Pairwise (fun a b => b.1 < a.1))
+    (hq : q.Pairwise (fun a b => b.1 < a.1))
+    (hp0 : ∀ t ∈ p, t.2 ≠ 0) (hq0 : ∀ t ∈ q, t.2 ≠ 0)
+    (h : ∀ e, coeffAt e p = coeffAt e q) : p = q := by
+  induction p generalizing q with
+  | nil =>
+      cases q with
+      | nil => rfl
+      | cons u us =>
+          have hu := h u.1
+          simp only [coeffAt] at hu
+          exact absurd hu.symm (hq0 u (List.mem_cons_self ..))
+  | cons t ts ih =>
+      cases q with
+      | nil =>
+          have ht := h t.1
+          simp only [coeffAt] at ht
+          exact absurd ht (hp0 t (List.mem_cons_self ..))
+      | cons u us =>
+          have hexp : t.1 = u.1 := by
+            cases hc : expCmp t.1 u.1 with
+            | eq =>
+                rw [expCmp_eq_compare] at hc
+                exact Std.LawfulEqCmp.eq_of_compare hc
+            | lt =>
+                have htu := expCmp_eq_lt_iff.mp hc
+                have hu := h u.1
+                rw [coeffAt_eq_zero_of_gt_head hp htu] at hu
+                rw [coeffAt, ite_eq_left rfl] at hu
+                exact absurd hu.symm (hq0 u (List.mem_cons_self ..))
+            | gt =>
+                have hut : u.1 < t.1 := by
+                  have hc' : expCmp u.1 t.1 = .lt := by
+                    rw [expCmp_eq_compare]
+                    apply Std.OrientedCmp.gt_iff_lt.mp
+                    simpa [expCmp_eq_compare] using hc
+                  exact expCmp_eq_lt_iff.mp hc'
+                have ht := h t.1
+                rw [coeffAt, ite_eq_left rfl] at ht
+                rw [coeffAt_eq_zero_of_gt_head hq hut] at ht
+                exact absurd ht (hp0 t (List.mem_cons_self ..))
+          have hcoeff : t.2 = u.2 := by
+            have ht := h t.1
+            rw [coeffAt, ite_eq_left rfl, coeffAt, ite_eq_left hexp] at ht
+            exact ht
+          have htail : ts = us := by
+            apply ih (List.pairwise_cons.mp hp).2 (List.pairwise_cons.mp hq).2
+              (fun v hv => hp0 v (List.mem_cons_of_mem _ hv))
+              (fun v hv => hq0 v (List.mem_cons_of_mem _ hv))
+            intro e
+            by_cases het : e = t.1
+            · subst e
+              rw [coeffAt_tail_eq_zero hp, hexp, coeffAt_tail_eq_zero hq]
+            · have heu : e ≠ u.1 := fun he => het (he.trans hexp.symm)
+              have he := h e
+              simp only [coeffAt, ite_eq_right het, ite_eq_right heu] at he
+              exact he
+          rw [Prod.ext hexp hcoeff, htail]
+
+/-- A lookup with the wrong arity is zero in a well-formed list. -/
+theorem coeffAt_eq_zero_of_length_ne [Zero κ] {e : List Nat}
+    {n : Nat} {p : PolyList κ} (hp : ∀ t ∈ p, t.1.length = n)
+    (he : e.length ≠ n) : coeffAt e p = 0 := by
+  induction p with
+  | nil => rfl
+  | cons t ts ih =>
+      have het : e ≠ t.1 := by
+        intro h
+        apply he
+        rw [h]
+        exact hp t (List.mem_cons_self ..)
+      rw [coeffAt, ite_eq_right het]
+      exact ih (fun u hu => hp u (List.mem_cons_of_mem _ hu))
+
+/-- Canonical list denotation is injective. -/
+theorem denote_injective {n : Nat} {κ : Type u} [Lean.Grind.Semiring κ]
+    [BEq κ] [LawfulBEq κ] [DecidableEq κ]
+    {cmp : Mono n → Mono n → Ordering} [Std.TransCmp cmp]
+    [Std.LawfulEqCmp cmp] {p q : PolyList κ}
+    (hp : Canonical n p) (hq : Canonical n q)
+    (h : denote (cmp := cmp) p = denote (cmp := cmp) q) : p = q := by
+  apply coeffAt_ext hp.2.1 hq.2.1 hp.2.2 hq.2.2
+  intro e
+  by_cases he : e.length = n
+  · rw [← coeff_denote (cmp := cmp) e p he hp,
+      ← coeff_denote (cmp := cmp) e q he hq, h]
+  · rw [coeffAt_eq_zero_of_length_ne hp.1 he,
+      coeffAt_eq_zero_of_length_ne hq.1 he]
+
+/-- A canonical list is recovered by converting its denotation back to list
+form. -/
+theorem toList_denote {n : Nat} {κ : Type u} [Lean.Grind.Semiring κ]
+    [BEq κ] [LawfulBEq κ] [DecidableEq κ]
+    {cmp : Mono n → Mono n → Ordering} [Std.TransCmp cmp]
+    [Std.LawfulEqCmp cmp] {p : PolyList κ} (hp : Canonical n p) :
+    toList (denote (cmp := cmp) p) = p := by
+  apply denote_injective (cmp := cmp)
+    (toList_canonical (cmp := cmp) (denote (cmp := cmp) p)) hp
+  exact denote_toList (cmp := cmp) (denote (cmp := cmp) p)
+
+/-! # Decidable certificate checks -/
+
+/-- Structural equality returns true exactly for equal term lists. -/
+theorem beq_eq_true_iff [DecidableEq κ] {p q : PolyList κ} :
+    beq p q = true ↔ p = q := by
+  induction p generalizing q with
+  | nil => cases q <;> simp [beq]
+  | cons t ts ih =>
+      cases q with
+      | nil => simp [beq]
+      | cons u us =>
+          simp only [beq, Bool.and_eq_true, decide_eq_true_eq, ih, expBeq_iff]
+          constructor
+          · rintro ⟨⟨he, hc⟩, htail⟩
+            have htu : t = u := Prod.ext he hc
+            subst u
+            subst us
+            rfl
+          · intro h
+            cases h
+            exact ⟨⟨rfl, rfl⟩, rfl⟩
+
+/-- The empty-list test agrees with zero denotation on canonical inputs. -/
+theorem isZero_iff {n : Nat} {κ : Type u} [Lean.Grind.Semiring κ]
+    [BEq κ] [LawfulBEq κ] [DecidableEq κ]
+    {cmp : Mono n → Mono n → Ordering} [Std.TransCmp cmp]
+    [Std.LawfulEqCmp cmp] {p : PolyList κ} (hp : Canonical n p) :
+    isZero p = true ↔ denote (cmp := cmp) p = 0 := by
+  constructor
+  · cases p with
+    | nil => intro; rfl
+    | cons t ts => simp [isZero]
+  · intro h
+    have hempty : Canonical n ([] : PolyList κ) :=
+      ⟨fun _ hmem => by contradiction, List.Pairwise.nil,
+        fun _ hmem => by contradiction⟩
+    have hd : denote (cmp := cmp) p = denote (cmp := cmp) [] := h
+    rw [denote_injective hp hempty hd]
+    rfl
+
+/-- Structural equality agrees with denotational equality on canonical
+inputs. -/
+theorem beq_iff {n : Nat} {κ : Type u} [Lean.Grind.Semiring κ]
+    [BEq κ] [LawfulBEq κ] [DecidableEq κ]
+    {cmp : Mono n → Mono n → Ordering} [Std.TransCmp cmp]
+    [Std.LawfulEqCmp cmp] {p q : PolyList κ}
+    (hp : Canonical n p) (hq : Canonical n q) :
+    beq p q = true ↔ denote (cmp := cmp) p = denote (cmp := cmp) q := by
+  rw [beq_eq_true_iff]
+  constructor
+  · exact fun h => congrArg denote h
+  · exact denote_injective hp hq
+
+/-- Reflexivity of list equality, stated at the kernel Boolean interface. -/
+theorem beq_refl [DecidableEq κ] (p : PolyList κ) : beq p p = true :=
+  beq_eq_true_iff.mpr rfl
+
+/-- Symmetry of list equality, stated at the kernel Boolean interface. -/
+theorem beq_symm [DecidableEq κ] {p q : PolyList κ} (h : beq p q = true) :
+    beq q p = true :=
+  beq_eq_true_iff.mpr (beq_eq_true_iff.mp h).symm
+
+/-- Transitivity of list equality, stated at the kernel Boolean interface. -/
+theorem beq_trans [DecidableEq κ] {p q r : PolyList κ}
+    (hpq : beq p q = true) (hqr : beq q r = true) : beq p r = true :=
+  beq_eq_true_iff.mpr ((beq_eq_true_iff.mp hpq).trans (beq_eq_true_iff.mp hqr))
+
+end Hex.MvPoly.Kernel

--- a/HexMvPoly/KernelTests.lean
+++ b/HexMvPoly/KernelTests.lean
@@ -228,6 +228,100 @@ example : (X 0 : P1) * X 0 = monomial
     (Mono.succAt 0 (Mono.unit 0)) 1 := by
   decide +kernel
 
+/-! # Canonical list-form replay -/
+
+abbrev PL := Kernel.PolyList Int
+
+@[expose] def listX : PL := [([1, 0], 1)]
+@[expose] def listY : PL := [([0, 1], 1)]
+@[expose] def listP : PL := Kernel.add (Kernel.one 2) (Kernel.add listX listY)
+
+example : Kernel.isCanonical 2 listP = true := by
+  decide +kernel
+
+example : Kernel.beq (Kernel.add listP (Kernel.neg listP)) [] = true := by
+  decide +kernel
+
+example : Kernel.isZero (Kernel.add listP (Kernel.neg listP)) = true := by
+  decide +kernel
+
+example :
+    Kernel.beq (Kernel.mul listP listP)
+      [([2, 0], 1), ([1, 1], 2), ([1, 0], 2),
+       ([0, 2], 1), ([0, 1], 2), ([0, 0], 1)] = true := by
+  decide +kernel
+
+example : Kernel.evalAt [2, 3] listP = 6 := by
+  decide +kernel
+
+abbrev QPL := Kernel.PolyList Rat
+
+@[expose] def listQ : QPL :=
+  [([1, 0], 1), ([0, 1], 1), ([0, 0], 1 / 2)]
+
+example : Kernel.evalAt [2, 3] listQ = 11 / 2 := by
+  decide +kernel
+
+example : Kernel.isCanonical 2 listQ = true := by
+  decide +kernel
+
+/-- Dot product over canonical polynomial lists. -/
+@[expose] def listDot : List PL → List PL → PL
+  | a :: as, b :: bs => Kernel.add (Kernel.mul a b) (listDot as bs)
+  | _, _ => []
+
+/-- The first `n` columns of a row-list matrix. -/
+@[expose] def listColumns : Nat → List (List PL) → List (List PL)
+  | 0, _ => []
+  | n + 1, rows =>
+      rows.map (fun row => row.getD 0 []) ::
+        listColumns n (rows.map (fun row => row.drop 1))
+
+/-- Matrix multiplication used only by the closed certificate replay below. -/
+@[expose] def listMatMul (columns : Nat) (a b : List (List PL)) :
+    List (List PL) :=
+  let bs := listColumns columns b
+  a.map fun row => bs.map (listDot row)
+
+/-- Entrywise equality through the polynomial list equality checker. -/
+@[expose] def listMatrixBeq : List (List PL) → List (List PL) → Bool
+  | [], [] => true
+  | a :: as, b :: bs =>
+      (a.zip b).all (fun e => Kernel.beq e.1 e.2) &&
+        Nat.beq a.length b.length && listMatrixBeq as bs
+  | _, _ => false
+
+@[expose] def listDiag4 (a : PL) : List (List PL) :=
+  [[a, [], [], []], [[], a, [], []], [[], [], a, []], [[], [], [], a]]
+
+@[expose] def listP3 : PL := Kernel.mul listP (Kernel.mul listP listP)
+@[expose] def listP4 : PL := Kernel.mul listP listP3
+
+set_option trace.profiler true in
+/-- A `4 × 4` diagonal adjugate identity. Its proof term evaluates only
+`List`, `Nat`, and `Int` primitives on the certificate path. -/
+theorem list_certificate_4x4 :
+    listMatrixBeq (listMatMul 4 (listDiag4 listP) (listDiag4 listP3))
+      (listDiag4 listP4) = true := by
+  decide +kernel
+
+example : Kernel.Canonical 2 listP := by
+  exact Kernel.isCanonical_iff.mp (by decide +kernel)
+
+example :
+    Kernel.isZero (Kernel.add listP (Kernel.neg listP)) = true ↔
+      Kernel.denote (cmp := Mono.lex)
+        (n := 2)
+        (Kernel.add listP (Kernel.neg listP)) = 0 :=
+  Kernel.isZero_iff
+    (Kernel.add_canonical
+      ((Kernel.isCanonical_iff (n := 2) (p := listP)).mp (by decide +kernel))
+      (Kernel.neg_canonical
+        ((Kernel.isCanonical_iff (n := 2) (p := listP)).mp (by decide +kernel))))
+
+example : Kernel.beq (Kernel.mul listP listP) (Kernel.mul listP listP) = true :=
+  Kernel.beq_refl _
+
 /-! # Axiom hygiene -/
 
 /-- info: 'Hex.MvPoly.KernelTests.splitFirst_roundtrip' depends on axioms: [propext, Classical.choice, Quot.sound] -/

--- a/HexMvPoly/SPEC/hex-mv-poly.md
+++ b/HexMvPoly/SPEC/hex-mv-poly.md
@@ -84,8 +84,10 @@ Ordered iteration gives the leading term in the monomial order, which
 every algorithm above the ring operations needs. Extensionality comes
 with the type, so two polynomials with equal key-value sets are
 propositionally equal and the canonical form condition reduces to "no
-zero values". The Phase 4 proof probes described below determine
-whether this representation also meets the kernel-reduction budget.
+zero values". The reference representation remains the
+compiled-computation interface. Kernel certificate replay uses the canonical
+list form specified below; the Phase 4 proof probes guard that separate
+path's reduction budget.
 
 Reusable map algorithms belong in `HexBasic/ExtTreeMap.lean`, in the
 `Std.ExtTreeMap` namespace, with no Hex-specific types or polynomial
@@ -212,39 +214,65 @@ laws, all of which the S-polynomial construction uses.
 
 ## Kernel reduction
 
-The tactic consumers (`sos`, and anything in the `factor_poly` family
-that grows a multivariate arm) check certificates with `decide +kernel`.
-The representation therefore has to reduce in the kernel, not merely
-compile.
+Certificate-producing tactics use the reference `MvPoly` for compiled
+computation and quote their results into `Hex.MvPoly.Kernel.PolyList` for
+`decide +kernel` replay. The two representations have deliberately separate
+jobs: the `Std.ExtTreeMap` representation remains the fast executable source
+of truth, while the list form keeps `Vector`, `Fin`, arrays, dependent
+conditionals, and well-founded recursion off the certificate path.
 
-`Std.ExtTreeMap` is the candidate representation, but it is not accepted
-for certificate replay until a downstream module proves that the full
-production equality and arithmetic path reduces. That probe uses
-`module`, `public import`, the intended `@[expose]` closure,
-`Vector Nat n` keys, the `nonzero` wrapper, and both `Int` and `Rat`
-coefficients. Testing a bare container or a legacy non-module file does
-not answer the question.
+`Kernel.Term κ` is `List Nat × κ`, and `Kernel.PolyList κ` is a list of
+terms. A list is `Canonical n` when every exponent has length `n`, exponent
+lists are strictly decreasing in ordinary lexicographic order, and every
+coefficient is nonzero. The arity condition is part of the invariant: without
+it, distinct lists can denote the same fixed-arity monomial through padding.
+The list order is fixed and does not depend on the reference polynomial's
+storage comparator.
 
-The comparative probe implements a competent canonical sorted-list
-representation as well. Its addition is a linear merge, and its
-multiplication uses translated-row merging or a produce-sort-combine
-pass rather than repeated linear insertion. Workloads include disjoint
-and interleaved addition, low- and high-collision multiplication,
-cancellation-heavy identities, sparse random supports, rename and
-substitution collisions, and real SOS certificate identities. They vary
-arity, degree, term count, coefficient type, and monomial order.
+The exposed computational API is structural recursion on `List` or `Nat`:
 
-These elaboration measurements live under the `mathlib: true`
-`HexMvPolyMathlib` proof-probe root. They are not LeanBench targets and
-do not define `main`. The Mathlib-free `HexMvPoly` bench contains only
-compiled performance measurements. A second kernel-specialised
-representation is justified only if the sorted form beats
-`ExtTreeMap` by more than 2× on at least two workload families at the
-largest size within the proof-probe time budget. Otherwise the single
-representation stands. The `PolyOps`-style abstraction in
-[future work](https://github.com/kim-em/hex-dev/blob/main/SPEC/future-work.md)
-is where a second representation would
-attach.
+```lean
+normalize, add, mul, neg, smul : PolyList κ → ... → PolyList κ
+isZero : PolyList κ → Bool
+beq : PolyList κ → PolyList κ → Bool
+evalAt : List κ → PolyList κ → κ
+```
+
+Exponent equality and ordering use `Nat.beq` and `Nat.blt`; exponent addition
+uses `Nat.add`. Coefficient computation uses the representation's ordinary
+primitive operations. Thus `Int` replay reduces through `Int.add`, `Int.mul`,
+and `Int.neg`; Lean's `Rat` supplies its reduced numerator-denominator
+representation. A positive-characteristic reflection provider supplies
+canonical `Nat` residues and modulus-parametrised operations before invoking
+this generic list layer.
+
+`denote` reads exact-length exponent lists as `Mono n` and sums their
+monomials in the Mathlib-free reference type. The public laws are
+`denote_add`, `denote_mul`, `denote_neg`, `denote_smul`, and
+`evalAt_denote`. Every arithmetic operation preserves `Canonical`; on
+canonical inputs:
+
+```lean
+isZero p = true ↔ denote p = 0
+beq p q = true ↔ denote p = denote q
+```
+
+Structural `beq` is reflexive, symmetric, and transitive. These results make
+dropping zeros and duplicate polynomials transport without asking the kernel
+to compare reference trees.
+
+`toList : MvPoly n κ cmp → PolyList κ` is producer-side only. It emits a
+canonical list and satisfies `denote_toList`; conversely `toList_denote`
+recovers every canonical list. A reflected matrix is quoted as nested term
+lists, so the consumer's identification hypothesis is definitionally
+`L.map (·.map denote) = rowLists P`, in the same way that the shared matrix
+literal layer identifies scalar row lists with `ofLists`. Certificate replay
+uses `L`, never the reference matrix or `toList` computation.
+
+`KernelTests.lean` exercises `Int` and `Rat`, canonicality, zero and equality
+fixtures, evaluation, and a `4 × 4` polynomial adjugate identity. The latter
+retains `trace.profiler` on its `decide +kernel` proof and must elaborate in
+well under one second on the shared host.
 
 ## Kernel exposure
 
@@ -280,14 +308,15 @@ The equality and construction constraints are shims for
 and disappear when it lands. The comparison shim remains until
 `Array.compareLex` itself is exposed upstream.
 
-The kernel replay closure is everything a certificate check touches:
-`Mono` operations, the comparator, `ExtTreeMap` lookup and `alter`,
-arithmetic and equality, direct and Horner evaluation, substitution and
-partial evaluation, and the recursive view. Each is `@[expose]`, and a
-downstream module carries `decide +kernel` tests that fail if any of them
-stops reducing. Storage-order and reporting queries such as
-`totalDegree`, `vars`, and pretty-printing remain outside that closure
-and expose their behavior through characterizing lemmas instead.
+The certificate replay closure is the API of `Kernel.lean`: list comparison,
+insertion and normalization, arithmetic, equality and zero checks, and list
+evaluation. The enclosing public section exposes each of these definitions,
+and a downstream module carries `decide +kernel` tests that fail if any stops
+reducing. The reference `Mono` comparators and `MvPoly` operations remain
+exposed for their smaller direct users, but symbolic matrix certificates do
+not place `ExtTreeMap`, `Vector`, or `Fin` in the replay closure. Storage-order
+and reporting queries such as `totalDegree`, `vars`, and pretty-printing stay
+outside that closure and expose their behavior through characterizing lemmas.
 
 Operations whose kernel-friendly shape differs from the fast shape carry
 a `@[csimp]` pair, as `Hex.Array.ofFn'` does. Multiplication is the
@@ -759,67 +788,27 @@ two consumers stress different things and a single number would hide
 both.
 
 **Kernel suite.** `decide +kernel` on identities, reported as
-elaboration wallclock. This is a build-only
-`HexMvPolyMathlib` proof probe, not a LeanBench target. It runs the
-production types (`Vector Nat n` keys, the real `DecidableEq`, `Rat` as
-well as `Int`) from a downstream module under the module system,
-against both the `ExtTreeMap` form and a competently implemented sorted
-form. Workload families are disjoint and interleaved addition,
+elaboration wallclock. `HexMvPoly/KernelTests.lean` covers the mandatory
+small list-form replay, while larger build-only `HexMvPolyMathlib` proof
+probes are not LeanBench targets. They run both `Int` and `Rat` from a
+downstream module under the module system. Workload families are disjoint
+and interleaved addition,
 low-collision and high-collision multiplication, cancellation-heavy
 identities, sparse random supports, `rename` and `subst` collisions, and
 real `sos` certificates. They vary arity, degree, term count, and
-comparator.
+reference comparator; the canonical list order itself is fixed.
 
 **Native suite.** Compiled throughput on the same families, which is
 what CompPoly's consumers care about and what would justify retiring
 their module.
 
-**Comparators.** CompPoly and `MvSparsePoly` are the two that matter and
-both are `informational` rather than required checks: they are
-structurally different designs, and the point of measuring them is to
-decide a design question rather than to hold a ratio. SymPy is not a
-performance comparator. Since both Lean comparators import Mathlib,
-their adapters run as external comparator drivers over the shared input
-corpus rather than as imports of the Mathlib-free LeanBench target.
-The core registration owns the five native-family comparisons. The
-Mathlib companion separately registers `MvSparsePoly` for the kernel
-families, where the representation decision is made.
-
-**The threshold, written down in advance.** A second, kernel-specialised
-representation is justified only if the kernel suite shows the sorted
-form beating `ExtTreeMap` by more than 2× on at least two workload
-families at the largest size that fits the bench time budget. The ratio
-is the median production workload time divided by the median sorted
-workload time after subtracting the same round's matched import-only
-module build from each arm. Raw fresh-module wall times are still
-reported, together with the maximum raw ratio attainable if the sorted
-workload itself took zero time; an import-dominated raw ratio is not
-used for this decision.
-
-Both baseline-subtracted medians must exceed the robust variability
-envelope of the round-matched import baseline. The record separately
-calibrates pair-order noise with same-module controls at three build
-magnitudes, including a large SOS-scale control. At each substantive build
-magnitude it interpolates median/MAD/IQR/Tukey statistics and makes the
-conservative envelope no smaller than the maximum observed absolute null
-delta. The record is invalid when a control's IQR exceeds 10% of its build
-magnitude. A baseline-limited ratio or a comparison whose arm delta is
-unresolved against the interpolated null envelope does not count toward the
-threshold. Reference and candidate arms use the same coefficient type,
-arity, comparator, support stream, and identity; the report records those
-axes for every pair. Anything short of two conservative greater-than-2×
-workload ratios leaves the single representation standing. Concretely, if
-the attributed reference and candidate workloads are `r` and `c` and the
-comparable null envelope is `e`, the threshold interval is
-`(r - e) / (c + e)` through `(r + e) / (c - e)`. A family passes only
-when the comparison is resolved and the lower bound exceeds 2; a point
-estimate above 2 is not sufficient.
-
-When a workload includes materially different input construction, a matched
-construction-only pair is subtracted round by round after import subtraction.
-The resulting net ratio counts only when both net arms exceed the sum of the
-full-workload and construction-control null envelopes. This prevents a faster
-constructor from being reported as a faster arithmetic operation.
+**Comparators.** CompPoly and the existing sorted-list proxy remain
+informational compiled-throughput comparators. SymPy is not a performance
+comparator. The kernel representation decision is no longer conditional:
+symbolic matrix certificates require the canonical `PolyList` path because
+the reference `Vector`/`Fin` path exceeds the matrix-tactic kernel budget.
+Measurements now guard that chosen path rather than deciding whether it
+exists.
 
 The native driver lives at `bench/HexMvPoly/Bench.lean`. Kernel probes
 live below `bench/HexMvPolyMathlib/ProofProbe/`, contain no `main`,
@@ -842,9 +831,11 @@ HexMvPoly/
   Eval.lean          -- eval, eval₂, Horner, partialEval
   Structural.lean    -- rename, reorder, subst, derivative, homogeneous parts
   Recursive.lean     -- toUnivariate, ofUnivariate, round trips
+  Kernel.lean        -- canonical list arithmetic and reference denotation
 HexMvPoly.lean       -- umbrella
 HexMvPolyMathlib/
   Equiv.lean         -- MvPoly n R cmp ≃+* MvPolynomial (Fin n) R
+  Kernel.lean        -- term-list denotation into MvPolynomial
   Recursive.lean     -- zero-arity, one-variable, and finSucc ring equivalences
   Aeval.lean         -- aeval and its homomorphism lemmas
   Correspondence.lean-- coeff/eval/degree/rename/subst/recursive-view transport
@@ -866,7 +857,7 @@ HexMvPolyMathlib.lean
           rationale: "CompPoly uses the same ExtTreeMap representation behind a Mathlib-dependent API; the comparison records integration and implementation overhead rather than gating release."
         - tool: "canonical sorted-list MvSparsePoly proxy"
           class: informational
-          rationale: "The pinned Mathlib revision has no MvSparsePoly, so a local canonical sorted-list proxy records compiled throughput for the alternative algorithmic shape. The native comparison is informational; only the registered kernel proof probes can decide whether a second representation is justified."
+          rationale: "The pinned Mathlib revision has no MvSparsePoly, so a local canonical sorted-list proxy records compiled throughput for the alternative algorithmic shape. The native comparison is informational; the registered kernel proof probes guard the canonical PolyList certificate path."
       input_families:
         - name: sparse-addition
           description: Disjoint and interleaved sparse supports across lexicographic, graded lexicographic, and graded reverse lexicographic order.
@@ -888,7 +879,7 @@ HexMvPolyMathlib.lean
       comparators:
         - tool: "canonical sorted-list MvSparsePoly proxy"
           class: informational
-          rationale: "Mathlib MvSparsePoly is not yet available in the pinned Mathlib revision, so a local canonical sorted-list proxy with linear merge addition and balanced translated-row multiplication is used to decide whether HexMvPoly needs a second representation."
+          rationale: "Mathlib MvSparsePoly is not yet available in the pinned Mathlib revision, so a local canonical sorted-list proxy with linear merge addition and balanced translated-row multiplication remains an informational comparison for the canonical PolyList certificate path."
       input_families:
         - name: kernel-sparse-addition
           description: Disjoint, interleaved, and scattered supports checked under lex and grevlex, including an arity-eight case.
@@ -969,21 +960,16 @@ check, because it is the acceptance test for the surface listed here.
    the recursive view.
 4. Add conformance fixtures and the Mathlib correspondence.
 5. Run the module-boundary kernel probes and native benchmarks. Keep
-   `ExtTreeMap` as the compiled representation. If the recorded threshold
-   selects the sorted form, record the justified kernel-specialized second
-   representation under
-   [future work](https://github.com/kim-em/hex-dev/blob/main/SPEC/future-work.md),
-   where the
-   representation abstraction belongs.
+   `ExtTreeMap` as the compiled representation and use `Kernel.PolyList` as
+   the mandatory quoted representation for symbolic matrix certificate
+   replay.
 
 ## Open questions
 
 - **Coefficient types.** The library is generic in `R`. CompPoly
-  compatibility and the later Hex work both require that, so it is not
-  in question. The open part is that `sos` needs `Rat`, whose
-  kernel-reduction cost must be measured separately from the polynomial
-  container. If that cost dominates, a kernel-friendly rational
-  representation is a separate library decision.
+  compatibility and later Hex work both require that. Kernel certificates
+  use representation types with primitive arithmetic: `Int`, reduced `Rat`,
+  or canonical `Nat` residues supplied by the reflection layer.
 - **Sparse coefficients versus sparse exponents.** `Mono n` as a dense
   `Vector Nat n` is right for small `n`. Whether large `n` with few
   active variables wants a sparse exponent vector should be settled by

--- a/HexMvPolyMathlib.lean
+++ b/HexMvPolyMathlib.lean
@@ -9,6 +9,7 @@ module
 public import HexMvPolyMathlib.Aeval
 public import HexMvPolyMathlib.Correspondence
 public import HexMvPolyMathlib.Equiv
+public import HexMvPolyMathlib.Kernel
 public import HexMvPolyMathlib.Recursive
 
 public section

--- a/HexMvPolyMathlib/Kernel.lean
+++ b/HexMvPolyMathlib/Kernel.lean
@@ -1,0 +1,122 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvPolyMathlib.Equiv
+
+public section
+
+/-!
+Mathlib denotation of canonical kernel term lists.
+
+This is deliberately only a semantic bridge. Certificate computation remains
+in `Hex.MvPoly.Kernel`, over ordinary lists and primitive coefficient
+arithmetic; the bridge transports its proved denotation through the ring
+equivalence with `MvPolynomial`.
+-/
+
+namespace HexMvPolyMathlib.Kernel
+
+open Hex
+open Hex.MvPoly
+open scoped HexMvPolyMathlib
+
+universe u
+
+abbrev Term := Hex.MvPoly.Kernel.Term
+abbrev PolyList := Hex.MvPoly.Kernel.PolyList
+
+/-- Denote a kernel term list as a Mathlib multivariate polynomial. -/
+noncomputable def denote {n : Nat} {R : Type u} [CommSemiring R]
+    [BEq R] [LawfulBEq R] [DecidableEq R]
+    {cmp : Mono n → Mono n → Ordering} [Std.TransCmp cmp]
+    [Std.LawfulEqCmp cmp] (p : PolyList R) : MvPolynomial (Fin n) R :=
+  HexMvPolyMathlib.equiv (cmp := cmp) (Hex.MvPoly.Kernel.denote (cmp := cmp) p)
+
+/-- List addition has the same denotation as Mathlib addition. -/
+theorem denote_add {n : Nat} {R : Type u} [CommSemiring R]
+    [BEq R] [LawfulBEq R] [DecidableEq R]
+    {cmp : Mono n → Mono n → Ordering} [Std.TransCmp cmp]
+    [Std.LawfulEqCmp cmp] (p q : PolyList R) :
+    denote (cmp := cmp) (Hex.MvPoly.Kernel.add p q) =
+      denote (cmp := cmp) p + denote (cmp := cmp) q := by
+  unfold denote
+  rw [Hex.MvPoly.Kernel.denote_add, map_add]
+
+/-- List multiplication has the same denotation as Mathlib multiplication. -/
+theorem denote_mul {n : Nat} {R : Type u} [CommSemiring R]
+    [BEq R] [LawfulBEq R] [DecidableEq R]
+    {cmp : Mono n → Mono n → Ordering} [Std.TransCmp cmp]
+    [Std.LawfulEqCmp cmp] (p q : PolyList R)
+    (hp : ∀ t ∈ p, t.1.length = n) (hq : ∀ t ∈ q, t.1.length = n) :
+    denote (cmp := cmp) (Hex.MvPoly.Kernel.mul p q) =
+      denote (cmp := cmp) p * denote (cmp := cmp) q := by
+  unfold denote
+  rw [Hex.MvPoly.Kernel.denote_mul p q hp hq, map_mul]
+
+/-- List negation has the same denotation as Mathlib negation. -/
+theorem denote_neg {n : Nat} {R : Type u} [CommRing R]
+    [BEq R] [LawfulBEq R] [DecidableEq R]
+    {cmp : Mono n → Mono n → Ordering} [Std.TransCmp cmp]
+    [Std.LawfulEqCmp cmp] (p : PolyList R) :
+    denote (cmp := cmp) (Hex.MvPoly.Kernel.neg p) = -denote (cmp := cmp) p := by
+  unfold denote
+  rw [Hex.MvPoly.Kernel.denote_neg, map_neg]
+
+/-- List scalar multiplication denotes multiplication by a Mathlib constant. -/
+theorem denote_smul {n : Nat} {R : Type u} [CommSemiring R]
+    [BEq R] [LawfulBEq R] [DecidableEq R]
+    {cmp : Mono n → Mono n → Ordering} [Std.TransCmp cmp]
+    [Std.LawfulEqCmp cmp] (a : R) (p : PolyList R) :
+    denote (cmp := cmp) (Hex.MvPoly.Kernel.smul a p) =
+      MvPolynomial.C a * denote (cmp := cmp) p := by
+  unfold denote
+  rw [Hex.MvPoly.Kernel.denote_smul, map_mul,
+    HexMvPolyMathlib.equiv_apply, HexMvPolyMathlib.toMvPolynomial_C]
+
+/-- Producer conversion reads as the corresponding Mathlib polynomial. -/
+theorem denote_toList {n : Nat} {R : Type u} [CommSemiring R]
+    [BEq R] [LawfulBEq R] [DecidableEq R]
+    {cmp : Mono n → Mono n → Ordering} [Std.TransCmp cmp]
+    [Std.LawfulEqCmp cmp] (p : MvPoly n R cmp) :
+    denote (cmp := cmp) (Hex.MvPoly.Kernel.toList p) =
+      HexMvPolyMathlib.equiv (cmp := cmp) p := by
+  unfold denote
+  rw [Hex.MvPoly.Kernel.denote_toList]
+
+/-- The list zero test agrees with zero Mathlib denotation on canonical
+inputs. -/
+theorem isZero_iff {n : Nat} {R : Type u} [CommSemiring R]
+    [BEq R] [LawfulBEq R] [DecidableEq R]
+    {cmp : Mono n → Mono n → Ordering} [Std.TransCmp cmp]
+    [Std.LawfulEqCmp cmp] {p : PolyList R}
+    (hp : Hex.MvPoly.Kernel.Canonical n p) :
+    Hex.MvPoly.Kernel.isZero p = true ↔ denote (cmp := cmp) p = 0 := by
+  rw [Hex.MvPoly.Kernel.isZero_iff (cmp := cmp) hp]
+  constructor
+  · intro h
+    unfold denote
+    rw [h, map_zero]
+  · intro h
+    apply (HexMvPolyMathlib.equiv (cmp := cmp)).injective
+    simpa [denote] using h
+
+/-- The list equality test agrees with equality of Mathlib denotations on
+canonical inputs. -/
+theorem beq_iff {n : Nat} {R : Type u} [CommSemiring R]
+    [BEq R] [LawfulBEq R] [DecidableEq R]
+    {cmp : Mono n → Mono n → Ordering} [Std.TransCmp cmp]
+    [Std.LawfulEqCmp cmp] {p q : PolyList R}
+    (hp : Hex.MvPoly.Kernel.Canonical n p)
+    (hq : Hex.MvPoly.Kernel.Canonical n q) :
+    Hex.MvPoly.Kernel.beq p q = true ↔
+      denote (cmp := cmp) p = denote (cmp := cmp) q := by
+  rw [Hex.MvPoly.Kernel.beq_iff (cmp := cmp) hp hq]
+  unfold denote
+  exact (HexMvPolyMathlib.equiv (n := n) (R := R) (cmp := cmp)).injective.eq_iff.symm
+
+end HexMvPolyMathlib.Kernel

--- a/HexMvPolyMathlib/SPEC/hex-mv-poly-mathlib.md
+++ b/HexMvPolyMathlib/SPEC/hex-mv-poly-mathlib.md
@@ -46,6 +46,25 @@ theorem coeff_toMvPolynomial [CommSemiring R] [DecidableEq R]
 Its inverse builds the canonical sparse form, so the two round trips are
 propositional equalities rather than quotient-level equivalences.
 
+## Kernel term-list denotation
+
+`HexMvPolyMathlib.Kernel.denote` composes the Mathlib-free canonical-list
+denotation with `equiv`:
+
+```lean
+noncomputable def Kernel.denote (p : Hex.MvPoly.Kernel.PolyList R) :
+    MvPolynomial (Fin n) R :=
+  equiv (Hex.MvPoly.Kernel.denote p)
+```
+
+It preserves list addition, multiplication, negation, and scalar
+multiplication by a constant. Consequently the canonical zero and equality
+theorems proved in `hex-mv-poly` transport to the exact `MvPolynomial`
+statements used by symbolic `rank`, `det`, and `rank_locus` consumers. The
+bridge is semantic only: no Mathlib value occurs in the closed Boolean
+certificate check, and matrix entries are related to nested term lists by
+mapping this denotation after replay.
+
 ## Evaluation
 
 `aeval` uses the executable core evaluator and agrees with Mathlib:


### PR DESCRIPTION
Symbolic matrix certificates need polynomial arithmetic that reduces without reference trees, vectors, or finite indices. This adds canonical `List Nat` term lists for that replay path, with proved denotation into `Hex.MvPoly` and Mathlib's `MvPolynomial`.

- Exposed structural arithmetic: linear-merge addition, balanced-row multiplication, negation, subtraction, scalar multiplication, identity, zero/equality checks, and evaluation.
- Arity-aware canonicality and preservation proofs, semantic zero/equality laws, and producer conversion round trips. `toList` has a checked linear path for the default lexicographic order.
- `denote_toRows` identifies nested quoted polynomial lists with their original rows; consumers instantiate it at `rowLists P` without adding a matrix dependency to `hex-mv-poly`.
- Int and Rat fixtures, plus a non-diagonal 4×4 adjugate identity checked against independent coefficient literals in both multiplication orders. A corrupted determinant is rejected.

Canonicality requires every exponent list to have the declared arity; otherwise denotation into a fixed-arity polynomial is not injective. The list order is fixed lexicographic order, independently of the reference storage comparator. The coefficient operations are generic; positive-characteristic reflection providers remain a separate prerequisite in the consumer SPECs.

Validation: `lake build` passed all 13,738 jobs; the focused core/test/Mathlib targets, `python3 scripts/check_dag.py`, and diff hygiene checks also passed. The 4×4 certificate's kernel check measured 77 ms on the shared host. The scoped profiler reports this timing but does not enforce a wall-clock limit; existing reference/proxy benchmarks do not establish a general PolyList scaling budget.

Closes #10229
